### PR TITLE
feat: add read-only funding advisory workflow (2/2)

### DIFF
--- a/alembic/versions/20260815_funding_advisory.py
+++ b/alembic/versions/20260815_funding_advisory.py
@@ -1,0 +1,295 @@
+"""Add funding advisory threads, revisions, deliveries, and proposal links.
+
+Revision ID: 20260815_funding_advisory
+Revises: 20260815_external_cash
+Create Date: 2026-08-15
+
+Additive DDL only. No candidate, delivery, proposal, or cash declaration row is
+created by this migration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260815_funding_advisory"
+down_revision: str | Sequence[str] | None = "20260815_external_cash"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "funding_advisories",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("advisory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("owner_user_id", sa.BigInteger(), nullable=False),
+        sa.Column("thread_key", sa.Text(), nullable=False),
+        sa.Column("source_kind", sa.Text(), nullable=False),
+        sa.Column("source_candidate_id", sa.Text(), nullable=False),
+        sa.Column("gate_name", sa.Text(), nullable=False),
+        sa.Column("gate_version", sa.Text(), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("target_account_mode", sa.Text(), nullable=False),
+        sa.Column("broker_account_id", sa.Text(), nullable=False),
+        sa.Column("currency", sa.CHAR(length=3), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("side", sa.Text(), server_default=sa.text("'buy'"), nullable=False),
+        sa.Column(
+            "state", sa.Text(), server_default=sa.text("'active'"), nullable=False
+        ),
+        sa.Column("valid_until", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "market IN ('crypto','equity_kr','equity_us')",
+            name="ck_funding_advisory_market",
+        ),
+        sa.CheckConstraint("side = 'buy'", name="ck_funding_advisory_buy_only"),
+        sa.CheckConstraint(
+            "state IN ('active','resolved','superseded')",
+            name="ck_funding_advisory_state",
+        ),
+        sa.ForeignKeyConstraint(
+            ["owner_user_id"],
+            ["users.id"],
+            name="fk_funding_advisory_owner_user",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("advisory_id", name="uq_funding_advisory_id"),
+        sa.UniqueConstraint("thread_key", name="uq_funding_advisory_thread_key"),
+        schema="review",
+    )
+    op.create_index(
+        "ix_funding_advisory_owner_state",
+        "funding_advisories",
+        ["owner_user_id", "state"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_funding_advisory_candidate",
+        "funding_advisories",
+        ["source_kind", "source_candidate_id"],
+        schema="review",
+    )
+
+    op.create_table(
+        "funding_advisory_revisions",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("revision_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("advisory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("revision_no", sa.Integer(), nullable=False),
+        sa.Column("fingerprint", sa.Text(), nullable=False),
+        sa.Column("evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("required_cash", sa.Numeric(38, 12), nullable=False),
+        sa.Column("target_buying_power", sa.Numeric(38, 12), nullable=False),
+        sa.Column(
+            "other_pending_required",
+            sa.Numeric(38, 12),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "reserved_cash",
+            sa.Numeric(38, 12),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column("shortfall", sa.Numeric(38, 12), nullable=False),
+        sa.Column("operational_gap", sa.Numeric(38, 12), nullable=False),
+        sa.Column("routes", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "combination", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column("evaluated_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "required_cash >= 0 AND target_buying_power >= 0 "
+            "AND other_pending_required >= 0 AND reserved_cash >= 0 "
+            "AND shortfall >= 0 AND operational_gap >= 0",
+            name="ck_funding_revision_amounts_nonnegative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["advisory_id"],
+            ["review.funding_advisories.advisory_id"],
+            name="fk_funding_revision_advisory",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("revision_id", name="uq_funding_advisory_revision_id"),
+        sa.UniqueConstraint(
+            "advisory_id",
+            "revision_no",
+            name="uq_funding_advisory_revision_no",
+        ),
+        sa.UniqueConstraint(
+            "advisory_id",
+            "fingerprint",
+            name="uq_funding_advisory_fingerprint",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_funding_revision_advisory_evaluated",
+        "funding_advisory_revisions",
+        ["advisory_id", "evaluated_at"],
+        schema="review",
+    )
+
+    op.create_table(
+        "funding_advisory_deliveries",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("delivery_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("advisory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "channel",
+            sa.Text(),
+            server_default=sa.text("'telegram'"),
+            nullable=False,
+        ),
+        sa.Column("kst_date", sa.Date(), nullable=False),
+        sa.Column(
+            "state", sa.Text(), server_default=sa.text("'claimed'"), nullable=False
+        ),
+        sa.Column("revision_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("chat_id", sa.Text(), nullable=True),
+        sa.Column("message_id", sa.BigInteger(), nullable=True),
+        sa.Column("failure_code", sa.Text(), nullable=True),
+        sa.Column("claimed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("delivered_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint("channel = 'telegram'", name="ck_funding_delivery_channel"),
+        sa.CheckConstraint(
+            "state IN ('claimed','sent','send_failed','edit_failed','delivery_unknown')",
+            name="ck_funding_delivery_state",
+        ),
+        sa.ForeignKeyConstraint(
+            ["advisory_id"],
+            ["review.funding_advisories.advisory_id"],
+            name="fk_funding_delivery_advisory",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["revision_id"],
+            ["review.funding_advisory_revisions.revision_id"],
+            name="fk_funding_delivery_revision",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("delivery_id", name="uq_funding_delivery_id"),
+        sa.UniqueConstraint(
+            "advisory_id",
+            "channel",
+            "kst_date",
+            name="uq_funding_delivery_advisory_channel_date",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_funding_delivery_state",
+        "funding_advisory_deliveries",
+        ["state", "kst_date"],
+        schema="review",
+    )
+
+    op.create_table(
+        "funding_advisory_proposal_links",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("advisory_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("proposal_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "source_kind",
+            sa.Text(),
+            server_default=sa.text("'order_proposal_create'"),
+            nullable=False,
+        ),
+        sa.Column(
+            "linked_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["advisory_id"],
+            ["review.funding_advisories.advisory_id"],
+            name="fk_funding_link_advisory",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["proposal_id"],
+            ["review.order_proposals.proposal_id"],
+            name="fk_funding_link_proposal",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("proposal_id", name="uq_funding_link_proposal_id"),
+        schema="review",
+    )
+    op.create_index(
+        "ix_funding_link_advisory_id",
+        "funding_advisory_proposal_links",
+        ["advisory_id"],
+        schema="review",
+    )
+
+    op.execute(
+        """
+        CREATE FUNCTION review.reject_funding_evidence_mutation()
+        RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION 'review.% is append-only; % rejected',
+                TG_TABLE_NAME, TG_OP USING ERRCODE = 'restrict_violation';
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    for table in (
+        "funding_advisory_revisions",
+        "funding_advisory_proposal_links",
+    ):
+        op.execute(
+            f"CREATE TRIGGER trg_{table}_append_only "
+            f"BEFORE UPDATE OR DELETE ON review.{table} FOR EACH ROW EXECUTE "
+            "FUNCTION review.reject_funding_evidence_mutation()"
+        )
+        op.execute(
+            f"CREATE TRIGGER trg_{table}_truncate_append_only "
+            f"BEFORE TRUNCATE ON review.{table} FOR EACH STATEMENT EXECUTE "
+            "FUNCTION review.reject_funding_evidence_mutation()"
+        )
+        op.execute(f"REVOKE UPDATE, DELETE, TRUNCATE ON review.{table} FROM PUBLIC")
+
+
+def downgrade() -> None:
+    op.drop_table("funding_advisory_proposal_links", schema="review")
+    op.drop_table("funding_advisory_deliveries", schema="review")
+    op.drop_table("funding_advisory_revisions", schema="review")
+    op.drop_table("funding_advisories", schema="review")
+    op.execute("DROP FUNCTION IF EXISTS review.reject_funding_evidence_mutation()")

--- a/app/core/invest_deep_links.py
+++ b/app/core/invest_deep_links.py
@@ -79,3 +79,24 @@ def build_order_detail_url(
         f"{settings.public_base_url.rstrip('/')}/invest/orders/"
         f"{broker_key}/{market_key}/{ledger_id}"
     )
