### PR TITLE
ROB-1255: preserve approval audit history

### DIFF
--- a/alembic/versions/20260815_rob1255_approval_audit.py
+++ b/alembic/versions/20260815_rob1255_approval_audit.py
@@ -1,0 +1,181 @@
+"""Add append-only approval audit facts without changing approval decisions.
+
+Revision ID: 20260815_rob1255_audit
+Revises: 20260814_lcapprove_b1
+Create Date: 2026-08-15
+
+The new table is additive and intentionally has no backfill. Existing latest-
+dispatch columns and the dispatch-attempt ledger remain unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260815_rob1255_audit"
+down_revision: str = "20260814_lcapprove_b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SCHEMA = "review"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "order_proposal_approval_audit_events",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("proposal_pk", sa.BigInteger(), nullable=False),
+        sa.Column("proposal_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("root_proposal_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "rung_indices",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("event_result", sa.Text()),
+        sa.Column("occurred_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("observed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("timing_source", sa.Text(), nullable=False),
+        sa.Column("actor_kind", sa.Text(), nullable=False),
+        sa.Column("actor_id", sa.Text()),
+        sa.Column("channel", sa.Text(), nullable=False),
+        sa.Column("nonce_digest", sa.Text()),
+        sa.Column(
+            "nonce_consumed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "nonce_invalidated",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("dispatch_attempt_id", postgresql.UUID(as_uuid=True)),
+        sa.Column("card_chat_id", sa.Text()),
+        sa.Column("card_message_id", sa.BigInteger()),
+        sa.Column("card_kind", sa.Text()),
+        sa.Column("predecessor_proposal_id", postgresql.UUID(as_uuid=True)),
+        sa.Column("successor_proposal_id", postgresql.UUID(as_uuid=True)),
+        sa.Column("reason_code", sa.Text()),
+        sa.Column("details", postgresql.JSONB()),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "event_type IN ("
+            "'expired','first_stage_approved','second_stage_clicked',"
+            "'second_stage_dispatched','superseded')",
+            name="order_proposal_approval_audit_events_type",
+        ),
+        sa.CheckConstraint(
+            "timing_source IN ("
+            "'approval_deadline','proposal_deadline','supersede_transaction',"
+            "'telegram_callback_received','telegram_dispatch_started')",
+            name="order_proposal_approval_audit_events_timing_source",
+        ),
+        sa.CheckConstraint(
+            "actor_kind IN ('system','telegram_user','web_user')",
+            name="order_proposal_approval_audit_events_actor_kind",
+        ),
+        sa.CheckConstraint(
+            "channel IN ('system','telegram','web')",
+            name="order_proposal_approval_audit_events_channel",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(rung_indices) = 'array'",
+            name="order_proposal_approval_audit_events_rung_indices",
+        ),
+        sa.ForeignKeyConstraint(
+            ["proposal_pk"],
+            ["review.order_proposals.id"],
+            name="fk_order_proposal_approval_audit_event_proposal",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint(
+            "event_id", name="uq_order_proposal_approval_audit_events_event_id"
+        ),
+        schema=_SCHEMA,
+        comment=(
+            "Append-only forensic facts. This table is never an approval gate or "
+            "authorization source."
+        ),
+    )
+    op.create_index(
+        "ix_order_proposal_approval_audit_events_proposal",
+        "order_proposal_approval_audit_events",
+        ["proposal_pk", "occurred_at"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_order_proposal_approval_audit_events_root",
+        "order_proposal_approval_audit_events",
+        ["root_proposal_id", "occurred_at"],
+        schema=_SCHEMA,
+    )
+    op.execute(
+        """
+        CREATE FUNCTION review.reject_order_proposal_approval_audit_event_mutation()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            RAISE EXCEPTION 'order proposal approval audit events are append-only';
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_order_proposal_approval_audit_events_append_only
+        BEFORE UPDATE OR DELETE ON review.order_proposal_approval_audit_events
+        FOR EACH ROW EXECUTE FUNCTION
+            review.reject_order_proposal_approval_audit_event_mutation()
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_order_proposal_approval_audit_events_truncate_append_only
+        BEFORE TRUNCATE ON review.order_proposal_approval_audit_events
+        FOR EACH STATEMENT EXECUTE FUNCTION
+            review.reject_order_proposal_approval_audit_event_mutation()
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP TRIGGER IF EXISTS "
+        "trg_order_proposal_approval_audit_events_truncate_append_only "
+        "ON review.order_proposal_approval_audit_events"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS "
+        "trg_order_proposal_approval_audit_events_append_only "
+        "ON review.order_proposal_approval_audit_events"
+    )
+    op.drop_index(
+        "ix_order_proposal_approval_audit_events_root",
+        table_name="order_proposal_approval_audit_events",
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "ix_order_proposal_approval_audit_events_proposal",
+        table_name="order_proposal_approval_audit_events",
+        schema=_SCHEMA,
+    )
+    op.drop_table("order_proposal_approval_audit_events", schema=_SCHEMA)
+    op.execute(
+        "DROP FUNCTION IF EXISTS "
+        "review.reject_order_proposal_approval_audit_event_mutation()"
+    )

--- a/app/models/order_proposals.py
+++ b/app/models/order_proposals.py
@@ -29,12 +29,30 @@ from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from app.models.base import Base
+from app.services.order_proposals.approval_record import (
+    APPROVAL_RECORD_ACTOR_KINDS,
+    APPROVAL_RECORD_CHANNELS,
+    APPROVAL_RECORD_EVENT_TYPES,
+    APPROVAL_RECORD_TIMING_SOURCES,
+)
 from app.services.order_proposals.state_machine import GROUP_STATES, RUNG_STATES
 
 _MARKETS = "'equity_kr','equity_us','crypto','forex','index'"
 _ACCOUNT_MODES = "'kis_live','kis_mock','toss_live','upbit','db_simulated'"
 _GROUP_STATES_SQL = ",".join(f"'{s}'" for s in sorted(GROUP_STATES))
 _RUNG_STATES_SQL = ",".join(f"'{s}'" for s in sorted(RUNG_STATES))
+_APPROVAL_RECORD_EVENT_TYPES_SQL = ",".join(
+    f"'{value}'" for value in sorted(APPROVAL_RECORD_EVENT_TYPES)
+)
+_APPROVAL_RECORD_TIMING_SOURCES_SQL = ",".join(
+    f"'{value}'" for value in sorted(APPROVAL_RECORD_TIMING_SOURCES)
+)
+_APPROVAL_RECORD_ACTOR_KINDS_SQL = ",".join(
+    f"'{value}'" for value in sorted(APPROVAL_RECORD_ACTOR_KINDS)
+)
+_APPROVAL_RECORD_CHANNELS_SQL = ",".join(
+    f"'{value}'" for value in sorted(APPROVAL_RECORD_CHANNELS)
+)
 
 
 class OrderProposal(Base):
@@ -410,6 +428,101 @@ class OrderProposalApprovalEvent(Base):
     observed_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False
     )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class OrderProposalApprovalAuditEvent(Base):
