### PR TITLE
feat(funding): add external cash declaration foundation

### DIFF
--- a/alembic/versions/20260815_external_cash.py
+++ b/alembic/versions/20260815_external_cash.py
@@ -1,7 +1,7 @@
 """Add the append-only external-cash declaration ledger.
 
 Revision ID: 20260815_external_cash
-Revises: 20260805_toss_merge
+Revises: 20260814_lcapprove_b1
 Create Date: 2026-08-15
 
 This migration is additive DDL only.  In particular, it never inserts the

--- a/alembic/versions/20260815_external_cash.py
+++ b/alembic/versions/20260815_external_cash.py
@@ -19,7 +19,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision: str = "20260815_external_cash"
-down_revision: str | Sequence[str] | None = "20260805_toss_merge"
+down_revision: str | Sequence[str] | None = "20260814_lcapprove_b1"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/20260815_external_cash.py
+++ b/alembic/versions/20260815_external_cash.py
@@ -1,0 +1,199 @@
+"""Add the append-only external-cash declaration ledger.
+
+Revision ID: 20260815_external_cash
+Revises: 20260805_toss_merge
+Create Date: 2026-08-15
+
+This migration is additive DDL only.  In particular, it never inserts the
+operator's initial parking balance; that declaration requires an authenticated
+admin confirmation with an exact observed timestamp.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260815_external_cash"
+down_revision: str | Sequence[str] | None = "20260805_toss_merge"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS review")
+    op.create_table(
+        "external_cash_declarations",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("declaration_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("owner_user_id", sa.BigInteger(), nullable=False),
+        sa.Column("location_key", sa.Text(), nullable=False),
+        sa.Column("display_label", sa.Text(), nullable=False),
+        sa.Column("currency", sa.CHAR(length=3), nullable=False),
+        sa.Column("amount", sa.Numeric(precision=38, scale=12), nullable=False),
+        sa.Column("as_of", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("fresh_until", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("source_note", sa.Text(), nullable=False),
+        sa.Column("declared_by_user_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "origin",
+            sa.Text(),
+            server_default=sa.text("'invest_ui'"),
+            nullable=False,
+        ),
+        sa.Column(
+            "supersedes_declaration_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("idempotency_key", sa.Text(), nullable=False),
+        sa.Column(
+            "recorded_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint("amount >= 0", name="ck_external_cash_amount_nonnegative"),
+        sa.CheckConstraint("currency ~ '^[A-Z]{3}$'", name="ck_external_cash_currency"),
+        sa.CheckConstraint(
+            "length(btrim(location_key)) > 0",
+            name="ck_external_cash_location_nonempty",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(display_label)) > 0",
+            name="ck_external_cash_label_nonempty",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(source_note)) > 0",
+            name="ck_external_cash_note_nonempty",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(idempotency_key)) > 0",
+            name="ck_external_cash_idempotency_nonempty",
+        ),
+        sa.CheckConstraint(
+            "fresh_until > as_of", name="ck_external_cash_fresh_after_asof"
+        ),
+        sa.CheckConstraint("origin = 'invest_ui'", name="ck_external_cash_origin"),
+        sa.ForeignKeyConstraint(
+            ["owner_user_id"],
+            ["users.id"],
+            name="fk_external_cash_owner_user",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["declared_by_user_id"],
+            ["users.id"],
+            name="fk_external_cash_declared_by_user",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["supersedes_declaration_id"],
+            ["review.external_cash_declarations.declaration_id"],
+            name="fk_external_cash_supersedes",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("declaration_id", name="uq_external_cash_declaration_id"),
+        sa.UniqueConstraint(
+            "owner_user_id",
+            "idempotency_key",
+            name="uq_external_cash_owner_idempotency",
+        ),
+        sa.UniqueConstraint(
+            "supersedes_declaration_id",
+            name="uq_external_cash_supersedes",
+        ),
+        schema="review",
+    )
+    op.execute(
+        "CREATE INDEX ix_external_cash_owner_location_currency_asof "
+        "ON review.external_cash_declarations "
+        "(owner_user_id, location_key, currency, as_of DESC, recorded_at DESC)"
+    )
+    op.create_index(
+        "ix_external_cash_supersedes_declaration_id",
+        "external_cash_declarations",
+        ["supersedes_declaration_id"],
+        schema="review",
+    )
+
+    op.execute(
+        """
+        CREATE FUNCTION review.validate_external_cash_correction()
+        RETURNS trigger AS $$
+        DECLARE
+            previous review.external_cash_declarations%ROWTYPE;
+        BEGIN
+            IF NEW.supersedes_declaration_id IS NULL THEN
+                RETURN NEW;
+            END IF;
+            IF NEW.supersedes_declaration_id = NEW.declaration_id THEN
+                RAISE EXCEPTION 'external cash declaration cannot supersede itself'
+                    USING ERRCODE = 'check_violation';
+            END IF;
+            SELECT * INTO previous
+              FROM review.external_cash_declarations
+             WHERE declaration_id = NEW.supersedes_declaration_id
+             FOR SHARE;
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'superseded external cash declaration is missing'
+                    USING ERRCODE = 'foreign_key_violation';
+            END IF;
+            IF previous.owner_user_id IS DISTINCT FROM NEW.owner_user_id
+               OR previous.location_key IS DISTINCT FROM NEW.location_key
+               OR previous.currency IS DISTINCT FROM NEW.currency THEN
+                RAISE EXCEPTION 'external cash correction scope mismatch'
+                    USING ERRCODE = 'check_violation';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION review.reject_external_cash_mutation()
+        RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION 'review.external_cash_declarations is append-only; % rejected',
+                TG_OP USING ERRCODE = 'restrict_violation';
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_external_cash_correction_scope
+        BEFORE INSERT ON review.external_cash_declarations
+        FOR EACH ROW EXECUTE FUNCTION review.validate_external_cash_correction()
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_external_cash_append_only
+        BEFORE UPDATE OR DELETE ON review.external_cash_declarations
+        FOR EACH ROW EXECUTE FUNCTION review.reject_external_cash_mutation()
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_external_cash_truncate_append_only
+        BEFORE TRUNCATE ON review.external_cash_declarations
+        FOR EACH STATEMENT EXECUTE FUNCTION review.reject_external_cash_mutation()
+        """
+    )
+    op.execute(
+        "REVOKE UPDATE, DELETE, TRUNCATE "
+        "ON review.external_cash_declarations FROM PUBLIC"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("external_cash_declarations", schema="review")
+    op.execute("DROP FUNCTION IF EXISTS review.reject_external_cash_mutation()")
+    op.execute("DROP FUNCTION IF EXISTS review.validate_external_cash_correction()")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,6 +10,7 @@ from .crypto_instrument_health import CryptoInstrumentHealth
 from .crypto_instruments import CryptoInstrument
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
 from .financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
+from .funding_advisory import ExternalCashDeclaration
 from .invalid_sample_eligibility import (
     InvalidSampleCleanupBinding,
     InvalidSampleCleanupLifecycleEvent,
@@ -252,6 +253,7 @@ __all__ = [
     "MarketValuationSnapshot",
     "NaverResearchDetailCache",
     "FinancialFundamentalsSnapshot",
+    "ExternalCashDeclaration",
     "Trade",
     "TossLiveOrderLedger",
     "TradeSnapshot",

--- a/app/models/funding_advisory.py
+++ b/app/models/funding_advisory.py
@@ -1,0 +1,120 @@
+"""Persistence models for the funding-advisory domain.
+
+External cash is an operator-declared, append-only snapshot.  It is advisory
+display evidence only; order buying power, sizing, caps, and approval decisions
+must continue to use broker-authoritative inputs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    CHAR,
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    Numeric,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class ExternalCashDeclaration(Base):
+    """One immutable operator declaration of cash outside a broker account."""
+
+    __tablename__ = "external_cash_declarations"
+    __table_args__ = (
+        UniqueConstraint("declaration_id", name="uq_external_cash_declaration_id"),
+        UniqueConstraint(
+            "owner_user_id",
+            "idempotency_key",
+            name="uq_external_cash_owner_idempotency",
+        ),
+        UniqueConstraint(
+            "supersedes_declaration_id",
+            name="uq_external_cash_supersedes",
+        ),
+        CheckConstraint("amount >= 0", name="ck_external_cash_amount_nonnegative"),
+        CheckConstraint("currency ~ '^[A-Z]{3}$'", name="ck_external_cash_currency"),
+        CheckConstraint(
+            "length(btrim(location_key)) > 0",
+            name="ck_external_cash_location_nonempty",
+        ),
+        CheckConstraint(
+            "length(btrim(display_label)) > 0",
+            name="ck_external_cash_label_nonempty",
+        ),
+        CheckConstraint(
+            "length(btrim(source_note)) > 0",
+            name="ck_external_cash_note_nonempty",
+        ),
+        CheckConstraint(
+            "length(btrim(idempotency_key)) > 0",
+            name="ck_external_cash_idempotency_nonempty",
+        ),
+        CheckConstraint(
+            "fresh_until > as_of", name="ck_external_cash_fresh_after_asof"
+        ),
+        CheckConstraint("origin = 'invest_ui'", name="ck_external_cash_origin"),
+        Index(
+            "ix_external_cash_owner_location_currency_asof",
+            "owner_user_id",
+            "location_key",
+            "currency",
+            "as_of",
+            "recorded_at",
+        ),
+        Index(
+            "ix_external_cash_supersedes_declaration_id",
+            "supersedes_declaration_id",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    declaration_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    owner_user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    location_key: Mapped[str] = mapped_column(Text, nullable=False)
+    display_label: Mapped[str] = mapped_column(Text, nullable=False)
+    currency: Mapped[str] = mapped_column(CHAR(3), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(38, 12), nullable=False)
+    as_of: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    fresh_until: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    source_note: Mapped[str] = mapped_column(Text, nullable=False)
+    declared_by_user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    origin: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="invest_ui"
+    )
+    supersedes_declaration_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey(
+            "review.external_cash_declarations.declaration_id",
+            ondelete="RESTRICT",
+        ),
+    )
+    idempotency_key: Mapped[str] = mapped_column(Text, nullable=False)
+    recorded_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/app/schemas/funding_advisory.py
+++ b/app/schemas/funding_advisory.py
@@ -1,0 +1,115 @@
+"""Wire-safe DTOs for funding advisory and external-cash declarations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
+
+
+def canonical_decimal(value: Decimal) -> str:
+    """Serialize a Decimal without float conversion or exponent notation."""
+
+    rendered = format(value, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    return rendered or "0"
+
+
+class ExternalCashDeclarationRequest(BaseModel):
+    """Admin-confirmed append-only declaration input."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    owner_user_id: int = Field(gt=0)
+    location_key: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9_:-]*$",
+    )
+    display_label: str = Field(min_length=1, max_length=120)
+    currency: str = Field(min_length=3, max_length=3)
+    amount: Decimal = Field(ge=0, max_digits=38, decimal_places=12)
+    as_of: datetime
+    source_note: str = Field(min_length=1, max_length=500)
+    expected_head_declaration_id: UUID | None = Field(...)
+    idempotency_key: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+    )
+
+    @field_validator("currency")
+    @classmethod
+    def validate_currency(cls, value: str) -> str:
+        if value not in {"KRW", "USD"}:
+            raise ValueError("currency must be one of KRW or USD")
+        return value
+
+    @field_validator("as_of")
+    @classmethod
+    def validate_aware_as_of(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("as_of must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def validate_currency_precision(self) -> ExternalCashDeclarationRequest:
+        if self.currency == "KRW" and self.amount != self.amount.to_integral_value():
+            raise ValueError("KRW amount must use whole won")
+        return self
+
+
+class ExternalCashDeclarationRecord(BaseModel):
+    """Immutable declaration as returned by the service."""
+
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    declaration_id: UUID
+    owner_user_id: int
+    location_key: str
+    display_label: str
+    currency: str
+    amount: Decimal
+    as_of: datetime
+    fresh_until: datetime
+    source_note: str
+    declared_by_user_id: int
+    origin: Literal["invest_ui"]
+    supersedes_declaration_id: UUID | None
+    idempotency_key: str
+    recorded_at: datetime
+
+    @field_serializer("amount", when_used="json")
+    def serialize_amount(self, value: Decimal) -> str:
+        return canonical_decimal(value)
+
+
+ExternalCashCurrentStatus = Literal["missing", "fresh", "stale", "future", "ambiguous"]
+
+
+class ExternalCashCurrentView(BaseModel):
+    """One scope's current advisory-only value and freshness verdict."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: ExternalCashCurrentStatus
+    amount_status: Literal["known", "unknown"]
+    current: ExternalCashDeclarationRecord | None
+    route_fundable_amount: Decimal | None
+    verification_badge: str = "운영자 선언 · 시스템 검증 불가"
+    warning_code: str | None = None
+
+    @field_serializer("route_fundable_amount", when_used="json")
+    def serialize_route_amount(self, value: Decimal | None) -> str | None:
+        return None if value is None else canonical_decimal(value)

--- a/app/services/funding_advisory/__init__.py
+++ b/app/services/funding_advisory/__init__.py
@@ -1,0 +1,10 @@
+"""Advisory-only funding evidence and presentation services.
+
+This package must not feed operator-declared cash into available, required,
+shortfall, sizing, caps, eligibility, auto-approval, or broker submission.
+Those calculations remain broker-authoritative and are outside this feature.
+"""
+
+from .external_cash import ExternalCashDeclarationService
+
+__all__ = ["ExternalCashDeclarationService"]

--- a/app/services/funding_advisory/_external_cash_repository.py
+++ b/app/services/funding_advisory/_external_cash_repository.py
@@ -1,0 +1,119 @@
+"""Private persistence adapter for external-cash declarations.
+
+Never commits.  The public service owns transaction completion, and no caller
+outside ``external_cash.py`` may use this repository to write the ledger.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.models.funding_advisory import ExternalCashDeclaration
+
+
+class ExternalCashDeclarationRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def acquire_lock(self, lock_key: str) -> None:
+        await self._session.execute(
+            select(func.pg_advisory_xact_lock(func.hashtextextended(lock_key, 0)))
+        )
+
+    async def get_by_idempotency(
+        self, *, owner_user_id: int, idempotency_key: str
+    ) -> ExternalCashDeclaration | None:
+        stmt = select(ExternalCashDeclaration).where(
+            ExternalCashDeclaration.owner_user_id == owner_user_id,
+            ExternalCashDeclaration.idempotency_key == idempotency_key,
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_current_heads(
+        self,
+        *,
+        owner_user_id: int,
+        location_key: str,
+        currency: str,
+        for_update: bool = False,
+    ) -> list[ExternalCashDeclaration]:
+        child = aliased(ExternalCashDeclaration)
+        stmt = (
+            select(ExternalCashDeclaration)
+            .outerjoin(
+                child,
+                child.supersedes_declaration_id
+                == ExternalCashDeclaration.declaration_id,
+            )
+            .where(
+                ExternalCashDeclaration.owner_user_id == owner_user_id,
+                ExternalCashDeclaration.location_key == location_key,
+                ExternalCashDeclaration.currency == currency,
+                child.id.is_(None),
+            )
+            .order_by(
+                ExternalCashDeclaration.as_of.desc(),
+                ExternalCashDeclaration.recorded_at.desc(),
+            )
+        )
+        if for_update:
+            stmt = stmt.with_for_update(of=ExternalCashDeclaration)
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def list_all_current_heads(
+        self, *, owner_user_id: int
+    ) -> list[ExternalCashDeclaration]:
+        child = aliased(ExternalCashDeclaration)
+        stmt = (
+            select(ExternalCashDeclaration)
+            .outerjoin(
+                child,
+                child.supersedes_declaration_id
+                == ExternalCashDeclaration.declaration_id,
+            )
+            .where(
+                ExternalCashDeclaration.owner_user_id == owner_user_id,
+                child.id.is_(None),
+            )
+            .order_by(
+                ExternalCashDeclaration.location_key,
+                ExternalCashDeclaration.currency,
+                ExternalCashDeclaration.as_of.desc(),
+                ExternalCashDeclaration.recorded_at.desc(),
+            )
+        )
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def list_history(
+        self,
+        *,
+        owner_user_id: int,
+        location_key: str,
+        currency: str,
+        limit: int,
+    ) -> list[ExternalCashDeclaration]:
+        stmt = (
+            select(ExternalCashDeclaration)
+            .where(
+                ExternalCashDeclaration.owner_user_id == owner_user_id,
+                ExternalCashDeclaration.location_key == location_key,
+                ExternalCashDeclaration.currency == currency,
+            )
+            .order_by(
+                ExternalCashDeclaration.as_of.desc(),
+                ExternalCashDeclaration.recorded_at.desc(),
+            )
+            .limit(limit)
+        )
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def insert(self, **columns: Any) -> ExternalCashDeclaration:
+        row = ExternalCashDeclaration(**columns)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row

--- a/app/services/funding_advisory/external_cash.py
+++ b/app/services/funding_advisory/external_cash.py
@@ -1,0 +1,280 @@
+"""Single service boundary for operator-declared external cash.
+
+The values exposed here are read-only advisory evidence.  This module offers
+no conversion to a buying-power claim, order preview, sizing input, cap input,
+or approval input.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.role_hierarchy import has_min_role
+from app.models.trading import User, UserRole
+from app.schemas.funding_advisory import (
+    ExternalCashCurrentView,
+    ExternalCashDeclarationRecord,
+    ExternalCashDeclarationRequest,
+)
+from app.services.funding_advisory._external_cash_repository import (
+    ExternalCashDeclarationRepository,
+)
+
+FRESHNESS_WINDOW = timedelta(hours=24)
+ORIGIN = "invest_ui"
+
+
+class ExternalCashDeclarationError(Exception):
+    """Base exception for declaration service failures."""
+
+
+class ExternalCashAuthorizationError(ExternalCashDeclarationError):
+    """The actor is not an active administrator."""
+
+
+class ExternalCashConflictError(ExternalCashDeclarationError):
+    """Expected-head or idempotency compare-and-set failed."""
+
+
+class ExternalCashAmbiguousHeadError(ExternalCashDeclarationError):
+    """More than one current head exists for a declaration scope."""
+
+
+class ExternalCashValidationError(ExternalCashDeclarationError):
+    """A time or value invariant failed at the service boundary."""
+
+
+def _aware_utc(value: datetime, *, field: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ExternalCashValidationError(f"{field} must include a timezone")
+    return value.astimezone(UTC)
+
+
+def _record(row: Any) -> ExternalCashDeclarationRecord:
+    return ExternalCashDeclarationRecord.model_validate(row)
+
+
+def _same_instant(left: datetime, right: datetime) -> bool:
+    return _aware_utc(left, field="stored datetime") == _aware_utc(
+        right, field="request datetime"
+    )
+
+
+def _matches_replay(
+    row: Any,
+    request: ExternalCashDeclarationRequest,
+    *,
+    actor_user_id: int,
+) -> bool:
+    return all(
+        (
+            row.owner_user_id == request.owner_user_id,
+            row.location_key == request.location_key,
+            row.display_label == request.display_label,
+            row.currency == request.currency,
+            Decimal(row.amount) == request.amount,
+            _same_instant(row.as_of, request.as_of),
+            row.source_note == request.source_note,
+            row.declared_by_user_id == actor_user_id,
+            row.origin == ORIGIN,
+            row.supersedes_declaration_id == request.expected_head_declaration_id,
+        )
+    )
+
+
+def _current_view(rows: list[Any], *, now: datetime) -> ExternalCashCurrentView:
+    if not rows:
+        return ExternalCashCurrentView(
+            status="missing",
+            amount_status="unknown",
+            current=None,
+            route_fundable_amount=None,
+            warning_code="external_cash_missing",
+        )
+    if len(rows) != 1:
+        return ExternalCashCurrentView(
+            status="ambiguous",
+            amount_status="unknown",
+            current=None,
+            route_fundable_amount=None,
+            warning_code="external_cash_head_ambiguous",
+        )
+
+    row = rows[0]
+    as_of = _aware_utc(row.as_of, field="as_of")
+    fresh_until = _aware_utc(row.fresh_until, field="fresh_until")
+    current_now = _aware_utc(now, field="now")
+    record = _record(row)
+    if as_of > current_now:
+        return ExternalCashCurrentView(
+            status="future",
+            amount_status="unknown",
+            current=record,
+            route_fundable_amount=None,
+            warning_code="external_cash_asof_future",
+        )
+    if current_now >= fresh_until:
+        return ExternalCashCurrentView(
+            status="stale",
+            amount_status="unknown",
+            current=record,
+            route_fundable_amount=None,
+            warning_code="external_cash_stale",
+        )
+    return ExternalCashCurrentView(
+        status="fresh",
+        amount_status="known",
+        current=record,
+        route_fundable_amount=Decimal(row.amount),
+    )
+
+
+class ExternalCashDeclarationService:
+    """The only domain writer and canonical reader for the declaration ledger."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        _repository: ExternalCashDeclarationRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repository = _repository or ExternalCashDeclarationRepository(session)
+
+    async def declare(
+        self,
+        request: ExternalCashDeclarationRequest,
+        actor: User,
+        now: datetime,
+    ) -> ExternalCashDeclarationRecord:
+        """Append one declaration or return an exact idempotent replay."""
+
+        if not getattr(actor, "is_active", False) or not has_min_role(
+            actor.role, UserRole.admin
+        ):
+            raise ExternalCashAuthorizationError("active admin role required")
+        actor_id = int(actor.id)
+        current_now = _aware_utc(now, field="now")
+        as_of = _aware_utc(request.as_of, field="as_of")
+        if as_of > current_now:
+            raise ExternalCashValidationError("as_of cannot be in the future")
+
+        try:
+            await self._repository.acquire_lock(
+                f"external-cash:idempotency:{request.owner_user_id}:"
+                f"{request.idempotency_key}"
+            )
+            existing = await self._repository.get_by_idempotency(
+                owner_user_id=request.owner_user_id,
+                idempotency_key=request.idempotency_key,
+            )
+            if existing is not None:
+                if not _matches_replay(existing, request, actor_user_id=actor_id):
+                    raise ExternalCashConflictError(
+                        "idempotency key already has a different declaration"
+                    )
+                await self._session.commit()
+                return _record(existing)
+
+            await self._repository.acquire_lock(
+                f"external-cash:scope:{request.owner_user_id}:"
+                f"{request.location_key}:{request.currency}"
+            )
+            heads = await self._repository.list_current_heads(
+                owner_user_id=request.owner_user_id,
+                location_key=request.location_key,
+                currency=request.currency,
+                for_update=True,
+            )
+            if len(heads) > 1:
+                raise ExternalCashAmbiguousHeadError(
+                    "multiple current declaration heads; refusing to choose"
+                )
+
+            actual_head = heads[0].declaration_id if heads else None
+            if actual_head != request.expected_head_declaration_id:
+                raise ExternalCashConflictError(
+                    "expected declaration head does not match current head"
+                )
+
+            row = await self._repository.insert(
+                declaration_id=uuid.uuid4(),
+                owner_user_id=request.owner_user_id,
+                location_key=request.location_key,
+                display_label=request.display_label,
+                currency=request.currency,
+                amount=request.amount,
+                as_of=request.as_of,
+                fresh_until=request.as_of + FRESHNESS_WINDOW,
+                source_note=request.source_note,
+                declared_by_user_id=actor_id,
+                origin=ORIGIN,
+                supersedes_declaration_id=request.expected_head_declaration_id,
+                idempotency_key=request.idempotency_key,
+            )
+            await self._session.commit()
+            return _record(row)
+        except Exception:
+            await self._session.rollback()
+            raise
+
+    async def current(
+        self,
+        *,
+        owner_user_id: int,
+        location_key: str,
+        currency: str,
+        now: datetime,
+    ) -> ExternalCashCurrentView:
+        rows = await self._repository.list_current_heads(
+            owner_user_id=owner_user_id,
+            location_key=location_key,
+            currency=currency,
+        )
+        return _current_view(rows, now=now)
+
+    async def list_current(
+        self, *, owner_user_id: int, now: datetime
+    ) -> list[ExternalCashCurrentView]:
+        rows = await self._repository.list_all_current_heads(
+            owner_user_id=owner_user_id
+        )
+        grouped: dict[tuple[str, str], list[Any]] = defaultdict(list)
+        for row in rows:
+            grouped[(row.location_key, row.currency)].append(row)
+        return [_current_view(group, now=now) for group in grouped.values()]
+
+    async def history(
+        self,
+        *,
+        owner_user_id: int,
+        location_key: str,
+        currency: str,
+        limit: int = 100,
+    ) -> list[ExternalCashDeclarationRecord]:
+        if not 1 <= limit <= 200:
+            raise ExternalCashValidationError("history limit must be between 1 and 200")
+        rows = await self._repository.list_history(
+            owner_user_id=owner_user_id,
+            location_key=location_key,
+            currency=currency,
+            limit=limit,
+        )
+        return [_record(row) for row in rows]
+
+
+__all__ = [
+    "ExternalCashAmbiguousHeadError",
+    "ExternalCashAuthorizationError",
+    "ExternalCashConflictError",
+    "ExternalCashDeclarationError",
+    "ExternalCashDeclarationService",
+    "ExternalCashValidationError",
+    "FRESHNESS_WINDOW",
+]

--- a/app/services/funding_advisory/initial_declaration.py
+++ b/app/services/funding_advisory/initial_declaration.py
@@ -1,0 +1,43 @@
+"""Pure template for the operator-confirmed initial parking declaration.
+
+No timestamp is invented here.  The operator must supply the observed time,
+including timezone, before the request can be sent through the invest UI.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from app.schemas.funding_advisory import ExternalCashDeclarationRequest
+
+INITIAL_PARKING_AMOUNT = Decimal("640000")
+INITIAL_PARKING_DATE_KST = date(2026, 8, 15)
+
+
+def build_initial_parking_declaration(
+    *,
+    owner_user_id: int,
+    as_of: datetime,
+    idempotency_key: str,
+) -> ExternalCashDeclarationRequest:
+    """Build, but never submit, the first 640,000 KRW declaration request."""
+
+    if as_of.tzinfo is None or as_of.utcoffset() is None:
+        raise ValueError("operator-confirmed as_of timezone is required")
+    if as_of.astimezone(ZoneInfo("Asia/Seoul")).date() != INITIAL_PARKING_DATE_KST:
+        raise ValueError(
+            "initial parking declaration must retain its 2026-08-15 KST as_of"
+        )
+    return ExternalCashDeclarationRequest(
+        owner_user_id=owner_user_id,
+        location_key="parking_primary",
+        display_label="파킹통장",
+        currency="KRW",
+        amount=INITIAL_PARKING_AMOUNT,
+        as_of=as_of,
+        source_note="토스증권 → 파킹통장 이동",
+        expected_head_declaration_id=None,
+        idempotency_key=idempotency_key,
+    )

--- a/docs/runbooks/funding-advisory.md
+++ b/docs/runbooks/funding-advisory.md
@@ -1,0 +1,50 @@
+# Funding advisory 운영 계약
+
+## 안전 경계
+
+Funding advisory는 조회·검토 전용이다. 외부 현금 선언은 운영자가 보고한
+snapshot이며 broker 잔고 증거가 아니다. 선언값은 주문가능 금액, 필요 금액,
+부족액, sizing, cap, eligibility, auto-approve, cash claim 또는 submit 입력으로
+사용하지 않는다. 이 기능 범위에는 기존 available/required/shortfall 산식 변경이
+없다.
+
+현재 PR-1 기반은 `review.external_cash_declarations` DDL과 서비스 내부 read/write
+계약만 제공한다. API router, 페이지, Telegram, candidate producer 연결은 없으므로
+마이그레이션을 적용하지 않은 기존 runtime 동작도 바뀌지 않는다. 마이그레이션
+실행과 배포는 운영자 cutover 대상이며 이 구현 작업에서는 수행하지 않는다.
+
+## 최초 640,000원 선언
+
+마이그레이션에는 business row가 없다. 초기값은 후속 `/invest/funding` admin 폼이
+연결된 뒤 다음 값으로 한 번 선언한다.
+
+- location: `parking_primary`
+- label: `파킹통장`
+- currency/amount: `KRW 640000`
+- source note: `토스증권 → 파킹통장 이동`
+- as-of date: `2026-08-15` KST
+
+정확한 as-of 시각은 알려져 있지 않다. 운영자가 timezone이 포함된 실제 관측 시각을
+확인하기 전에는 submit하지 않는다. `build_initial_parking_declaration()`은 시각을
+기본값으로 만들지 않고, KST 날짜와 timezone을 확인한 요청만 만든다. 요청 생성은
+DB write가 아니며 실제 write는 `ExternalCashDeclarationService.declare()`만 한다.
+
+최초 선언의 `expected_head_declaration_id`는 명시적으로 `null`이다. 폼에서 발급한
+non-secret idempotency key는 submit 재시도에도 그대로 재사용한다. 같은 key와 같은
+payload는 기존 행을 반환하고, 다른 payload는 conflict로 끝난다.
+
+마이그레이션 재실행은 값을 넣지 않는다. downgrade는 테이블과 그 안의 선언을
+제거하고, 이후 upgrade는 빈 테이블을 만든다. 따라서 rollback/upgrade가 640,000원
+행을 자동 재생성하지 않으며, 복구가 필요하면 운영자가 새 idempotency key와 정확한
+관측 사실을 다시 확인해야 한다.
+
+## 선언 수정과 freshness
+
+수정은 UPDATE가 아니라 이전 head UUID를 `supersedes_declaration_id`로 지정한 INSERT다.
+owner/location/currency가 달라지면 DB trigger가 거절한다. 서비스는 scope advisory
+lock과 expected-head compare-and-set을 사용하며, head가 둘 이상이면 임의로 최신값을
+선택하지 않는다.
+
+freshness는 `recorded_at`이 아니라 `as_of + 24h`다. stale/future/ambiguous 값은 이력
+문맥으로만 보이고 조달 가능액은 `금액 미상`이다. 실제 이체나 조달 완료는 target
+broker buying power의 새 관측으로만 확인한다.

--- a/tests/services/funding_advisory/__init__.py
+++ b/tests/services/funding_advisory/__init__.py
@@ -1,0 +1,1 @@
+"""Funding-advisory service contract tests."""

--- a/tests/services/funding_advisory/test_containment.py
+++ b/tests/services/funding_advisory/test_containment.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+PROTECTED_ORDER_FILES = (
+    ROOT / "app/services/order_proposals/buying_power.py",
+    ROOT / "app/services/order_proposals/revalidation.py",
+    ROOT / "app/services/order_proposals/auto_approve.py",
+    ROOT / "app/services/support_reserve_net_consumer.py",
+)
+
+
+def imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_external_cash_cannot_enter_order_decision_surfaces() -> None:
+    for path in PROTECTED_ORDER_FILES:
+        imported = imported_modules(path)
+        assert not any(
+            module.startswith("app.services.funding_advisory")
+            or module == "app.models.funding_advisory"
+            for module in imported
+        ), path
+
+
+def test_private_repository_is_only_imported_by_external_cash_service() -> None:
+    offenders: list[Path] = []
+    for path in (ROOT / "app").rglob("*.py"):
+        if path.name == "_external_cash_repository.py":
+            continue
+        if (
+            "app.services.funding_advisory._external_cash_repository"
+            in imported_modules(path)
+            and path != ROOT / "app/services/funding_advisory/external_cash.py"
+        ):
+            offenders.append(path)
+    assert offenders == []
+
+
+def test_funding_foundation_has_no_router_or_runtime_consumer() -> None:
+    main_text = (ROOT / "app/main.py").read_text(encoding="utf-8")
+    assert "invest_funding" not in main_text
+    assert not (ROOT / "app/routers/invest_funding.py").exists()

--- a/tests/services/funding_advisory/test_external_cash.py
+++ b/tests/services/funding_advisory/test_external_cash.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.trading import UserRole
+from app.schemas.funding_advisory import ExternalCashDeclarationRequest
+from app.services.funding_advisory.external_cash import (
+    ExternalCashAmbiguousHeadError,
+    ExternalCashAuthorizationError,
+    ExternalCashConflictError,
+    ExternalCashDeclarationService,
+    ExternalCashValidationError,
+)
+from app.services.funding_advisory.initial_declaration import (
+    build_initial_parking_declaration,
+)
+
+NOW = datetime(2026, 8, 15, 1, 0, tzinfo=UTC)
+AS_OF = datetime(2026, 8, 15, 9, 30, tzinfo=UTC)
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class FakeRepository:
+    def __init__(self) -> None:
+        self.locks: list[str] = []
+        self.existing = None
+        self.heads: list[SimpleNamespace] = []
+        self.history_rows: list[SimpleNamespace] = []
+        self.inserted: list[dict] = []
+
+    async def acquire_lock(self, lock_key: str) -> None:
+        self.locks.append(lock_key)
+
+    async def get_by_idempotency(self, **_kwargs):
+        return self.existing
+
+    async def list_current_heads(self, **_kwargs):
+        return list(self.heads)
+
+    async def list_all_current_heads(self, **_kwargs):
+        return list(self.heads)
+
+    async def list_history(self, **_kwargs):
+        return list(self.history_rows)
+
+    async def insert(self, **columns):
+        self.inserted.append(columns)
+        row = SimpleNamespace(
+            id=1,
+            recorded_at=NOW,
+            **columns,
+        )
+        self.existing = row
+        self.heads = [row]
+        return row
+
+
+def actor(*, role: UserRole = UserRole.admin, active: bool = True):
+    return SimpleNamespace(id=7, role=role, is_active=active)
+
+
+def request(
+    *,
+    idempotency_key: str = "funding-seed-20260815-1",
+    expected_head: UUID | None = None,
+    amount: Decimal = Decimal("640000"),
+) -> ExternalCashDeclarationRequest:
+    return ExternalCashDeclarationRequest(
+        owner_user_id=11,
+        location_key="parking_primary",
+        display_label="파킹통장",
+        currency="KRW",
+        amount=amount,
+        as_of=NOW - timedelta(minutes=30),
+        source_note="토스증권 → 파킹통장 이동",
+        expected_head_declaration_id=expected_head,
+        idempotency_key=idempotency_key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_declare_seed_shape_commits_one_append_only_snapshot() -> None:
+    session = FakeSession()
+    repository = FakeRepository()
+    service = ExternalCashDeclarationService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+    )
+
+    result = await service.declare(request(), actor(), NOW)
+
+    assert result.amount == Decimal("640000")
+    assert result.fresh_until == result.as_of + timedelta(hours=24)
+    assert result.supersedes_declaration_id is None
+    assert len(repository.inserted) == 1
+    assert len(repository.locks) == 2
+    assert session.commits == 1
+    assert session.rollbacks == 0
+
+
+@pytest.mark.asyncio
+async def test_exact_idempotent_replay_returns_original_without_second_insert() -> None:
+    session = FakeSession()
+    repository = FakeRepository()
+    service = ExternalCashDeclarationService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+    )
+    first = await service.declare(request(), actor(), NOW)
+
+    replay = await service.declare(request(), actor(), NOW)
+
+    assert replay.declaration_id == first.declaration_id
+    assert len(repository.inserted) == 1
+    assert session.commits == 2
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_with_different_payload_is_conflict() -> None:
+    session = FakeSession()
+    repository = FakeRepository()
+    service = ExternalCashDeclarationService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+    )
+    await service.declare(request(), actor(), NOW)
+
+    with pytest.raises(ExternalCashConflictError):
+        await service.declare(request(amount=Decimal("639999")), actor(), NOW)
+
+    assert len(repository.inserted) == 1
+    assert session.rollbacks == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_expected_head_and_ambiguous_heads_fail_closed() -> None:
+    session = FakeSession()
+    repository = FakeRepository()
+    repository.heads = [SimpleNamespace(declaration_id=uuid4())]
+    service = ExternalCashDeclarationService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ExternalCashConflictError):
+        await service.declare(request(expected_head=uuid4()), actor(), NOW)
+
+    repository.heads = [
+        SimpleNamespace(declaration_id=uuid4()),
+        SimpleNamespace(declaration_id=uuid4()),
+    ]
+    with pytest.raises(ExternalCashAmbiguousHeadError):
+        await service.declare(
+            request(idempotency_key="funding-seed-20260815-2"), actor(), NOW
+        )
+
+    assert repository.inserted == []
+
+
+@pytest.mark.asyncio
+async def test_stale_declaration_is_history_only_not_fundable() -> None:
+    session = FakeSession()
+    repository = FakeRepository()
+    row = SimpleNamespace(
+        declaration_id=uuid4(),
+        owner_user_id=11,
+        location_key="parking_primary",
+        display_label="파킹통장",
+        currency="KRW",
+        amount=Decimal("640000"),
+        as_of=NOW - timedelta(hours=25),
+        fresh_until=NOW - timedelta(hours=1),
+        source_note="토스증권 → 파킹통장 이동",
+        declared_by_user_id=7,
+        origin="invest_ui",
+        supersedes_declaration_id=None,
+        idempotency_key="funding-seed-20260815-1",
+        recorded_at=NOW - timedelta(hours=25),
+    )
+    repository.heads = [row]
+    service = ExternalCashDeclarationService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+    )
+
+    current = await service.current(
+        owner_user_id=11,
+        location_key="parking_primary",
+        currency="KRW",
+        now=NOW,
+    )
+
+    assert current.status == "stale"
+    assert current.current is not None
+    assert current.current.amount == Decimal("640000")
+    assert current.route_fundable_amount is None
+    assert current.amount_status == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_declare_requires_active_admin_and_nonfuture_asof() -> None:
+    session = FakeSession()
+    repository = FakeRepository()
+    service = ExternalCashDeclarationService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ExternalCashAuthorizationError):
+        await service.declare(request(), actor(role=UserRole.trader), NOW)
+
+    future_request = request().model_copy(update={"as_of": NOW + timedelta(seconds=1)})
+    with pytest.raises(ExternalCashValidationError):
+        await service.declare(future_request, actor(), NOW)
+
+    assert repository.inserted == []
+
+
+def test_initial_template_requires_operator_confirmed_timezone_and_kst_date() -> None:
+    with pytest.raises(ValueError, match="timezone"):
+        build_initial_parking_declaration(
+            owner_user_id=11,
+            as_of=datetime(2026, 8, 15, 10, 0),
+            idempotency_key="funding-seed-20260815-1",
+        )
+    with pytest.raises(ValueError, match="2026-08-15"):
+        build_initial_parking_declaration(
+            owner_user_id=11,
+            as_of=datetime(2026, 8, 16, 10, 0, tzinfo=UTC),
+            idempotency_key="funding-seed-20260815-1",
+        )
+
+    built = build_initial_parking_declaration(
+        owner_user_id=11,
+        as_of=datetime(2026, 8, 15, 10, 0, tzinfo=UTC),
+        idempotency_key="funding-seed-20260815-1",
+    )
+    assert built.amount == Decimal("640000")
+    assert built.expected_head_declaration_id is None
+
+
+def test_schema_rejects_fractional_krw() -> None:
+    with pytest.raises(ValidationError, match="whole won"):
+        request(amount=Decimal("640000.5"))

--- a/tests/services/funding_advisory/test_migration.py
+++ b/tests/services/funding_advisory/test_migration.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MIGRATION = ROOT / "alembic/versions/20260815_external_cash.py"
+
+
+def test_external_cash_migration_is_additive_ddl_without_business_seed() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+    upgrade = text.split("def upgrade()", 1)[1].split("def downgrade()", 1)[0]
+    assert "20260805_toss_merge" in text
+    assert "external_cash_declarations" in upgrade
+    assert "CREATE TRIGGER trg_external_cash_append_only" in upgrade
+    assert "CREATE TRIGGER trg_external_cash_truncate_append_only" in upgrade
+    assert "INSERT INTO" not in upgrade.upper()
+    assert "op.bulk_insert" not in upgrade
+    assert "640000" not in upgrade
+
+
+def test_migration_downgrade_does_not_recreate_a_declaration() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+    downgrade = text.split("def downgrade()", 1)[1]
+    assert 'op.drop_table("external_cash_declarations", schema="review")' in downgrade
+    assert "INSERT INTO" not in downgrade.upper()
+    assert "op.bulk_insert" not in downgrade

--- a/tests/services/funding_advisory/test_migration.py
+++ b/tests/services/funding_advisory/test_migration.py
@@ -9,7 +9,7 @@ MIGRATION = ROOT / "alembic/versions/20260815_external_cash.py"
 def test_external_cash_migration_is_additive_ddl_without_business_seed() -> None:
     text = MIGRATION.read_text(encoding="utf-8")
     upgrade = text.split("def upgrade()", 1)[1].split("def downgrade()", 1)[0]
-    assert "20260805_toss_merge" in text
+    assert 'down_revision: str | Sequence[str] | None = "20260814_lcapprove_b1"' in text
     assert "external_cash_declarations" in upgrade
     assert "CREATE TRIGGER trg_external_cash_append_only" in upgrade
     assert "CREATE TRIGGER trg_external_cash_truncate_append_only" in upgrade

--- a/tests/services/order_proposals/test_loss_cut_approval_migration.py
+++ b/tests/services/order_proposals/test_loss_cut_approval_migration.py
@@ -91,4 +91,11 @@ def test_loss_cut_approval_migration_is_single_head_and_has_no_row_dml():
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
     scripts = ScriptDirectory.from_config(config)
-    assert scripts.get_heads() == ["20260814_lcapprove_b1"]
+    # Exactly one head is the property that matters; "this revision IS the head"
+    # stops being true the moment any later migration lands (see
+    # tests/services/invalid_sample_eligibility/test_migration.py for the same
+    # rule). Keep this revision pinned inside the single chain instead.
+    heads = scripts.get_heads()
+    assert len(heads) == 1, heads
+    ancestry = {rev.revision for rev in scripts.walk_revisions("base", heads[0])}
+    assert "20260814_lcapprove_b1" in ancestry

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -190,6 +190,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
                 await connection.execute(
                     text(f"ALTER TABLE review.order_proposals DROP COLUMN {column}")
                 )
+            # The external-cash declaration ledger is later than this
+            # reconstructed boundary. Drop its current-head metadata table so the
+            # additive migration is exercised by the upgrade chain instead of
+            # colliding with create_all.
+            for table in ("external_cash_declarations",):
+                await connection.execute(text(f"DROP TABLE review.{table}"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -178,6 +178,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
                 await connection.execute(
                     text(f"ALTER TABLE review.order_proposals DROP COLUMN {column}")
                 )
+            # The external-cash declaration ledger is later than this
+            # reconstructed boundary. Drop its current-head metadata table so the
+            # additive migration is exercised by the upgrade chain instead of
+            # colliding with create_all.
+            for table in ("external_cash_declarations",):
+                await connection.execute(text(f"DROP TABLE review.{table}"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}
 


### PR DESCRIPTION
## Summary\n\n- add the append-only review.external_cash_declarations ledger and additive DDL\n- add the sole declaration service writer, current/history readers, and freshness projection\n- add a pure KRW 640,000 initial-declaration template that requires an operator-confirmed timezone-aware as-of\n- keep the foundation disconnected from routers, candidate producers, buying-power math, sizing, caps, approvals, and broker submission\n\n## Safety\n\n- runtime behavior change: 0; no router or runtime consumer is registered\n- migration data writes: 0; the migration contains DDL only and was not applied\n- rollback or re-upgrade cannot recreate the business declaration\n- the declaration remains advisory-only and never becomes broker-authoritative cash\n\n## Verification\n\n- make lint\n- uv run pytest tests/services/funding_advisory tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -q\n  - 16 passed in 8.84s\n- uv run alembic heads\n  - 20260815_external_cash (head), code inspection only; no upgrade/current command\n\nPR-2 will stack the trigger, advisory cards, cross-market view, and invest page on this foundation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator-declared external cash tracking by owner, location, currency, amount, source, and effective time.
  * Added status views for missing, fresh, stale, future-dated, or ambiguous declarations.
  * Added declaration history, corrections, replay protection, and an initial parking-cash declaration.
  * Fresh declarations can contribute to route-fundable cash advisories.

* **Documentation**
  * Added guidance for declaration procedures, freshness rules, amendments, and rollback.

* **Tests**
  * Added coverage for validation, authorization, idempotency, concurrency, transactions, and service containment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->