+
+
+def build_funding_advisory_url(advisory_id: str) -> str | None:
+    """Build a read-only funding detail URL with no approval authority."""
+
+    normalized = str(advisory_id or "").strip()
+    if not normalized:
+        return None
+    return (
+        f"{settings.public_base_url.rstrip('/')}/invest/funding/"
+        f"{quote(normalized, safe='')}"
+    )
+
+
+def build_funding_declaration_url() -> str:
+    """Build the admin declaration form URL; opening it never writes cash."""
+
+    return (
+        f"{settings.public_base_url.rstrip('/')}/invest/funding"
+        "#external-cash-declaration"
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,7 @@ from app.routers import (
     invest_artifacts,
     invest_fills,
     invest_forecasts,
+    invest_funding,
     invest_loss_cut_approvals,
     invest_open_orders,
     invest_retrospectives,
@@ -209,6 +210,7 @@ def create_app() -> FastAPI:
     app.include_router(invest_watches.router)
     app.include_router(invest_retrospectives.router)
     app.include_router(invest_forecasts.router)
+    app.include_router(invest_funding.router)
     app.include_router(invest_artifacts.router)
     app.include_router(invest_session_context.router)
     app.include_router(invest_app_spa.router)

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -25,6 +25,9 @@ from app.mcp_server.caller_identity import get_caller_agent_id
 from app.mcp_server.tooling.support_reserve_net_consumer_tool import (
     support_reserve_net_consume,
 )
+from app.services.funding_advisory.contracts import FundingCandidateEvent
+from app.services.funding_advisory.service import FundingAdvisoryService
+from app.services.funding_advisory.telegram import deliver_claimed_advisory
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.alerts import send_approval_dispatch_alert
 from app.services.order_proposals.approval_window import ApprovalWindowDecision
@@ -483,6 +486,105 @@ async def _edit_superseded_approval_message(
     )
 
 
+async def _evaluate_funding_candidate_fail_open(
+    payload: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Keep advisory evaluation strictly non-blocking for proposal creation."""
+
+    if payload is None:
+        return None
+    try:
+        event = FundingCandidateEvent.model_validate(payload)
+        evaluated_at = now_kst()
+        async with AsyncSessionLocal() as session:
+            service = FundingAdvisoryService(session)
+            result = await service.evaluate_candidate_event(
+                event,
+                now=evaluated_at,
+            )
+        if result.get("status") == "triggered":
+            result["telegram_delivery"] = await deliver_claimed_advisory(
+                result,
+                now=evaluated_at,
+            )
+        return result
+    except Exception as exc:  # noqa: BLE001 - advisory can never gate create
+        logger.error(
+            "order_proposal_create.funding_advisory_evaluation_failed",
+            extra={
+                "failure_code": "funding_advisory_evaluation_failed",
+                "exception_type": type(exc).__name__,
+            },
+        )
+        return {
+            "status": "unavailable",
+            "failure_code": "funding_advisory_evaluation_failed",
+        }
+
+
+def _funding_provenance_id(
+    *,
+    explicit_id: str | None,
+    evaluation: dict[str, Any] | None,
+) -> tuple[uuid.UUID | None, dict[str, Any] | None]:
+    automatic_id = (
+        evaluation.get("advisory_id")
+        if evaluation and evaluation.get("status") == "triggered"
+        else None
+    )
+    if explicit_id and automatic_id and explicit_id != automatic_id:
+        return None, {
+            "status": "unavailable",
+            "failure_code": "funding_provenance_id_mismatch",
+        }
+    raw = explicit_id or automatic_id
+    if not raw:
+        return None, None
+    try:
+        return uuid.UUID(raw), None
+    except (TypeError, ValueError):
+        return None, {
+            "status": "unavailable",
+            "failure_code": "invalid_source_funding_advisory_id",
+        }
+
+
+async def _link_funding_provenance_fail_open(
+    *, proposal_id: uuid.UUID, advisory_id: uuid.UUID | None
+) -> dict[str, Any] | None:
+    """Link after proposal commit; link loss cannot alter create success."""
+
+    if advisory_id is None:
+        return None
+    try:
+        async with AsyncSessionLocal() as session:
+            service = OrderProposalsService(session)
+            await service.link_funding_advisory_provenance(
+                proposal_id=proposal_id,
+                source_funding_advisory_id=advisory_id,
+                now=now_kst(),
+            )
+            await session.commit()
+        return {
+            "status": "linked",
+            "source_funding_advisory_id": str(advisory_id),
+            "provenance_only": True,
+        }
+    except Exception as exc:  # noqa: BLE001 - proposal is already committed
+        logger.error(
+            "order_proposal_create.funding_provenance_link_failed",
+            extra={
+                "proposal_id": str(proposal_id),
+                "failure_code": "funding_provenance_link_failed",
+                "exception_type": type(exc).__name__,
+            },
+        )
+        return {
+            "status": "unavailable",
+            "failure_code": "funding_provenance_link_failed",
+        }
+
+
 async def order_proposal_create(
     symbol: str,
     market: str,
@@ -504,6 +606,8 @@ async def order_proposal_create(
     approval_issue_id: str | None = None,
     action: str = "place",
     target_broker_order_id: str | None = None,
+    funding_candidate_event: dict | None = None,
+    source_funding_advisory_id: str | None = None,
 ) -> dict[str, Any]:
     """Create a place, replace, or cancel proposal without broker mutation.
 
@@ -531,6 +635,11 @@ async def order_proposal_create(
                 structured supported_matrix (per action) instead of a bare
                 error string.
         target_broker_order_id: required broker order ID for replace/cancel.
+        funding_candidate_event: optional typed proof that non-funding gates passed
+                plus a fresh broker-authoritative funding snapshot. Evaluation is
+                advisory-only and fail-open; errors never block proposal create.
+        source_funding_advisory_id: optional provenance-only reference. It is not
+                a classification, sizing, eligibility, or approval input.
     """
     try:
         market = _normalize_order_proposal_market(market)
@@ -561,6 +670,13 @@ async def order_proposal_create(
                 account_mode=account_mode,
                 now=now_kst(),
             )
+        funding_evaluation = await _evaluate_funding_candidate_fail_open(
+            funding_candidate_event
+        )
+        funding_link_id, funding_link_status = _funding_provenance_id(
+            explicit_id=source_funding_advisory_id,
+            evaluation=funding_evaluation,
+        )
         superseded_message: tuple[Any, Any] | None = None
         async with AsyncSessionLocal() as session:
             svc = OrderProposalsService(session)
@@ -625,7 +741,11 @@ async def order_proposal_create(
         # Telegram dispatch and every secondary ledger path live behind a
         # separate never-raise boundary. The proposal transaction above is
         # already closed and its immutable success snapshot is authoritative.
-        return await _complete_committed_proposal_create(
+        linked = await _link_funding_provenance_fail_open(
+            proposal_id=proposal_id,
+            advisory_id=funding_link_id,
+        )
+        completed = await _complete_committed_proposal_create(
             committed_result,
             proposal_id=proposal_id,
             superseded_message=superseded_message,
@@ -635,6 +755,13 @@ async def order_proposal_create(
             broker_account_id=broker_account_id,
             market=market,
         )
+        if funding_evaluation is not None:
+            completed["funding_advisory"] = funding_evaluation
+        if funding_link_status is not None:
+            completed["funding_provenance"] = funding_link_status
+        elif linked is not None:
+            completed["funding_provenance"] = linked
+        return completed
     except OrderProposalUnsupportedTargetAction as exc:
         return {
             "success": False,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,7 +10,13 @@ from .crypto_instrument_health import CryptoInstrumentHealth
 from .crypto_instruments import CryptoInstrument
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
 from .financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
-from .funding_advisory import ExternalCashDeclaration
+from .funding_advisory import (
+    ExternalCashDeclaration,
+    FundingAdvisory,
+    FundingAdvisoryDelivery,
+    FundingAdvisoryProposalLink,
+    FundingAdvisoryRevision,
+)
 from .invalid_sample_eligibility import (
     InvalidSampleCleanupBinding,
     InvalidSampleCleanupLifecycleEvent,
@@ -254,6 +260,10 @@ __all__ = [
     "NaverResearchDetailCache",
     "FinancialFundamentalsSnapshot",
     "ExternalCashDeclaration",
+    "FundingAdvisory",
+    "FundingAdvisoryDelivery",
+    "FundingAdvisoryProposalLink",
+    "FundingAdvisoryRevision",
     "Trade",
     "TossLiveOrderLedger",
     "TradeSnapshot",

--- a/app/models/funding_advisory.py
+++ b/app/models/funding_advisory.py
@@ -8,7 +8,7 @@ must continue to use broker-authoritative inputs.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 
 from sqlalchemy import (
@@ -16,12 +16,15 @@ from sqlalchemy import (
     TIMESTAMP,
     BigInteger,
     CheckConstraint,
+    Date,
     ForeignKey,
     Index,
+    Integer,
     Numeric,
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
@@ -116,5 +119,213 @@ class ExternalCashDeclaration(Base):
     )
     idempotency_key: Mapped[str] = mapped_column(Text, nullable=False)
     recorded_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class FundingAdvisory(Base):
+    """Mutable lifecycle head for one candidate/gate/account funding thread."""
+
+    __tablename__ = "funding_advisories"
+    __table_args__ = (
+        UniqueConstraint("advisory_id", name="uq_funding_advisory_id"),
+        UniqueConstraint("thread_key", name="uq_funding_advisory_thread_key"),
+        CheckConstraint(
+            "market IN ('crypto','equity_kr','equity_us')",
+            name="ck_funding_advisory_market",
+        ),
+        CheckConstraint("side = 'buy'", name="ck_funding_advisory_buy_only"),
+        CheckConstraint(
+            "state IN ('active','resolved','superseded')",
+            name="ck_funding_advisory_state",
+        ),
+        Index("ix_funding_advisory_owner_state", "owner_user_id", "state"),
+        Index(
+            "ix_funding_advisory_candidate",
+            "source_kind",
+            "source_candidate_id",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    advisory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    owner_user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    thread_key: Mapped[str] = mapped_column(Text, nullable=False)
+    source_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    source_candidate_id: Mapped[str] = mapped_column(Text, nullable=False)
+    gate_name: Mapped[str] = mapped_column(Text, nullable=False)
+    gate_version: Mapped[str] = mapped_column(Text, nullable=False)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    target_account_mode: Mapped[str] = mapped_column(Text, nullable=False)
+    broker_account_id: Mapped[str] = mapped_column(Text, nullable=False)
+    currency: Mapped[str] = mapped_column(CHAR(3), nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    side: Mapped[str] = mapped_column(Text, nullable=False, server_default="buy")
+    state: Mapped[str] = mapped_column(Text, nullable=False, server_default="active")
+    valid_until: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class FundingAdvisoryRevision(Base):
+    """Immutable calculation snapshot for one advisory thread."""
+
+    __tablename__ = "funding_advisory_revisions"
+    __table_args__ = (
+        UniqueConstraint("revision_id", name="uq_funding_advisory_revision_id"),
+        UniqueConstraint(
+            "advisory_id",
+            "revision_no",
+            name="uq_funding_advisory_revision_no",
+        ),
+        UniqueConstraint(
+            "advisory_id",
+            "fingerprint",
+            name="uq_funding_advisory_fingerprint",
+        ),
+        CheckConstraint(
+            "required_cash >= 0 AND target_buying_power >= 0 "
+            "AND other_pending_required >= 0 AND reserved_cash >= 0 "
+            "AND shortfall >= 0 AND operational_gap >= 0",
+            name="ck_funding_revision_amounts_nonnegative",
+        ),
+        Index(
+            "ix_funding_revision_advisory_evaluated",
+            "advisory_id",
+            "evaluated_at",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    revision_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    advisory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("review.funding_advisories.advisory_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    revision_no: Mapped[int] = mapped_column(Integer, nullable=False)
+    fingerprint: Mapped[str] = mapped_column(Text, nullable=False)
+    evidence: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    required_cash: Mapped[Decimal] = mapped_column(Numeric(38, 12), nullable=False)
+    target_buying_power: Mapped[Decimal] = mapped_column(
+        Numeric(38, 12), nullable=False
+    )
+    other_pending_required: Mapped[Decimal] = mapped_column(
+        Numeric(38, 12), nullable=False, server_default="0"
+    )
+    reserved_cash: Mapped[Decimal] = mapped_column(
+        Numeric(38, 12), nullable=False, server_default="0"
+    )
+    shortfall: Mapped[Decimal] = mapped_column(Numeric(38, 12), nullable=False)
+    operational_gap: Mapped[Decimal] = mapped_column(Numeric(38, 12), nullable=False)
+    routes: Mapped[list[dict]] = mapped_column(JSONB, nullable=False)
+    combination: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    evaluated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class FundingAdvisoryDelivery(Base):
+    """Per-channel/day claim that enforces the notification cap."""
+
+    __tablename__ = "funding_advisory_deliveries"
+    __table_args__ = (
+        UniqueConstraint("delivery_id", name="uq_funding_delivery_id"),
+        UniqueConstraint(
+            "advisory_id",
+            "channel",
+            "kst_date",
+            name="uq_funding_delivery_advisory_channel_date",
+        ),
+        CheckConstraint("channel = 'telegram'", name="ck_funding_delivery_channel"),
+        CheckConstraint(
+            "state IN ('claimed','sent','send_failed','edit_failed','delivery_unknown')",
+            name="ck_funding_delivery_state",
+        ),
+        Index("ix_funding_delivery_state", "state", "kst_date"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    delivery_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    advisory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("review.funding_advisories.advisory_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    channel: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="telegram"
+    )
+    kst_date: Mapped[date] = mapped_column(Date, nullable=False)
+    state: Mapped[str] = mapped_column(Text, nullable=False, server_default="claimed")
+    revision_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey(
+            "review.funding_advisory_revisions.revision_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    chat_id: Mapped[str | None] = mapped_column(Text)
+    message_id: Mapped[int | None] = mapped_column(BigInteger)
+    failure_code: Mapped[str | None] = mapped_column(Text)
+    claimed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class FundingAdvisoryProposalLink(Base):
+    """Provenance-only link; never an order classifier or sizing input."""
+
+    __tablename__ = "funding_advisory_proposal_links"
+    __table_args__ = (
+        UniqueConstraint("proposal_id", name="uq_funding_link_proposal_id"),
+        Index("ix_funding_link_advisory_id", "advisory_id"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    advisory_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("review.funding_advisories.advisory_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    proposal_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("review.order_proposals.proposal_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    source_kind: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="order_proposal_create"
+    )
+    linked_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )

--- a/app/routers/invest_funding.py
+++ b/app/routers/invest_funding.py
@@ -1,0 +1,193 @@
+"""Authenticated funding-advisory reads and the sole external-cash UI write."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.admin_router import require_admin
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.funding_advisory import ExternalCashDeclarationRequest
+from app.services.funding_advisory.external_cash import (
+    ExternalCashAmbiguousHeadError,
+    ExternalCashAuthorizationError,
+    ExternalCashConflictError,
+    ExternalCashDeclarationService,
+    ExternalCashValidationError,
+)
+from app.services.funding_advisory.initial_declaration import (
+    INITIAL_PARKING_AMOUNT,
+)
+from app.services.funding_advisory.service import (
+    FundingAdvisoryNotFound,
+    FundingAdvisoryService,
+)
+
+router = APIRouter(prefix="/invest/api/funding", tags=["invest-funding"])
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+@router.get("/advisories")
+async def list_advisories(
+    user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    state_filter: Annotated[
+        Literal["active", "resolved", "superseded"] | None,
+        Query(alias="state"),
+    ] = "active",
+    limit: Annotated[int, Query(ge=1, le=200)] = 100,
+) -> dict[str, Any]:
+    service = FundingAdvisoryService(db)
+    rows = await service.list_details(
+        owner_user_id=user.id,
+        state=state_filter,
+        limit=limit,
+    )
+    return {"advisories": rows, "count": len(rows)}
+
+
+@router.get("/allocation")
+async def get_cross_market_allocation(
+    user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:
+    service = FundingAdvisoryService(db)
+    return await service.cross_market_allocation(owner_user_id=user.id, now=_now())
+
+
+@router.get("/advisories/{advisory_id}")
+async def get_advisory(
+    advisory_id: UUID,
+    user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    refresh: Annotated[bool, Query()] = True,
+) -> dict[str, Any]:
+    service = FundingAdvisoryService(db)
+    try:
+        if refresh:
+            refreshed = await service.refresh_detail(
+                advisory_id=advisory_id,
+                owner_user_id=user.id,
+                now=_now(),
+            )
+            if refreshed.get("status") == "triggered":
+                return refreshed
+            detail = await service.get_detail(
+                advisory_id=advisory_id,
+                owner_user_id=user.id,
+            )
+            detail["refresh"] = refreshed
+            return detail
+        return await service.get_detail(
+            advisory_id=advisory_id,
+            owner_user_id=user.id,
+        )
+    except FundingAdvisoryNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND) from exc
+
+
+@router.get("/external-cash/current")
+async def get_external_cash_current(
+    user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    location_key: Annotated[str, Query(alias="locationKey")] = "parking_primary",
+    currency: Annotated[str, Query(pattern=r"^[A-Z]{3}$")] = "KRW",
+) -> dict[str, Any]:
+    service = ExternalCashDeclarationService(db)
+    view = await service.current(
+        owner_user_id=user.id,
+        location_key=location_key,
+        currency=currency,
+        now=_now(),
+    )
+    return view.model_dump(mode="json")
+
+
+@router.get("/external-cash/history")
+async def get_external_cash_history(
+    user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    location_key: Annotated[str, Query(alias="locationKey")] = "parking_primary",
+    currency: Annotated[str, Query(pattern=r"^[A-Z]{3}$")] = "KRW",
+    limit: Annotated[int, Query(ge=1, le=200)] = 100,
+) -> dict[str, Any]:
+    service = ExternalCashDeclarationService(db)
+    rows = await service.history(
+        owner_user_id=user.id,
+        location_key=location_key,
+        currency=currency,
+        limit=limit,
+    )
+    return {
+        "declarations": [row.model_dump(mode="json") for row in rows],
+        "count": len(rows),
+    }
+
+
+@router.get("/external-cash/form")
+async def get_external_cash_form(
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    owner_user_id: Annotated[int | None, Query(alias="ownerUserId", gt=0)] = None,
+) -> dict[str, Any]:
+    owner_id = owner_user_id or admin.id
+    service = ExternalCashDeclarationService(db)
+    current = await service.current(
+        owner_user_id=owner_id,
+        location_key="parking_primary",
+        currency="KRW",
+        now=_now(),
+    )
+    head = current.current
+    return {
+        "owner_user_id": owner_id,
+        "location_key": "parking_primary",
+        "display_label": head.display_label if head else "파킹통장",
+        "currency": "KRW",
+        "amount": str(head.amount if head else INITIAL_PARKING_AMOUNT),
+        "as_of": None,
+        "source_note": head.source_note if head else "토스증권 → 파킹통장 이동",
+        "expected_head_declaration_id": (
+            str(head.declaration_id) if head is not None else None
+        ),
+        "idempotency_key": f"funding-ui:{uuid.uuid4()}",
+        "requires_exact_operator_confirmed_time": True,
+        "creates_money_movement": False,
+    }
+
+
+@router.post("/external-cash/declarations", status_code=status.HTTP_201_CREATED)
+async def declare_external_cash(
+    request: ExternalCashDeclarationRequest,
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:
+    service = ExternalCashDeclarationService(db)
+    try:
+        row = await service.declare(request, admin, _now())
+        return row.model_dump(mode="json")
+    except (ExternalCashConflictError, ExternalCashAmbiguousHeadError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    except ExternalCashAuthorizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except ExternalCashValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc

--- a/app/services/funding_advisory/_repository.py
+++ b/app/services/funding_advisory/_repository.py
@@ -1,0 +1,141 @@
+"""Private persistence adapter for funding advisory threads and revisions."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.funding_advisory import (
+    FundingAdvisory,
+    FundingAdvisoryDelivery,
+    FundingAdvisoryRevision,
+)
+
+
+class FundingAdvisoryRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def acquire_lock(self, lock_key: str) -> None:
+        await self._session.execute(
+            select(func.pg_advisory_xact_lock(func.hashtextextended(lock_key, 0)))
+        )
+
+    async def get_advisory_by_thread(
+        self, thread_key: str, *, for_update: bool = False
+    ) -> FundingAdvisory | None:
+        stmt = select(FundingAdvisory).where(FundingAdvisory.thread_key == thread_key)
+        if for_update:
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_advisory(
+        self,
+        advisory_id: UUID,
+        *,
+        owner_user_id: int | None = None,
+        for_update: bool = False,
+    ) -> FundingAdvisory | None:
+        stmt = select(FundingAdvisory).where(FundingAdvisory.advisory_id == advisory_id)
+        if owner_user_id is not None:
+            stmt = stmt.where(FundingAdvisory.owner_user_id == owner_user_id)
+        if for_update:
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def insert_advisory(self, **columns: Any) -> FundingAdvisory:
+        row = FundingAdvisory(**columns)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def update_advisory(self, row: FundingAdvisory, **columns: Any) -> None:
+        for key, value in columns.items():
+            setattr(row, key, value)
+        await self._session.flush()
+
+    async def latest_revision(
+        self, advisory_id: UUID
+    ) -> FundingAdvisoryRevision | None:
+        stmt = (
+            select(FundingAdvisoryRevision)
+            .where(FundingAdvisoryRevision.advisory_id == advisory_id)
+            .order_by(FundingAdvisoryRevision.revision_no.desc())
+            .limit(1)
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_revision_by_fingerprint(
+        self, *, advisory_id: UUID, fingerprint: str
+    ) -> FundingAdvisoryRevision | None:
+        stmt = select(FundingAdvisoryRevision).where(
+            FundingAdvisoryRevision.advisory_id == advisory_id,
+            FundingAdvisoryRevision.fingerprint == fingerprint,
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def insert_revision(self, **columns: Any) -> FundingAdvisoryRevision:
+        row = FundingAdvisoryRevision(**columns)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def list_advisories(
+        self, *, owner_user_id: int, state: str | None = None, limit: int = 100
+    ) -> list[FundingAdvisory]:
+        stmt = (
+            select(FundingAdvisory)
+            .where(FundingAdvisory.owner_user_id == owner_user_id)
+            .order_by(FundingAdvisory.updated_at.desc())
+            .limit(limit)
+        )
+        if state is not None:
+            stmt = stmt.where(FundingAdvisory.state == state)
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def get_delivery(
+        self,
+        *,
+        advisory_id: UUID,
+        channel: str,
+        kst_date: date,
+        for_update: bool = False,
+    ) -> FundingAdvisoryDelivery | None:
+        stmt = select(FundingAdvisoryDelivery).where(
+            FundingAdvisoryDelivery.advisory_id == advisory_id,
+            FundingAdvisoryDelivery.channel == channel,
+            FundingAdvisoryDelivery.kst_date == kst_date,
+        )
+        if for_update:
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_delivery_by_id(
+        self, delivery_id: UUID, *, for_update: bool = False
+    ) -> FundingAdvisoryDelivery | None:
+        stmt = select(FundingAdvisoryDelivery).where(
+            FundingAdvisoryDelivery.delivery_id == delivery_id
+        )
+        if for_update:
+            stmt = stmt.with_for_update().execution_options(populate_existing=True)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def insert_delivery(self, **columns: Any) -> FundingAdvisoryDelivery:
+        row = FundingAdvisoryDelivery(**columns)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def update_delivery(
+        self, row: FundingAdvisoryDelivery, **columns: Any
+    ) -> None:
+        for key, value in columns.items():
+            setattr(row, key, value)
+        await self._session.flush()

--- a/app/services/funding_advisory/contracts.py
+++ b/app/services/funding_advisory/contracts.py
@@ -1,0 +1,242 @@
+"""Typed, hash-bound evidence accepted by the funding advisory layer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.schemas.funding_advisory import canonical_decimal
+
+SUPPORTED_MARKETS = frozenset({"crypto", "equity_kr", "equity_us"})
+REAL_ACCOUNT_MODES = frozenset({"upbit", "kis_live", "toss_live"})
+_EVALUATION_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _aware(value: datetime, field: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must include a timezone")
+    return value.astimezone(UTC)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_evidence_hash(payload_without_hash: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(payload_without_hash).encode()).hexdigest()
+
+
+class NonFundingCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    check_id: str = Field(min_length=1, max_length=120)
+    check_version: str = Field(min_length=1, max_length=64)
+    verdict: Literal["passed"]
+    evaluated_at: datetime
+
+    @field_validator("evaluated_at")
+    @classmethod
+    def validate_evaluated_at(cls, value: datetime) -> datetime:
+        _aware(value, "non_funding_checks.evaluated_at")
+        return value
+
+
+class PassedNonFundingGateEvidence(BaseModel):
+    """Proof that every non-cash check passed before funding assessment.
+
+    ``gate_version`` is the gate contract/schema version. It stays stable
+    across evaluations of that contract and is distinct from the per-evaluation
+    ``evidence_hash``.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    owner_user_id: int = Field(gt=0)
+    source_kind: str = Field(min_length=1, max_length=64)
+    source_candidate_id: str = Field(min_length=1, max_length=160)
+    gate_name: str = Field(min_length=1, max_length=120)
+    gate_version: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z][A-Za-z0-9._-]*$",
+    )
+    gate_verdict: Literal["passed"]
+    gate_evaluated_at: datetime
+    valid_until: datetime
+    market: Literal["crypto", "equity_kr", "equity_us"]
+    target_account_mode: Literal["upbit", "kis_live", "toss_live"]
+    broker_account_id: str = Field(min_length=1, max_length=160)
+    currency: str = Field(pattern=r"^[A-Z]{3}$")
+    symbol: str = Field(min_length=1, max_length=64)
+    side: Literal["buy"]
+    order_type: Literal["limit", "market"]
+    quantity: str | None = None
+    price_reference: str | None = None
+    blocking_reasons: list[str] = Field(default_factory=list, max_length=0)
+    non_funding_checks: list[NonFundingCheck] = Field(min_length=1)
+    upstream_priority: str | None = Field(default=None, max_length=120)
+    evidence_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @field_validator("gate_evaluated_at", "valid_until")
+    @classmethod
+    def validate_datetimes(cls, value: datetime) -> datetime:
+        _aware(value, "gate datetime")
+        return value
+
+    @model_validator(mode="after")
+    def validate_contract(self) -> Self:
+        if _EVALUATION_HASH_RE.fullmatch(self.gate_version):
+            raise ValueError(
+                "gate_version is a contract/schema version, not an evaluation hash"
+            )
+        if _aware(self.valid_until, "valid_until") <= _aware(
+            self.gate_evaluated_at, "gate_evaluated_at"
+        ):
+            raise ValueError("valid_until must be after gate_evaluated_at")
+        expected = compute_evidence_hash(self.canonical_payload())
+        if self.evidence_hash != expected:
+            raise ValueError("evidence_hash does not match canonical evidence")
+        return self
+
+    def canonical_payload(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", exclude={"evidence_hash"})
+
+    @classmethod
+    def issue(cls, **payload: Any) -> PassedNonFundingGateEvidence:
+        """Issue test/upstream evidence while keeping verification mandatory."""
+
+        normalized = dict(payload)
+        normalized["non_funding_checks"] = [
+            check
+            if isinstance(check, NonFundingCheck)
+            else NonFundingCheck.model_validate(check)
+            for check in normalized.get("non_funding_checks", [])
+        ]
+        provisional = cls.model_construct(
+            **normalized,
+            evidence_hash="0" * 64,
+        )
+        normalized["evidence_hash"] = compute_evidence_hash(
+            provisional.canonical_payload()
+        )
+        return cls.model_validate(normalized)
+
+
+class FundingAssessment(BaseModel):
+    """Broker-authoritative, read-only funding observation for one candidate."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    required_cash: Decimal = Field(ge=0, max_digits=38, decimal_places=12)
+    target_buying_power: Decimal = Field(ge=0, max_digits=38, decimal_places=12)
+    other_pending_required: Decimal = Field(
+        default=Decimal("0"), ge=0, max_digits=38, decimal_places=12
+    )
+    reserved_cash: Decimal = Field(
+        default=Decimal("0"), ge=0, max_digits=38, decimal_places=12
+    )
+    currency: str = Field(pattern=r"^[A-Z]{3}$")
+    observed_at: datetime
+    valid_until: datetime
+    source: str = Field(min_length=1, max_length=160)
+
+    @field_validator("observed_at", "valid_until")
+    @classmethod
+    def validate_datetimes(cls, value: datetime) -> datetime:
+        _aware(value, "funding assessment datetime")
+        return value
+
+    @model_validator(mode="after")
+    def validate_window(self) -> Self:
+        if _aware(self.valid_until, "valid_until") <= _aware(
+            self.observed_at, "observed_at"
+        ):
+            raise ValueError("funding assessment valid_until must be after observed_at")
+        return self
+
+    def canonical_payload(self) -> dict[str, Any]:
+        return {
+            "required_cash": canonical_decimal(self.required_cash),
+            "target_buying_power": canonical_decimal(self.target_buying_power),
+            "other_pending_required": canonical_decimal(self.other_pending_required),
+            "reserved_cash": canonical_decimal(self.reserved_cash),
+            "currency": self.currency,
+            "observed_at": self.observed_at.isoformat(),
+            "valid_until": self.valid_until.isoformat(),
+            "source": self.source,
+        }
+
+
+class FundingCandidateEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence: PassedNonFundingGateEvidence
+    assessment: FundingAssessment
+
+    @model_validator(mode="after")
+    def validate_binding(self) -> Self:
+        if self.evidence.currency != self.assessment.currency:
+            raise ValueError("evidence and funding assessment currency mismatch")
+        if _aware(self.assessment.valid_until, "assessment.valid_until") > _aware(
+            self.evidence.valid_until, "evidence.valid_until"
+        ):
+            raise ValueError("funding assessment cannot outlive gate evidence")
+        return self
+
+
+class FundingRoute(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    route_id: Literal[
+        "EXTERNAL_PARKING_KRW",
+        "USD_CONVERSION",
+        "CREDIT_LINE_SHORT_TERM",
+        "PROFITABLE_TRIM",
+        "LOSS_CUT_ROTATION",
+    ]
+    label: str
+    amount_status: Literal["known", "unknown", "conditional"]
+    route_fundable_amount: Decimal | None = None
+    counted_fundable_amount: Decimal = Decimal("0")
+    confidence: Literal[
+        "broker_authoritative", "operator_declared", "conditional", "unknown"
+    ]
+    source_as_of: datetime | None = None
+    deadline_status: Literal["met", "missed", "unknown"]
+    explicit_cost: Decimal | None = None
+    eta_minutes: int | None = Field(default=None, ge=0)
+    realized_impact: Decimal | None = None
+    reversibility: Literal["reversible", "conditional", "irreversible", "unknown"]
+    eligibility: Literal["eligible", "locked", "comparison_unavailable"]
+    reason_codes: list[str] = Field(default_factory=list)
+    comparison: Literal[
+        "preferred", "situation_dependent", "dominated", "unavailable"
+    ] = "unavailable"
+
+    def json_payload(self) -> dict[str, Any]:
+        payload = self.model_dump(mode="json")
+        for field in (
+            "route_fundable_amount",
+            "counted_fundable_amount",
+            "explicit_cost",
+            "realized_impact",
+        ):
+            value = getattr(self, field)
+            payload[field] = None if value is None else canonical_decimal(value)
+        return payload
+
+
+__all__ = [
+    "FundingAssessment",
+    "FundingCandidateEvent",
+    "FundingRoute",
+    "NonFundingCheck",
+    "PassedNonFundingGateEvidence",
+    "compute_evidence_hash",
+]

--- a/app/services/funding_advisory/ranking.py
+++ b/app/services/funding_advisory/ranking.py
@@ -1,0 +1,116 @@
+"""Multi-axis funding-route comparison with no hidden scalar score."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from app.schemas.funding_advisory import canonical_decimal
+from app.services.funding_advisory.contracts import FundingRoute
+
+_REVERSIBILITY_RANK = {
+    "reversible": 0,
+    "conditional": 1,
+    "irreversible": 2,
+    "unknown": 3,
+}
+
+
+def _comparable(route: FundingRoute) -> bool:
+    return (
+        route.amount_status == "known"
+        and route.route_fundable_amount is not None
+        and route.route_fundable_amount > 0
+        and route.deadline_status == "met"
+        and route.explicit_cost is not None
+        and route.eta_minutes is not None
+        and route.realized_impact is not None
+        and route.reversibility != "unknown"
+        and route.eligibility == "eligible"
+    )
+
+
+def dominates(left: FundingRoute, right: FundingRoute) -> bool:
+    """True when left is no worse on every disclosed axis and better on one."""
+
+    if not _comparable(left) or not _comparable(right):
+        return False
+    left_axes = (
+        -Decimal(left.route_fundable_amount or 0),
+        Decimal(left.explicit_cost or 0),
+        Decimal(left.eta_minutes or 0),
+        abs(Decimal(left.realized_impact or 0)),
+        Decimal(_REVERSIBILITY_RANK[left.reversibility]),
+    )
+    right_axes = (
+        -Decimal(right.route_fundable_amount or 0),
+        Decimal(right.explicit_cost or 0),
+        Decimal(right.eta_minutes or 0),
+        abs(Decimal(right.realized_impact or 0)),
+        Decimal(_REVERSIBILITY_RANK[right.reversibility]),
+    )
+    return all(a <= b for a, b in zip(left_axes, right_axes, strict=True)) and any(
+        a < b for a, b in zip(left_axes, right_axes, strict=True)
+    )
+
+
+def compare_routes(routes: list[FundingRoute]) -> list[FundingRoute]:
+    comparable = [route for route in routes if _comparable(route)]
+    result: list[FundingRoute] = []
+    for route in routes:
+        if not _comparable(route):
+            result.append(route.model_copy(update={"comparison": "unavailable"}))
+            continue
+        if any(dominates(other, route) for other in comparable if other is not route):
+            comparison = "dominated"
+        elif len(comparable) > 1 and all(
+            dominates(route, other) for other in comparable if other is not route
+        ):
+            comparison = "preferred"
+        else:
+            comparison = "situation_dependent"
+        result.append(route.model_copy(update={"comparison": comparison}))
+    return result
+
+
+def build_reference_combination(
+    routes: list[FundingRoute], *, shortfall: Decimal
+) -> dict[str, Any]:
+    """Return a disclosed-cost reference only; it is never auto-selected."""
+
+    candidates = [route for route in compare_routes(routes) if _comparable(route)]
+    candidates.sort(
+        key=lambda route: (
+            route.comparison == "dominated",
+            Decimal(route.explicit_cost or 0),
+            int(route.eta_minutes or 0),
+            route.route_id,
+        )
+    )
+    remaining = shortfall
+    cumulative = Decimal("0")
+    legs: list[dict[str, str]] = []
+    for route in candidates:
+        if remaining <= 0:
+            break
+        amount = min(Decimal(route.route_fundable_amount or 0), remaining)
+        cumulative += amount
+        remaining -= amount
+        legs.append(
+            {
+                "route_id": route.route_id,
+                "planned_amount": canonical_decimal(amount),
+                "cumulative_planned_amount": canonical_decimal(cumulative),
+                "remaining_gap": canonical_decimal(max(remaining, Decimal("0"))),
+            }
+        )
+    return {
+        "selected": False,
+        "scenario_kind": "reference_only",
+        "selection_basis": "operator_decision_required_multi_axis",
+        "legs": legs,
+        "remaining_gap": canonical_decimal(max(remaining, Decimal("0"))),
+    }
+
+
+__all__ = ["build_reference_combination", "compare_routes", "dominates"]

--- a/app/services/funding_advisory/service.py
+++ b/app/services/funding_advisory/service.py
@@ -1,0 +1,647 @@
+"""Funding advisory evaluation, revision, and delivery-claim orchestration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.funding_advisory import canonical_decimal
+from app.services.funding_advisory._repository import FundingAdvisoryRepository
+from app.services.funding_advisory.contracts import (
+    FundingCandidateEvent,
+    FundingRoute,
+)
+from app.services.funding_advisory.external_cash import (
+    ExternalCashDeclarationService,
+)
+from app.services.funding_advisory.ranking import (
+    build_reference_combination,
+    compare_routes,
+)
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+class FundingAdvisoryError(Exception):
+    """Base domain error."""
+
+
+class FundingAdvisoryNotFound(FundingAdvisoryError):
+    """No owner-scoped advisory exists for the requested id."""
+
+
+def _aware(value: datetime, field: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise FundingAdvisoryError(f"{field} must include a timezone")
+    return value.astimezone(UTC)
+
+
+def _canonical_hash(value: Any) -> str:
+    payload = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _thread_key(event: FundingCandidateEvent) -> str:
+    evidence = event.evidence
+    identity = {
+        "owner_user_id": evidence.owner_user_id,
+        "source_kind": evidence.source_kind,
+        "source_candidate_id": evidence.source_candidate_id,
+        "gate_name": evidence.gate_name,
+        # Contract/schema version only. Per-evaluation evidence_hash is excluded
+        # so repeated evaluation cannot escape the one-thread/day delivery cap.
+        "gate_version": evidence.gate_version,
+        "target_account_mode": evidence.target_account_mode,
+        "broker_account_id": evidence.broker_account_id,
+        "currency": evidence.currency,
+    }
+    return f"funding:{_canonical_hash(identity)}"
+
+
+def _unknown_route(
+    route_id: str,
+    label: str,
+    *,
+    amount_status: str = "unknown",
+    confidence: str = "unknown",
+    eligibility: str = "comparison_unavailable",
+    reason_codes: list[str],
+) -> FundingRoute:
+    return FundingRoute.model_validate(
+        {
+            "route_id": route_id,
+            "label": label,
+            "amount_status": amount_status,
+            "route_fundable_amount": None,
+            "counted_fundable_amount": Decimal("0"),
+            "confidence": confidence,
+            "source_as_of": None,
+            "deadline_status": "unknown",
+            "explicit_cost": None,
+            "eta_minutes": None,
+            "realized_impact": None,
+            "reversibility": "unknown",
+            "eligibility": eligibility,
+            "reason_codes": reason_codes,
+        }
+    )
+
+
+class FundingAdvisoryService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        _repository: FundingAdvisoryRepository | None = None,
+        _external_cash_service: ExternalCashDeclarationService | None = None,
+    ) -> None:
+        self._session = session
+        self._repository = _repository or FundingAdvisoryRepository(session)
+        self._external_cash = _external_cash_service or ExternalCashDeclarationService(
+            session
+        )
+
+    async def _routes(
+        self,
+        event: FundingCandidateEvent,
+        *,
+        shortfall: Decimal,
+        now: datetime,
+    ) -> list[FundingRoute]:
+        external_views = await self._external_cash.list_current(
+            owner_user_id=event.evidence.owner_user_id,
+            now=now,
+        )
+        external_rows = [
+            view.current
+            for view in external_views
+            if view.status == "fresh"
+            and view.current is not None
+            and view.current.currency == event.evidence.currency
+        ]
+        declared_total = sum((row.amount for row in external_rows), start=Decimal("0"))
+        if declared_total > 0:
+            external = FundingRoute(
+                route_id="EXTERNAL_PARKING_KRW",
+                label="외부 파킹 현금",
+                amount_status="known",
+                route_fundable_amount=min(declared_total, shortfall),
+                counted_fundable_amount=Decimal("0"),
+                confidence="operator_declared",
+                source_as_of=max(row.as_of for row in external_rows),
+                deadline_status="unknown",
+                explicit_cost=None,
+                eta_minutes=None,
+                realized_impact=Decimal("0"),
+                reversibility="reversible",
+                eligibility="comparison_unavailable",
+                reason_codes=[
+                    "operator_declared_unverified",
+                    "transfer_eta_unknown",
+                    "target_balance_not_yet_confirmed",
+                ],
+            )
+        else:
+            external = _unknown_route(
+                "EXTERNAL_PARKING_KRW",
+                "외부 파킹 현금",
+                reason_codes=["fresh_external_cash_unavailable"],
+            )
+
+        routes = [
+            external,
+            _unknown_route(
+                "USD_CONVERSION",
+                "USD 환전",
+                reason_codes=["executable_sell_fx_or_fee_unavailable"],
+            ),
+            _unknown_route(
+                "CREDIT_LINE_SHORT_TERM",
+                "단기 신용한도",
+                reason_codes=["verified_limit_apr_and_eta_unavailable"],
+            ),
+            _unknown_route(
+                "PROFITABLE_TRIM",
+                "수익권 트림",
+                amount_status="conditional",
+                confidence="conditional",
+                eligibility="locked",
+                reason_codes=["strict_sellable_quote_fee_tax_output_unavailable"],
+            ),
+            _unknown_route(
+                "LOSS_CUT_ROTATION",
+                "독립 손절 전환",
+                amount_status="conditional",
+                confidence="conditional",
+                eligibility="locked",
+                reason_codes=[
+                    "independent_loss_cut_intent_required",
+                    "existing_two_click_confirmation_required",
+                ],
+            ),
+        ]
+        return compare_routes(routes)
+
+    async def evaluate_candidate_event(
+        self, event: FundingCandidateEvent, *, now: datetime
+    ) -> dict[str, Any]:
+        """Evaluate an upstream candidate event and optionally claim Telegram."""
+
+        return await self._evaluate(event, now=now, event_kind="candidate_event")
+
+    async def _evaluate(
+        self,
+        event: FundingCandidateEvent,
+        *,
+        now: datetime,
+        event_kind: Literal["candidate_event", "page_refresh"],
+    ) -> dict[str, Any]:
+        current_now = _aware(now, "now")
+        evidence = event.evidence
+        assessment = event.assessment
+        if current_now >= _aware(evidence.valid_until, "evidence.valid_until"):
+            return {"status": "not_triggered", "reason": "evidence_expired"}
+        if current_now >= _aware(assessment.valid_until, "assessment.valid_until"):
+            return {"status": "not_triggered", "reason": "funding_snapshot_expired"}
+
+        required = assessment.required_cash
+        target = assessment.target_buying_power
+        shortfall = max(required - target, Decimal("0"))
+        operational_gap = max(
+            required
+            + assessment.other_pending_required
+            + assessment.reserved_cash
+            - target,
+            Decimal("0"),
+        )
+        thread_key = _thread_key(event)
+
+        try:
+            await self._repository.acquire_lock(thread_key)
+            advisory = await self._repository.get_advisory_by_thread(
+                thread_key, for_update=True
+            )
+            if shortfall <= 0:
+                if advisory is not None and advisory.state == "active":
+                    await self._repository.update_advisory(
+                        advisory, state="resolved", updated_at=current_now
+                    )
+                await self._session.commit()
+                return {
+                    "status": "not_triggered",
+                    "reason": "no_candidate_shortfall",
+                    "shortfall": "0",
+                    "other_pending_required": canonical_decimal(
+                        assessment.other_pending_required
+                    ),
+                    "reserved_cash": canonical_decimal(assessment.reserved_cash),
+                    "operational_gap": canonical_decimal(operational_gap),
+                }
+
+            routes = await self._routes(event, shortfall=shortfall, now=current_now)
+            combination = build_reference_combination(routes, shortfall=shortfall)
+            evidence_payload = {
+                "gate": evidence.model_dump(mode="json"),
+                "assessment": assessment.canonical_payload(),
+            }
+            route_payloads = [route.json_payload() for route in routes]
+            fingerprint = _canonical_hash(
+                {
+                    "evidence_hash": evidence.evidence_hash,
+                    "assessment": assessment.canonical_payload(),
+                    "routes": route_payloads,
+                    "combination": combination,
+                }
+            )
+
+            if advisory is None:
+                advisory = await self._repository.insert_advisory(
+                    advisory_id=uuid.uuid4(),
+                    owner_user_id=evidence.owner_user_id,
+                    thread_key=thread_key,
+                    source_kind=evidence.source_kind,
+                    source_candidate_id=evidence.source_candidate_id,
+                    gate_name=evidence.gate_name,
+                    gate_version=evidence.gate_version,
+                    market=evidence.market,
+                    target_account_mode=evidence.target_account_mode,
+                    broker_account_id=evidence.broker_account_id,
+                    currency=evidence.currency,
+                    symbol=evidence.symbol,
+                    side="buy",
+                    state="active",
+                    valid_until=evidence.valid_until,
+                    updated_at=current_now,
+                )
+            else:
+                await self._repository.update_advisory(
+                    advisory,
+                    state="active",
+                    valid_until=evidence.valid_until,
+                    updated_at=current_now,
+                )
+
+            revision = await self._repository.get_revision_by_fingerprint(
+                advisory_id=advisory.advisory_id,
+                fingerprint=fingerprint,
+            )
+            if revision is None:
+                previous = await self._repository.latest_revision(advisory.advisory_id)
+                revision = await self._repository.insert_revision(
+                    revision_id=uuid.uuid4(),
+                    advisory_id=advisory.advisory_id,
+                    revision_no=(previous.revision_no + 1) if previous else 1,
+                    fingerprint=fingerprint,
+                    evidence=evidence_payload,
+                    required_cash=required,
+                    target_buying_power=target,
+                    other_pending_required=assessment.other_pending_required,
+                    reserved_cash=assessment.reserved_cash,
+                    shortfall=shortfall,
+                    operational_gap=operational_gap,
+                    routes=route_payloads,
+                    combination=combination,
+                    evaluated_at=current_now,
+                    expires_at=min(evidence.valid_until, assessment.valid_until),
+                )
+
+            delivery = {"action": "none", "reason": "page_refresh_no_delivery"}
+            if event_kind == "candidate_event":
+                delivery = await self._claim_delivery(
+                    advisory_id=advisory.advisory_id,
+                    revision_id=revision.revision_id,
+                    now=current_now,
+                )
+            await self._session.commit()
+            return self._projection(advisory, revision, delivery=delivery)
+        except Exception:
+            await self._session.rollback()
+            raise
+
+    async def _claim_delivery(
+        self, *, advisory_id: UUID, revision_id: UUID, now: datetime
+    ) -> dict[str, Any]:
+        kst_date = now.astimezone(KST).date()
+        row = await self._repository.get_delivery(
+            advisory_id=advisory_id,
+            channel="telegram",
+            kst_date=kst_date,
+            for_update=True,
+        )
+        if row is None:
+            row = await self._repository.insert_delivery(
+                delivery_id=uuid.uuid4(),
+                advisory_id=advisory_id,
+                channel="telegram",
+                kst_date=kst_date,
+                state="claimed",
+                revision_id=revision_id,
+                claimed_at=now,
+                updated_at=now,
+            )
+            return {
+                "action": "send",
+                "delivery_id": str(row.delivery_id),
+                "chat_id": None,
+                "message_id": None,
+            }
+        if row.state == "sent" and row.revision_id != revision_id:
+            return {
+                "action": "edit",
+                "delivery_id": str(row.delivery_id),
+                "chat_id": row.chat_id,
+                "message_id": row.message_id,
+            }
+        return {
+            "action": "none",
+            "delivery_id": str(row.delivery_id),
+            "reason": "same_day_delivery_already_claimed",
+        }
+
+    async def record_delivery_result(
+        self,
+        *,
+        delivery_id: UUID,
+        revision_id: UUID,
+        action: Literal["send", "edit"],
+        state: Literal["sent", "send_failed", "edit_failed", "delivery_unknown"],
+        now: datetime,
+        chat_id: str | None = None,
+        message_id: int | None = None,
+        failure_code: str | None = None,
+    ) -> None:
+        current_now = _aware(now, "now")
+        try:
+            await self._repository.acquire_lock(f"funding-delivery:{delivery_id}")
+            row = await self._repository.get_delivery_by_id(
+                delivery_id, for_update=True
+            )
+            if row is None:
+                raise FundingAdvisoryNotFound(str(delivery_id))
+            if action == "edit" and row.state != "sent":
+                raise FundingAdvisoryError("only a sent delivery can be edited")
+            await self._repository.update_delivery(
+                row,
+                state=state,
+                revision_id=revision_id if state == "sent" else row.revision_id,
+                chat_id=chat_id if chat_id is not None else row.chat_id,
+                message_id=message_id if message_id is not None else row.message_id,
+                failure_code=failure_code,
+                delivered_at=current_now if state == "sent" else row.delivered_at,
+                updated_at=current_now,
+            )
+            await self._session.commit()
+        except Exception:
+            await self._session.rollback()
+            raise
+
+    def _projection(
+        self, advisory: Any, revision: Any, *, delivery: dict[str, Any]
+    ) -> dict[str, Any]:
+        gate = revision.evidence["gate"]
+        return {
+            "status": "triggered",
+            "advisory_id": str(advisory.advisory_id),
+            "thread_key": advisory.thread_key,
+            "state": advisory.state,
+            "revision_id": str(revision.revision_id),
+            "revision_no": revision.revision_no,
+            "fingerprint": revision.fingerprint,
+            "trigger": {
+                "source_kind": advisory.source_kind,
+                "source_candidate_id": advisory.source_candidate_id,
+                "gate_name": advisory.gate_name,
+                "gate_version": advisory.gate_version,
+                "gate_version_kind": "contract_schema_version",
+                "gate_verdict": "passed",
+                "gate_evaluated_at": gate["gate_evaluated_at"],
+                "valid_until": gate["valid_until"],
+                "upstream_priority": gate.get("upstream_priority"),
+            },
+            "target": {
+                "market": advisory.market,
+                "account_mode": advisory.target_account_mode,
+                "broker_account_id": advisory.broker_account_id,
+                "currency": advisory.currency,
+                "symbol": advisory.symbol,
+                "side": "buy",
+            },
+            "need": {
+                "required_cash": canonical_decimal(Decimal(revision.required_cash)),
+                "target_buying_power": canonical_decimal(
+                    Decimal(revision.target_buying_power)
+                ),
+                "shortfall": canonical_decimal(Decimal(revision.shortfall)),
+                "funding_needed": canonical_decimal(Decimal(revision.shortfall)),
+                "other_pending_required": canonical_decimal(
+                    Decimal(revision.other_pending_required)
+                ),
+                "reserved_cash": canonical_decimal(Decimal(revision.reserved_cash)),
+                "operational_gap_including_other_pending": canonical_decimal(
+                    Decimal(revision.operational_gap)
+                ),
+                "shortfall_scope": "this_candidate_only",
+            },
+            "routes": revision.routes,
+            "combination": revision.combination,
+            "safety": {
+                "advisory_only": True,
+                "executes_money_movement": False,
+                "creates_proposal": False,
+                "authoritative_for_order_gate": False,
+            },
+            "proposal_handoff": {
+                "source_funding_advisory_id": str(advisory.advisory_id),
+                "provenance_only": True,
+                "classifier_input": False,
+                "sizing_input": False,
+                "eligibility_input": False,
+                "action_label": "경로 설명 · 이 화면에서 주문 안 만듦",
+                "ordinary_trim": "별도 create 확인 뒤 기존 dispatch 분류와 승인/veto 경로 적용",
+                "loss_cut": "기존 loss_cut_intent 거절 규칙과 2-click nonce 유지",
+            },
+            "evaluated_at": revision.evaluated_at.isoformat(),
+            "expires_at": revision.expires_at.isoformat(),
+            "delivery": delivery,
+        }
+
+    async def get_detail(
+        self, *, advisory_id: UUID, owner_user_id: int
+    ) -> dict[str, Any]:
+        advisory = await self._repository.get_advisory(
+            advisory_id, owner_user_id=owner_user_id
+        )
+        if advisory is None:
+            raise FundingAdvisoryNotFound(str(advisory_id))
+        revision = await self._repository.latest_revision(advisory.advisory_id)
+        if revision is None:
+            raise FundingAdvisoryNotFound(f"{advisory_id}:revision")
+        delivery_row = await self._repository.get_delivery(
+            advisory_id=advisory.advisory_id,
+            channel="telegram",
+            kst_date=datetime.now(KST).date(),
+        )
+        delivery = (
+            {
+                "action": "none",
+                "delivery_id": str(delivery_row.delivery_id),
+                "state": delivery_row.state,
+                "message_id": delivery_row.message_id,
+            }
+            if delivery_row is not None
+            else {"action": "none", "state": "not_claimed"}
+        )
+        return self._projection(advisory, revision, delivery=delivery)
+
+    async def refresh_detail(
+        self, *, advisory_id: UUID, owner_user_id: int, now: datetime
+    ) -> dict[str, Any]:
+        advisory = await self._repository.get_advisory(
+            advisory_id, owner_user_id=owner_user_id
+        )
+        if advisory is None:
+            raise FundingAdvisoryNotFound(str(advisory_id))
+        revision = await self._repository.latest_revision(advisory.advisory_id)
+        if revision is None:
+            raise FundingAdvisoryNotFound(f"{advisory_id}:revision")
+        event = FundingCandidateEvent.model_validate(
+            {
+                "evidence": revision.evidence["gate"],
+                "assessment": revision.evidence["assessment"],
+            }
+        )
+        return await self._evaluate(event, now=now, event_kind="page_refresh")
+
+    async def list_details(
+        self, *, owner_user_id: int, state: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        advisories = await self._repository.list_advisories(
+            owner_user_id=owner_user_id, state=state, limit=limit
+        )
+        rows: list[dict[str, Any]] = []
+        for advisory in advisories:
+            revision = await self._repository.latest_revision(advisory.advisory_id)
+            if revision is not None:
+                rows.append(
+                    self._projection(
+                        advisory,
+                        revision,
+                        delivery={"action": "none", "state": "not_evaluated"},
+                    )
+                )
+        return rows
+
+    async def cross_market_allocation(
+        self, *, owner_user_id: int, now: datetime
+    ) -> dict[str, Any]:
+        details = await self.list_details(owner_user_id=owner_user_id, state="active")
+        broker_by_account: dict[tuple[str, str, str], Decimal] = {}
+        buckets: dict[str, dict[str, Any]] = {}
+        for detail in details:
+            target = detail["target"]
+            need = detail["need"]
+            currency = target["currency"]
+            broker_by_account[
+                (target["account_mode"], target["broker_account_id"], currency)
+            ] = Decimal(need["target_buying_power"])
+            bucket = buckets.setdefault(
+                currency,
+                {
+                    "currency": currency,
+                    "broker_confirmed_total_native": Decimal("0"),
+                    "declared_total_native": Decimal("0"),
+                    "conditional_total_native": Decimal("0"),
+                    "display_total_native_including_declared": Decimal("0"),
+                    "demands": [],
+                    "contention": False,
+                    "krw_equivalent": None,
+                    "krw_equivalent_status": (
+                        "native" if currency == "KRW" else "conversion_unavailable"
+                    ),
+                },
+            )
+            bucket["demands"].append(
+                {
+                    "advisory_id": detail["advisory_id"],
+                    "market": target["market"],
+                    "symbol": target["symbol"],
+                    "shortfall": need["shortfall"],
+                    "upstream_priority": detail["trigger"]["upstream_priority"],
+                }
+            )
+
+        for (
+            account_mode,
+            broker_account_id,
+            currency,
+        ), amount in broker_by_account.items():
+            _ = (account_mode, broker_account_id)
+            buckets[currency]["broker_confirmed_total_native"] += amount
+
+        external = await self._external_cash.list_current(
+            owner_user_id=owner_user_id, now=now
+        )
+        for view in external:
+            if view.status != "fresh" or view.current is None:
+                continue
+            currency = view.current.currency
+            bucket = buckets.setdefault(
+                currency,
+                {
+                    "currency": currency,
+                    "broker_confirmed_total_native": Decimal("0"),
+                    "declared_total_native": Decimal("0"),
+                    "conditional_total_native": Decimal("0"),
+                    "display_total_native_including_declared": Decimal("0"),
+                    "demands": [],
+                    "contention": False,
+                    "krw_equivalent": None,
+                    "krw_equivalent_status": (
+                        "native" if currency == "KRW" else "conversion_unavailable"
+                    ),
+                },
+            )
+            bucket["declared_total_native"] += view.current.amount
+
+        serialized: list[dict[str, Any]] = []
+        for bucket in buckets.values():
+            bucket["display_total_native_including_declared"] = (
+                bucket["broker_confirmed_total_native"]
+                + bucket["declared_total_native"]
+            )
+            bucket["contention"] = (
+                bucket["declared_total_native"] > 0 and len(bucket["demands"]) > 1
+            )
+            for field in (
+                "broker_confirmed_total_native",
+                "declared_total_native",
+                "conditional_total_native",
+                "display_total_native_including_declared",
+            ):
+                bucket[field] = canonical_decimal(bucket[field])
+            serialized.append(bucket)
+        serialized.sort(key=lambda bucket: bucket["currency"])
+        return {
+            "buckets": serialized,
+            "cross_currency_total": None,
+            "cross_currency_total_status": "not_summed_without_executable_fx",
+            "investment_priority_recomputed": False,
+            "generated_at": _aware(now, "now").isoformat(),
+        }
+
+
+__all__ = [
+    "FundingAdvisoryError",
+    "FundingAdvisoryNotFound",
+    "FundingAdvisoryService",
+]

--- a/app/services/funding_advisory/telegram.py
+++ b/app/services/funding_advisory/telegram.py
@@ -1,0 +1,231 @@
+"""Read-only Telegram card formatter and claimed-delivery adapter.
+
+Every button is a URL. There is no callback data, proposal create, approval
+nonce, broker mutation, or money-movement action in this module.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.core.invest_deep_links import (
+    build_funding_advisory_url,
+    build_funding_declaration_url,
+)
+from app.services.funding_advisory.service import FundingAdvisoryService
+
+logger = logging.getLogger(__name__)
+
+CARD_HEADER = (
+    "자금 조달 권고 — 조회/검토 전용 · "
+    "이 카드는 입금·환전·차입·매도를 실행하지 않습니다"
+)
+HANDOFF_LABEL = "경로 설명 · 이 화면에서 주문 안 만듦"
+
+
+@dataclass(frozen=True)
+class FundingAdvisoryCard:
+    text: str
+    inline_keyboard: dict[str, list[list[dict[str, str]]]]
+
+
+def _amount(route: dict[str, Any]) -> str:
+    value = route.get("route_fundable_amount")
+    return str(value) if value is not None else "금액 미상"
+
+
+def render_funding_advisory_card(view: dict[str, Any]) -> FundingAdvisoryCard:
+    target = view["target"]
+    trigger = view["trigger"]
+    need = view["need"]
+    lines = [
+        CARD_HEADER,
+        "",
+        f"대상: {target['market']} · {target['account_mode']} · {target['symbol']}",
+        f"상류 gate 통과: {trigger['gate_name']} {trigger['gate_version']} "
+        f"@ {trigger['gate_evaluated_at']}",
+        f"필요 현금: {need['required_cash']} {target['currency']}",
+        f"broker 주문가능액: {need['target_buying_power']} {target['currency']}",
+        f"이 후보 shortfall: {need['shortfall']} {target['currency']}",
+        f"다른 pending 매수: {need['other_pending_required']} {target['currency']}",
+        f"별도 reserved: {need['reserved_cash']} {target['currency']}",
+        "pending/reserved 포함 운영상 gap: "
+        f"{need['operational_gap_including_other_pending']} {target['currency']}",
+        "",
+        "조달 경로:",
+    ]
+    for route in view["routes"]:
+        comparison = route.get("comparison", "unavailable")
+        lines.append(
+            f"- {route['label']}: {_amount(route)} · {comparison} · "
+            f"ETA {route.get('deadline_status', 'unknown')}"
+        )
+        if route["route_id"] in {"PROFITABLE_TRIM", "LOSS_CUT_ROTATION"}:
+            lines.append(f"  {HANDOFF_LABEL}")
+    combination = view["combination"]
+    lines.extend(
+        [
+            "",
+            "부분 조달: 참고 시나리오이며 자동 선택 아님",
+            f"남은 gap: {combination['remaining_gap']} {target['currency']}",
+            "조달 완료 판정은 target broker buying power 재조회 후",
+            "자동 실행 없음 · 선언 갱신도 실제 이체가 아닙니다",
+        ]
+    )
+    detail_url = build_funding_advisory_url(view["advisory_id"])
+    keyboard_rows: list[list[dict[str, str]]] = []
+    if detail_url is not None:
+        keyboard_rows.append([{"text": "상세 보기 · 읽기 전용", "url": detail_url}])
+    keyboard_rows.append(
+        [
+            {
+                "text": "외부 잔고 선언 갱신 · 돈 이동 아님",
+                "url": build_funding_declaration_url(),
+            }
+        ]
+    )
+    return FundingAdvisoryCard(
+        text="\n".join(lines),
+        inline_keyboard={"inline_keyboard": keyboard_rows},
+    )
+
+
+async def _record_delivery(
+    *,
+    delivery_id: UUID,
+    revision_id: UUID,
+    action: str,
+    state: str,
+    now: datetime,
+    chat_id: str | None,
+    message_id: int | None,
+    failure_code: str | None,
+) -> None:
+    async with AsyncSessionLocal() as session:
+        service = FundingAdvisoryService(session)
+        await service.record_delivery_result(
+            delivery_id=delivery_id,
+            revision_id=revision_id,
+            action=action,  # type: ignore[arg-type]
+            state=state,  # type: ignore[arg-type]
+            now=now,
+            chat_id=chat_id,
+            message_id=message_id,
+            failure_code=failure_code,
+        )
+
+
+def _notifier() -> Any:
+    from app.monitoring.trade_notifier.notifier import get_trade_notifier
+
+    return get_trade_notifier()
+
+
+async def deliver_claimed_advisory(
+    view: dict[str, Any], *, now: datetime, notifier: Any | None = None
+) -> dict[str, Any]:
+    """Send/edit only when an upstream candidate event already claimed a row."""
+
+    delivery = view.get("delivery") or {}
+    action = delivery.get("action")
+    if action not in {"send", "edit"}:
+        return {"status": "not_sent", "reason": delivery.get("reason", "no_claim")}
+
+    delivery_id = UUID(delivery["delivery_id"])
+    revision_id = UUID(view["revision_id"])
+    allowlist = settings.order_proposals_telegram_chat_allowlist
+    if not settings.ORDER_PROPOSALS_TELEGRAM_ENABLED or not allowlist:
+        state = "send_failed" if action == "send" else "edit_failed"
+        failure = (
+            "funding_telegram_disabled"
+            if not settings.ORDER_PROPOSALS_TELEGRAM_ENABLED
+            else "telegram_allowlist_empty"
+        )
+        await _record_delivery(
+            delivery_id=delivery_id,
+            revision_id=revision_id,
+            action=action,
+            state=state,
+            now=now,
+            chat_id=delivery.get("chat_id"),
+            message_id=delivery.get("message_id"),
+            failure_code=failure,
+        )
+        return {"status": state, "failure_code": failure}
+
+    card = render_funding_advisory_card(view)
+    sender = notifier or _notifier()
+    chat_id = delivery.get("chat_id") or allowlist[0]
+    message_id = delivery.get("message_id")
+    try:
+        if action == "edit":
+            if not chat_id or message_id is None:
+                result = None
+                state = "edit_failed"
+                failure = "existing_message_identity_missing"
+            else:
+                result = await sender.edit_message(
+                    str(chat_id),
+                    int(message_id),
+                    card.text,
+                    reply_markup=card.inline_keyboard,
+                )
+                state = "sent" if result.ok else "edit_failed"
+                failure = result.failure_code
+        else:
+            result = await sender.send_approval_message(
+                card.text,
+                card.inline_keyboard,
+                chat_id=str(chat_id),
+                parse_mode=None,
+            )
+            state = "sent" if result.ok else "send_failed"
+            failure = result.failure_code
+            if result.ok:
+                message_id = result.message_id
+        await _record_delivery(
+            delivery_id=delivery_id,
+            revision_id=revision_id,
+            action=action,
+            state=state,
+            now=now,
+            chat_id=str(chat_id) if chat_id else None,
+            message_id=int(message_id) if message_id is not None else None,
+            failure_code=failure,
+        )
+        return {
+            "status": state,
+            "message_id": message_id,
+            "failure_code": failure,
+        }
+    except Exception as exc:  # result may be unknown; never retry automatically
+        logger.exception("funding advisory Telegram delivery outcome unknown")
+        try:
+            await _record_delivery(
+                delivery_id=delivery_id,
+                revision_id=revision_id,
+                action=action,
+                state="delivery_unknown",
+                now=now,
+                chat_id=str(chat_id) if chat_id else None,
+                message_id=int(message_id) if message_id is not None else None,
+                failure_code=type(exc).__name__,
+            )
+        except Exception:
+            logger.exception("funding advisory delivery ledger update failed")
+        return {"status": "delivery_unknown", "failure_code": type(exc).__name__}
+
+
+__all__ = [
+    "CARD_HEADER",
+    "HANDOFF_LABEL",
+    "FundingAdvisoryCard",
+    "deliver_claimed_advisory",
+    "render_funding_advisory_card",
+]

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -16,6 +16,10 @@ from sqlalchemy import TIMESTAMP, Text, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
+from app.models.funding_advisory import (
+    FundingAdvisory,
+    FundingAdvisoryProposalLink,
+)
 from app.models.order_proposals import (
     OrderProposal,
     OrderProposalApprovalBatch,
@@ -46,6 +50,38 @@ class OrderProposalRepository:
 
     async def insert_rung(self, **cols: Any) -> OrderProposalRung:
         row = OrderProposalRung(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def funding_advisory_exists(self, advisory_id: uuid.UUID) -> bool:
+        stmt = select(FundingAdvisory.id).where(
+            FundingAdvisory.advisory_id == advisory_id
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none() is not None
+
+    async def get_funding_advisory_link(
+        self, proposal_id: uuid.UUID
+    ) -> FundingAdvisoryProposalLink | None:
+        stmt = select(FundingAdvisoryProposalLink).where(
+            FundingAdvisoryProposalLink.proposal_id == proposal_id
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def insert_funding_advisory_link(
+        self,
+        *,
+        advisory_id: uuid.UUID,
+        proposal_id: uuid.UUID,
+        linked_at: datetime,
+    ) -> FundingAdvisoryProposalLink:
+        row = FundingAdvisoryProposalLink(
+            advisory_id=advisory_id,
+            proposal_id=proposal_id,
+            source_kind="order_proposal_create",
+            linked_at=linked_at,
+        )
         self._session.add(row)
         await self._session.flush()
         await self._session.refresh(row)

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1001,6 +1001,40 @@ class OrderProposalsService:
         rungs = await self._repo.list_rungs(group.id)
         return group, rungs
 
+    async def link_funding_advisory_provenance(
+        self,
+        *,
+        proposal_id: uuid.UUID,
+        source_funding_advisory_id: uuid.UUID,
+        now: datetime,
+    ) -> None:
+        """Persist provenance without changing classification or order inputs.
+
+        This link is deliberately absent from group ``source_asof`` and the
+        proposal payload hash. Dispatch classification, sizing, eligibility,
+        loss guards, and revalidation therefore receive the same proposal as
+        they would without funding advisory provenance.
+        """
+
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        if not await self._repo.funding_advisory_exists(source_funding_advisory_id):
+            raise OrderProposalError("source funding advisory not found")
+        existing = await self._repo.get_funding_advisory_link(proposal_id)
+        if existing is not None:
+            if existing.advisory_id != source_funding_advisory_id:
+                raise OrderProposalError(
+                    "proposal already has different funding advisory provenance"
+                )
+            return
+        await self._repo.insert_funding_advisory_link(
+            advisory_id=source_funding_advisory_id,
+            proposal_id=proposal_id,
+            linked_at=now,
+        )
+
     async def resolve_proposal_id_prefix(
         self, proposal_prefix: str
     ) -> uuid.UUID | None:

--- a/docs/runbooks/funding-advisory.md
+++ b/docs/runbooks/funding-advisory.md
@@ -8,15 +8,16 @@ snapshot이며 broker 잔고 증거가 아니다. 선언값은 주문가능 금�
 사용하지 않는다. 이 기능 범위에는 기존 available/required/shortfall 산식 변경이
 없다.
 
-현재 PR-1 기반은 `review.external_cash_declarations` DDL과 서비스 내부 read/write
-계약만 제공한다. API router, 페이지, Telegram, candidate producer 연결은 없으므로
-마이그레이션을 적용하지 않은 기존 runtime 동작도 바뀌지 않는다. 마이그레이션
-실행과 배포는 운영자 cutover 대상이며 이 구현 작업에서는 수행하지 않는다.
+PR-1 기반은 `review.external_cash_declarations` DDL과 서비스 내부 read/write 계약만
+제공하며 아무 runtime 호출자가 없다. 따라서 PR-1 자체는 기존 동작을 바꾸지 않는다.
+PR-2가 typed candidate evidence, 조회 API, 페이지와 Telegram delivery claim을 연결한다.
+두 마이그레이션의 실행과 배포는 운영자 cutover 대상이며 구현 작업에서는 수행하지
+않는다.
 
 ## 최초 640,000원 선언
 
-마이그레이션에는 business row가 없다. 초기값은 후속 `/invest/funding` admin 폼이
-연결된 뒤 다음 값으로 한 번 선언한다.
+마이그레이션에는 business row가 없다. 초기값은 `/invest/funding` admin 폼에서 다음
+값으로 한 번 선언한다.
 
 - location: `parking_primary`
 - label: `파킹통장`
@@ -48,3 +49,49 @@ lock과 expected-head compare-and-set을 사용하며, head가 둘 이상이면 
 freshness는 `recorded_at`이 아니라 `as_of + 24h`다. stale/future/ambiguous 값은 이력
 문맥으로만 보이고 조달 가능액은 `금액 미상`이다. 실제 이체나 조달 완료는 target
 broker buying power의 새 관측으로만 확인한다.
+
+## Candidate와 숫자 계약
+
+producer가 넘기는 `PassedNonFundingGateEvidence`는 비-자금 gate 전건 통과와
+broker-authoritative funding snapshot을 함께 묶는다. mock·paper account mode는 이
+계약을 만들 수 없다. `gate_version`은 평가마다 바뀌는 해시가 아니라 gate
+계약/스키마 버전이다. 평가별 무결성 값은 별도 `evidence_hash`다.
+
+후보 shortfall은 해당 후보 한 건의 `required_cash - target_buying_power`다. 기존
+Toss 경로처럼 같은 계좌의 다른 pending limit buy가 존재할 수 있으므로 화면과
+Telegram에는 `other_pending_required`, `reserved_cash`, 그리고 둘을 포함한 운영상
+gap을 별도 행으로 항상 공개한다. 외부 현금 선언은 경로 카드의 운영자 선언 근거일
+뿐이며 counted 금액은 0이다. 기존 `buying_power.py`와 `revalidation.py`의 available,
+required, shortfall 산식은 이 기능 범위에서 바꾸지 않는다.
+
+## 발화와 fail-open
+
+Telegram 발송은 상류 candidate event에서만 delivery ledger의 당일 row를 claim한 뒤
+가능하다. 같은 날 내용이 바뀌면 기존 message edit만 시도한다. 상태가 불명확한 send
+또는 edit은 자동 재시도하지 않는다. 페이지 GET/refresh는 evidence가 유효한 동안
+revision을 다시 계산할 수 있지만 delivery claim이나 Telegram send를 호출하지 않는다.
+
+advisory `evaluate()`는 proposal create 전에 호출되지만 완전한 fail-open 경계 안에
+있다. validation, DB, Telegram 등 어떤 예외도 구조화된 unavailable 상태로 기록하고
+기존 proposal create를 계속한다. proposal commit 뒤 provenance link가 실패해도 이미
+성공한 create 결과는 바뀌지 않는다.
+
+## 경로 비교와 기존 승인 분류
+
+모든 단일 경로는 금액, 비용, 시간, 실현 영향, 가역성의 다축 지배 규칙으로 비교한다.
+부분 조달 조합도 그 비교 결과에서 만든 참고 시나리오일 뿐 `selected=false`이며 자동
+선택되지 않는다. 저비용만으로 느리고 비가역적인 경로를 1순위로 만들지 않는다.
+
+`source_funding_advisory_id`는 별도 append-only link의 provenance 전용 값이다. proposal
+payload, source_asof, payload hash, dispatch classifier, sizing, eligibility에는 들어가지
+않는다. 수익 종목 축소가 별도 create 확인으로 ordinary limit sell이 되면 기존 dispatch
+분류와 승인/veto를 그대로 받는다. 손실 종목 교체는 기존 `loss_cut_intent` 거절과
+2-click nonce를 그대로 유지한다. create 확인은 곧 기존 승인/veto 경로 진입이며
+funding 예외 태그는 없다.
+
+Telegram과 `/invest/funding`의 두 매도 경로는 다음 고정 문구를 쓴다.
+
+`경로 설명 · 이 화면에서 주문 안 만듦`
+
+카드 버튼은 읽기 전용 URL뿐이며 callback이나 proposal create 동작이 없다. 외부현금
+폼의 submit은 append-only 선언만 만들며 돈을 이동시키지 않는다.

--- a/frontend/invest/src/__tests__/FundingAdvisoryDetail.test.tsx
+++ b/frontend/invest/src/__tests__/FundingAdvisoryDetail.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FundingAdvisoryDetail } from "../pages/FundingRoute";
+import type { FundingAdvisoryView, FundingRouteView } from "../types/fundingAdvisory";
+
+function route(routeId: FundingRouteView["route_id"], label: string): FundingRouteView {
+  return {
+    route_id: routeId,
+    label,
+    amount_status: "conditional",
+    route_fundable_amount: null,
+    counted_fundable_amount: "0",
+    confidence: "conditional",
+    source_as_of: null,
+    deadline_status: "unknown",
+    explicit_cost: null,
+    eta_minutes: null,
+    realized_impact: null,
+    reversibility: "irreversible",
+    eligibility: "comparison_unavailable",
+    reason_codes: ["review_required"],
+    comparison: "unavailable",
+  };
+}
+
+const ADVISORY: FundingAdvisoryView = {
+  status: "triggered",
+  advisory_id: "a67f8983-95ec-4d3f-aeb2-2b13f3ec6a0b",
+  thread_key: "candidate:funding-contract-v1",
+  state: "active",
+  revision_id: "c0141bcb-90ec-437f-b516-ea039e0ee4c0",
+  revision_no: 1,
+  fingerprint: "fingerprint",
+  trigger: {
+    source_kind: "reservation_candidate",
+    source_candidate_id: "candidate-1",
+    gate_name: "candidate-gate",
+    gate_version: "funding-contract-v1",
+    gate_version_kind: "contract_schema_version",
+    gate_verdict: "passed",
+    gate_evaluated_at: "2026-08-15T00:00:00Z",
+    valid_until: "2026-08-15T01:00:00Z",
+    upstream_priority: "operator-ranked",
+  },
+  target: {
+    market: "crypto",
+    account_mode: "upbit",
+    broker_account_id: "account-1",
+    currency: "KRW",
+    symbol: "BTC",
+    side: "buy",
+  },
+  need: {
+    required_cash: "1000000",
+    target_buying_power: "200000",
+    shortfall: "800000",
+    funding_needed: "800000",
+    other_pending_required: "150000",
+    reserved_cash: "50000",
+    operational_gap_including_other_pending: "1000000",
+    shortfall_scope: "this_candidate_only",
+  },
+  routes: [
+    route("PROFITABLE_TRIM", "수익 종목 축소 경로"),
+    route("LOSS_CUT_ROTATION", "손실 종목 교체 경로"),
+  ],
+  combination: {
+    selected: false,
+    scenario_kind: "reference_only",
+    selection_basis: "operator_decision_required_multi_axis",
+    legs: [],
+    remaining_gap: "800000",
+  },
+  safety: {
+    advisory_only: true,
+    executes_money_movement: false,
+    creates_proposal: false,
+    authoritative_for_order_gate: false,
+  },
+  proposal_handoff: {
+    source_funding_advisory_id: "a67f8983-95ec-4d3f-aeb2-2b13f3ec6a0b",
+    provenance_only: true,
+    classifier_input: false,
+    sizing_input: false,
+    eligibility_input: false,
+    action_label: "경로 설명 · 이 화면에서 주문 안 만듦",
+    ordinary_trim: "별도 create 확인 뒤 기존 dispatch 분류와 승인/veto 경로 적용",
+    loss_cut: "기존 loss_cut_intent 거절 규칙과 2-click nonce 유지",
+  },
+  evaluated_at: "2026-08-15T00:00:00Z",
+  expires_at: "2026-08-15T01:00:00Z",
+  delivery: { action: "none" },
+};
+
+describe("FundingAdvisoryDetail safety presentation", () => {
+  it("discloses candidate shortfall, other pending demand, reserved cash, and operational gap separately", () => {
+    render(<FundingAdvisoryDetail advisory={ADVISORY} />);
+
+    expect(screen.getByText("이 후보 shortfall")).toBeInTheDocument();
+    expect(screen.getByText("다른 pending limit buy")).toBeInTheDocument();
+    expect(screen.getByText("별도 reserved")).toBeInTheDocument();
+    expect(screen.getByText("pending/reserved 포함 운영상 gap")).toBeInTheDocument();
+  });
+
+  it("uses the fixed non-CTA label for both sell paths and offers no order button", () => {
+    render(<FundingAdvisoryDetail advisory={ADVISORY} />);
+
+    expect(screen.getAllByText("경로 설명 · 이 화면에서 주문 안 만듦")).toHaveLength(3);
+    expect(screen.queryByText("매도 제안 검토")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("states that the combination is a reference and preserves inherited approval rules", () => {
+    render(<FundingAdvisoryDetail advisory={ADVISORY} />);
+
+    expect(screen.getByText("selected: false")).toBeInTheDocument();
+    expect(screen.getByText(/기존 dispatch 분류와 승인\/veto 경로 적용/)).toBeInTheDocument();
+    expect(screen.getByText(/loss_cut_intent 거절 규칙과 2-click nonce 유지/)).toBeInTheDocument();
+    expect(screen.getByText(/분류·사이징·eligibility 입력 아님/)).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/fundingAdvisory.api.test.ts
+++ b/frontend/invest/src/__tests__/fundingAdvisory.api.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { declareExternalCash, readCsrfCookie } from "../api/fundingAdvisory";
+import type { ExternalCashForm } from "../types/fundingAdvisory";
+
+const FORM: ExternalCashForm = {
+  owner_user_id: 7,
+  location_key: "parking_primary",
+  display_label: "파킹통장",
+  currency: "KRW",
+  amount: "640000",
+  as_of: null,
+  source_note: "토스증권 → 파킹통장 이동",
+  expected_head_declaration_id: null,
+  idempotency_key: "funding-ui:test-key",
+  requires_exact_operator_confirmed_time: true,
+  creates_money_movement: false,
+};
+
+afterEach(() => {
+  document.cookie = "csrftoken=; Max-Age=0; path=/";
+  vi.restoreAllMocks();
+});
+
+describe("funding advisory declaration API", () => {
+  it("reads the CSRF cookie without exposing another cookie", () => {
+    expect(readCsrfCookie("session=secret; csrftoken=signed%3Atoken; theme=dark")).toBe("signed:token");
+  });
+
+  it("submits only an explicit timezone-aware declaration with CSRF protection", async () => {
+    document.cookie = "csrftoken=signed-token; path=/";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ declaration_id: "new-row" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await declareExternalCash(FORM, {
+      amount: "640000",
+      asOf: "2026-08-15T08:20:00+09:00",
+      sourceNote: "토스증권 → 파킹통장 이동",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(init).toMatchObject({
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrftoken": "signed-token",
+      },
+    });
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      amount: "640000",
+      as_of: "2026-08-15T08:20:00+09:00",
+      expected_head_declaration_id: null,
+      idempotency_key: "funding-ui:test-key",
+    });
+  });
+});

--- a/frontend/invest/src/__tests__/routes.test.tsx
+++ b/frontend/invest/src/__tests__/routes.test.tsx
@@ -34,3 +34,9 @@ test("router exposes B0 evidence and B1 loss-cut approval routes", () => {
   expect(paths).toContain("/approvals/loss-cut/evidence/:symbol");
   expect(paths).toContain("/approvals/loss-cut/:proposalId");
 });
+
+test("router exposes funding advisory list and detail entry points", () => {
+  const paths = pathsOf((router as any).routes);
+  expect(paths).toContain("/funding");
+  expect(paths).toContain("/funding/:advisoryId");
+});

--- a/frontend/invest/src/api/fundingAdvisory.ts
+++ b/frontend/invest/src/api/fundingAdvisory.ts
@@ -1,0 +1,87 @@
+import type {
+  ExternalCashCurrentView,
+  ExternalCashDeclaration,
+  ExternalCashForm,
+  ExternalCashHistoryView,
+  FundingAdvisoryListResponse,
+  FundingAdvisoryView,
+  FundingAllocationView,
+} from "../types/fundingAdvisory";
+
+const BASE = "/invest/api/funding";
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(url, { credentials: "include", signal });
+  if (!response.ok) throw new Error(`${url} ${response.status}`);
+  return response.json();
+}
+
+export function fetchFundingAdvisories(signal?: AbortSignal): Promise<FundingAdvisoryListResponse> {
+  return getJson(`${BASE}/advisories?state=active`, signal);
+}
+
+export function fetchFundingAdvisory(
+  advisoryId: string,
+  signal?: AbortSignal,
+): Promise<FundingAdvisoryView> {
+  return getJson(`${BASE}/advisories/${encodeURIComponent(advisoryId)}?refresh=true`, signal);
+}
+
+export function fetchFundingAllocation(signal?: AbortSignal): Promise<FundingAllocationView> {
+  return getJson(`${BASE}/allocation`, signal);
+}
+
+export function fetchExternalCashCurrent(signal?: AbortSignal): Promise<ExternalCashCurrentView> {
+  return getJson(`${BASE}/external-cash/current`, signal);
+}
+
+export function fetchExternalCashHistory(signal?: AbortSignal): Promise<ExternalCashHistoryView> {
+  return getJson(`${BASE}/external-cash/history`, signal);
+}
+
+export async function fetchExternalCashForm(signal?: AbortSignal): Promise<ExternalCashForm | null> {
+  const response = await fetch(`${BASE}/external-cash/form`, {
+    credentials: "include",
+    signal,
+  });
+  if (response.status === 403) return null;
+  if (!response.ok) throw new Error(`${BASE}/external-cash/form ${response.status}`);
+  return response.json();
+}
+
+export function readCsrfCookie(cookie = document.cookie): string | null {
+  const token = cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("csrftoken="));
+  return token ? decodeURIComponent(token.slice("csrftoken=".length)) : null;
+}
+
+export async function declareExternalCash(
+  form: ExternalCashForm,
+  values: { amount: string; asOf: string; sourceNote: string },
+): Promise<ExternalCashDeclaration> {
+  const csrfToken = readCsrfCookie();
+  if (!csrfToken) throw new Error("CSRF token is unavailable; reload the form before submitting");
+  const response = await fetch(`${BASE}/external-cash/declarations`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "x-csrftoken": csrfToken,
+    },
+    body: JSON.stringify({
+      owner_user_id: form.owner_user_id,
+      location_key: form.location_key,
+      display_label: form.display_label,
+      currency: form.currency,
+      amount: values.amount,
+      as_of: values.asOf,
+      source_note: values.sourceNote,
+      expected_head_declaration_id: form.expected_head_declaration_id,
+      idempotency_key: form.idempotency_key,
+    }),
+  });
+  if (!response.ok) throw new Error(`${BASE}/external-cash/declarations ${response.status}`);
+  return response.json();
+}

--- a/frontend/invest/src/pages/FundingRoute.tsx
+++ b/frontend/invest/src/pages/FundingRoute.tsx
@@ -1,0 +1,398 @@
+import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  declareExternalCash,
+  fetchExternalCashCurrent,
+  fetchExternalCashForm,
+  fetchExternalCashHistory,
+  fetchFundingAdvisories,
+  fetchFundingAdvisory,
+  fetchFundingAllocation,
+} from "../api/fundingAdvisory";
+import { PageSafetyNote } from "../components/PageSafetyNote";
+import { DesktopShell } from "../desktop/DesktopShell";
+import { Button, Card, Pill } from "../ds";
+import { useViewport } from "../hooks/useViewport";
+import { MobileShell } from "../mobile/MobileShell";
+import type {
+  ExternalCashCurrentView,
+  ExternalCashForm,
+  ExternalCashHistoryView,
+  FundingAdvisoryView,
+  FundingAllocationView,
+  FundingRouteView,
+} from "../types/fundingAdvisory";
+import "../styles/funding.css";
+
+const NON_CTA_LABEL = "경로 설명 · 이 화면에서 주문 안 만듦";
+const SELL_ROUTE_IDS = new Set(["PROFITABLE_TRIM", "LOSS_CUT_ROTATION"]);
+
+interface FundingPageData {
+  advisories: FundingAdvisoryView[];
+  detail: FundingAdvisoryView | null;
+  allocation: FundingAllocationView;
+  external: ExternalCashCurrentView;
+  history: ExternalCashHistoryView;
+  declarationForm: ExternalCashForm | null;
+}
+
+function formatAmount(value: string | null, currency: string): string {
+  if (value === null) return "금액 미상";
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return `${value} ${currency}`;
+  return `${new Intl.NumberFormat(currency === "KRW" ? "ko-KR" : "en-US", {
+    maximumFractionDigits: currency === "KRW" ? 0 : 2,
+  }).format(parsed)} ${currency}`;
+}
+
+function formatTime(value: string): string {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.valueOf()) ? value : parsed.toLocaleString("ko-KR");
+}
+
+function SafetyBoundary({ position }: { position: "top" | "bottom" }) {
+  return (
+    <PageSafetyNote
+      routeId={`funding-${position}`}
+      heading="조회·검토 전용 자금 조달 권고"
+      tag="자동 실행 없음"
+      dismissible={false}
+      items={[
+        "이 화면은 입금·환전·차입·매도·주문을 실행하거나 proposal을 만들지 않습니다.",
+        "외부 현금 선언은 broker 잔고 증거가 아니며 주문가능액·사이징·cap·승인 판단에 쓰이지 않습니다.",
+        "페이지 조회는 revision을 재계산할 수 있지만 Telegram 발송 조건이 아닙니다.",
+      ]}
+    />
+  );
+}
+
+function Metric({ label, value, emphasis = false }: { label: string; value: ReactNode; emphasis?: boolean }) {
+  return (
+    <div className={`funding-metric${emphasis ? " funding-metric--emphasis" : ""}`}>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function RouteCard({ route, currency }: { route: FundingRouteView; currency: string }) {
+  const isSellPath = SELL_ROUTE_IDS.has(route.route_id);
+  return (
+    <article className="funding-route" data-testid={`funding-route-${route.route_id}`}>
+      <div className="funding-route__head">
+        <div>
+          <h3>{route.label}</h3>
+          <p>{formatAmount(route.route_fundable_amount, currency)}</p>
+        </div>
+        <Pill tone={route.comparison === "dominated" ? "warn" : "paper"} size="sm">
+          {route.comparison}
+        </Pill>
+      </div>
+      <dl className="funding-route__axes">
+        <Metric label="금액 상태" value={route.amount_status} />
+        <Metric label="근거 신뢰" value={route.confidence} />
+        <Metric label="기한" value={route.deadline_status} />
+        <Metric label="예상 시간" value={route.eta_minutes === null ? "미상" : `${route.eta_minutes}분`} />
+        <Metric label="가역성" value={route.reversibility} />
+        <Metric label="적격성" value={route.eligibility} />
+      </dl>
+      {isSellPath ? (
+        <div className="funding-non-cta" data-testid="funding-non-cta">
+          <strong>{NON_CTA_LABEL}</strong>
+          <span>별도의 create 확인 뒤 기존 승인·veto 경로로만 진입합니다.</span>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export function FundingAdvisoryDetail({ advisory }: { advisory: FundingAdvisoryView }) {
+  const { target, need, trigger } = advisory;
+  return (
+    <div className="funding-detail" data-testid="funding-advisory-detail">
+      <Card>
+        <div className="funding-card-head">
+          <div>
+            <div className="funding-eyebrow">후보 1건의 broker-authoritative 관측</div>
+            <h2>{target.symbol}</h2>
+            <p>{target.market} · {target.account_mode} · {target.currency}</p>
+          </div>
+          <Pill tone="warn">shortfall</Pill>
+        </div>
+        <dl className="funding-metrics">
+          <Metric label="필요 현금" value={formatAmount(need.required_cash, target.currency)} />
+          <Metric label="target broker 주문가능액" value={formatAmount(need.target_buying_power, target.currency)} />
+          <Metric label="이 후보 shortfall" value={formatAmount(need.shortfall, target.currency)} emphasis />
+          <Metric label="다른 pending limit buy" value={formatAmount(need.other_pending_required, target.currency)} />
+          <Metric label="별도 reserved" value={formatAmount(need.reserved_cash, target.currency)} />
+          <Metric
+            label="pending/reserved 포함 운영상 gap"
+            value={formatAmount(need.operational_gap_including_other_pending, target.currency)}
+            emphasis
+          />
+        </dl>
+        <p className="funding-disclosure">
+          shortfall은 이 후보 1건의 required cash − target buying power입니다. 다른 대기 매수와 reserved는
+          숨기지 않고 별도 행 및 운영상 gap에 표시합니다.
+        </p>
+      </Card>
+
+      <Card>
+        <div className="funding-section-head">
+          <div>
+            <h2>조달 경로 비교</h2>
+            <p>단일 점수가 아니라 금액·비용·시간·실현 영향·가역성 축으로 비교합니다.</p>
+          </div>
+        </div>
+        <div className="funding-route-grid">
+          {advisory.routes.map((route) => <RouteCard key={route.route_id} route={route} currency={target.currency} />)}
+        </div>
+      </Card>
+
+      <Card soft>
+        <div className="funding-section-head">
+          <div>
+            <h2>부분 조달 참고 시나리오</h2>
+            <p>같은 다축 비교 결과를 공개하는 참고안이며 selected가 아닙니다.</p>
+          </div>
+          <Pill tone="paper">selected: false</Pill>
+        </div>
+        {advisory.combination.legs.length ? (
+          <ol className="funding-combination">
+            {advisory.combination.legs.map((leg) => (
+              <li key={`${leg.route_id}:${leg.cumulative_planned_amount}`}>
+                <span>{leg.route_id}</span>
+                <strong>{formatAmount(leg.planned_amount, target.currency)}</strong>
+                <small>남은 gap {formatAmount(leg.remaining_gap, target.currency)}</small>
+              </li>
+            ))}
+          </ol>
+        ) : <p className="funding-muted">비교 가능한 조합이 없습니다.</p>}
+      </Card>
+
+      <Card>
+        <div className="funding-section-head">
+          <div>
+            <h2>상류 gate와 기존 승인 경로</h2>
+            <p>gate version은 평가별 해시가 아닌 계약·스키마 버전입니다.</p>
+          </div>
+        </div>
+        <dl className="funding-metrics funding-metrics--compact">
+          <Metric label="gate" value={`${trigger.gate_name} · ${trigger.gate_version}`} />
+          <Metric label="gate 통과 시각" value={formatTime(trigger.gate_evaluated_at)} />
+          <Metric label="유효 종료" value={formatTime(trigger.valid_until)} />
+          <Metric label="provenance" value="분류·사이징·eligibility 입력 아님" />
+        </dl>
+        <div className="funding-handoff">
+          <strong>{advisory.proposal_handoff.action_label}</strong>
+          <p>{advisory.proposal_handoff.ordinary_trim}</p>
+          <p>{advisory.proposal_handoff.loss_cut}</p>
+          <p>create 확인은 곧 기존 승인·veto 경로 진입입니다. funding 예외 태그는 없습니다.</p>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function AdvisoryList({ advisories }: { advisories: FundingAdvisoryView[] }) {
+  return (
+    <section className="funding-section">
+      <div className="funding-section-head">
+        <div><h2>활성 shortfall 권고</h2><p>상류 비-자금 gate를 모두 통과한 후보만 표시합니다.</p></div>
+        <Pill tone="paper">{advisories.length}건</Pill>
+      </div>
+      {advisories.length === 0 ? <Card soft><p className="funding-muted">현재 활성 권고가 없습니다.</p></Card> : (
+        <div className="funding-advisory-list">
+          {advisories.map((advisory) => (
+            <Card key={advisory.advisory_id}>
+              <div className="funding-card-head">
+                <div>
+                  <div className="funding-eyebrow">{advisory.target.market} · {advisory.target.account_mode}</div>
+                  <h2>{advisory.target.symbol}</h2>
+                  <p>이 후보 shortfall {formatAmount(advisory.need.shortfall, advisory.target.currency)}</p>
+                </div>
+                <Pill tone="warn">active</Pill>
+              </div>
+              <dl className="funding-metrics funding-metrics--compact">
+                <Metric label="다른 pending" value={formatAmount(advisory.need.other_pending_required, advisory.target.currency)} />
+                <Metric label="reserved" value={formatAmount(advisory.need.reserved_cash, advisory.target.currency)} />
+                <Metric label="운영상 gap" value={formatAmount(advisory.need.operational_gap_including_other_pending, advisory.target.currency)} />
+                <Metric label="평가 시각" value={formatTime(advisory.evaluated_at)} />
+              </dl>
+              <Link className="funding-read-link" to={`/funding/${advisory.advisory_id}`}>권고 상세 열기 · 읽기 전용</Link>
+            </Card>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AllocationView({ allocation }: { allocation: FundingAllocationView }) {
+  return (
+    <section className="funding-section">
+      <div className="funding-section-head">
+        <div><h2>시장 간 배분 뷰</h2><p>통화별 원 단위를 유지하며 실행 가능한 FX 없이 KRW+USD를 합산하지 않습니다.</p></div>
+      </div>
+      <div className="funding-buckets">
+        {allocation.buckets.map((bucket) => (
+          <Card key={bucket.currency} soft>
+            <div className="funding-card-head">
+              <h3>{bucket.currency} native bucket</h3>
+              {bucket.contention ? <Pill tone="warn">중복 수요 주의</Pill> : null}
+            </div>
+            <dl className="funding-metrics funding-metrics--compact">
+              <Metric label="broker 확인액" value={formatAmount(bucket.broker_confirmed_total_native, bucket.currency)} />
+              <Metric label="운영자 선언액" value={formatAmount(bucket.declared_total_native, bucket.currency)} />
+              <Metric label="조건부 금액" value={formatAmount(bucket.conditional_total_native, bucket.currency)} />
+              <Metric label="표시 합계" value={formatAmount(bucket.display_total_native_including_declared, bucket.currency)} />
+            </dl>
+            <p className="funding-disclosure">선언액은 표시용이며 자동판단 입력이 아닙니다.</p>
+          </Card>
+        ))}
+        {allocation.buckets.length === 0 ? <Card soft><p className="funding-muted">표시할 통화 bucket이 없습니다.</p></Card> : null}
+      </div>
+    </section>
+  );
+}
+
+function ExternalCashPanel({
+  current,
+  history,
+  form,
+  onSaved,
+}: {
+  current: ExternalCashCurrentView;
+  history: ExternalCashHistoryView;
+  form: ExternalCashForm | null;
+  onSaved: () => Promise<void>;
+}) {
+  const [amount, setAmount] = useState(form?.amount ?? "640000");
+  const [asOf, setAsOf] = useState("");
+  const [sourceNote, setSourceNote] = useState(form?.source_note ?? "토스증권 → 파킹통장 이동");
+  const [submitState, setSubmitState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  useEffect(() => {
+    if (!form) return;
+    setAmount(form.amount);
+    setSourceNote(form.source_note);
+    setAsOf("");
+  }, [form]);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!form || !asOf) return;
+    setSubmitState("saving");
+    try {
+      await declareExternalCash(form, { amount, asOf, sourceNote });
+      setSubmitState("saved");
+      await onSaved();
+    } catch {
+      setSubmitState("error");
+    }
+  }
+
+  return (
+    <section className="funding-section" id="external-cash-declaration">
+      <div className="funding-section-head">
+        <div><h2>외부 현금 선언</h2><p>append-only 운영자 snapshot이며 실제 이체 또는 broker 잔고 확인이 아닙니다.</p></div>
+        <Pill tone={current.status === "fresh" ? "gain" : "warn"}>{current.status}</Pill>
+      </div>
+      <div className="funding-external-grid">
+        <Card>
+          {current.current ? (
+            <dl className="funding-metrics funding-metrics--compact">
+              <Metric label="위치" value={current.current.display_label} />
+              <Metric label="선언액" value={formatAmount(current.current.amount, current.current.currency)} />
+              <Metric label="관측 시각" value={formatTime(current.current.as_of)} />
+              <Metric label="fresh until" value={formatTime(current.current.fresh_until)} />
+            </dl>
+          ) : <p className="funding-muted">현재 선언이 없습니다.</p>}
+          <p className="funding-verification">{current.verification_badge}</p>
+          {history.declarations.length ? (
+            <details className="funding-history">
+              <summary>변경 이력 {history.count}건</summary>
+              <ol>{history.declarations.map((row) => <li key={row.declaration_id}>{formatTime(row.as_of)} · {formatAmount(row.amount, row.currency)}</li>)}</ol>
+            </details>
+          ) : null}
+        </Card>
+
+        {form ? (
+          <Card>
+            <form className="funding-form" onSubmit={submit}>
+              <div className="funding-form__notice">관리자 선언 저장 · 돈 이동 아님</div>
+              <label>금액 ({form.currency})<input value={amount} inputMode="numeric" onChange={(event) => setAmount(event.target.value)} required /></label>
+              <label>정확한 관측 시각 + timezone<input value={asOf} onChange={(event) => setAsOf(event.target.value)} placeholder="2026-08-15T08:20:00+09:00" required /></label>
+              <label>출처 메모<input value={sourceNote} onChange={(event) => setSourceNote(event.target.value)} required /></label>
+              <p className="funding-disclosure">시각은 자동 채우지 않습니다. 실제 관측 시각과 timezone을 확인한 뒤 저장하세요.</p>
+              <Button type="submit" disabled={submitState === "saving"}>{submitState === "saving" ? "저장 중…" : "선언 저장 · 돈 이동 아님"}</Button>
+              {submitState === "saved" ? <p role="status">새 선언을 append했습니다. 실제 이체는 발생하지 않았습니다.</p> : null}
+              {submitState === "error" ? <p role="alert">저장하지 못했습니다. head·시각·권한을 다시 확인하세요.</p> : null}
+            </form>
+          </Card>
+        ) : <Card soft><p className="funding-muted">관리자만 새 선언을 append할 수 있습니다.</p></Card>}
+      </div>
+    </section>
+  );
+}
+
+export function FundingPageContent({ data, onReload }: { data: FundingPageData; onReload: () => Promise<void> }) {
+  return (
+    <div className="funding-page">
+      <SafetyBoundary position="top" />
+      <header className="funding-page__header">
+        <div>
+          <div className="funding-eyebrow">FUNDING ADVISORY</div>
+          <h1>자금 조달 권고</h1>
+          <p>shortfall의 숫자 근거와 조달 경로를 검토합니다. 실행은 이 화면 밖의 기존 승인 경로에서만 가능합니다.</p>
+        </div>
+        {data.detail ? <Link className="funding-read-link" to="/funding">전체 권고로 돌아가기</Link> : null}
+      </header>
+      {data.detail ? <FundingAdvisoryDetail advisory={data.detail} /> : <AdvisoryList advisories={data.advisories} />}
+      <AllocationView allocation={data.allocation} />
+      <ExternalCashPanel current={data.external} history={data.history} form={data.declarationForm} onSaved={onReload} />
+      <SafetyBoundary position="bottom" />
+    </div>
+  );
+}
+
+function FundingPageLoader({ advisoryId }: { advisoryId?: string }) {
+  const [data, setData] = useState<FundingPageData | null>(null);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setError(false);
+    try {
+      const [list, detail, allocation, external, history, declarationForm] = await Promise.all([
+        fetchFundingAdvisories(signal),
+        advisoryId ? fetchFundingAdvisory(advisoryId, signal) : Promise.resolve(null),
+        fetchFundingAllocation(signal),
+        fetchExternalCashCurrent(signal),
+        fetchExternalCashHistory(signal),
+        fetchExternalCashForm(signal),
+      ]);
+      setData({ advisories: list.advisories, detail, allocation, external, history, declarationForm });
+    } catch (caught) {
+      if (!(caught instanceof DOMException && caught.name === "AbortError")) setError(true);
+    }
+  }, [advisoryId]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  if (error) return <div className="funding-load-state" role="alert">권고 데이터를 불러오지 못했습니다.</div>;
+  if (!data) return <div className="funding-load-state" role="status">권고 데이터를 불러오는 중…</div>;
+  return <FundingPageContent data={data} onReload={() => load()} />;
+}
+
+export function FundingRoute() {
+  const { advisoryId } = useParams();
+  const viewport = useViewport();
+  const content = <FundingPageLoader advisoryId={advisoryId} />;
+  return viewport === "mobile" ? (
+    <MobileShell title="자금 조달 권고"><div className="funding-mobile-wrap">{content}</div></MobileShell>
+  ) : <DesktopShell center={content} />;
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -30,6 +30,8 @@
 //                             §57차 item ②. `market` is required alongside
 //                             `broker` (verify-r1 BLOCKER-1) — broker alone
 //                             is ambiguous between two ledger tables.
+// /invest/funding           — Read-only funding advisory list/allocation view.
+// /invest/funding/:advisoryId — One advisory revision and route comparison.
 // ─────────────────────────────────────────────────────────────────────────────
 import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom";
 import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
@@ -56,6 +58,7 @@ import {
   LossCutApprovalRoute,
   LossCutEvidenceRoute,
 } from "./pages/LossCutApprovalRoute";
+import { FundingRoute } from "./pages/FundingRoute";
 
 // Static legacy /app/* redirect that preserves any ?search and #hash
 // from the source URL so market-scoped or anchor-scoped bookmarks
@@ -116,6 +119,8 @@ export const router = createBrowserRouter(
       path: "/approvals/loss-cut/:proposalId",
       element: <LossCutApprovalRoute />,
     },
+    { path: "/funding", element: <FundingRoute /> },
+    { path: "/funding/:advisoryId", element: <FundingRoute /> },
 
     // Legacy /invest/app/* URLs redirect to their canonical /invest/*
     // siblings. The retired legacy components were removed after the

--- a/frontend/invest/src/styles/funding.css
+++ b/frontend/invest/src/styles/funding.css
@@ -1,0 +1,54 @@
+.funding-page { display: grid; gap: 20px; width: 100%; }
+.funding-page__header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; }
+.funding-page__header h1 { margin: 3px 0 6px; font-size: 30px; letter-spacing: -0.045em; }
+.funding-page__header p, .funding-section-head p, .funding-card-head p { margin: 0; color: var(--fg-2); font-size: 13px; line-height: 1.6; }
+.funding-eyebrow { color: var(--accent); font-size: 10px; font-weight: 800; letter-spacing: .12em; }
+.funding-section, .funding-detail { display: grid; gap: 14px; }
+.funding-section-head, .funding-card-head, .funding-route__head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
+.funding-section-head h2, .funding-card-head h2, .funding-card-head h3, .funding-route__head h3 { margin: 0 0 4px; letter-spacing: -.025em; }
+.funding-section-head h2 { font-size: 18px; }
+.funding-card-head h2 { font-size: 23px; }
+.funding-card-head h3, .funding-route__head h3 { font-size: 15px; }
+.funding-advisory-list, .funding-buckets, .funding-external-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.funding-metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1px; margin: 18px 0 0; overflow: hidden; border: 1px solid var(--divider); border-radius: 12px; background: var(--divider); }
+.funding-metrics--compact { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.funding-metric { min-width: 0; padding: 11px 12px; background: var(--surface); }
+[data-soft] .funding-metric { background: var(--surface-2); }
+.funding-metric dt { color: var(--fg-3); font-size: 10px; font-weight: 700; }
+.funding-metric dd { margin: 5px 0 0; color: var(--fg-1); font-size: 13px; font-weight: 700; overflow-wrap: anywhere; }
+.funding-metric--emphasis dd { color: var(--loss); }
+.funding-disclosure, .funding-verification { margin: 12px 0 0; padding: 10px 12px; border-radius: 10px; background: var(--surface-2); color: var(--fg-2); font-size: 11px; line-height: 1.65; }
+.funding-verification { color: var(--warn); font-weight: 700; }
+.funding-route-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin-top: 15px; }
+.funding-route { min-width: 0; padding: 14px; border: 1px solid var(--border); border-radius: 13px; background: var(--surface-2); }
+.funding-route__head p { margin: 0; color: var(--fg-2); font-size: 12px; }
+.funding-route__axes { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; margin: 13px 0 0; }
+.funding-route__axes .funding-metric { padding: 0; background: transparent; }
+.funding-non-cta { display: grid; gap: 3px; margin-top: 12px; padding: 10px; border: 1px dashed var(--warn); border-radius: 9px; color: var(--fg-2); font-size: 11px; }
+.funding-non-cta strong { color: var(--warn); }
+.funding-combination { display: grid; gap: 8px; margin: 14px 0 0; padding-left: 22px; }
+.funding-combination li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 3px 12px; color: var(--fg-2); font-size: 12px; }
+.funding-combination small { grid-column: 1 / -1; color: var(--fg-3); }
+.funding-handoff { margin-top: 14px; padding: 13px; border-left: 3px solid var(--warn); background: var(--warn-soft); color: var(--fg-2); font-size: 12px; line-height: 1.55; }
+.funding-handoff strong { color: var(--warn); }
+.funding-handoff p { margin: 4px 0 0; }
+.funding-read-link { display: inline-flex; align-items: center; width: fit-content; margin-top: 14px; padding: 8px 11px; border: 1px solid var(--border); border-radius: 9px; color: var(--fg-1); font-size: 12px; font-weight: 700; text-decoration: none; }
+.funding-muted { margin: 0; color: var(--fg-3); font-size: 13px; }
+.funding-history { margin-top: 12px; color: var(--fg-2); font-size: 12px; }
+.funding-history ol { display: grid; gap: 5px; margin-bottom: 0; padding-left: 20px; }
+.funding-form { display: grid; gap: 12px; }
+.funding-form__notice { padding: 9px 11px; border: 1px solid var(--accent); border-radius: 9px; color: var(--accent); font-size: 12px; font-weight: 800; }
+.funding-form label { display: grid; gap: 5px; color: var(--fg-2); font-size: 11px; font-weight: 700; }
+.funding-form input { width: 100%; padding: 9px 10px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface-2); color: var(--fg); font: inherit; }
+.funding-form [role="status"] { margin: 0; color: var(--gain); font-size: 12px; }
+.funding-form [role="alert"] { margin: 0; color: var(--loss); font-size: 12px; }
+.funding-load-state { padding: 28px; border: 1px solid var(--border); border-radius: 14px; color: var(--fg-2); background: var(--surface); }
+.funding-mobile-wrap { padding: 14px 16px 24px; }
+
+@media (max-width: 760px) {
+  .funding-page { gap: 16px; }
+  .funding-page__header { display: grid; align-items: start; }
+  .funding-page__header h1 { font-size: 24px; }
+  .funding-advisory-list, .funding-buckets, .funding-external-grid, .funding-route-grid { grid-template-columns: 1fr; }
+  .funding-metrics, .funding-metrics--compact { grid-template-columns: 1fr 1fr; }
+}

--- a/frontend/invest/src/types/fundingAdvisory.ts
+++ b/frontend/invest/src/types/fundingAdvisory.ts
@@ -1,0 +1,172 @@
+export type FundingRouteId =
+  | "EXTERNAL_PARKING_KRW"
+  | "USD_CONVERSION"
+  | "CREDIT_LINE_SHORT_TERM"
+  | "PROFITABLE_TRIM"
+  | "LOSS_CUT_ROTATION";
+
+export interface FundingRouteView {
+  route_id: FundingRouteId;
+  label: string;
+  amount_status: "known" | "unknown" | "conditional";
+  route_fundable_amount: string | null;
+  counted_fundable_amount: string;
+  confidence: "broker_authoritative" | "operator_declared" | "conditional" | "unknown";
+  source_as_of: string | null;
+  deadline_status: "met" | "missed" | "unknown";
+  explicit_cost: string | null;
+  eta_minutes: number | null;
+  realized_impact: string | null;
+  reversibility: "reversible" | "conditional" | "irreversible" | "unknown";
+  eligibility: "eligible" | "locked" | "comparison_unavailable";
+  reason_codes: string[];
+  comparison: "preferred" | "situation_dependent" | "dominated" | "unavailable";
+}
+
+export interface FundingAdvisoryView {
+  status: "triggered";
+  advisory_id: string;
+  thread_key: string;
+  state: "active" | "resolved" | "superseded";
+  revision_id: string;
+  revision_no: number;
+  fingerprint: string;
+  trigger: {
+    source_kind: string;
+    source_candidate_id: string;
+    gate_name: string;
+    gate_version: string;
+    gate_version_kind: "contract_schema_version";
+    gate_verdict: "passed";
+    gate_evaluated_at: string;
+    valid_until: string;
+    upstream_priority: string | null;
+  };
+  target: {
+    market: "crypto" | "equity_kr" | "equity_us";
+    account_mode: "upbit" | "kis_live" | "toss_live";
+    broker_account_id: string;
+    currency: "KRW" | "USD";
+    symbol: string;
+    side: "buy";
+  };
+  need: {
+    required_cash: string;
+    target_buying_power: string;
+    shortfall: string;
+    funding_needed: string;
+    other_pending_required: string;
+    reserved_cash: string;
+    operational_gap_including_other_pending: string;
+    shortfall_scope: "this_candidate_only";
+  };
+  routes: FundingRouteView[];
+  combination: {
+    selected: false;
+    scenario_kind: "reference_only";
+    selection_basis: "operator_decision_required_multi_axis";
+    legs: Array<{
+      route_id: FundingRouteId;
+      planned_amount: string;
+      cumulative_planned_amount: string;
+      remaining_gap: string;
+    }>;
+    remaining_gap: string;
+  };
+  safety: {
+    advisory_only: true;
+    executes_money_movement: false;
+    creates_proposal: false;
+    authoritative_for_order_gate: false;
+  };
+  proposal_handoff: {
+    source_funding_advisory_id: string;
+    provenance_only: true;
+    classifier_input: false;
+    sizing_input: false;
+    eligibility_input: false;
+    action_label: string;
+    ordinary_trim: string;
+    loss_cut: string;
+  };
+  evaluated_at: string;
+  expires_at: string;
+  delivery: Record<string, unknown>;
+  refresh?: Record<string, unknown>;
+}
+
+export interface FundingAdvisoryListResponse {
+  advisories: FundingAdvisoryView[];
+  count: number;
+}
+
+export interface FundingAllocationBucket {
+  currency: string;
+  broker_confirmed_total_native: string;
+  declared_total_native: string;
+  conditional_total_native: string;
+  display_total_native_including_declared: string;
+  demands: Array<{
+    advisory_id: string;
+    market: string;
+    symbol: string;
+    shortfall: string;
+    upstream_priority: string | null;
+  }>;
+  contention: boolean;
+  krw_equivalent: string | null;
+  krw_equivalent_status: "native" | "conversion_unavailable";
+}
+
+export interface FundingAllocationView {
+  buckets: FundingAllocationBucket[];
+  cross_currency_total: null;
+  cross_currency_total_status: "not_summed_without_executable_fx";
+  investment_priority_recomputed: false;
+  generated_at: string;
+}
+
+export interface ExternalCashDeclaration {
+  declaration_id: string;
+  owner_user_id: number;
+  location_key: string;
+  display_label: string;
+  currency: string;
+  amount: string;
+  as_of: string;
+  fresh_until: string;
+  source_note: string;
+  declared_by_user_id: number;
+  origin: "invest_ui";
+  supersedes_declaration_id: string | null;
+  idempotency_key: string;
+  recorded_at: string;
+}
+
+export interface ExternalCashCurrentView {
+  status: "missing" | "fresh" | "stale" | "future" | "ambiguous";
+  amount_status: "known" | "unknown";
+  current: ExternalCashDeclaration | null;
+  route_fundable_amount: string | null;
+  verification_badge: string;
+  warning_code: string | null;
+}
+
+export interface ExternalCashHistoryView {
+  declarations: ExternalCashDeclaration[];
+  count: number;
+}
+
+export interface ExternalCashForm {
+  owner_user_id: number;
+  location_key: string;
+  display_label: string;
+  currency: "KRW";
+  amount: string;
+  as_of: null;
+  source_note: string;
+  expected_head_declaration_id: string | null;
+  idempotency_key: string;
+  requires_exact_operator_confirmed_time: true;
+  creates_money_movement: false;
+}

--- a/tests/core/test_invest_deep_links.py
+++ b/tests/core/test_invest_deep_links.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 
 from app.core.invest_deep_links import (
+    build_funding_advisory_url,
+    build_funding_declaration_url,
     build_loss_cut_approval_url,
     build_order_detail_url,
     build_watches_url,
@@ -81,3 +83,18 @@ def test_build_order_detail_url_missing_market_returns_none():
 @pytest.mark.unit
 def test_build_order_detail_url_missing_ledger_id_returns_none():
     assert build_order_detail_url(broker="kis", market="kr", ledger_id=None) is None
+
+
+@pytest.mark.unit
+def test_build_funding_urls_land_on_read_only_detail_and_exact_form_anchor():
+    detail = build_funding_advisory_url("advisory id")
+    assert detail is not None
+    assert detail.endswith("/invest/funding/advisory%20id")
+    assert build_funding_declaration_url().endswith(
+        "/invest/funding#external-cash-declaration"
+    )
+
+
+@pytest.mark.unit
+def test_build_funding_detail_url_rejects_empty_id():
+    assert build_funding_advisory_url("") is None

--- a/tests/research/test_kr_backfill_build_clients.py
+++ b/tests/research/test_kr_backfill_build_clients.py
@@ -38,6 +38,11 @@ def _minimal_subprocess_env() -> dict[str, str]:
     }
     env.update(
         {
+            # Settings otherwise reads the developer checkout's .env even
+            # though this subprocess deliberately supplies a minimal env.
+            # Point dotenv loading at an empty OS file so "without env" is a
+            # stable test condition on configured workstations too.
+            "ENV_FILE": os.devnull,
             "KIWOOM_MOCK_APP_KEY": "test-kiwoom-key",
             "KIWOOM_MOCK_APP_SECRET": "test-kiwoom-secret",
         }

--- a/tests/services/funding_advisory/test_containment.py
+++ b/tests/services/funding_advisory/test_containment.py
@@ -9,6 +9,7 @@ PROTECTED_ORDER_FILES = (
     ROOT / "app/services/order_proposals/revalidation.py",
     ROOT / "app/services/order_proposals/auto_approve.py",
     ROOT / "app/services/support_reserve_net_consumer.py",
+    ROOT / "app/services/order_proposals/dispatch.py",
 )
 
 
@@ -47,7 +48,58 @@ def test_private_repository_is_only_imported_by_external_cash_service() -> None:
     assert offenders == []
 
 
-def test_funding_foundation_has_no_router_or_runtime_consumer() -> None:
+def test_private_advisory_repository_is_only_imported_by_advisory_service() -> None:
+    offenders: list[Path] = []
+    for path in (ROOT / "app").rglob("*.py"):
+        if path.name == "_repository.py":
+            continue
+        if (
+            "app.services.funding_advisory._repository" in imported_modules(path)
+            and path != ROOT / "app/services/funding_advisory/service.py"
+        ):
+            offenders.append(path)
+    assert offenders == []
+
+
+def test_funding_router_is_registered_without_order_or_broker_imports() -> None:
     main_text = (ROOT / "app/main.py").read_text(encoding="utf-8")
-    assert "invest_funding" not in main_text
-    assert not (ROOT / "app/routers/invest_funding.py").exists()
+    router_path = ROOT / "app/routers/invest_funding.py"
+    assert "app.include_router(invest_funding.router)" in main_text
+    assert router_path.exists()
+    imported = imported_modules(router_path)
+    assert not any(
+        module.startswith("app.services.order_proposals")
+        or module.startswith("app.services.brokers")
+        or module.startswith("app.mcp_server.tooling")
+        for module in imported
+    )
+
+
+def test_funding_package_has_no_proposal_create_or_broker_dependency() -> None:
+    offenders: list[tuple[Path, str]] = []
+    for path in (ROOT / "app/services/funding_advisory").rglob("*.py"):
+        for module in imported_modules(path):
+            if (
+                module.startswith("app.services.order_proposals")
+                or module.startswith("app.services.brokers")
+                or module.startswith("app.mcp_server.tooling")
+            ):
+                offenders.append((path, module))
+    assert offenders == []
+
+    for path in (ROOT / "app/services/funding_advisory").rglob("*.py"):
+        assert "create_proposal(" not in path.read_text(encoding="utf-8"), path
+
+
+def test_provenance_identifier_is_absent_from_decision_classifiers() -> None:
+    for path in PROTECTED_ORDER_FILES:
+        assert "source_funding_advisory_id" not in path.read_text(encoding="utf-8")
+
+
+def test_provenance_table_has_no_classification_or_sizing_columns() -> None:
+    model_text = (ROOT / "app/models/funding_advisory.py").read_text(encoding="utf-8")
+    link_model = model_text.split("class FundingAdvisoryProposalLink", 1)[1]
+    assert "rationale" not in link_model
+    assert "quantity" not in link_model
+    assert "notional" not in link_model
+    assert "eligibility" not in link_model

--- a/tests/services/funding_advisory/test_contracts.py
+++ b/tests/services/funding_advisory/test_contracts.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.services.funding_advisory.contracts import (
+    FundingAssessment,
+    FundingCandidateEvent,
+    FundingRoute,
+    PassedNonFundingGateEvidence,
+)
+from app.services.funding_advisory.ranking import (
+    build_reference_combination,
+    compare_routes,
+    dominates,
+)
+
+NOW = datetime(2026, 8, 15, 0, 0, tzinfo=UTC)
+
+
+def evidence(**overrides) -> PassedNonFundingGateEvidence:
+    payload = {
+        "owner_user_id": 11,
+        "source_kind": "upbit_live_candidate",
+        "source_candidate_id": "candidate-1",
+        "gate_name": "crypto_non_funding_gate",
+        "gate_version": "crypto-gate.v1",
+        "gate_verdict": "passed",
+        "gate_evaluated_at": NOW,
+        "valid_until": NOW + timedelta(hours=1),
+        "market": "crypto",
+        "target_account_mode": "upbit",
+        "broker_account_id": "upbit-primary",
+        "currency": "KRW",
+        "symbol": "KRW-BTC",
+        "side": "buy",
+        "order_type": "limit",
+        "quantity": "0.001",
+        "price_reference": "100000000",
+        "blocking_reasons": [],
+        "non_funding_checks": [
+            {
+                "check_id": "candidate_quality",
+                "check_version": "v3",
+                "verdict": "passed",
+                "evaluated_at": NOW,
+            }
+        ],
+        "upstream_priority": "source-rank-1",
+    }
+    payload.update(overrides)
+    return PassedNonFundingGateEvidence.issue(**payload)
+
+
+def assessment(**overrides) -> FundingAssessment:
+    payload = {
+        "required_cash": Decimal("100000"),
+        "target_buying_power": Decimal("40000"),
+        "other_pending_required": Decimal("20000"),
+        "reserved_cash": Decimal("10000"),
+        "currency": "KRW",
+        "observed_at": NOW,
+        "valid_until": NOW + timedelta(minutes=30),
+        "source": "upbit_accounts_free_krw",
+    }
+    payload.update(overrides)
+    return FundingAssessment(**payload)
+
+
+def route(
+    route_id: str,
+    *,
+    amount: str,
+    cost: str,
+    eta: int,
+    impact: str,
+    reversibility: str,
+) -> FundingRoute:
+    return FundingRoute.model_validate(
+        {
+            "route_id": route_id,
+            "label": route_id,
+            "amount_status": "known",
+            "route_fundable_amount": Decimal(amount),
+            "counted_fundable_amount": Decimal(amount),
+            "confidence": "broker_authoritative",
+            "source_as_of": NOW,
+            "deadline_status": "met",
+            "explicit_cost": Decimal(cost),
+            "eta_minutes": eta,
+            "realized_impact": Decimal(impact),
+            "reversibility": reversibility,
+            "eligibility": "eligible",
+            "reason_codes": [],
+        }
+    )
+
+
+def test_gate_version_is_contract_version_and_hash_is_per_evaluation() -> None:
+    issued = evidence()
+    assert issued.gate_version == "crypto-gate.v1"
+    assert len(issued.evidence_hash) == 64
+
+    with pytest.raises(ValidationError, match="contract/schema version"):
+        evidence(gate_version="a" * 64)
+
+
+def test_evidence_hash_tamper_is_rejected() -> None:
+    issued = evidence()
+    payload = issued.model_dump(mode="json")
+    payload["source_candidate_id"] = "candidate-tampered"
+    with pytest.raises(ValidationError, match="evidence_hash"):
+        PassedNonFundingGateEvidence.model_validate(payload)
+
+
+def test_mock_shadow_and_paper_accounts_are_not_valid_evidence() -> None:
+    with pytest.raises(ValidationError):
+        evidence(target_account_mode="upbit_shadow")
+
+
+def test_assessment_is_bound_to_evidence_currency_and_lifetime() -> None:
+    with pytest.raises(ValidationError, match="currency mismatch"):
+        FundingCandidateEvent(
+            evidence=evidence(), assessment=assessment(currency="USD")
+        )
+    with pytest.raises(ValidationError, match="cannot outlive"):
+        FundingCandidateEvent(
+            evidence=evidence(valid_until=NOW + timedelta(minutes=10)),
+            assessment=assessment(valid_until=NOW + timedelta(minutes=20)),
+        )
+
+
+def test_multi_axis_dominance_has_no_hidden_scalar_score() -> None:
+    dominant = route(
+        "EXTERNAL_PARKING_KRW",
+        amount="70000",
+        cost="10",
+        eta=5,
+        impact="0",
+        reversibility="reversible",
+    )
+    dominated = route(
+        "USD_CONVERSION",
+        amount="60000",
+        cost="20",
+        eta=10,
+        impact="1",
+        reversibility="conditional",
+    )
+    assert dominates(dominant, dominated) is True
+    compared = compare_routes([dominant, dominated])
+    assert compared[0].comparison == "preferred"
+    assert compared[1].comparison == "dominated"
+
+
+def test_cheap_slow_irreversible_route_is_not_auto_selected() -> None:
+    cheap_slow = route(
+        "LOSS_CUT_ROTATION",
+        amount="60000",
+        cost="1",
+        eta=120,
+        impact="5000",
+        reversibility="irreversible",
+    )
+    dear_fast = route(
+        "USD_CONVERSION",
+        amount="60000",
+        cost="100",
+        eta=5,
+        impact="0",
+        reversibility="reversible",
+    )
+    compared = compare_routes([cheap_slow, dear_fast])
+    assert {item.comparison for item in compared} == {"situation_dependent"}
+
+    scenario = build_reference_combination(compared, shortfall=Decimal("60000"))
+    assert scenario["scenario_kind"] == "reference_only"
+    assert scenario["selected"] is False
+    assert scenario["selection_basis"] == "operator_decision_required_multi_axis"

--- a/tests/services/funding_advisory/test_migration.py
+++ b/tests/services/funding_advisory/test_migration.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 MIGRATION = ROOT / "alembic/versions/20260815_external_cash.py"
+ADVISORY_MIGRATION = ROOT / "alembic/versions/20260815_funding_advisory.py"
 
 
 def test_external_cash_migration_is_additive_ddl_without_business_seed() -> None:
@@ -24,3 +25,35 @@ def test_migration_downgrade_does_not_recreate_a_declaration() -> None:
     assert 'op.drop_table("external_cash_declarations", schema="review")' in downgrade
     assert "INSERT INTO" not in downgrade.upper()
     assert "op.bulk_insert" not in downgrade
+
+
+def test_advisory_migration_is_stacked_additive_ddl_without_data() -> None:
+    text = ADVISORY_MIGRATION.read_text(encoding="utf-8")
+    upgrade = text.split("def upgrade()", 1)[1].split("def downgrade()", 1)[0]
+    assert (
+        'down_revision: str | Sequence[str] | None = "20260815_external_cash"' in text
+    )
+    for table in (
+        "funding_advisories",
+        "funding_advisory_revisions",
+        "funding_advisory_deliveries",
+        "funding_advisory_proposal_links",
+    ):
+        assert table in upgrade
+    assert "fk_funding_delivery_revision" in upgrade
+    assert "INSERT INTO" not in upgrade.upper()
+    assert "op.bulk_insert" not in upgrade
+    assert "640000" not in upgrade
+
+
+def test_advisory_evidence_and_provenance_tables_are_append_only() -> None:
+    text = ADVISORY_MIGRATION.read_text(encoding="utf-8")
+    upgrade = text.split("def upgrade()", 1)[1].split("def downgrade()", 1)[0]
+    for table in (
+        "funding_advisory_revisions",
+        "funding_advisory_proposal_links",
+    ):
+        assert f'"{table}",' in upgrade
+    assert 'f"CREATE TRIGGER trg_{table}_append_only "' in upgrade
+    assert 'f"CREATE TRIGGER trg_{table}_truncate_append_only "' in upgrade
+    assert 'f"REVOKE UPDATE, DELETE, TRUNCATE ON review.{table} FROM PUBLIC"' in upgrade

--- a/tests/services/funding_advisory/test_router.py
+++ b/tests/services/funding_advisory/test_router.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.routers import invest_funding
+
+
+@pytest.mark.asyncio
+async def test_page_get_refreshes_view_without_delivery_api(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    class FakeService:
+        def __init__(self, _db):
+            pass
+
+        async def refresh_detail(self, **kwargs):
+            calls.append(("refresh", kwargs))
+            return {"status": "triggered", "delivery": {"action": "none"}}
+
+    monkeypatch.setattr(invest_funding, "FundingAdvisoryService", FakeService)
+    monkeypatch.setattr(
+        invest_funding,
+        "_now",
+        lambda: datetime(2026, 8, 15, 0, 0, tzinfo=UTC),
+    )
+    advisory_id = uuid4()
+
+    result = await invest_funding.get_advisory(
+        advisory_id=advisory_id,
+        user=SimpleNamespace(id=11),
+        db=object(),
+        refresh=True,
+    )
+
+    assert result["delivery"] == {"action": "none"}
+    assert calls == [
+        (
+            "refresh",
+            {
+                "advisory_id": advisory_id,
+                "owner_user_id": 11,
+                "now": datetime(2026, 8, 15, 0, 0, tzinfo=UTC),
+            },
+        )
+    ]
+    source = inspect.getsource(invest_funding.get_advisory)
+    assert "deliver_claimed_advisory" not in source
+    assert "_claim_delivery" not in source
+
+
+def test_router_write_delegates_to_service_and_never_commits_directly() -> None:
+    source = inspect.getsource(invest_funding.declare_external_cash)
+    assert "ExternalCashDeclarationService" in source
+    assert ".declare(" in source
+    assert ".commit(" not in source
+
+
+def test_invest_api_prefix_remains_csrf_protected() -> None:
+    main_source = (invest_funding.__file__ and inspect.getsource(invest_funding)) or ""
+    assert 'prefix="/invest/api/funding"' in main_source
+    app_main = (Path(invest_funding.__file__).parents[1] / "main.py").read_text(
+        encoding="utf-8"
+    )
+    assert 're.compile(r"^/invest/api/")' not in app_main

--- a/tests/services/funding_advisory/test_service.py
+++ b/tests/services/funding_advisory/test_service.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.schemas.funding_advisory import (
+    ExternalCashCurrentView,
+    ExternalCashDeclarationRecord,
+)
+from app.services.funding_advisory.contracts import (
+    FundingAssessment,
+    FundingCandidateEvent,
+    PassedNonFundingGateEvidence,
+)
+from app.services.funding_advisory.service import FundingAdvisoryService
+
+NOW = datetime(2026, 8, 15, 0, 5, tzinfo=UTC)
+
+
+def event(
+    *,
+    required: str = "100000",
+    available: str = "40000",
+    other_pending: str = "20000",
+    reserved: str = "10000",
+) -> FundingCandidateEvent:
+    evidence = PassedNonFundingGateEvidence.issue(
+        owner_user_id=11,
+        source_kind="upbit_live_candidate",
+        source_candidate_id="candidate-1",
+        gate_name="crypto_non_funding_gate",
+        gate_version="crypto-gate.v1",
+        gate_verdict="passed",
+        gate_evaluated_at=NOW - timedelta(minutes=5),
+        valid_until=NOW + timedelta(hours=1),
+        market="crypto",
+        target_account_mode="upbit",
+        broker_account_id="upbit-primary",
+        currency="KRW",
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="limit",
+        quantity="0.001",
+        price_reference="100000000",
+        blocking_reasons=[],
+        non_funding_checks=[
+            {
+                "check_id": "candidate_quality",
+                "check_version": "v3",
+                "verdict": "passed",
+                "evaluated_at": NOW - timedelta(minutes=5),
+            }
+        ],
+    )
+    assessment = FundingAssessment(
+        required_cash=Decimal(required),
+        target_buying_power=Decimal(available),
+        other_pending_required=Decimal(other_pending),
+        reserved_cash=Decimal(reserved),
+        currency="KRW",
+        observed_at=NOW - timedelta(minutes=1),
+        valid_until=NOW + timedelta(minutes=30),
+        source="upbit_accounts_free_krw",
+    )
+    return FundingCandidateEvent(evidence=evidence, assessment=assessment)
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class FakeExternalCash:
+    def __init__(self, rows=None) -> None:
+        self.rows = rows or []
+
+    async def list_current(self, **_kwargs):
+        return list(self.rows)
+
+
+class FakeRepository:
+    def __init__(self) -> None:
+        self.advisory = None
+        self.revisions: list[SimpleNamespace] = []
+        self.delivery = None
+        self.delivery_inserts = 0
+        self.locks: list[str] = []
+
+    async def acquire_lock(self, lock_key: str) -> None:
+        self.locks.append(lock_key)
+
+    async def get_advisory_by_thread(self, _thread_key, **_kwargs):
+        return self.advisory
+
+    async def get_advisory(self, advisory_id: UUID, **_kwargs):
+        if self.advisory and self.advisory.advisory_id == advisory_id:
+            return self.advisory
+        return None
+
+    async def insert_advisory(self, **columns):
+        self.advisory = SimpleNamespace(id=1, **columns)
+        return self.advisory
+
+    async def update_advisory(self, row, **columns) -> None:
+        for key, value in columns.items():
+            setattr(row, key, value)
+
+    async def latest_revision(self, _advisory_id):
+        return self.revisions[-1] if self.revisions else None
+
+    async def get_revision_by_fingerprint(self, **kwargs):
+        return next(
+            (
+                row
+                for row in self.revisions
+                if row.advisory_id == kwargs["advisory_id"]
+                and row.fingerprint == kwargs["fingerprint"]
+            ),
+            None,
+        )
+
+    async def insert_revision(self, **columns):
+        row = SimpleNamespace(id=len(self.revisions) + 1, **columns)
+        self.revisions.append(row)
+        return row
+
+    async def list_advisories(self, **_kwargs):
+        return [self.advisory] if self.advisory else []
+
+    async def get_delivery(self, **_kwargs):
+        return self.delivery
+
+    async def get_delivery_by_id(self, delivery_id, **_kwargs):
+        if self.delivery and self.delivery.delivery_id == delivery_id:
+            return self.delivery
+        return None
+
+    async def insert_delivery(self, **columns):
+        self.delivery_inserts += 1
+        self.delivery = SimpleNamespace(
+            id=1,
+            chat_id=None,
+            message_id=None,
+            failure_code=None,
+            delivered_at=None,
+            **columns,
+        )
+        return self.delivery
+
+    async def update_delivery(self, row, **columns) -> None:
+        for key, value in columns.items():
+            setattr(row, key, value)
+
+
+def external_cash_view() -> ExternalCashCurrentView:
+    record = ExternalCashDeclarationRecord(
+        declaration_id=uuid4(),
+        owner_user_id=11,
+        location_key="parking_primary",
+        display_label="파킹통장",
+        currency="KRW",
+        amount=Decimal("640000"),
+        as_of=NOW - timedelta(hours=1),
+        fresh_until=NOW + timedelta(hours=23),
+        source_note="토스증권 → 파킹통장 이동",
+        declared_by_user_id=7,
+        origin="invest_ui",
+        supersedes_declaration_id=None,
+        idempotency_key="seed-1",
+        recorded_at=NOW - timedelta(hours=1),
+    )
+    return ExternalCashCurrentView(
+        status="fresh",
+        amount_status="known",
+        current=record,
+        route_fundable_amount=record.amount,
+    )
+
+
+def service(*, external_rows=None):
+    session = FakeSession()
+    repository = FakeRepository()
+    instance = FundingAdvisoryService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+        _external_cash_service=FakeExternalCash(external_rows),  # type: ignore[arg-type]
+    )
+    return instance, repository, session
+
+
+@pytest.mark.asyncio
+async def test_shortfall_is_candidate_only_and_other_pending_is_disclosed() -> None:
+    instance, repository, session = service(external_rows=[external_cash_view()])
+
+    result = await instance.evaluate_candidate_event(event(), now=NOW)
+
+    assert result["status"] == "triggered"
+    assert result["need"] == {
+        "required_cash": "100000",
+        "target_buying_power": "40000",
+        "shortfall": "60000",
+        "funding_needed": "60000",
+        "other_pending_required": "20000",
+        "reserved_cash": "10000",
+        "operational_gap_including_other_pending": "90000",
+        "shortfall_scope": "this_candidate_only",
+    }
+    assert result["delivery"]["action"] == "send"
+    assert result["combination"]["selected"] is False
+    assert len(result["routes"]) == 5
+    assert result["routes"][0]["route_fundable_amount"] == "60000"
+    assert result["routes"][0]["counted_fundable_amount"] == "0"
+    assert repository.delivery_inserts == 1
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_declared_cash_never_changes_available_required_or_shortfall() -> None:
+    without_declaration, _repository, _session = service()
+    with_declaration, _repository_with, _session_with = service(
+        external_rows=[external_cash_view()]
+    )
+
+    baseline = await without_declaration.evaluate_candidate_event(event(), now=NOW)
+    declared = await with_declaration.evaluate_candidate_event(event(), now=NOW)
+
+    assert declared["need"] == baseline["need"]
+    assert declared["routes"][0]["route_fundable_amount"] == "60000"
+    assert declared["routes"][0]["counted_fundable_amount"] == "0"
+    assert declared["safety"]["authoritative_for_order_gate"] is False
+
+
+@pytest.mark.asyncio
+async def test_same_event_reuses_revision_and_daily_delivery_claim() -> None:
+    instance, repository, _session = service()
+    first = await instance.evaluate_candidate_event(event(), now=NOW)
+
+    second = await instance.evaluate_candidate_event(
+        event(), now=NOW + timedelta(minutes=1)
+    )
+
+    assert first["revision_id"] == second["revision_id"]
+    assert len(repository.revisions) == 1
+    assert repository.delivery_inserts == 1
+    assert second["delivery"]["action"] == "none"
+    assert second["delivery"]["reason"] == "same_day_delivery_already_claimed"
+
+
+@pytest.mark.asyncio
+async def test_same_day_changed_revision_edits_existing_message_not_new_send() -> None:
+    instance, repository, _session = service()
+    await instance.evaluate_candidate_event(event(), now=NOW)
+    repository.delivery.state = "sent"
+    repository.delivery.chat_id = "chat-1"
+    repository.delivery.message_id = 42
+
+    changed = await instance.evaluate_candidate_event(
+        event(available="30000"), now=NOW + timedelta(minutes=1)
+    )
+
+    assert len(repository.revisions) == 2
+    assert repository.delivery_inserts == 1
+    assert changed["delivery"] == {
+        "action": "edit",
+        "delivery_id": str(repository.delivery.delivery_id),
+        "chat_id": "chat-1",
+        "message_id": 42,
+    }
+
+
+@pytest.mark.asyncio
+async def test_page_refresh_recalculates_revision_without_delivery_claim() -> None:
+    instance, repository, _session = service()
+    created = await instance.evaluate_candidate_event(event(), now=NOW)
+    claims_before = repository.delivery_inserts
+
+    refreshed = await instance.refresh_detail(
+        advisory_id=UUID(created["advisory_id"]),
+        owner_user_id=11,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert refreshed["delivery"] == {
+        "action": "none",
+        "reason": "page_refresh_no_delivery",
+    }
+    assert repository.delivery_inserts == claims_before
+
+
+@pytest.mark.asyncio
+async def test_no_shortfall_resolves_without_route_or_delivery() -> None:
+    instance, repository, _session = service()
+
+    result = await instance.evaluate_candidate_event(
+        event(required="100000", available="110000"), now=NOW
+    )
+
+    assert result["status"] == "not_triggered"
+    assert result["reason"] == "no_candidate_shortfall"
+    assert repository.advisory is None
+    assert repository.delivery_inserts == 0

--- a/tests/services/funding_advisory/test_telegram.py
+++ b/tests/services/funding_advisory/test_telegram.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.funding_advisory.telegram import (
+    CARD_HEADER,
+    HANDOFF_LABEL,
+    deliver_claimed_advisory,
+    render_funding_advisory_card,
+)
+
+
+def advisory_view() -> dict:
+    route_ids = [
+        "EXTERNAL_PARKING_KRW",
+        "USD_CONVERSION",
+        "CREDIT_LINE_SHORT_TERM",
+        "PROFITABLE_TRIM",
+        "LOSS_CUT_ROTATION",
+    ]
+    return {
+        "advisory_id": "26c5cbf1-ab53-4ac8-bdbb-979a13e12f03",
+        "revision_id": "b320f8f4-934f-4d81-bc3c-e8cc25a80a5d",
+        "target": {
+            "market": "crypto",
+            "account_mode": "upbit",
+            "symbol": "KRW-BTC",
+            "currency": "KRW",
+        },
+        "trigger": {
+            "gate_name": "crypto_non_funding_gate",
+            "gate_version": "crypto-gate.v1",
+            "gate_evaluated_at": "2026-08-15T09:00:00+09:00",
+        },
+        "need": {
+            "required_cash": "100000",
+            "target_buying_power": "40000",
+            "shortfall": "60000",
+            "other_pending_required": "20000",
+            "reserved_cash": "10000",
+            "operational_gap_including_other_pending": "90000",
+        },
+        "routes": [
+            {
+                "route_id": route_id,
+                "label": route_id,
+                "route_fundable_amount": "60000"
+                if route_id == "EXTERNAL_PARKING_KRW"
+                else None,
+                "comparison": "unavailable",
+                "deadline_status": "unknown",
+            }
+            for route_id in route_ids
+        ],
+        "combination": {"remaining_gap": "60000", "selected": False},
+    }
+
+
+def test_card_is_explicitly_non_executing_and_discloses_pending_cash() -> None:
+    card = render_funding_advisory_card(advisory_view())
+
+    assert card.text.startswith(CARD_HEADER)
+    assert "이 후보 shortfall: 60000 KRW" in card.text
+    assert "다른 pending 매수: 20000 KRW" in card.text
+    assert "pending/reserved 포함 운영상 gap: 90000 KRW" in card.text
+    assert "자동 실행 없음" in card.text
+    assert "조달 완료 판정은 target broker buying power 재조회 후" in card.text
+
+
+def test_trim_and_loss_rows_use_non_cta_handoff_label() -> None:
+    card = render_funding_advisory_card(advisory_view())
+
+    assert card.text.count(HANDOFF_LABEL) == 2
+    assert "매도 제안 검토" not in card.text
+
+
+def test_card_buttons_are_reference_only_urls_without_callbacks() -> None:
+    card = render_funding_advisory_card(advisory_view())
+    buttons = [
+        button for row in card.inline_keyboard["inline_keyboard"] for button in row
+    ]
+
+    assert {button["text"] for button in buttons} == {
+        "상세 보기 · 읽기 전용",
+        "외부 잔고 선언 갱신 · 돈 이동 아님",
+    }
+    assert all("url" in button for button in buttons)
+    assert all("callback_data" not in button for button in buttons)
+
+
+@pytest.mark.asyncio
+async def test_unclaimed_page_view_never_calls_telegram_notifier() -> None:
+    view = advisory_view()
+    view["delivery"] = {"action": "none", "reason": "page_refresh_no_delivery"}
+    notifier = AsyncMock()
+
+    result = await deliver_claimed_advisory(
+        view,
+        now=datetime(2026, 8, 15, 0, 0, tzinfo=UTC),
+        notifier=notifier,
+    )
+
+    assert result == {"status": "not_sent", "reason": "page_refresh_no_delivery"}
+    notifier.send_approval_message.assert_not_called()
+    notifier.edit_message.assert_not_called()

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -190,11 +190,16 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
                 await connection.execute(
                     text(f"ALTER TABLE review.order_proposals DROP COLUMN {column}")
                 )
-            # The external-cash declaration ledger is later than this
-            # reconstructed boundary. Drop its current-head metadata table so the
-            # additive migration is exercised by the upgrade chain instead of
-            # colliding with create_all.
-            for table in ("external_cash_declarations",):
+            # Funding advisory is later than this reconstructed boundary. Drop
+            # its current-head metadata tables so the additive migrations are
+            # exercised by the upgrade chain instead of colliding with create_all.
+            for table in (
+                "funding_advisory_proposal_links",
+                "funding_advisory_deliveries",
+                "funding_advisory_revisions",
+                "funding_advisories",
+                "external_cash_declarations",
+            ):
                 await connection.execute(text(f"DROP TABLE review.{table}"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -178,11 +178,16 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
                 await connection.execute(
                     text(f"ALTER TABLE review.order_proposals DROP COLUMN {column}")
                 )
-            # The external-cash declaration ledger is later than this
-            # reconstructed boundary. Drop its current-head metadata table so the
-            # additive migration is exercised by the upgrade chain instead of
-            # colliding with create_all.
-            for table in ("external_cash_declarations",):
+            # Funding advisory is later than this reconstructed boundary. Drop
+            # its current-head metadata tables so the additive migrations are
+            # exercised by the upgrade chain instead of colliding with create_all.
+            for table in (
+                "funding_advisory_proposal_links",
+                "funding_advisory_deliveries",
+                "funding_advisory_revisions",
+                "funding_advisories",
+                "external_cash_declarations",
+            ):
                 await connection.execute(text(f"DROP TABLE review.{table}"))
 
         env = {**os.environ, "DATABASE_URL": target_url_text}

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1677,3 +1677,125 @@ async def test_list_expired_defensive_filters_by_market(monkeypatch):
 
     assert result["success"] is True
     assert str(proposal_id) not in {p["proposal_id"] for p in result["proposals"]}
+
+
+@pytest.mark.asyncio
+async def test_funding_evaluation_exception_never_blocks_proposal_create(monkeypatch):
+    from app.services.funding_advisory.contracts import (
+        FundingAssessment,
+        FundingCandidateEvent,
+        PassedNonFundingGateEvidence,
+    )
+
+    observed_at = datetime.now(UTC)
+    evidence = PassedNonFundingGateEvidence.issue(
+        owner_user_id=1,
+        source_kind="upbit_live_candidate",
+        source_candidate_id=f"fail-open-{uuid.uuid4()}",
+        gate_name="crypto_non_funding_gate",
+        gate_version="crypto-gate.v1",
+        gate_verdict="passed",
+        gate_evaluated_at=observed_at,
+        valid_until=observed_at + timedelta(hours=1),
+        market="crypto",
+        target_account_mode="upbit",
+        broker_account_id="upbit-primary",
+        currency="KRW",
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="limit",
+        blocking_reasons=[],
+        non_funding_checks=[
+            {
+                "check_id": "candidate_quality",
+                "check_version": "v1",
+                "verdict": "passed",
+                "evaluated_at": observed_at,
+            }
+        ],
+    )
+    candidate_event = FundingCandidateEvent(
+        evidence=evidence,
+        assessment=FundingAssessment(
+            required_cash=Decimal("100000"),
+            target_buying_power=Decimal("40000"),
+            currency="KRW",
+            observed_at=observed_at,
+            valid_until=observed_at + timedelta(minutes=30),
+            source="upbit_accounts_free_krw",
+        ),
+    )
+    evaluate = AsyncMock(side_effect=RuntimeError("injected evaluator failure"))
+    monkeypatch.setattr(
+        opt.FundingAdvisoryService,
+        "evaluate_candidate_event",
+        evaluate,
+    )
+
+    proposal_id = uuid.uuid4()
+    create_calls = []
+
+    class FakeSession:
+        commits = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def commit(self):
+            self.commits += 1
+
+    class FakeOrderService:
+        def __init__(self, _session):
+            pass
+
+        async def create_proposal(self, **kwargs):
+            create_calls.append(kwargs)
+            return SimpleNamespace(
+                proposal_id=proposal_id,
+                lifecycle_state="proposed",
+                action="place",
+                target_broker_order_id=None,
+                valid_until=observed_at + timedelta(hours=1),
+            )
+
+        async def get_proposal(self, _proposal_id):
+            rung = SimpleNamespace(
+                rung_index=0,
+                side="buy",
+                quantity=Decimal("10"),
+                limit_price=Decimal("70000"),
+                notional=None,
+                state="pending_approval",
+                broker_order_id=None,
+                correlation_id=None,
+            )
+            return SimpleNamespace(source_asof=None), [rung]
+
+    monkeypatch.setattr(opt, "AsyncSessionLocal", FakeSession)
+    monkeypatch.setattr(opt, "OrderProposalsService", FakeOrderService)
+
+    async def complete(committed_result, **_kwargs):
+        return dict(committed_result)
+
+    monkeypatch.setattr(opt, "_complete_committed_proposal_create", complete)
+
+    created = await opt.order_proposal_create(
+        **_create_kwargs(
+            symbol="KRW-BTC",
+            market="crypto",
+            account_mode="upbit",
+            funding_candidate_event=candidate_event.model_dump(mode="json"),
+        )
+    )
+
+    assert created["success"] is True
+    assert created["funding_advisory"] == {
+        "status": "unavailable",
+        "failure_code": "funding_advisory_evaluation_failed",
+    }
+    evaluate.assert_awaited_once()
+    assert len(create_calls) == 1
+    assert create_calls[0]["symbol"] == "KRW-BTC"


### PR DESCRIPTION
## Stack\n\n- Base: #1866 (external-cash foundation, runtime behavior unchanged)\n- This PR: typed shortfall evaluation, read-only cards/allocation/page, and provenance-only handoff\n\n## Safety boundaries\n\n- Declared external cash remains display-only and never enters buying power, required cash, shortfall, sizing, cap, eligibility, or approval inputs.\n- Advisory evaluation is fail-open before proposal creation.\n- Funding advisory creates no proposal and executes no transfer, FX, credit, sell, or order action.\n- Page refresh cannot claim or send Telegram delivery.\n- Existing dispatch classification and loss-cut two-click confirmation remain unchanged.\n- Migration is additive DDL with no business seed row; no deployment or target-database migration was performed.\n\n## Verification\n\n- make test: 19536 passed, 13 skipped, 7 deselected, 35 warnings\n- make lint: Ruff, format check, and ty passed\n- frontend Vitest: 115 files / 651 tests passed\n- frontend production build passed (existing chunk-size warning)\n- required ingress, fail-open, and CTA mutants failed their guards and were reverted\n