+    """Append-only forensic facts; never consulted by approval decisions."""
+
+    __tablename__ = "order_proposal_approval_audit_events"
+    __table_args__ = (
+        UniqueConstraint(
+            "event_id", name="uq_order_proposal_approval_audit_events_event_id"
+        ),
+        CheckConstraint(
+            f"event_type IN ({_APPROVAL_RECORD_EVENT_TYPES_SQL})",
+            name="order_proposal_approval_audit_events_type",
+        ),
+        CheckConstraint(
+            f"timing_source IN ({_APPROVAL_RECORD_TIMING_SOURCES_SQL})",
+            name="order_proposal_approval_audit_events_timing_source",
+        ),
+        CheckConstraint(
+            f"actor_kind IN ({_APPROVAL_RECORD_ACTOR_KINDS_SQL})",
+            name="order_proposal_approval_audit_events_actor_kind",
+        ),
+        CheckConstraint(
+            f"channel IN ({_APPROVAL_RECORD_CHANNELS_SQL})",
+            name="order_proposal_approval_audit_events_channel",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(rung_indices) = 'array'",
+            name="order_proposal_approval_audit_events_rung_indices",
+        ),
+        Index(
+            "ix_order_proposal_approval_audit_events_proposal",
+            "proposal_pk",
+            "occurred_at",
+        ),
+        Index(
+            "ix_order_proposal_approval_audit_events_root",
+            "root_proposal_id",
+            "occurred_at",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    proposal_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposals.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    proposal_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    root_proposal_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    rung_indices: Mapped[list[int]] = mapped_column(
+        JSONB, nullable=False, server_default="[]"
+    )
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    event_result: Mapped[str | None] = mapped_column(Text)
+    occurred_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    observed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    timing_source: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_id: Mapped[str | None] = mapped_column(Text)
+    channel: Mapped[str] = mapped_column(Text, nullable=False)
+    nonce_digest: Mapped[str | None] = mapped_column(Text)
+    nonce_consumed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    nonce_invalidated: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    dispatch_attempt_id: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    card_chat_id: Mapped[str | None] = mapped_column(Text)
+    card_message_id: Mapped[int | None] = mapped_column(BigInteger)
+    card_kind: Mapped[str | None] = mapped_column(Text)
+    predecessor_proposal_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True)
+    )
+    successor_proposal_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True)
+    )
+    reason_code: Mapped[str | None] = mapped_column(Text)
+    details: Mapped[dict | None] = mapped_column(JSONB)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )

