### PR TITLE
fix(ROB-1258): repair paper MCP native deploy coverage

### DIFF
--- a/ops/native/plists/com.robinco.auto-trader.mcp-paper_001.plist
+++ b/ops/native/plists/com.robinco.auto-trader.mcp-paper_001.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.robinco.auto-trader.mcp-paper_001</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/mgh3326/services/auto_trader/scripts/run-mcp-paper_001.sh</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/mgh3326/services/auto_trader/current</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>/Users/mgh3326</string>
+    <key>PATH</key>
+    <string>/Users/mgh3326/.local/bin:/Users/mgh3326/.hermes/node/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>AUTO_TRADER_BASE</key>
+    <string>/Users/mgh3326/services/auto_trader</string>
+    <key>AUTO_TRADER_ENV_FILE</key>
+    <string>/Users/mgh3326/services/auto_trader/shared/.env.prod.native</string>
+    <key>AUTO_TRADER_MCP_PROFILE</key>
+    <string>hermes-paper-kis</string>
+    <key>AUTO_TRADER_MCP_PORT</key>
+    <string>8771</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/mgh3326/services/auto_trader/logs/com.robinco.auto-trader.mcp-paper_001.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/mgh3326/services/auto_trader/logs/com.robinco.auto-trader.mcp-paper_001.err.log</string>
+</dict>
+</plist>

--- a/ops/native/scripts/run-mcp-paper_001.sh
+++ b/ops/native/scripts/run-mcp-paper_001.sh
@@ -16,7 +16,9 @@ source "${AUTO_TRADER_BASE:-$HOME/services/auto_trader}/scripts/common.sh"
 _export_selected_env_prefixes MCP_ KIS_MOCK
 
 export MCP_PROFILE="$PROFILE"
-export MCP_PORT="$PORT"
+# Keep this literal: an installed pre-ROB-1258 plist has no port metadata, so
+# deploy preflight reads the resident wrapper during an interrupted upgrade.
+export MCP_PORT="8771"
 export MCP_HOST="127.0.0.1"
 
 exec uv run python -m app.mcp_server.main

--- a/ops/native/scripts/run-mcp-paper_001.sh
+++ b/ops/native/scripts/run-mcp-paper_001.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Resident hermes-paper-kis MCP launcher (ROB-1258).
+set -euo pipefail
+
+# Defaults preserve compatibility with the pre-ROB-1258 installed plist during
+# the narrow window between syncing this wrapper and installing the new plist.
+PROFILE="${AUTO_TRADER_MCP_PROFILE:-hermes-paper-kis}"
+PORT="${AUTO_TRADER_MCP_PORT:-8771}"
+if [[ "$PROFILE" != "hermes-paper-kis" || "$PORT" != "8771" ]]; then
+  echo "run-mcp-paper_001.sh: profile/port must remain hermes-paper-kis:8771" >&2
+  exit 78
+fi
+
+# shellcheck source=/dev/null
+source "${AUTO_TRADER_BASE:-$HOME/services/auto_trader}/scripts/common.sh"
+_export_selected_env_prefixes MCP_ KIS_MOCK
+
+export MCP_PROFILE="$PROFILE"
+export MCP_PORT="$PORT"
+export MCP_HOST="127.0.0.1"
+
+exec uv run python -m app.mcp_server.main

