### PR TITLE
Record cap observations for auto-approved proposals

### DIFF
--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -26,6 +26,7 @@ from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.alerts import send_approval_dispatch_alert
 from app.services.order_proposals.approval_window import ApprovalWindowDecision
 from app.services.order_proposals.auto_approve_audit import (
+    project_auto_approve_cap_observations,
     project_auto_approve_rejections,
 )
 from app.services.order_proposals.broker_gateway import (
@@ -125,6 +126,9 @@ def _group_dict(g: Any) -> dict[str, Any]:
         "approval_dispatch_failure_code": g.approval_dispatch_failure_code,
         "approval_dispatch_payload_chars": g.approval_dispatch_payload_chars,
         "approval_dispatch_alert": (g.source_asof or {}).get("approval_dispatch_alert"),
+        "auto_approve_cap_observations": project_auto_approve_cap_observations(
+            g.source_asof
+        ),
         "auto_approve_rejections": project_auto_approve_rejections(g.source_asof),
         "created_at": g.created_at.isoformat() if g.created_at else None,
     }

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -55,7 +55,7 @@ from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
     DispatchBinding,
 )
-from app.services.trading_policy_service import load_trading_policy
+from app.services.trading_policy_service import load_trading_policy, policy_content_hash
 
 _POLICY_MARKET = {
     "equity_kr": "kr",
@@ -151,6 +151,9 @@ class AutoApproveLimits:
     mode: str = "off"
     breakeven_band_pct: Decimal = Decimal("1")
     round_trip_cost_bps: Decimal = Decimal("90")
+    # Audit-only policy provenance. Eligibility deliberately never reads this value.
+    # Kept last so legacy positional constructions retain their semantics.
+    policy_content_hash: str | None = None
 
 
 @dataclass(frozen=True)
@@ -210,6 +213,7 @@ def limits_for_market(market: str) -> AutoApproveLimits | None:
     if policy_market is None:
         return None
     document = load_trading_policy()
+    content_hash = policy_content_hash()
     policy = document.order_proposals.auto_approve
     declared_cost = Decimal(str(policy.round_trip_cost_bps[policy_market]))
     return AutoApproveLimits(
@@ -217,6 +221,7 @@ def limits_for_market(market: str) -> AutoApproveLimits | None:
         per_order_cap=Decimal(str(policy.per_order_cap[policy_market])),
         daily_cap=Decimal(str(policy.daily_cap[policy_market])),
         policy_version=document.version,
+        policy_content_hash=content_hash,
         mode=str(settings.ORDER_PROPOSALS_AUTO_APPROVE_MODE),
         breakeven_band_pct=Decimal(str(policy.breakeven_band_pct)),
         # The floor wins whenever the policy is cheaper than it.

--- a/app/services/order_proposals/auto_approve_audit.py
+++ b/app/services/order_proposals/auto_approve_audit.py
@@ -15,10 +15,12 @@ from datetime import datetime
 from typing import Any
 
 AUTO_APPROVE_REJECTIONS_KEY = "auto_approve_rejections"
+AUTO_APPROVE_CAP_OBSERVATIONS_KEY = "cap_observations"
 
 _MAX_ATTEMPTS = 8
 _MAX_RUNGS_PER_ATTEMPT = 16
 _MAX_TAG_MATCHES_PER_RUNG = 12
+_MAX_CAP_OBSERVATIONS = 16
 _ALLOWED_TAGS = frozenset({"policy_deviation", "table_disagreement"})
 _ALLOWED_TAG_FIELDS = frozenset(
     {
@@ -105,6 +107,14 @@ _KNOWN_REASON_CODES = frozenset(
 )
 _DECIMAL_TEXT_PATTERN = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?")
 _POLICY_VERSION_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}(?:\.[0-9]{1,4})?")
+_POLICY_CONTENT_HASH_PATTERN = re.compile(r"[0-9a-f]{12,64}")
+_CAP_OBSERVATION_NUMERIC_KEYS = (
+    "daily_cap",
+    "daily_notional_before",
+    "daily_notional_after",
+    "per_order_cap",
+    "notional",
+)
 _SAFE_PATH_SEGMENT = (
     r"(?:\.(?:context|decision|flags|labels|metadata|notes|reason|review|tag|tags)"
     r"|\[(?:0|[1-9][0-9]{0,3})\])"
@@ -126,6 +136,12 @@ def _safe_decimal_text(value: Any) -> str | None:
 
 def _safe_policy_version(value: Any) -> str | None:
     if not isinstance(value, str) or not _POLICY_VERSION_PATTERN.fullmatch(value):
+        return None
+    return value
+
+
+def _safe_policy_content_hash(value: Any) -> str | None:
+    if not isinstance(value, str) or not _POLICY_CONTENT_HASH_PATTERN.fullmatch(value):
         return None
     return value
 
@@ -350,6 +366,76 @@ def append_auto_approve_rejection_attempt(
     return source
 
 
+def _safe_cap_observation(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    rung_index = _safe_rung_index(value.get("rung_index"))
+    policy_version = _safe_policy_version(value.get("policy_version"))
+    content_hash = _safe_policy_content_hash(value.get("content_hash"))
+    evaluated_at = _safe_evaluated_at(value.get("evaluated_at"))
+    numeric_values = {
+        key: _safe_decimal_text(value.get(key)) for key in _CAP_OBSERVATION_NUMERIC_KEYS
+    }
+    if (
+        rung_index is None
+        or policy_version is None
+        or content_hash is None
+        or evaluated_at is None
+        or any(item is None for item in numeric_values.values())
+    ):
+        return None
+    return {
+        "rung_index": rung_index,
+        **numeric_values,
+        "policy_version": policy_version,
+        "content_hash": content_hash,
+        "evaluated_at": evaluated_at,
+    }
+
+
+def build_auto_approve_cap_observations(
+    *,
+    decisions: Sequence[Mapping[str, Any]],
+    policy_content_hash: str | None,
+    evaluated_at: datetime,
+) -> list[dict[str, Any]]:
+    """Project complete, bounded cap evidence for eligible rungs only."""
+    observations: list[dict[str, Any]] = []
+    evaluated_at_text = evaluated_at.isoformat()
+    for decision in decisions[:_MAX_CAP_OBSERVATIONS]:
+        if decision.get("eligible") is not True:
+            continue
+        candidate = {
+            "rung_index": decision.get("rung_index"),
+            **{key: decision.get(key) for key in _CAP_OBSERVATION_NUMERIC_KEYS},
+            "policy_version": decision.get("policy_version"),
+            "content_hash": policy_content_hash,
+            "evaluated_at": evaluated_at_text,
+        }
+        if (safe := _safe_cap_observation(candidate)) is not None:
+            observations.append(safe)
+    return observations
+
+
+def project_auto_approve_cap_observations(source_asof: Any) -> list[dict[str, Any]]:
+    """Return only complete, safe cap evidence from an auto-approved proposal."""
+    if not isinstance(source_asof, Mapping):
+        return []
+    auto_approved = source_asof.get("auto_approved")
+    if not isinstance(auto_approved, Mapping):
+        return []
+    raw_observations = auto_approved.get(AUTO_APPROVE_CAP_OBSERVATIONS_KEY)
+    if not isinstance(raw_observations, Sequence) or isinstance(
+        raw_observations, (str, bytes)
+    ):
+        return []
+    return [
+        safe
+        for raw in raw_observations[:_MAX_CAP_OBSERVATIONS]
+        if (safe := _safe_cap_observation(raw)) is not None
+    ]
+
+
 def build_auto_approve_rejection_card_block(source_asof: Any) -> str | None:
     """Render a bounded safe summary for the existing manual approval card."""
     attempts = project_auto_approve_rejections(source_asof)
@@ -372,9 +458,12 @@ def build_auto_approve_rejection_card_block(source_asof: Any) -> str | None:
 
 
 __all__ = [
+    "AUTO_APPROVE_CAP_OBSERVATIONS_KEY",
     "AUTO_APPROVE_REJECTIONS_KEY",
     "append_auto_approve_rejection_attempt",
+    "build_auto_approve_cap_observations",
     "build_auto_approve_rejection_attempt",
     "build_auto_approve_rejection_card_block",
+    "project_auto_approve_cap_observations",
     "project_auto_approve_rejections",
 ]

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -859,9 +859,11 @@ async def dispatch_proposal(
                 await service.record_auto_approval(
                     proposal_id,
                     policy_version=limits.policy_version,
+                    policy_content_hash=getattr(limits, "policy_content_hash", None),
                     eligibility=decisions,
                     outcomes=[outcome.result for outcome in outcomes],
                     now=now,
+                    evaluated_at=gate_now,
                 )
                 veto_nonce = _generate_nonce()
                 await service.set_approval_nonce(proposal_id, veto_nonce)

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -33,6 +33,7 @@ from app.services.order_proposals import state_machine as sm
 from app.services.order_proposals.approval_window_contract import valid_until_block
 from app.services.order_proposals.auto_approve_audit import (
     append_auto_approve_rejection_attempt,
+    build_auto_approve_cap_observations,
 )
 from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
 from app.services.order_proposals.defensive_ttl import (
@@ -2737,23 +2738,34 @@ class OrderProposalsService:
         proposal_id: uuid.UUID,
         *,
         policy_version: str,
+        policy_content_hash: str | None = None,
         eligibility: list[dict[str, Any]],
         outcomes: list[str],
         now: datetime,
+        evaluated_at: datetime | None = None,
     ) -> OrderProposal:
         """Persist machine approval provenance without impersonating a human."""
         self._require_timezone_aware(now)
+        observation_time = evaluated_at or now
+        self._require_timezone_aware(observation_time)
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
+        auto_approved: dict[str, Any] = {
+            "policy_version": policy_version,
+            "approved_at": now.isoformat(),
+            "eligibility": eligibility,
+            "outcomes": outcomes,
+        }
+        if cap_observations := build_auto_approve_cap_observations(
+            decisions=eligibility,
+            policy_content_hash=policy_content_hash,
+            evaluated_at=observation_time,
+        ):
+            auto_approved["cap_observations"] = cap_observations
         source_asof = {
             **(group.source_asof or {}),
-            "auto_approved": {
-                "policy_version": policy_version,
-                "approved_at": now.isoformat(),
-                "eligibility": eligibility,
-                "outcomes": outcomes,
-            },
+            "auto_approved": auto_approved,
         }
         return await self._repo.update_group(group, source_asof=source_asof)
 

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import random
 import uuid
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
@@ -19,6 +21,7 @@ from app.services.order_proposals.auto_approve import (
 )
 from app.services.order_proposals.auto_approve_audit import (
     append_auto_approve_rejection_attempt,
+    project_auto_approve_cap_observations,
     project_auto_approve_rejections,
 )
 from app.services.order_proposals.dispatch_contract import (
@@ -60,6 +63,22 @@ _LIMITS = AutoApproveLimits(
     daily_cap=Decimal("500000"),
     policy_version="test-policy",
 )
+
+
+def test_limits_policy_content_hash_preserves_legacy_positional_order():
+    limits = AutoApproveLimits(
+        Decimal("3"),
+        Decimal("200000"),
+        Decimal("500000"),
+        "test-policy",
+        "expanded",
+        Decimal("1"),
+        Decimal("200"),
+    )
+
+    assert limits.mode == "expanded"
+    assert limits.round_trip_cost_bps == Decimal("200")
+    assert limits.policy_content_hash is None
 
 
 def test_buy_at_distance_and_daily_cap_boundary_is_eligible():
@@ -519,6 +538,127 @@ def test_rejection_projection_drops_untrusted_metadata_without_losing_reason():
         )[0]["rungs"][0]["reason_code"]
         == "invalid_reason_code"
     )
+
+
+def test_cap_observation_projection_requires_complete_safe_fields():
+    raw_input = "private-cap-observation-material-must-not-escape"
+    valid = {
+        "rung_index": 0,
+        "daily_cap": "800",
+        "daily_notional_before": "0",
+        "daily_notional_after": "741.41",
+        "per_order_cap": "1000",
+        "notional": "741.41",
+        "policy_version": "2026-08-14.1",
+        "content_hash": "51c789434f6a",
+        "evaluated_at": "2026-08-14T22:35:00+00:00",
+        "private": raw_input,
+    }
+    incomplete = dict(valid)
+    incomplete.pop("daily_notional_after")
+
+    projected = project_auto_approve_cap_observations(
+        {"auto_approved": {"cap_observations": [valid, incomplete]}}
+    )
+
+    assert projected == [
+        {
+            "rung_index": 0,
+            "daily_cap": "800",
+            "daily_notional_before": "0",
+            "daily_notional_after": "741.41",
+            "per_order_cap": "1000",
+            "notional": "741.41",
+            "policy_version": "2026-08-14.1",
+            "content_hash": "51c789434f6a",
+            "evaluated_at": "2026-08-14T22:35:00+00:00",
+        }
+    ]
+    assert raw_input not in json.dumps(projected)
+
+
+def test_cap_observation_stamp_is_decision_inert_across_26000_fuzz_cases():
+    randomizer = random.Random(1244)
+    unobserved_limits = replace(_EXPANDED, policy_content_hash=None)
+    observed_limits = replace(
+        _EXPANDED,
+        policy_content_hash="51c789434f6a",
+    )
+    observation = {
+        "rung_index": 0,
+        "daily_cap": "800",
+        "daily_notional_before": "0",
+        "daily_notional_after": "741.41",
+        "per_order_cap": "1000",
+        "notional": "741.41",
+        "policy_version": "2026-08-14.1",
+        "content_hash": "51c789434f6a",
+        "evaluated_at": "2026-08-14T22:35:00+00:00",
+    }
+    compared = 0
+    mismatches: list[int] = []
+    for case in range(26_000):
+        group_kwargs = {
+            "market": randomizer.choice(["equity_kr", "equity_us", "crypto", "index"]),
+            "account_mode": randomizer.choice(
+                ["kis_live", "toss_live", "upbit", "unknown"]
+            ),
+            "order_type": randomizer.choice(["limit", "market", "unknown"]),
+            "action": randomizer.choice(["place", "replace", "cancel", None]),
+            "exit_intent": randomizer.choice([None, "loss_cut", "other_exit"]),
+            "thesis": randomizer.choice(["cap fixture", "", None]),
+        }
+        rung = _rung(
+            side=randomizer.choice(["buy", "sell", "other"]),
+            limit_price=randomizer.choice(
+                [
+                    Decimal("0"),
+                    Decimal("741.41"),
+                    Decimal("800"),
+                    Decimal("1000"),
+                ]
+            ),
+            quantity=randomizer.choice(
+                [Decimal("0"), Decimal("1"), Decimal("2"), Decimal("3")]
+            ),
+        )
+        preview = {
+            "success": randomizer.choice([True, False, "true", None]),
+            "current_price": randomizer.choice(
+                [None, "0", "741.41", "800", "not-a-price"]
+            ),
+            "avg_buy_price": randomizer.choice(
+                [None, "700", "741.41", "800", "not-a-price"]
+            ),
+            "realized_pnl": randomizer.choice([None, "-1", "0", "1", "not-a-price"]),
+        }
+        daily_notional = Decimal(randomizer.randrange(0, 120_001)) / Decimal("100")
+        baseline = evaluate_auto_approve_eligibility(
+            group=_group(**group_kwargs, source_asof={}),
+            rung=rung,
+            preview=preview,
+            limits=unobserved_limits,
+            daily_notional=daily_notional,
+        )
+        observed = evaluate_auto_approve_eligibility(
+            group=_group(
+                **group_kwargs,
+                source_asof={"auto_approved": {"cap_observations": [observation]}},
+            ),
+            rung=rung,
+            preview=preview,
+            limits=observed_limits,
+            daily_notional=daily_notional,
+        )
+        compared += 1
+        if observed != baseline:
+            mismatches.append(case)
+
+    print(
+        f"decision_differential_cases={compared} decision_mismatches={len(mismatches)}"
+    )
+    assert compared == 26_000
+    assert mismatches == []
 
 
 def test_tag_match_evidence_records_token_and_structural_location_only():

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -24,6 +24,7 @@ from app.services.order_proposals.approval_window import (
     SubmissionSessionEvidence,
     evaluate_approval_window,
 )
+from app.services.order_proposals.auto_approve import AutoApproveLimits
 from app.services.order_proposals.dispatch import (
     dispatch_proposal,
     publish_approval_messages,
@@ -835,6 +836,94 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     assert duplicate.ok is False
     assert duplicate.failure_code == "proposal_not_pending_approval"
     assert len(notifier.sent_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_eligible_qqq_records_cap_observation(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    now = datetime(2026, 8, 14, 22, 35, tzinfo=UTC)
+    limits = AutoApproveLimits(
+        min_distance_pct=Decimal("3"),
+        per_order_cap=Decimal("1000"),
+        daily_cap=Decimal("800"),
+        policy_version="2026-08-14.1",
+        policy_content_hash="51c789434f6a",
+    )
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    monkeypatch.setattr(dispatch_module, "limits_for_market", lambda _market: limits)
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="QQQ",
+        market="equity_us",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="cap-observation-fixture",
+        thesis="resting entry",
+        broker_account_id=f"cap-observation-{uuid.uuid4()}",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("741.41"), None)],
+        now=now,
+        valid_until=now + timedelta(hours=1),
+    )
+    await db_session.commit()
+
+    async def fake_revalidate(*, service, proposal_id, now, eligibility_gate):
+        fresh_group, rungs = await service.get_proposal(proposal_id)
+        decision = await eligibility_gate(
+            group=fresh_group,
+            rung=rungs[0],
+            preview={
+                "success": True,
+                "current_price": "800",
+                "price": "741.41",
+                "quantity": "1",
+            },
+            now=now,
+        )
+        assert decision.eligible is True
+        await service.transition_rung(proposal_id, 0, new_state="revalidating")
+        await service.transition_rung(proposal_id, 0, new_state="approved")
+        await service.transition_rung(proposal_id, 0, new_state="submitting")
+        await service.record_resting(
+            proposal_id,
+            0,
+            broker_order_id="cap-observation-order",
+            correlation_id="cap-observation-correlation",
+            idempotency_key="cap-observation-idempotency",
+            approval_hash_digest="cap-observation-digest",
+            now=now,
+        )
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=_FakeNotifier(),
+        now=now,
+        service_factory=_session_factory(db_session),
+        revalidate_fn=fake_revalidate,
+    )
+
+    refreshed, _rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.source_asof["auto_approved"]["cap_observations"] == [
+        {
+            "rung_index": 0,
+            "daily_cap": "800",
+            "daily_notional_before": "0",
+            "daily_notional_after": "741.41",
+            "per_order_cap": "1000",
+            "notional": "741.41",
+            "policy_version": "2026-08-14.1",
+            "content_hash": "51c789434f6a",
+            "evaluated_at": now.isoformat(),
+        }
+    ]
+    assert "auto_approve_rejections" not in refreshed.source_asof
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -967,6 +967,84 @@ async def test_get_and_list_project_safe_auto_approve_rejection_evidence():
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_and_list_project_auto_approved_cap_observations():
+    created = await opt.order_proposal_create(
+        symbol="QQQ",
+        market="equity_us",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="operator:cap-observation",
+        thesis="ordinary support retest",
+        strategy="ladder",
+        rungs=[
+            {
+                "rung_index": 0,
+                "side": "buy",
+                "quantity": "1",
+                "limit_price": "741.41",
+                "notional": None,
+            }
+        ],
+    )
+    now = datetime(2026, 8, 14, 22, 35, tzinfo=UTC)
+    raw_input = "private-cap-observation-material-must-not-escape"
+    async with AsyncSessionLocal() as session:
+        service = OrderProposalsService(session)
+        await service.record_auto_approval(
+            uuid.UUID(created["proposal_id"]),
+            policy_version="2026-08-14.1",
+            policy_content_hash="51c789434f6a",
+            eligibility=[
+                {
+                    "rung_index": 0,
+                    "eligible": True,
+                    "reason": "eligible",
+                    "daily_cap": "800",
+                    "daily_notional_before": "0",
+                    "daily_notional_after": "741.41",
+                    "per_order_cap": "1000",
+                    "notional": "741.41",
+                    "policy_version": "2026-08-14.1",
+                    "private": raw_input,
+                }
+            ],
+            outcomes=["submitted_resting"],
+            now=now,
+            evaluated_at=now,
+        )
+        await session.commit()
+
+    got = await opt.order_proposal_get(created["proposal_id"])
+    listed = await opt.order_proposal_list(symbol="QQQ")
+    expected = [
+        {
+            "rung_index": 0,
+            "daily_cap": "800",
+            "daily_notional_before": "0",
+            "daily_notional_after": "741.41",
+            "per_order_cap": "1000",
+            "notional": "741.41",
+            "policy_version": "2026-08-14.1",
+            "content_hash": "51c789434f6a",
+            "evaluated_at": now.isoformat(),
+        }
+    ]
+    assert got["proposal"]["auto_approve_cap_observations"] == expected
+    assert got["proposal"]["auto_approve_rejections"] == []
+    row = next(
+        proposal
+        for proposal in listed["proposals"]
+        if proposal["proposal_id"] == created["proposal_id"]
+    )
+    assert row["auto_approve_cap_observations"] == expected
+    assert row["auto_approve_rejections"] == []
+    assert raw_input not in json.dumps(got)
+    assert raw_input not in json.dumps(listed)
+
+
+@pytest.mark.asyncio
 async def test_loss_cut_binding_round_trips_through_create_get_list(monkeypatch):
     async def fake_lookup(session, retrospective_id):
         return SimpleNamespace(


### PR DESCRIPTION
## Summary
- persist bounded cap observations for eligible auto-approve decisions
- expose safe observations through proposal get/list while preserving rejection evidence semantics
- add QQQ cap fixture, differential coverage, and caller tests

## Verification
- make lint
- targeted order-proposal suite: 137 passed
- make test: 3 unrelated existing research backfill client-contract failures; details in implementation report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Order proposal details and lists now include sanitized auto-approval cap observations when available.
  - Auto-approval records now preserve policy provenance and evaluation timing for improved auditability.
- **Bug Fixes**
  - Cap-observation data is validated before being displayed, ensuring incomplete or unsafe details are excluded.
  - Added safeguards to ensure audit metadata does not affect auto-approval eligibility decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->