--- a/app/services/order_proposals/approval_record.py
+++ b/app/services/order_proposals/approval_record.py
@@ -1,0 +1,53 @@
+"""Typed, decision-free contract for approval audit records (ROB-1255).
+
+This module deliberately has no database, broker, or approval-decision imports.
+The values describe facts that have already occurred; they never authorize an
+approval or change nonce validity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from enum import StrEnum
+
+
+class ApprovalRecordEventType(StrEnum):
+    FIRST_STAGE_APPROVED = "first_stage_approved"
+    SECOND_STAGE_DISPATCHED = "second_stage_dispatched"
+    SECOND_STAGE_CLICKED = "second_stage_clicked"
+    EXPIRED = "expired"
+    SUPERSEDED = "superseded"
+
+
+class ApprovalRecordTimingSource(StrEnum):
+    TELEGRAM_CALLBACK_RECEIVED = "telegram_callback_received"
+    TELEGRAM_DISPATCH_STARTED = "telegram_dispatch_started"
+    APPROVAL_DEADLINE = "approval_deadline"
+    PROPOSAL_DEADLINE = "proposal_deadline"
+    SUPERSEDE_TRANSACTION = "supersede_transaction"
+
+
+APPROVAL_RECORD_EVENT_TYPES = frozenset(item.value for item in ApprovalRecordEventType)
+APPROVAL_RECORD_TIMING_SOURCES = frozenset(
+    item.value for item in ApprovalRecordTimingSource
+)
+APPROVAL_RECORD_ACTOR_KINDS = frozenset({"telegram_user", "web_user", "system"})
+APPROVAL_RECORD_CHANNELS = frozenset({"telegram", "web", "system"})
+
+
+def approval_nonce_digest(nonce: str | None) -> str | None:
+    """Return a one-way nonce fingerprint; raw approval nonces are never audited."""
+    if nonce is None:
+        return None
+    return hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "APPROVAL_RECORD_ACTOR_KINDS",
+    "APPROVAL_RECORD_CHANNELS",
+    "APPROVAL_RECORD_EVENT_TYPES",
+    "APPROVAL_RECORD_TIMING_SOURCES",
+    "ApprovalRecordEventType",
+    "ApprovalRecordTimingSource",
+    "approval_nonce_digest",
+]

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from app.models.order_proposals import (
     OrderProposal,
+    OrderProposalApprovalAuditEvent,
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
     OrderProposalApprovalDispatchAttempt,
@@ -56,6 +57,45 @@ class OrderProposalRepository:
         await self._session.flush()
         await self._session.refresh(row)
         return row
+
+    async def insert_approval_audit_event(
+        self, **cols: Any
+    ) -> OrderProposalApprovalAuditEvent:
+        row = OrderProposalApprovalAuditEvent(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def list_approval_audit_events_by_root(
+        self, root_proposal_id: uuid.UUID
+    ) -> list[OrderProposalApprovalAuditEvent]:
+        stmt = (
+            select(OrderProposalApprovalAuditEvent)
+            .where(OrderProposalApprovalAuditEvent.root_proposal_id == root_proposal_id)
+            .order_by(
+                OrderProposalApprovalAuditEvent.occurred_at,
+                OrderProposalApprovalAuditEvent.id,
+            )
+        )
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def list_approval_dispatch_attempts_by_root(
+        self, root_proposal_id: uuid.UUID
+    ) -> list[OrderProposalApprovalDispatchAttempt]:
+        stmt = (
+            select(OrderProposalApprovalDispatchAttempt)
+            .join(
+                OrderProposal,
+                OrderProposalApprovalDispatchAttempt.proposal_pk == OrderProposal.id,
+            )
+            .where(OrderProposal.root_proposal_id == root_proposal_id)
+            .order_by(
+                OrderProposalApprovalDispatchAttempt.attempted_at,
+                OrderProposalApprovalDispatchAttempt.id,
+            )
+        )
+        return list((await self._session.execute(stmt)).scalars().all())
 
     async def insert_approval_event(self, **cols: Any) -> OrderProposalApprovalEvent:
         row = OrderProposalApprovalEvent(**cols)

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.timezone import KST
 from app.models.order_proposals import (
     OrderProposal,
+    OrderProposalApprovalAuditEvent,
     OrderProposalApprovalBatch,
     OrderProposalApprovalBatchMember,
     OrderProposalApprovalDispatchAttempt,
@@ -32,6 +33,13 @@ from app.models.order_proposals import (
 )
 from app.models.review import TossLiveOrderLedger
 from app.services.order_proposals import state_machine as sm
+from app.services.order_proposals.approval_record import (
+    APPROVAL_RECORD_ACTOR_KINDS,
+    APPROVAL_RECORD_CHANNELS,
+    ApprovalRecordEventType,
+    ApprovalRecordTimingSource,
+    approval_nonce_digest,
+)
 from app.services.order_proposals.approval_window_contract import valid_until_block
 from app.services.order_proposals.auto_approve_audit import (
     append_auto_approve_rejection_attempt,
@@ -911,6 +919,32 @@ class OrderProposalsService:
                 superseded_by_proposal_id=proposal_id,
                 approval_nonce_used_at=now,
             )
+            await self.append_approval_audit_event_best_effort(
+                group=superseded_group,
+                rung_indices=[rung.rung_index for rung in superseded_rungs],
+                event_type=ApprovalRecordEventType.SUPERSEDED,
+                event_result="preserved_not_inherited",
+                occurred_at=now,
+                observed_at=now,
+                timing_source=ApprovalRecordTimingSource.SUPERSEDE_TRANSACTION,
+                actor_kind="system",
+                actor_id=None,
+                channel="system",
+                nonce=superseded_group.approval_nonce,
+                nonce_consumed=False,
+                nonce_invalidated=superseded_group.approval_nonce is not None,
+                dispatch_attempt_id=superseded_group.approval_dispatch_attempt_id,
+                card_chat_id=str(
+                    (superseded_group.source_asof or {}).get("approval_chat_id") or ""
+                )
+                or None,
+                card_message_id=(superseded_group.source_asof or {}).get(
+                    "approval_message_id"
+                ),
+                card_kind=superseded_group.approval_dispatch_card_kind,
+                successor_proposal_id=proposal_id,
+                reason_code="proposal_superseded",
+            )
         return group
 
     async def _validate_exit_binding(
@@ -1098,6 +1132,36 @@ class OrderProposalsService:
             return "approved"
         return "proposed"
 
+    async def _append_proposal_expiry_audit(
+        self,
+        *,
+        group: OrderProposal,
+        rungs: list[OrderProposalRung],
+        nonce: str | None,
+        observed_at: datetime,
+    ) -> None:
+        source_asof = group.source_asof or {}
+        await self.append_approval_audit_event_best_effort(
+            group=group,
+            rung_indices=[rung.rung_index for rung in rungs],
+            event_type=ApprovalRecordEventType.EXPIRED,
+            event_result="expired",
+            occurred_at=group.valid_until or observed_at,
+            observed_at=observed_at,
+            timing_source=ApprovalRecordTimingSource.PROPOSAL_DEADLINE,
+            actor_kind="system",
+            actor_id=None,
+            channel="system",
+            nonce=nonce,
+            nonce_consumed=False,
+            nonce_invalidated=nonce is not None,
+            dispatch_attempt_id=group.approval_dispatch_attempt_id,
+            card_chat_id=str(source_asof.get("approval_chat_id") or "") or None,
+            card_message_id=source_asof.get("approval_message_id"),
+            card_kind=group.approval_dispatch_card_kind,
+            reason_code="proposal_valid_until_expired",
+        )
+
     async def expire_if_needed(self, proposal_id: uuid.UUID, *, now: datetime) -> bool:
         self._require_timezone_aware(now)
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
@@ -1116,6 +1180,7 @@ class OrderProposalsService:
                 f"in state {invalid_rung.state!r}"
             )
 
+        expired_nonce = group.approval_nonce
         expired_rungs = []
         for rung in rungs:
             sm.assert_rung_transition(rung.state, "expired")
@@ -1126,6 +1191,12 @@ class OrderProposalsService:
             group,
             lifecycle_state=self._recompute_group_state(expired_rungs),
             approval_nonce=None,
+        )
+        await self._append_proposal_expiry_audit(
+            group=group,
+            rungs=expired_rungs,
+            nonce=expired_nonce,
+            observed_at=now,
         )
         return True
 
@@ -1155,6 +1226,7 @@ class OrderProposalsService:
                 f"cannot expire proposal rung {rung_index} in state {rung.state!r}"
             )
         sm.assert_rung_transition(rung.state, "expired")
+        expired_nonce = group.approval_nonce
         expired = await self._repo.update_rung(
             rung,
             state="expired",
@@ -1179,6 +1251,12 @@ class OrderProposalsService:
             group,
             lifecycle_state=self._recompute_group_state(materialized),
             **({"approval_nonce": None} if all_local_terminal else {}),
+        )
+        await self._append_proposal_expiry_audit(
+            group=group,
+            rungs=[expired],
+            nonce=expired_nonce,
+            observed_at=now,
         )
         return True
 
@@ -2346,6 +2424,112 @@ class OrderProposalsService:
         if not nonce:
             raise OrderProposalError("approval_nonce_missing")
         return self._current_callback_envelope(group, action=action, nonce=nonce)
+
+    async def append_approval_audit_event_best_effort(
+        self,
+        *,
+        group: OrderProposal,
+        rung_indices: list[int],
+        event_type: ApprovalRecordEventType | str,
+        event_result: str | None,
+        occurred_at: datetime,
+        observed_at: datetime | None,
+        timing_source: ApprovalRecordTimingSource | str,
+        actor_kind: str,
+        actor_id: str | None,
+        channel: str,
+        nonce: str | None,
+        nonce_consumed: bool,
+        nonce_invalidated: bool = False,
+        dispatch_attempt_id: uuid.UUID | None = None,
+        card_chat_id: str | None = None,
+        card_message_id: int | None = None,
+        card_kind: str | None = None,
+        predecessor_proposal_id: uuid.UUID | None = None,
+        successor_proposal_id: uuid.UUID | None = None,
+        reason_code: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> OrderProposalApprovalAuditEvent | None:
+        """Append a forensic fact inside a savepoint and never block approval.
+
+        The event has no decision role. A failed INSERT rolls back only its
+        savepoint, logs identifiers (never a raw nonce), and returns ``None``;
+        the caller's approval/nonce transaction remains usable.
+        """
+        event_type_value = "unavailable"
+        try:
+            event_type_value = str(event_type)
+            timing_source_value = str(timing_source)
+            observed = observed_at or datetime.now(UTC)
+            self._require_timezone_aware(occurred_at)
+            self._require_timezone_aware(observed)
+            if actor_kind not in APPROVAL_RECORD_ACTOR_KINDS:
+                raise ValueError("invalid approval audit actor_kind")
+            if channel not in APPROVAL_RECORD_CHANNELS:
+                raise ValueError("invalid approval audit channel")
+            normalized_actor_id = (actor_id or "").strip() or None
+            if actor_kind != "system" and normalized_actor_id is None:
+                raise ValueError("approval audit user actor_id is required")
+            normalized_rungs = sorted({int(index) for index in rung_indices})
+            async with self._session.begin_nested():
+                return await self._repo.insert_approval_audit_event(
+                    event_id=uuid.uuid4(),
+                    proposal_pk=group.id,
+                    proposal_id=group.proposal_id,
+                    root_proposal_id=group.root_proposal_id,
+                    rung_indices=normalized_rungs,
+                    event_type=event_type_value,
+                    event_result=event_result,
+                    occurred_at=occurred_at,
+                    observed_at=observed,
+                    timing_source=timing_source_value,
+                    actor_kind=actor_kind,
+                    actor_id=normalized_actor_id,
+                    channel=channel,
+                    nonce_digest=approval_nonce_digest(nonce),
+                    nonce_consumed=bool(nonce_consumed),
+                    nonce_invalidated=bool(nonce_invalidated),
+                    dispatch_attempt_id=dispatch_attempt_id,
+                    card_chat_id=card_chat_id,
+                    card_message_id=card_message_id,
+                    card_kind=card_kind,
+                    predecessor_proposal_id=predecessor_proposal_id,
+                    successor_proposal_id=successor_proposal_id,
+                    reason_code=reason_code,
+                    details=details,
+                )
+        except Exception as exc:  # noqa: BLE001 - audit must remain fail-open
+            logger.error(
+                "order_proposals.approval_audit_record_failed",
+                extra={
+                    "proposal_id": str(group.proposal_id),
+                    "approval_event_type": event_type_value,
+                    "exception_type": type(exc).__name__,
+                },
+            )
+            return None
+
+    async def list_approval_audit_events(
+        self, proposal_id: uuid.UUID
+    ) -> list[OrderProposalApprovalAuditEvent]:
+        """Return ordered facts for the proposal's full supersession lineage."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        return await self._repo.list_approval_audit_events_by_root(
+            group.root_proposal_id
+        )
+
+    async def list_approval_dispatch_history(
+        self, proposal_id: uuid.UUID
+    ) -> list[OrderProposalApprovalDispatchAttempt]:
+        """Return ordered dispatch attempts without replacing legacy latest fields."""
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        return await self._repo.list_approval_dispatch_attempts_by_root(
+            group.root_proposal_id
+        )
 
     async def append_approval_event(self, **cols: Any) -> OrderProposalApprovalEvent:
         return await self._repo.insert_approval_event(**cols)