--- a/scripts/check_native_mcp_profile_registry.py
+++ b/scripts/check_native_mcp_profile_registry.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Fail closed when resident fixed-profile MCP services escape deploy wiring.
+
+The blue/green MCP pair and its watchdog have separate lifecycle contracts.
+Every other native ``com.robinco.auto-trader.mcp-*`` plist is a fixed-profile
+service and must have one source plist, one ``SINGLE_ACTIVE_LABELS`` entry,
+and one matching ``MCP_PROFILE_PORTS`` label:port entry.
+
+The optional installed-plist inventory catches locally added LaunchAgents that
+have not yet been brought under source/deploy ownership.  Only plist metadata,
+wrapper port constants, labels, and ports are read; environment values and
+credentials are never emitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import re
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+LABEL_PREFIX = "com.robinco.auto-trader.mcp-"
+LIFECYCLE_EXEMPT_LABELS = frozenset(
+    {
+        f"{LABEL_PREFIX}blue",
+        f"{LABEL_PREFIX}green",
+        f"{LABEL_PREFIX}watchdog",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ProfileService:
+    label: str
+    port: int
+    plist_path: Path
+
+
+@dataclass(frozen=True)
+class RegistryValidation:
+    source: dict[str, ProfileService]
+    installed: dict[str, ProfileService]
+    mapped_ports: dict[str, int]
+    errors: tuple[str, ...]
+
+
+class InventoryError(ValueError):
+    """A plist inventory cannot be interpreted safely."""
+
+
+def _parse_port(value: object, *, context: str) -> int:
+    text = str(value).strip() if value is not None else ""
+    if not text.isdigit() or not 1 <= int(text) <= 65535:
+        raise InventoryError(f"{context}: invalid or missing MCP port {text!r}")
+    return int(text)
+
+
+def _wrapper_port(plist: dict[str, object], *, context: str) -> int | None:
+    arguments = plist.get("ProgramArguments")
+    if not isinstance(arguments, list) or not arguments:
+        return None
+    wrapper_value = arguments[0]
+    if not isinstance(wrapper_value, str):
+        return None
+    wrapper = Path(wrapper_value)
+    if not wrapper.is_file():
+        return None
+    body = wrapper.read_text(encoding="utf-8")
+    match = re.search(
+        r"^\s*export\s+MCP_PORT\s*=\s*['\"]?([0-9]+)['\"]?\s*$",
+        body,
+        re.MULTILINE,
+    )
+    if match is None:
+        return None
+    return _parse_port(match.group(1), context=f"{context} wrapper")
+
+
+def discover_fixed_profile_plists(directory: Path) -> dict[str, ProfileService]:
+    if not directory.is_dir():
+        raise InventoryError(f"plist directory does not exist: {directory}")
+
+    services: dict[str, ProfileService] = {}
+    for path in sorted(directory.glob(f"{LABEL_PREFIX}*.plist")):
+        try:
+            with path.open("rb") as handle:
+                plist = plistlib.load(handle)
+        except (OSError, plistlib.InvalidFileException) as exc:
+            raise InventoryError(f"cannot parse {path}: {exc}") from exc
+
+        label = plist.get("Label")
+        if not isinstance(label, str) or not label.startswith(LABEL_PREFIX):
+            raise InventoryError(f"{path}: missing fixed-profile MCP Label")
+        if path.name != f"{label}.plist":
+            raise InventoryError(
+                f"{path}: filename does not match plist Label {label!r}"
+            )
+        if label in LIFECYCLE_EXEMPT_LABELS:
+            continue
+
+        environment = plist.get("EnvironmentVariables")
+        raw_port = (
+            environment.get("AUTO_TRADER_MCP_PORT")
+            if isinstance(environment, dict)
+            else None
+        )
+        port = (
+            _parse_port(raw_port, context=str(path))
+            if raw_port is not None
+            else _wrapper_port(plist, context=str(path))
+        )
+        if port is None:
+            raise InventoryError(
+                f"{path}: fixed-profile plist has no AUTO_TRADER_MCP_PORT "
+                "and its wrapper has no literal MCP_PORT export"
+            )
+        if label in services:
+            raise InventoryError(f"duplicate fixed-profile plist Label: {label}")
+        services[label] = ProfileService(label=label, port=port, plist_path=path)
+
+    return services
+
+
+def _parse_profile_ports(entries: Sequence[str]) -> tuple[dict[str, int], list[str]]:
+    mapped: dict[str, int] = {}
+    used_ports: dict[int, str] = {}
+    errors: list[str] = []
+    for entry in entries:
+        label, separator, raw_port = entry.rpartition(":")
+        if not separator or not label:
+            errors.append(f"invalid MCP_PROFILE_PORTS entry: {entry!r}")
+            continue
+        try:
+            port = _parse_port(raw_port, context=f"MCP_PROFILE_PORTS {label}")
+        except InventoryError as exc:
+            errors.append(str(exc))
+            continue
+        if label in mapped:
+            errors.append(f"duplicate MCP_PROFILE_PORTS label: {label}")
+            continue
+        if port in used_ports:
+            errors.append(
+                f"duplicate MCP_PROFILE_PORTS port :{port}: "
+                f"{used_ports[port]} and {label}"
+            )
+        mapped[label] = port
+        used_ports[port] = label
+    return mapped, errors
+
+
+def validate_registry(
+    *,
+    source_plist_dir: Path,
+    single_active_labels: Sequence[str],
+    profile_port_entries: Sequence[str],
+    installed_plist_dir: Path | None = None,
+) -> RegistryValidation:
+    errors: list[str] = []
+    source: dict[str, ProfileService] = {}
+    installed: dict[str, ProfileService] = {}
+
+    try:
+        source = discover_fixed_profile_plists(source_plist_dir)
+    except InventoryError as exc:
+        errors.append(f"source inventory: {exc}")
+
+    if installed_plist_dir is not None:
+        try:
+            installed = discover_fixed_profile_plists(installed_plist_dir)
+        except InventoryError as exc:
+            errors.append(f"installed inventory: {exc}")
+
+    mapped_ports, mapping_errors = _parse_profile_ports(profile_port_entries)
+    errors.extend(mapping_errors)
+
+    single_active = set(single_active_labels)
+    if len(single_active) != len(single_active_labels):
+        errors.append("SINGLE_ACTIVE_LABELS contains duplicate labels")
+
+    source_labels = set(source)
+    mapped_labels = set(mapped_ports)
+    for label in sorted(source_labels - mapped_labels):
+        errors.append(f"source fixed-profile missing from MCP_PROFILE_PORTS: {label}")
+    for label in sorted(mapped_labels - source_labels):
+        errors.append(
+            f"MCP_PROFILE_PORTS label has no source fixed-profile plist: {label}"
+        )
+    for label in sorted(source_labels - single_active):
+        errors.append(
+            f"source fixed-profile missing from SINGLE_ACTIVE_LABELS: {label}"
+        )
+
+    for label in sorted(source_labels & mapped_labels):
+        source_port = source[label].port
+        mapped_port = mapped_ports[label]
+        if source_port != mapped_port:
+            errors.append(
+                f"source port mismatch for {label}: plist=:{source_port} "
+                f"MCP_PROFILE_PORTS=:{mapped_port}"
+            )
+
+    for label, service in sorted(installed.items()):
+        if label not in source:
+            errors.append(f"installed fixed-profile has no source plist: {label}")
+        if label not in single_active:
+            errors.append(
+                f"installed fixed-profile missing from SINGLE_ACTIVE_LABELS: {label}"
+            )
+        if label not in mapped_ports:
+            errors.append(
+                f"installed fixed-profile missing from MCP_PROFILE_PORTS: {label}"
+            )
+        elif service.port != mapped_ports[label]:
+            errors.append(
+                f"installed port mismatch for {label}: installed=:{service.port} "
+                f"MCP_PROFILE_PORTS=:{mapped_ports[label]}"
+            )
+
+    return RegistryValidation(
+        source=source,
+        installed=installed,
+        mapped_ports=mapped_ports,
+        errors=tuple(errors),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-plist-dir", type=Path, required=True)
+    parser.add_argument("--installed-plist-dir", type=Path)
+    parser.add_argument("--single-active-label", action="append", default=[])
+    parser.add_argument("--profile-port", action="append", default=[])
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    result = validate_registry(
+        source_plist_dir=args.source_plist_dir,
+        installed_plist_dir=args.installed_plist_dir,
+        single_active_labels=args.single_active_label,
+        profile_port_entries=args.profile_port,
+    )
+    if result.errors:
+        for error in result.errors:
+            print(f"MCP_PROFILE_REGISTRY_ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "MCP_PROFILE_REGISTRY_OK "
+        f"source={len(result.source)} "
+        f"installed={len(result.installed)} "
+        f"mapped={len(result.mapped_ports)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_native_mcp_profile_registry.py
+++ b/scripts/check_native_mcp_profile_registry.py
@@ -79,7 +79,9 @@ def _wrapper_port(plist: dict[str, object], *, context: str) -> int | None:
     return _parse_port(match.group(1), context=f"{context} wrapper")
 
 
-def discover_fixed_profile_plists(directory: Path) -> dict[str, ProfileService]:
+def discover_fixed_profile_plists(
+    directory: Path, *, allow_canonical_shadow_copies: bool = False
+) -> dict[str, ProfileService]:
     if not directory.is_dir():
         raise InventoryError(f"plist directory does not exist: {directory}")
 
@@ -94,7 +96,13 @@ def discover_fixed_profile_plists(directory: Path) -> dict[str, ProfileService]:
         label = plist.get("Label")
         if not isinstance(label, str) or not label.startswith(LABEL_PREFIX):
             raise InventoryError(f"{path}: missing fixed-profile MCP Label")
-        if path.name != f"{label}.plist":
+        canonical_path = directory / f"{label}.plist"
+        if path != canonical_path:
+            # A rollback candidate cannot create a second resident job under
+            # the same launchd Label.  Ignore it only while the canonical
+            # installed plist exists; a lone misnamed plist still fails closed.
+            if allow_canonical_shadow_copies and canonical_path.is_file():
+                continue
             raise InventoryError(
                 f"{path}: filename does not match plist Label {label!r}"
             )
@@ -169,7 +177,9 @@ def validate_registry(
 
     if installed_plist_dir is not None:
         try:
-            installed = discover_fixed_profile_plists(installed_plist_dir)
+            installed = discover_fixed_profile_plists(
+                installed_plist_dir, allow_canonical_shadow_copies=True
+            )
         except InventoryError as exc:
             errors.append(f"installed inventory: {exc}")
 
@@ -182,6 +192,15 @@ def validate_registry(
 
     source_labels = set(source)
     mapped_labels = set(mapped_ports)
+    single_active_fixed_labels = {
+        label
+        for label in single_active
+        if label.startswith(LABEL_PREFIX) and label not in LIFECYCLE_EXEMPT_LABELS
+    }
+    for label in sorted(single_active_fixed_labels - source_labels):
+        errors.append(
+            f"SINGLE_ACTIVE_LABELS fixed-profile has no source plist: {label}"
+        )
     for label in sorted(source_labels - mapped_labels):
         errors.append(f"source fixed-profile missing from MCP_PROFILE_PORTS: {label}")
     for label in sorted(mapped_labels - source_labels):

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -58,6 +58,8 @@ SINGLE_ACTIVE_LABELS=(
   "com.robinco.auto-trader.mcp-account-read"
   # ROB-762: TradingCodex execution MCP service outside the blue/green pair.
   "com.robinco.auto-trader.mcp-tradingcodex-execution"
+  # ROB-1258: resident hermes-paper-kis MCP service outside the blue/green pair.
+  "com.robinco.auto-trader.mcp-paper_001"
   # ROB-469 PR3: single non-color-specific watchdog that restarts a wedged MCP color.
   "com.robinco.auto-trader.mcp-watchdog"
 )
@@ -76,6 +78,7 @@ MCP_PROFILE_PORTS=(
   "com.robinco.auto-trader.mcp-analysis-readonly:8768"
   "com.robinco.auto-trader.mcp-account-read:8769"
   "com.robinco.auto-trader.mcp-tradingcodex-execution:8770"
+  "com.robinco.auto-trader.mcp-paper_001:8771"
 )
 
 NEW_RELEASE="$RELEASES/$SHA"
@@ -113,6 +116,24 @@ sync_release_ops_to_base() {
   mkdir -p "$BASE/scripts/haproxy"
   rsync -a "$NEW_RELEASE/ops/native/haproxy/" "$BASE/scripts/haproxy/"
   chmod +x "$BASE/scripts/"*.sh 2>/dev/null || true
+}
+
+verify_mcp_profile_registry() {
+  local -a args
+  local label entry
+
+  args=(
+    --source-plist-dir "$NEW_RELEASE/ops/native/plists"
+    --installed-plist-dir "$HOME/Library/LaunchAgents"
+  )
+  for label in "${SINGLE_ACTIVE_LABELS[@]}"; do
+    args+=(--single-active-label "$label")
+  done
+  for entry in "${MCP_PROFILE_PORTS[@]}"; do
+    args+=(--profile-port "$entry")
+  done
+
+  python3 "$NEW_RELEASE/scripts/check_native_mcp_profile_registry.py" "${args[@]}"
 }
 
 build_frontend_workspace() {
@@ -419,6 +440,9 @@ fi
 git cat-file -e "$SHA^{commit}"
 git checkout --detach "$SHA"
 git clean -fdx -e .venv
+
+log "Preflight: verifying fixed-profile MCP registry completeness"
+verify_mcp_profile_registry
 
 log "Installing dependencies with uv"
 uv sync --frozen

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -439,10 +439,11 @@ if ! git cat-file -e "$SHA^{commit}" 2>/dev/null; then
 fi
 git cat-file -e "$SHA^{commit}"
 git checkout --detach "$SHA"
-git clean -fdx -e .venv
 
 log "Preflight: verifying fixed-profile MCP registry completeness"
 verify_mcp_profile_registry
+
+git clean -fdx -e .venv
 
 log "Installing dependencies with uv"
 uv sync --frozen

--- a/tests/scripts/test_deploy_mcp_profile_release_verification.py
+++ b/tests/scripts/test_deploy_mcp_profile_release_verification.py
@@ -1,6 +1,5 @@
-"""ROB-831: deploy-native.sh must restart AND re-verify the fixed-profile MCP
-services (mcp-analysis-readonly / mcp-account-read / mcp-tradingcodex-execution)
-after the API blue/green cutover succeeds.
+"""ROB-831/ROB-1258: deploy-native.sh must restart AND re-verify every
+fixed-profile MCP service after the API blue/green cutover succeeds.
 
 Incident (2026-07-11): after a normal deploy, PR-3a's order_proposal_void tool
 was missing from :8770 (mcp-tradingcodex-execution) — the process was still
@@ -34,6 +33,7 @@ EXPECTED_PROFILE_PORTS = {
     "com.robinco.auto-trader.mcp-analysis-readonly": "8768",
     "com.robinco.auto-trader.mcp-account-read": "8769",
     "com.robinco.auto-trader.mcp-tradingcodex-execution": "8770",
+    "com.robinco.auto-trader.mcp-paper_001": "8771",
 }
 
 
@@ -42,7 +42,7 @@ EXPECTED_PROFILE_PORTS = {
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_profile_ports_declared_for_all_three_fixed_profile_services() -> None:
+def test_mcp_profile_ports_declared_for_all_fixed_profile_services() -> None:
     body = DEPLOY.read_text()
     for label, port in EXPECTED_PROFILE_PORTS.items():
         assert f'"{label}:{port}"' in body, (
@@ -195,7 +195,7 @@ def _run_verify(
     )
 
 
-def test_verify_passes_when_all_three_profiles_report_expected_cwd(
+def test_verify_passes_when_all_profiles_report_expected_cwd(
     tmp_path: Path,
 ) -> None:
     new_release = tmp_path / "releases" / "sha-new"
@@ -208,6 +208,7 @@ def test_verify_passes_when_all_three_profiles_report_expected_cwd(
             f"8768 111 {canonical}",
             f"8769 222 {canonical}",
             f"8770 333 {canonical}",
+            f"8771 444 {canonical}",
         ],
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -228,6 +229,7 @@ def test_verify_fails_when_no_process_listens_on_a_profile_port(
             f"8768 111 {canonical}",
             f"8769 222 {canonical}",
             # 8770 (mcp-tradingcodex-execution) has no listener at all.
+            f"8771 444 {canonical}",
         ],
     )
     assert proc.returncode != 0
@@ -253,6 +255,7 @@ def test_verify_fails_when_process_still_serving_stale_release_cwd(
             f"8768 111 {canonical_new}",
             f"8769 222 {canonical_new}",
             f"8770 333 {canonical_old}",
+            f"8771 444 {canonical_new}",
         ],
     )
     assert proc.returncode != 0
@@ -277,8 +280,8 @@ def test_verify_retries_before_giving_up(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
     attempt_counter = tmp_path / "lsof_attempts_8770"
-    # lsof stub: 8768/8769 always resolve correctly; 8770 only resolves to the
-    # NEW release cwd from the 3rd call onward (simulating restart lag).
+    # lsof stub: 8768/8769/8771 always resolve correctly; 8770 only resolves to
+    # the NEW release cwd from the 3rd call onward (simulating restart lag).
     stub = bin_dir / "lsof"
     stub.write_text(
         "#!/usr/bin/env bash\n"
@@ -289,6 +292,7 @@ def test_verify_retries_before_giving_up(tmp_path: Path) -> None:
         "    8768) echo 111; exit 0 ;;\n"
         "    8769) echo 222; exit 0 ;;\n"
         "    8770) echo 333; exit 0 ;;\n"
+        "    8771) echo 444; exit 0 ;;\n"
         "  esac\n"
         "  exit 1\n"
         'elif [[ "$1" == "-a" ]]; then\n'
@@ -296,6 +300,7 @@ def test_verify_retries_before_giving_up(tmp_path: Path) -> None:
         '  case "$pid" in\n'
         f'    111) printf "p111\\nfcwd\\nn{canonical}\\n"; exit 0 ;;\n'
         f'    222) printf "p222\\nfcwd\\nn{canonical}\\n"; exit 0 ;;\n'
+        f'    444) printf "p444\\nfcwd\\nn{canonical}\\n"; exit 0 ;;\n'
         "    333)\n"
         '      n=$(( $(cat "$counter" 2>/dev/null || echo 0) + 1 ))\n'
         '      echo "$n" > "$counter"\n'

--- a/tests/scripts/test_native_mcp_profile_registry.py
+++ b/tests/scripts/test_native_mcp_profile_registry.py
@@ -14,6 +14,7 @@ from scripts.check_native_mcp_profile_registry import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY = REPO_ROOT / "scripts" / "deploy-native.sh"
 SOURCE_PLISTS = REPO_ROOT / "ops" / "native" / "plists"
+PAPER_WRAPPER = REPO_ROOT / "ops" / "native" / "scripts" / "run-mcp-paper_001.sh"
 
 
 def _extract_array_values(body: str, name: str) -> list[str]:
@@ -30,6 +31,7 @@ def _write_plist(
     label: str,
     port: int | None,
     wrapper: Path | None = None,
+    filename: str | None = None,
 ) -> None:
     environment: dict[str, str] = {}
     if port is not None:
@@ -40,7 +42,7 @@ def _write_plist(
         "EnvironmentVariables": environment,
     }
     directory.mkdir(parents=True, exist_ok=True)
-    with (directory / f"{label}.plist").open("wb") as handle:
+    with (directory / (filename or f"{label}.plist")).open("wb") as handle:
         plistlib.dump(payload, handle)
 
 
@@ -134,6 +136,94 @@ def test_installed_literal_wrapper_port_is_compared(tmp_path: Path) -> None:
     assert any("installed port mismatch" in error for error in result.errors)
 
 
+def test_interrupted_wrapper_sync_remains_redeployable_with_old_plist(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    installed = tmp_path / "installed"
+    label = "com.robinco.auto-trader.mcp-paper_001"
+    _write_plist(source, label=label, port=8771)
+    _write_plist(installed, label=label, port=None, wrapper=PAPER_WRAPPER)
+
+    result = validate_registry(
+        source_plist_dir=source,
+        installed_plist_dir=installed,
+        single_active_labels=[label],
+        profile_port_entries=[f"{label}:8771"],
+    )
+
+    assert not result.errors, "\n".join(result.errors)
+
+
+def test_single_active_fixed_profile_without_source_fails_closed(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    orphan = "com.robinco.auto-trader.mcp-orphan-typo"
+
+    result = validate_registry(
+        source_plist_dir=source,
+        single_active_labels=[orphan],
+        profile_port_entries=[],
+    )
+
+    assert (
+        f"SINGLE_ACTIVE_LABELS fixed-profile has no source plist: {orphan}"
+        in result.errors
+    )
+
+
+def test_installed_rollback_shadow_does_not_block_canonical_inventory(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    installed = tmp_path / "installed"
+    label = "com.robinco.auto-trader.mcp-paper_001"
+    _write_plist(source, label=label, port=8771)
+    _write_plist(installed, label=label, port=8771)
+    _write_plist(
+        installed,
+        label=label,
+        port=8771,
+        filename=f"{label}-rollback.plist",
+    )
+
+    result = validate_registry(
+        source_plist_dir=source,
+        installed_plist_dir=installed,
+        single_active_labels=[label],
+        profile_port_entries=[f"{label}:8771"],
+    )
+
+    assert not result.errors, "\n".join(result.errors)
+    assert set(result.installed) == {label}
+
+
+def test_lone_misnamed_rollback_plist_still_fails_closed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    installed = tmp_path / "installed"
+    label = "com.robinco.auto-trader.mcp-paper_001"
+    _write_plist(source, label=label, port=8771)
+    _write_plist(
+        installed,
+        label=label,
+        port=8771,
+        filename=f"{label}-rollback.plist",
+    )
+
+    result = validate_registry(
+        source_plist_dir=source,
+        installed_plist_dir=installed,
+        single_active_labels=[label],
+        profile_port_entries=[f"{label}:8771"],
+    )
+
+    assert any(
+        "filename does not match plist Label" in error for error in result.errors
+    )
+
+
 def test_blue_green_and_watchdog_plists_are_lifecycle_exempt(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()
@@ -152,7 +242,9 @@ def test_blue_green_and_watchdog_plists_are_lifecycle_exempt(tmp_path: Path) -> 
 
 def test_registry_preflight_runs_before_dependency_install_and_migrations() -> None:
     lines = DEPLOY.read_text().splitlines()
+    checkout_index = lines.index('git checkout --detach "$SHA"')
     call_index = lines.index("verify_mcp_profile_registry")
+    clean_index = lines.index("git clean -fdx -e .venv")
     install_index = next(
         i for i, line in enumerate(lines) if "uv sync --frozen" in line
     )
@@ -161,4 +253,5 @@ def test_registry_preflight_runs_before_dependency_install_and_migrations() -> N
     )
     sync_index = lines.index("sync_release_ops_to_base")
 
-    assert call_index < install_index < migration_index < sync_index
+    assert checkout_index < call_index < clean_index < install_index
+    assert install_index < migration_index < sync_index

--- a/tests/scripts/test_native_mcp_profile_registry.py
+++ b/tests/scripts/test_native_mcp_profile_registry.py
@@ -1,0 +1,164 @@
+"""ROB-1258 fixed-profile MCP deploy-registry completeness guard."""
+
+from __future__ import annotations
+
+import plistlib
+import re
+from pathlib import Path
+
+from scripts.check_native_mcp_profile_registry import (
+    LIFECYCLE_EXEMPT_LABELS,
+    validate_registry,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY = REPO_ROOT / "scripts" / "deploy-native.sh"
+SOURCE_PLISTS = REPO_ROOT / "ops" / "native" / "plists"
+
+
+def _extract_array_values(body: str, name: str) -> list[str]:
+    match = re.search(
+        rf"^{re.escape(name)}=\(\n(.*?)\n\)", body, re.DOTALL | re.MULTILINE
+    )
+    assert match, f"{name}=(...) array not found"
+    return re.findall(r'^\s*"([^"]+)"\s*$', match.group(1), re.MULTILINE)
+
+
+def _write_plist(
+    directory: Path,
+    *,
+    label: str,
+    port: int | None,
+    wrapper: Path | None = None,
+) -> None:
+    environment: dict[str, str] = {}
+    if port is not None:
+        environment["AUTO_TRADER_MCP_PORT"] = str(port)
+    payload: dict[str, object] = {
+        "Label": label,
+        "ProgramArguments": [str(wrapper or Path("/bin/false"))],
+        "EnvironmentVariables": environment,
+    }
+    directory.mkdir(parents=True, exist_ok=True)
+    with (directory / f"{label}.plist").open("wb") as handle:
+        plistlib.dump(payload, handle)
+
+
+def test_repository_inventory_exactly_matches_both_deploy_registries() -> None:
+    body = DEPLOY.read_text()
+    result = validate_registry(
+        source_plist_dir=SOURCE_PLISTS,
+        single_active_labels=_extract_array_values(body, "SINGLE_ACTIVE_LABELS"),
+        profile_port_entries=_extract_array_values(body, "MCP_PROFILE_PORTS"),
+    )
+    assert not result.errors, "\n".join(result.errors)
+
+
+def test_new_fixed_profile_plist_fails_when_both_registries_omit_it(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    existing = "com.robinco.auto-trader.mcp-existing"
+    added = "com.robinco.auto-trader.mcp-added-later"
+    _write_plist(source, label=existing, port=9101)
+    _write_plist(source, label=added, port=9102)
+
+    result = validate_registry(
+        source_plist_dir=source,
+        single_active_labels=[existing],
+        profile_port_entries=[f"{existing}:9101"],
+    )
+
+    assert (
+        f"source fixed-profile missing from MCP_PROFILE_PORTS: {added}" in result.errors
+    )
+    assert (
+        f"source fixed-profile missing from SINGLE_ACTIVE_LABELS: {added}"
+        in result.errors
+    )
+
+
+def test_source_plist_port_mismatch_fails_closed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    label = "com.robinco.auto-trader.mcp-profile"
+    _write_plist(source, label=label, port=9101)
+
+    result = validate_registry(
+        source_plist_dir=source,
+        single_active_labels=[label],
+        profile_port_entries=[f"{label}:9102"],
+    )
+
+    assert any("source port mismatch" in error for error in result.errors)
+
+
+def test_installed_out_of_band_profile_fails_closed(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    installed = tmp_path / "installed"
+    known = "com.robinco.auto-trader.mcp-known"
+    unknown = "com.robinco.auto-trader.mcp-manual"
+    _write_plist(source, label=known, port=9101)
+    _write_plist(installed, label=known, port=9101)
+    _write_plist(installed, label=unknown, port=9102)
+
+    result = validate_registry(
+        source_plist_dir=source,
+        installed_plist_dir=installed,
+        single_active_labels=[known],
+        profile_port_entries=[f"{known}:9101"],
+    )
+
+    assert f"installed fixed-profile has no source plist: {unknown}" in result.errors
+    assert (
+        f"installed fixed-profile missing from MCP_PROFILE_PORTS: {unknown}"
+        in result.errors
+    )
+
+
+def test_installed_literal_wrapper_port_is_compared(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    installed = tmp_path / "installed"
+    label = "com.robinco.auto-trader.mcp-paper-test"
+    wrapper = tmp_path / "run-paper.sh"
+    wrapper.write_text('#!/usr/bin/env bash\nexport MCP_PORT="9102"\n')
+    _write_plist(source, label=label, port=9101)
+    _write_plist(installed, label=label, port=None, wrapper=wrapper)
+
+    result = validate_registry(
+        source_plist_dir=source,
+        installed_plist_dir=installed,
+        single_active_labels=[label],
+        profile_port_entries=[f"{label}:9101"],
+    )
+
+    assert any("installed port mismatch" in error for error in result.errors)
+
+
+def test_blue_green_and_watchdog_plists_are_lifecycle_exempt(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    for label in LIFECYCLE_EXEMPT_LABELS:
+        _write_plist(source, label=label, port=None)
+
+    result = validate_registry(
+        source_plist_dir=source,
+        single_active_labels=[],
+        profile_port_entries=[],
+    )
+
+    assert not result.errors
+    assert not result.source
+
+
+def test_registry_preflight_runs_before_dependency_install_and_migrations() -> None:
+    lines = DEPLOY.read_text().splitlines()
+    call_index = lines.index("verify_mcp_profile_registry")
+    install_index = next(
+        i for i, line in enumerate(lines) if "uv sync --frozen" in line
+    )
+    migration_index = next(
+        i for i, line in enumerate(lines) if "uv run alembic upgrade head" in line
+    )
+    sync_index = lines.index("sync_release_ops_to_base")
+
+    assert call_index < install_index < migration_index < sync_index

--- a/tests/scripts/test_native_plists.py
+++ b/tests/scripts/test_native_plists.py
@@ -20,6 +20,7 @@ PLISTS = [
     "com.robinco.auto-trader.mcp-analysis-readonly.plist",
     "com.robinco.auto-trader.mcp-account-read.plist",
     "com.robinco.auto-trader.mcp-tradingcodex-execution.plist",
+    "com.robinco.auto-trader.mcp-paper_001.plist",
     "com.robinco.auto-trader.worker.plist",
     "com.robinco.auto-trader.worker-log-rotation.plist",
     "com.robinco.auto-trader.scheduler.plist",
@@ -123,3 +124,12 @@ def test_mcp_tradingcodex_execution_plist_profile_port_and_token_env() -> None:
     ) in body
     assert ("<key>TOSS_APPROVAL_HASH_MODE</key>\n    <string>required</string>") in body
     assert "current</string>" in body
+
+
+def test_mcp_paper_001_plist_profile_port_and_wrapper() -> None:
+    body = (PLIST_DIR / "com.robinco.auto-trader.mcp-paper_001.plist").read_text()
+    assert "scripts/run-mcp-paper_001.sh" in body
+    assert "<string>hermes-paper-kis</string>" in body
+    assert "<string>8771</string>" in body
+    assert "current</string>" in body
+    assert "<key>KeepAlive</key>\n  <true/>" in body

--- a/tests/scripts/test_native_run_wrappers.py
+++ b/tests/scripts/test_native_run_wrappers.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_API = REPO_ROOT / "ops" / "native" / "scripts" / "run-api.sh"
 RUN_MCP = REPO_ROOT / "ops" / "native" / "scripts" / "run-mcp.sh"
 RUN_MCP_PROFILE = REPO_ROOT / "ops" / "native" / "scripts" / "run-mcp-profile.sh"
+RUN_MCP_PAPER = REPO_ROOT / "ops" / "native" / "scripts" / "run-mcp-paper_001.sh"
 
 
 def _build_base(tmp_path: Path, color: str) -> Path:
@@ -248,3 +249,63 @@ def test_run_mcp_profile_exports_tradingcodex_execution_profile(tmp_path: Path) 
     assert "MCP_PROFILE=tradingcodex_execution" in proc.stdout
     assert "MCP_PORT=8770" in proc.stdout
     assert "MCP_AUTH_TOKEN=execution-token" in proc.stdout
+
+
+# ----- run-mcp-paper_001 -----------------------------------------------------
+
+
+def test_run_mcp_paper_001_defaults_preserve_installed_plist_compatibility(
+    tmp_path: Path,
+) -> None:
+    proc = _run_profile(RUN_MCP_PAPER, {}, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "MCP_PROFILE=hermes-paper-kis" in proc.stdout
+    assert "MCP_PORT=8771" in proc.stdout
+    assert "MCP_HOST=127.0.0.1" in proc.stdout
+    assert "current" in proc.stdout
+
+
+def test_run_mcp_paper_001_rejects_profile_or_port_override(tmp_path: Path) -> None:
+    proc = _run_profile(
+        RUN_MCP_PAPER,
+        {
+            "AUTO_TRADER_MCP_PROFILE": "default",
+            "AUTO_TRADER_MCP_PORT": "9999",
+        },
+        tmp_path,
+    )
+    assert proc.returncode == 78
+    assert "must remain hermes-paper-kis:8771" in proc.stderr
+
+
+def test_run_mcp_paper_001_exports_only_mcp_and_kis_mock_env(
+    tmp_path: Path,
+) -> None:
+    base = _build_base(tmp_path, "blue")
+    (base / "current").mkdir(exist_ok=True)
+    (base / "shared" / ".env.prod.native").write_text(
+        "MCP_AUTH_TOKEN=fake-paper-token\n"
+        "KIS_MOCK_ENABLED=true\n"
+        "KIS_MOCK_APP_KEY=fake-mock-key\n"
+        "KIS_APP_KEY=must-not-export\n"
+        "OTHER_VAR=must-not-export\n"
+    )
+    bin_dir = _uv_stub_dir(tmp_path)
+    env = {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "AUTO_TRADER_BASE": str(base),
+    }
+    proc = subprocess.run(
+        ["bash", str(RUN_MCP_PAPER)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "MCP_AUTH_TOKEN=fake-paper-token" in proc.stdout
+    assert "KIS_MOCK_ENABLED=true" in proc.stdout
+    assert "KIS_MOCK_APP_KEY=fake-mock-key" in proc.stdout
+    assert "KIS_APP_KEY" not in proc.stdout
+    assert "OTHER_VAR" not in proc.stdout


### PR DESCRIPTION
## Summary

- add com.robinco.auto-trader.mcp-paper_001 to both native single-active restart and release-path verification registries
- bring the paper LaunchAgent plist and mock-only wrapper under the native deployment bundle
- add a fail-closed preflight and CI guard that compares source plists, installed LaunchAgents, labels, and ports
- extend ROB-831 verification to all four fixed-profile MCP services

## Verification

- uv run pytest -q tests/scripts: 1321 passed, 3 skipped
- make lint: Ruff, format check, and ty passed
- bash -n, shellcheck, and plutil lint passed
- mutant check: removing the paper profile-port entry failed with the expected missing-registry error, then passed after restoration
- live installed-inventory preflight: source=4 installed=4 mapped=4

## Operational boundary

No deploy, service restart, launchctl mutation, broker mutation, or database mutation was performed. The existing 8771 process remains on release ebadeb937 and operator approval is required before the first restart.

Linear: ROB-1258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `mcp-paper_001` paper-trading service.
  - The service starts automatically, stays available, and listens on port 8771.
  - Added standardized configuration for the paper-trading environment.

- **Bug Fixes**
  - Deployments now detect missing, duplicate, mismatched, or unexpected MCP services before installation.
  - Improved safeguards for service updates, rollbacks, and interrupted deployments.

- **Tests**
  - Added coverage for service startup, configuration, port enforcement, registry validation, and deployment preflight checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->