@@ -3584,6 +3768,7 @@ class OrderProposalsService:
                 )
                 continue
 
+            expired_nonce = group.approval_nonce
             expired_rungs = []
             for rung in rungs:
                 sm.assert_rung_transition(rung.state, "expired")
@@ -3594,6 +3779,12 @@ class OrderProposalsService:
                 group,
                 lifecycle_state=self._recompute_group_state(expired_rungs),
                 approval_nonce=None,
+            )
+            await self._append_proposal_expiry_audit(
+                group=group,
+                rungs=expired_rungs,
+                nonce=expired_nonce,
+                observed_at=now,
             )
             source_asof = group.source_asof or {}
             results.append(

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -47,7 +47,7 @@ import logging
 import secrets
 import uuid
 from collections.abc import Callable, Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -63,6 +63,10 @@ from app.services.order_proposals.approval_message import (
     build_buying_power_shortfall_text,
     build_loss_cut_confirmation_message,
     parse_callback_data,
+)
+from app.services.order_proposals.approval_record import (
+    ApprovalRecordEventType,
+    ApprovalRecordTimingSource,
 )
 from app.services.order_proposals.approval_window import (
     ApprovalWindowCode,
@@ -323,6 +327,34 @@ async def _safe_edit_message(
             failure_code="telegram_transport_error",
             error_classification=TelegramErrorClassification.TRANSPORT_ERROR,
         )
+
+
+async def _append_approval_audit_best_effort(service: Any, **event: Any) -> Any | None:
+    """Keep audit failures outside every approval decision/result branch."""
+    try:
+        return await service.append_approval_audit_event_best_effort(**event)
+    except Exception as exc:  # noqa: BLE001 - caller behavior must be unchanged
+        logger.error(
+            "order_proposals.approval_audit_boundary_failed",
+            extra={
+                "proposal_id": str(event["group"].proposal_id),
+                "approval_event_type": str(event["event_type"]),
+                "exception_type": type(exc).__name__,
+            },
+        )
+        return None
+
+
+def _loss_cut_confirmation_expiry(group: Any, *, fallback: datetime) -> datetime:
+    """Read the bound deadline for audit timing without changing validation."""
+    envelope = (group.source_asof or {}).get("loss_cut_confirmation")
+    if not isinstance(envelope, dict):
+        return fallback
+    try:
+        expires_at = datetime.fromisoformat(str(envelope["expires_at"]))
+    except (KeyError, TypeError, ValueError):
+        return fallback
+    return expires_at if expires_at.tzinfo is not None else fallback
 
 
 async def _alert_non_sent_callback_dispatch(
@@ -690,7 +722,7 @@ async def _handle_approve(
     # Lock the broker target before taking any proposal row lock. Independently
     # created proposals may point at the same manual/session order, so the
     # proposal-scoped commit lease alone cannot prevent a double mutation.
-    target_group, _ = await service.get_proposal(proposal_id)
+    target_group, target_rungs = await service.get_proposal(proposal_id)
     await service.acquire_target_mutation_lock(target_group)
 
     window = await _evaluate_bound_window(
@@ -745,10 +777,58 @@ async def _handle_approve(
                 now=approval_now,
             )
     except OrderProposalError as exc:
+        if loss_cut_confirmation and str(exc) == "loss_cut_confirmation_expired":
+            await _append_approval_audit_best_effort(
+                service,
+                group=target_group,
+                rung_indices=[rung.rung_index for rung in target_rungs],
+                event_type=ApprovalRecordEventType.EXPIRED,
+                event_result="expired",
+                occurred_at=_loss_cut_confirmation_expiry(
+                    target_group, fallback=approval_now
+                ),
+                observed_at=approval_now,
+                timing_source=ApprovalRecordTimingSource.APPROVAL_DEADLINE,
+                actor_kind="system",
+                actor_id=None,
+                channel="telegram",
+                nonce=callback.nonce,
+                nonce_consumed=False,
+                nonce_invalidated=True,
+                dispatch_attempt_id=callback.attempt_id,
+                card_chat_id=str(chat_id) if chat_id is not None else None,
+                card_message_id=message_id,
+                card_kind=target_group.approval_dispatch_card_kind,
+                reason_code="loss_cut_confirmation_expired",
+                details={"observed_by_actor_id": telegram_user_id},
+            )
         # See `_handle_deny`'s matching comment: no mutation happened above,
         # but commit anyway to release the row lock.
         await session.commit()
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+
+    if loss_cut_confirmation:
+        # Telegram supplies no trusted device-click time. ``now`` is handler
+        # receipt; ``approval_now`` is the sample accepted at nonce consumption.
+        await _append_approval_audit_best_effort(
+            service,
+            group=target_group,
+            rung_indices=[rung.rung_index for rung in target_rungs],
+            event_type=ApprovalRecordEventType.SECOND_STAGE_CLICKED,
+            event_result="nonce_consumed",
+            occurred_at=now,
+            observed_at=approval_now,
+            timing_source=ApprovalRecordTimingSource.TELEGRAM_CALLBACK_RECEIVED,
+            actor_kind="telegram_user",
+            actor_id=telegram_user_id,
+            channel="telegram",
+            nonce=callback.nonce,
+            nonce_consumed=True,
+            dispatch_attempt_id=callback.attempt_id,
+            card_chat_id=str(chat_id) if chat_id is not None else None,
+            card_message_id=message_id,
+            card_kind=target_group.approval_dispatch_card_kind,
+        )
 
     acquired = await service.acquire_commit_lease(proposal_id, now=approval_now)
     if not acquired:
@@ -1539,6 +1619,27 @@ async def _handle_loss_cut_first_click(
         now=post_preview_now,
     )
     group, rungs = await service.get_proposal(proposal_id)
+    # Append only after successful nonce consumption. The supplied timestamps
+    # mean handler receipt and the accepted nonce-boundary sample, respectively.
+    await _append_approval_audit_best_effort(
+        service,
+        group=group,
+        rung_indices=[rung.rung_index for rung in rungs],
+        event_type=ApprovalRecordEventType.FIRST_STAGE_APPROVED,
+        event_result="accepted",
+        occurred_at=now,
+        observed_at=post_preview_now,
+        timing_source=ApprovalRecordTimingSource.TELEGRAM_CALLBACK_RECEIVED,
+        actor_kind="telegram_user",
+        actor_id=telegram_user_id,
+        channel="telegram",
+        nonce=callback.nonce,
+        nonce_consumed=True,
+        dispatch_attempt_id=callback.attempt_id,
+        card_chat_id=str(chat_id) if chat_id is not None else None,
+        card_message_id=message_id,
+        card_kind=ApprovalCardKind.MANUAL.value,
+    )
     dispatch_attempt_id = uuid.uuid4()
     binding = build_proposal_dispatch_binding(
         proposal_id=group.proposal_id,
@@ -1630,6 +1731,29 @@ async def _handle_loss_cut_first_click(
         chat_id=str(chat_id),
         now=publish_window.observed_at,
         approval_window_policy_stamp=publish_window.policy_stamp,
+    )
+    # The pre-publication approval-window sample identifies dispatch start;
+    # this fresh sample records when the publication result became observable.
+    dispatch_completed_at = datetime.now(UTC)
+    await _append_approval_audit_best_effort(
+        service,
+        group=group,
+        rung_indices=[rung.rung_index for rung in rungs],
+        event_type=ApprovalRecordEventType.SECOND_STAGE_DISPATCHED,
+        event_result=dispatch_result.state.value,
+        occurred_at=publish_window.observed_at,
+        observed_at=dispatch_completed_at,
+        timing_source=ApprovalRecordTimingSource.TELEGRAM_DISPATCH_STARTED,
+        actor_kind="system",
+        actor_id=None,
+        channel="telegram",
+        nonce=confirmation_nonce,
+        nonce_consumed=False,
+        dispatch_attempt_id=dispatch_attempt_id,
+        card_chat_id=str(chat_id) if chat_id is not None else None,
+        card_message_id=dispatch_result.message_id or message_id,
+        card_kind=ApprovalCardKind.LOSS_CUT_CONFIRMATION.value,
+        reason_code=dispatch_result.failure_code,
     )
     await session.commit()
     operator_alert = None

--- a/docs/runbooks/order-proposal-approval-records.md
+++ b/docs/runbooks/order-proposal-approval-records.md
@@ -1,0 +1,106 @@
+# Order proposal approval records (ROB-1255)
+
+This runbook defines the persistence contract that an approval-history reader
+(including a later apphub design) may rely on. It does not add a UI field,
+change an approval rule, or authorize broker execution.
+
+## Storage surfaces
+
+`review.order_proposal_approval_audit_events` is the append-only forensic
+ledger. Application code can only insert through
+`OrderProposalsService.append_approval_audit_event_best_effort`; the database
+rejects `UPDATE`, `DELETE`, and `TRUNCATE`. The repository exposes no mutation
+method for existing rows.
+
+`review.order_proposal_approval_dispatch_attempts` remains the normalized
+dispatch-history collection. Every card publication receives a distinct
+`attempt_id`. `OrderProposalsService.list_approval_dispatch_history` returns all
+attempts in `(attempted_at, id)` order across the proposal's root lineage. An
+attempt itself moves from `pending` to its final publication state, but a later
+attempt never replaces or deletes the earlier row.
+
+The existing `order_proposals.approval_dispatch_*` columns remain the compatible
+latest-value projection. They intentionally still point at the newest attempt.
+Readers that need history use the ordered attempt collection; existing readers
+can continue using the single-value columns unchanged.
+
+## Audit fields
+
+| Field | Meaning |
+| --- | --- |
+| `event_id` | Unique identity for one immutable fact. |
+| `event_type` | `first_stage_approved`, `second_stage_dispatched`, `second_stage_clicked`, `expired`, or `superseded`. A click fact is not an approval decision. |
+| `event_result` | Observed result, such as `accepted`, `sent_current`, or `expired`; it is evidence, never an authorization input. |
+| `proposal_id` / `root_proposal_id` | The card that produced the fact and its stable supersession lineage. Querying the root preserves facts from older cards. |
+| `rung_indices` | Exact rung indexes covered by the card-level fact. An empty array means no rung was available to bind. |
+| `actor_kind` / `actor_id` | Telegram/web user identity for click facts. System events have `actor_id = NULL`; this does not assert that anyone approved. |
+| `channel` | Channel on which the fact occurred: `telegram`, `web`, or `system`. |
+| `nonce_digest` | SHA-256 fingerprint used only to correlate events. A raw nonce is never stored in this table. |
+| `nonce_consumed` | Whether this event itself successfully consumed the single-use nonce. Dispatch, expiry, and supersede events are `false`. |
+| `nonce_invalidated` | Whether expiry or supersede made an otherwise present nonce unusable without calling that action an approval. |
+| `dispatch_attempt_id` | Link to the exact dispatch-history row when a card binding exists. |
+| `card_chat_id` / `card_message_id` / `card_kind` | Best available physical card identity. Telegram stage two may edit the same message ID while using a new dispatch attempt. |
+| `predecessor_proposal_id` / `successor_proposal_id` | Explicit lineage edge for preserved supersession facts. No approval state is inherited. |
+| `reason_code` / `details` | Typed context for a failure, lazy expiry observation, or lineage event. |
+| `occurred_at` | Time defined by `timing_source`, below. |
+| `observed_at` | Time the server finished observing enough evidence to append the fact. |
+| `created_at` | Database insert time; it is not presented as click time. |
+
+## Timing semantics
+
+The code never labels database commit time as a human click time.
+
+- `telegram_callback_received`: `occurred_at` is the server timestamp supplied
+  when webhook handling began. Telegram callback payloads contain no trusted
+  user-device click timestamp. `observed_at` is the later in-handler sample
+  supplied to the nonce-consumption check; the row is appended only after that
+  consumption succeeds. A `second_stage_clicked` fact is appended at this nonce
+  boundary, before later lease or submission outcomes, and therefore does not
+  claim that the proposal was approved.
+- `telegram_dispatch_started`: `occurred_at` is the approval-window sample that
+  authorized the durable dispatch attempt before channel publication. The event
+  is appended only after the publication result returns; that actual completion
+  observation is `observed_at`, and `event_result` records the result.
+- `approval_deadline`: `occurred_at` is the bound 90-second confirmation
+  deadline. Because no scheduler is added here, `observed_at` is when a later
+  callback first proves that the deadline passed.
+- `proposal_deadline`: `occurred_at` is `valid_until`; `observed_at` is the
+  callback or expiry sweep that materialized the expiry.
+- `supersede_transaction`: both timestamps identify the transaction that linked
+  the replacement and killed the old nonce.
+
+## Failure and decision boundary
+
+Audit insertion runs in a database savepoint. Any validation or database error
+rolls back only that savepoint, logs the proposal ID, event type, and exception
+class, and returns `None`. Raw nonces and actor secrets are not logged. The
+approval, nonce, rung, broker, and Telegram result paths continue with their
+pre-existing return values.
+
+No approval decision reads the audit table or dispatch-history query. The
+single-use nonce gate, 90-second confirmation rule, principal match, supersede
+invalidation, and approval-window checks remain authoritative in their existing
+code paths.
+
+## Supersession example
+
+If card A records `first_stage_approved` and card B supersedes it, card A keeps
+that immutable event and receives a `superseded` event whose
+`successor_proposal_id` is B. B remains unapproved with no nonce until its own
+dispatch. A reader starting from B queries by `root_proposal_id` and can show
+what happened on A without treating A's approval as B's approval.
+
+For the observed JUP shape, a roughly 5,000-character first card and a
+397-character stage-two edit are two ordered dispatch-attempt rows, even when
+both reference the same Telegram message. The compatible single-value columns
+show the 397-character latest attempt; the history still contains both rows.
+
+## Migration boundary
+
+The Alembic revision is shipped with the code but is not applied to a shared or
+production database by this job. Migration acceptance tests may exercise it
+only in uniquely named temporary databases that are dropped after the test.
+Database rollout remains a separate operator action. Until rollout, audit
+writes fail open and approval behavior remains available; operators should
+monitor `order_proposals.approval_audit_record_failed` and apply the revision
+before relying on completeness of the new history.

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -72,7 +72,9 @@ from sqlalchemy import text
 # persistent local test DB to re-bootstrap once.
 # v36: web loss-cut approval events/scopes are new ORM tables. The production
 # migration is deliberately not run by tests; create_all owns the test copy.
-SCHEMA_BOOTSTRAP_VERSION = 36
+# v37 (ROB-1255): append-only approval audit facts are a new ORM table; mirror
+# the update/delete/truncate trigger because create_all cannot create triggers.
+SCHEMA_BOOTSTRAP_VERSION = 37
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -1192,6 +1194,26 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "BEFORE TRUNCATE ON review.order_proposal_approval_events "
     "FOR EACH STATEMENT EXECUTE FUNCTION "
     "review.reject_order_proposal_approval_event_mutation()",
+    "CREATE OR REPLACE FUNCTION "
+    "review.reject_order_proposal_approval_audit_event_mutation() "
+    "RETURNS trigger AS $$ BEGIN RAISE EXCEPTION "
+    "'order proposal approval audit events are append-only' "
+    "USING ERRCODE = 'restrict_violation'; END; $$ LANGUAGE plpgsql",
+    "DROP TRIGGER IF EXISTS "
+    "trg_order_proposal_approval_audit_events_append_only "
+    "ON review.order_proposal_approval_audit_events",
+    "CREATE TRIGGER trg_order_proposal_approval_audit_events_append_only "
+    "BEFORE UPDATE OR DELETE ON review.order_proposal_approval_audit_events "
+    "FOR EACH ROW EXECUTE FUNCTION "
+    "review.reject_order_proposal_approval_audit_event_mutation()",
+    "DROP TRIGGER IF EXISTS "
+    "trg_order_proposal_approval_audit_events_truncate_append_only "
+    "ON review.order_proposal_approval_audit_events",
+    "CREATE TRIGGER "
+    "trg_order_proposal_approval_audit_events_truncate_append_only "
+    "BEFORE TRUNCATE ON review.order_proposal_approval_audit_events "
+    "FOR EACH STATEMENT EXECUTE FUNCTION "
+    "review.reject_order_proposal_approval_audit_event_mutation()",
     "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
     "WHERE conname = 'order_proposals_approval_dispatch_card_kind' "
     "AND conrelid = 'review.order_proposals'::regclass) THEN "

--- a/tests/services/order_proposals/test_approval_audit.py
+++ b/tests/services/order_proposals/test_approval_audit.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import ast
+import re
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import delete, text, update
+from sqlalchemy.exc import DBAPIError
+
+from app.core.db import AsyncSessionLocal
+from app.models.order_proposals import (
+    OrderProposal,
+    OrderProposalApprovalAuditEvent,
+    OrderProposalApprovalDispatchAttempt,
+)
+from app.services.order_proposals.approval_record import (
+    APPROVAL_RECORD_EVENT_TYPES,
+    ApprovalRecordEventType,
+    ApprovalRecordTimingSource,
+    approval_nonce_digest,
+)
+from app.services.order_proposals.dispatch_contract import (
+    ApprovalCardKind,
+    ApprovalPublication,
+    build_proposal_dispatch_binding,
+)
+from app.services.order_proposals.service import OrderProposalsService, RungInput
+from app.telegram_contract import TelegramMethodResult
+
+_REPO = Path(__file__).resolve().parents[3]
+_MIGRATION = _REPO / "alembic/versions/20260815_rob1255_approval_audit.py"
+
+
+async def _group(db_session, *, now: datetime | None = None):
+    observed = now or datetime.now(UTC)
+    return await OrderProposalsService(db_session).create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="audit-test",
+        rungs=[RungInput(0, "sell", Decimal("1"), Decimal("100"), None)],
+        valid_until=observed + timedelta(hours=3),
+        now=observed,
+    )
+
+
+def _publication(*, message_id: int, payload_chars: int) -> ApprovalPublication:
+    return ApprovalPublication.published(
+        payload_chars=payload_chars,
+        method_result=TelegramMethodResult(
+            ok=True,
+            message_id=message_id,
+            status_code=200,
+            error_code=None,
+            error_classification=None,
+            payload_chars=payload_chars,
+        ),
+    )
+
+
+def _migration_application_dml(source: str) -> list[str]:
+    tree = ast.parse(source)
+    findings: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr == "bulk_insert":
+            findings.append("bulk_insert")
+            continue
+        if node.func.attr != "execute" or not node.args:
+            continue
+        sql = "".join(
+            item.value
+            for item in ast.walk(node.args[0])
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        )
+        if re.match(
+            r"^\s*(insert\s+into|update\s+\w+\s+set|delete\s+from)\b",
+            sql,
+            re.I,
+        ):
+            findings.append(sql)
+    return findings
+
+
+@pytest.mark.unit
+def test_approval_audit_schema_is_additive_typed_and_nonce_safe():
+    event = OrderProposalApprovalAuditEvent.__table__
+    proposal = OrderProposal.__table__
+    attempt = OrderProposalApprovalDispatchAttempt.__table__
+
+    assert event.schema == "review"
+    assert {
+        "event_type",
+        "occurred_at",
+        "observed_at",
+        "timing_source",
+        "actor_id",
+        "nonce_consumed",
+        "proposal_id",
+        "root_proposal_id",
+        "rung_indices",
+        "card_message_id",
+        "dispatch_attempt_id",
+        "successor_proposal_id",
+    } <= set(event.columns.keys())
+    assert set(APPROVAL_RECORD_EVENT_TYPES) == {
+        "first_stage_approved",
+        "second_stage_dispatched",
+        "second_stage_clicked",
+        "expired",
+        "superseded",
+    }
+    assert "approval_nonce" not in event.columns
+    assert approval_nonce_digest("secret-nonce") != "secret-nonce"
+
+    # Legacy last-value compatibility remains present and unchanged in place.
+    assert {
+        "approval_dispatch_state",
+        "approval_dispatch_attempt_id",
+        "approval_dispatch_attempted_at",
+        "approval_dispatch_payload_chars",
+    } <= set(proposal.columns.keys())
+    assert attempt.name == "order_proposal_approval_dispatch_attempts"
+
+
+@pytest.mark.unit
+def test_approval_audit_migration_is_additive_single_head_and_append_only():
+    source = _MIGRATION.read_text(encoding="utf-8")
+    assert _migration_application_dml(source) == []
+    assert "trg_order_proposal_approval_audit_events_append_only" in source
+    assert "trg_order_proposal_approval_audit_events_truncate_append_only" in source
+    assert "BEFORE UPDATE OR DELETE" in source
+    assert "BEFORE TRUNCATE" in source
+
+    config = Config(str(_REPO / "alembic.ini"))
+    config.set_main_option("script_location", str(_REPO / "alembic"))
+    scripts = ScriptDirectory.from_config(config)
+    assert scripts.get_heads() == ["20260815_rob1255_audit"]
+    revision = scripts.get_revision("20260815_rob1255_audit")
+    assert revision is not None
+    assert revision.down_revision == "20260814_lcapprove_b1"
+
+
+@pytest.mark.asyncio
+async def test_approval_audit_events_reject_update_delete_and_truncate(
+    db_session,
+):
+    now = datetime.now(UTC)
+    group = await _group(db_session, now=now)
+    service = OrderProposalsService(db_session)
+    event = await service.append_approval_audit_event_best_effort(
+        group=group,
+        rung_indices=[0],
+        event_type=ApprovalRecordEventType.FIRST_STAGE_APPROVED,
+        event_result="accepted",
+        occurred_at=now,
+        observed_at=now,
+        timing_source=ApprovalRecordTimingSource.TELEGRAM_CALLBACK_RECEIVED,
+        actor_kind="telegram_user",
+        actor_id="777",
+        channel="telegram",
+        nonce="raw-nonce",
+        nonce_consumed=True,
+    )
+    assert event is not None
+    event_id = event.event_id
+    await db_session.commit()
+
+    async with AsyncSessionLocal() as session:
+        with pytest.raises(DBAPIError):
+            await session.execute(
+                update(OrderProposalApprovalAuditEvent)
+                .where(OrderProposalApprovalAuditEvent.event_id == event_id)
+                .values(event_result="changed")
+            )
+        await session.rollback()
+        with pytest.raises(DBAPIError):
+            await session.execute(
+                delete(OrderProposalApprovalAuditEvent).where(
+                    OrderProposalApprovalAuditEvent.event_id == event_id
+                )
+            )
+        await session.rollback()
+        with pytest.raises(DBAPIError):
+            await session.execute(
+                text("TRUNCATE review.order_proposal_approval_audit_events")
+            )
+        await session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_audit_insert_failure_keeps_approval_transaction_usable(
+    db_session, monkeypatch
+):
+    now = datetime.now(UTC)
+    group = await _group(db_session, now=now)
+    service = OrderProposalsService(db_session)
+
+    async def fail_insert(**_cols):
+        raise RuntimeError("injected audit failure")
+
+    monkeypatch.setattr(service._repo, "insert_approval_audit_event", fail_insert)
+    event = await service.append_approval_audit_event_best_effort(
+        group=group,
+        rung_indices=[0],
+        event_type=ApprovalRecordEventType.SECOND_STAGE_CLICKED,
+        event_result="accepted",
+        occurred_at=now,
+        observed_at=now,
+        timing_source=ApprovalRecordTimingSource.TELEGRAM_CALLBACK_RECEIVED,
+        actor_kind="telegram_user",
+        actor_id="777",
+        channel="telegram",
+        nonce="second-nonce",
+        nonce_consumed=True,
+    )
+    assert event is None
+
+    await service.record_approval(group.proposal_id, telegram_user_id="777", now=now)
+    await db_session.commit()
+    refreshed, _rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.approved_by_telegram_user_id == "777"
+    assert refreshed.approved_at == now
+
+
+@pytest.mark.asyncio
+async def test_dispatch_history_preserves_jup_first_card_after_52_minute_second_card(
+    db_session,
+):
+    first_at = datetime(2026, 8, 15, 0, 0, tzinfo=UTC)
+    group = await _group(db_session, now=first_at)
+    service = OrderProposalsService(db_session)
+
+    first_nonce = "first-stage"
+    await service.set_approval_nonce(group.proposal_id, first_nonce)
+    first_id = uuid.uuid4()
+    first_binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=first_nonce,
+        attempt_id=first_id,
+        card_kind=ApprovalCardKind.MANUAL,
+        current_membership_revision=group.approval_dispatch_membership_revision,
+    )
+    await service.start_approval_dispatch(
+        group.proposal_id,
+        attempt_id=first_id,
+        binding=first_binding,
+        now=first_at,
+        payload_chars=5000,
+        context_message_count=0,
+    )
+    await service.finish_approval_dispatch(
+        group.proposal_id,
+        attempt_id=first_id,
+        publication=_publication(message_id=555, payload_chars=5000),
+        chat_id="42",
+        now=first_at,
+    )
+
+    second_at = first_at + timedelta(minutes=52)
+    second_nonce = "second-stage"
+    await service.set_approval_nonce(group.proposal_id, second_nonce)
+    refreshed, _rungs = await service.get_proposal(group.proposal_id)
+    second_id = uuid.uuid4()
+    second_binding = build_proposal_dispatch_binding(
+        proposal_id=group.proposal_id,
+        nonce=second_nonce,
+        attempt_id=second_id,
+        card_kind=ApprovalCardKind.LOSS_CUT_CONFIRMATION,
+        current_membership_revision=refreshed.approval_dispatch_membership_revision,
+    )
+    await service.start_approval_dispatch(
+        group.proposal_id,
+        attempt_id=second_id,
+        binding=second_binding,
+        now=second_at,
+        payload_chars=397,
+        context_message_count=0,
+    )
+    await service.finish_approval_dispatch(
+        group.proposal_id,
+        attempt_id=second_id,
+        publication=_publication(message_id=555, payload_chars=397),
+        chat_id="42",
+        now=second_at,
+    )
+    await db_session.commit()
+
+    history = await service.list_approval_dispatch_history(group.proposal_id)
+    assert [row.attempt_id for row in history] == [first_id, second_id]
+    assert [row.payload_chars for row in history] == [5000, 397]
+    assert [row.attempted_at for row in history] == [first_at, second_at]
+    assert history[1].attempted_at - history[0].attempted_at == timedelta(minutes=52)
+    assert [row.state for row in history] == ["sent_superseded", "sent_current"]
+    assert [row.card_kind for row in history] == [
+        "manual",
+        "loss_cut_confirmation",
+    ]
+    assert history[0].message_id == history[1].message_id == 555
+
+    latest, _ = await service.get_proposal(group.proposal_id)
+    assert latest.approval_dispatch_attempt_id == second_id
+    assert latest.approval_dispatch_payload_chars == 397
+    assert latest.approval_dispatch_card_kind == "loss_cut_confirmation"
+
+
+@pytest.mark.asyncio
+async def test_supersede_keeps_prior_approval_facts_without_inheriting_approval(
+    db_session,
+):
+    now = datetime.now(UTC)
+    old = await _group(db_session, now=now)
+    service = OrderProposalsService(db_session)
+    await service.set_approval_nonce(old.proposal_id, "old-nonce")
+    await service.append_approval_audit_event_best_effort(
+        group=old,
+        rung_indices=[0],
+        event_type=ApprovalRecordEventType.FIRST_STAGE_APPROVED,
+        event_result="accepted",
+        occurred_at=now,
+        observed_at=now,
+        timing_source=ApprovalRecordTimingSource.TELEGRAM_CALLBACK_RECEIVED,
+        actor_kind="telegram_user",
+        actor_id="777",
+        channel="telegram",
+        nonce="old-nonce",
+        nonce_consumed=True,
+    )
+    replacement = await service.create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="audit-test",
+        rungs=[RungInput(0, "sell", Decimal("1"), Decimal("99"), None)],
+        valid_until=now + timedelta(hours=3),
+        supersedes_proposal_id=old.proposal_id,
+        now=now + timedelta(seconds=1),
+    )
+    await db_session.commit()
+
+    old_after, _ = await service.get_proposal(old.proposal_id)
+    replacement_after, _ = await service.get_proposal(replacement.proposal_id)
+    assert old_after.lifecycle_state == "superseded"
+    assert old_after.approval_nonce == "old-nonce"
+    assert old_after.approval_nonce_used_at == now + timedelta(seconds=1)
+    assert replacement_after.approval_nonce is None
+    assert replacement_after.approved_at is None
+
+    lineage = await service.list_approval_audit_events(replacement.proposal_id)
+    assert [row.event_type for row in lineage] == [
+        "first_stage_approved",
+        "superseded",
+    ]
+    assert lineage[0].proposal_id == old.proposal_id
+    assert lineage[1].successor_proposal_id == replacement.proposal_id
+    assert lineage[1].nonce_consumed is False
+    assert lineage[1].nonce_invalidated is True

--- a/tests/services/order_proposals/test_loss_cut_approval_migration.py
+++ b/tests/services/order_proposals/test_loss_cut_approval_migration.py
@@ -91,4 +91,4 @@ def test_loss_cut_approval_migration_is_single_head_and_has_no_row_dml():
     config = Config(str(_REPO / "alembic.ini"))
     config.set_main_option("script_location", str(_REPO / "alembic"))
     scripts = ScriptDirectory.from_config(config)
-    assert scripts.get_heads() == ["20260814_lcapprove_b1"]
+    assert scripts.get_heads() == ["20260815_rob1255_audit"]

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -30,6 +30,7 @@ from app.services.order_proposals.dispatch_contract import (
     DispatchBinding,
     build_proposal_dispatch_binding,
 )
+from app.services.order_proposals.repository import OrderProposalRepository
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
 from app.services.order_proposals.target_order import TargetOrderSnapshot
@@ -1830,6 +1831,71 @@ async def test_loss_cut_requires_second_click_before_submit(monkeypatch, db_sess
     assert audit["second_click"]["telegram_user_id"] == str(USER_ID)
     assert audit["second_click"]["nonce"] == second_nonce
 
+    events = await service.list_approval_audit_events(group.proposal_id)
+    assert [event.event_type for event in events] == [
+        "first_stage_approved",
+        "second_stage_dispatched",
+        "second_stage_clicked",
+    ]
+    assert [event.nonce_consumed for event in events] == [True, False, True]
+    assert events[0].actor_id == events[2].actor_id == str(USER_ID)
+    assert events[0].occurred_at == issued
+    assert events[1].occurred_at == issued
+    assert events[1].event_result == "sent_current"
+    assert events[2].occurred_at == issued + timedelta(seconds=30)
+    assert events[2].event_result == "nonce_consumed"
+    assert events[0].card_message_id == events[1].card_message_id == 555
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_audit_failure_does_not_block_either_click(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_loss_cut_proposal(db_session, monkeypatch)
+    notifier = _FakeNotifier()
+    submit_calls = []
+
+    async def fail_insert(self, **_cols):
+        raise RuntimeError("injected audit write failure")
+
+    async def fake_revalidate(**kwargs):
+        submit_calls.append(kwargs)
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    monkeypatch.setattr(
+        OrderProposalRepository, "insert_approval_audit_event", fail_insert
+    )
+    issued = datetime(2026, 7, 13, 11, 0, tzinfo=UTC)
+    first = await handle_callback_update(
+        _make_update(
+            data=_proposal_callback_data(group, action="op", nonce="loss-cut-first")
+        ),
+        now=issued,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+    callback_data = notifier.edited[-1][3]["inline_keyboard"][0][0]["callback_data"]
+    second = await handle_callback_update(
+        _make_update(data=callback_data, callback_id="cbq-audit-failure-second"),
+        now=issued + timedelta(seconds=30),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+
+    assert first["reason"] == "loss_cut_confirmation_required"
+    assert second["reason"] == "approved"
+    assert len(submit_calls) == 1
+    service = OrderProposalsService(db_session)
+    refreshed, _rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.approved_by_telegram_user_id == str(USER_ID)
+    assert refreshed.approval_nonce_used_at == issued + timedelta(seconds=30)
+    assert await service.list_approval_audit_events(group.proposal_id) == []
+
 
 @pytest.mark.asyncio
 async def test_loss_cut_second_nonce_replay_is_rejected(monkeypatch, db_session):
@@ -1934,6 +2000,18 @@ async def test_loss_cut_second_nonce_expires_after_90_seconds(monkeypatch, db_se
     )
 
     assert expired["reason"] == "loss_cut_confirmation_expired"
+    events = await OrderProposalsService(db_session).list_approval_audit_events(
+        group.proposal_id
+    )
+    assert [event.event_type for event in events] == [
+        "first_stage_approved",
+        "second_stage_dispatched",
+        "expired",
+    ]
+    assert events[-1].occurred_at == issued + timedelta(seconds=90)
+    assert events[-1].observed_at == issued + timedelta(seconds=91)
+    assert events[-1].nonce_consumed is False
+    assert events[-1].nonce_invalidated is True
 
 
 @pytest.mark.asyncio

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -163,6 +163,9 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             # upgrade exercises the migration instead of colliding with
             # objects materialized by Base.metadata.create_all.
             await connection.execute(
+                text("DROP TABLE review.order_proposal_approval_audit_events")
+            )
+            await connection.execute(
                 text("DROP TABLE review.order_proposal_approval_events")
             )
             await connection.execute(

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -151,6 +151,9 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             # upgrade exercises the migration instead of colliding with
             # objects materialized by Base.metadata.create_all.
             await connection.execute(
+                text("DROP TABLE review.order_proposal_approval_audit_events")
+            )
+            await connection.execute(
                 text("DROP TABLE review.order_proposal_approval_events")
             )
             await connection.execute(


### PR DESCRIPTION
## Summary

- add an append-only approval audit ledger for first-stage approval, stage-two dispatch, stage-two click, expiry, and supersession facts
- expose ordered dispatch history across a proposal lineage while preserving the existing latest-value fields
- keep audit writes fail-open with savepoints and document exact timestamp semantics for later approval-history readers

## Verification

- order proposal suite: 776 passed
- MCP and router callers: 63 passed
- temporary PostgreSQL migration round trips: 2 passed
- ROB-501 static guard: 3 passed
- lint: Ruff, format, and ty passed
- full suite: 19643 passed, 13 skipped, 7 deselected, 3 pre-existing KR backfill failures; all failing files are unchanged from origin/main
- mutants: append-only bypass, fail-open removal, and principal-decision inversion were each detected and fully restored

## Safety boundary

No approval decision, nonce lifetime, supersede invalidation, broker execution, scheduler, policy configuration, deployment, merge, or shared/production database migration is changed or performed.