### PR TITLE
feat(ROB-1259): freeze mock integration contract

### DIFF
--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, NewType
 
 from pydantic import (
     BaseModel,
@@ -214,10 +214,11 @@ class OrderLifecycleEvent(BaseModel):
 # scheduler, or an order path.
 J1NonBlank = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 J1JsonObject = dict[str, Any]
+TimingOwner = NewType("TimingOwner", str)
 
 
-class LaneState(StrEnum):
-    """The complete ROB-1259 J1 lane-state allowlist."""
+class LaneStatus(StrEnum):
+    """The complete ROB-1259 J1 lane-status allowlist."""
 
     AUTO_ENABLED = "AUTO_ENABLED"
     AUTO_READY = "AUTO_READY"
@@ -232,7 +233,52 @@ class LaneState(StrEnum):
     UNKNOWN = "UNKNOWN"
 
 
-LANE_STATES: frozenset[str] = frozenset(state.value for state in LaneState)
+LaneState = LaneStatus
+LANE_STATUSES: frozenset[str] = frozenset(status.value for status in LaneStatus)
+LANE_STATES = LANE_STATUSES
+
+
+class ActivationStatus(StrEnum):
+    """Signed activation state kept distinct from a lane status."""
+
+    READY_FOR_MOCK_DEPLOYMENT = "READY_FOR_MOCK_DEPLOYMENT"
+
+
+ACTIVATION_STATUSES: frozenset[str] = frozenset(
+    status.value for status in ActivationStatus
+)
+
+
+class LaneRole(StrEnum):
+    """A registry role is one signed value, never a composite value."""
+
+    PRIMARY_AUTO = "PRIMARY_AUTO"
+    AUTO_MIRROR = "AUTO_MIRROR"
+    BROKER_REGRESSION = "BROKER_REGRESSION"
+    EXECUTION_AUTO = "EXECUTION_AUTO"
+
+
+LANE_ROLES: frozenset[str] = frozenset(role.value for role in LaneRole)
+
+
+class SchedulerOwner(StrEnum):
+    """The exact scheduler-owner vocabulary from the integration contract."""
+
+    TASKIQ = "taskiq"
+    PREFECT = "prefect"
+    ORCH = "orch"
+    MANUAL = "manual"
+    DISABLED = "disabled"
+
+
+SCHEDULER_OWNERS: frozenset[str] = frozenset(owner.value for owner in SchedulerOwner)
+
+CurrencyAlignmentError = Literal[
+    "currency_conversion_not_authorized", "lane_quote_currency_mismatch"
+]
+CURRENCY_ALIGNMENT_ERROR_CODES: frozenset[CurrencyAlignmentError] = frozenset(
+    {"currency_conversion_not_authorized", "lane_quote_currency_mismatch"}
+)
 
 
 class EvidenceTier(StrEnum):
@@ -263,6 +309,7 @@ class DecisionIntent(_J1FrozenContract):
     symbol: J1NonBlank
     side: Literal["buy", "sell"]
     target_notional: Decimal = Field(gt=0, allow_inf_nan=False)
+    target_notional_currency: Literal["KRW", "USD", "USDT"]
     limit_policy: J1JsonObject
     expiry_policy: J1JsonObject
     rationale: J1NonBlank
@@ -293,6 +340,7 @@ class ExecutionPlan(_J1FrozenContract):
     normalized_symbol: J1NonBlank
     quantity: Decimal = Field(gt=0, allow_inf_nan=False)
     limit_price: Decimal | None
+    quote_currency: Literal["KRW", "USD", "USDT"]
     tick_rounding: J1JsonObject
     session: J1NonBlank | None
     time_in_force: J1NonBlank | None
@@ -307,6 +355,25 @@ class ExecutionPlan(_J1FrozenContract):
         if value is not None and (not value.is_finite() or value <= 0):
             raise ValueError("limit_price must be finite and positive when present")
         return value
+
+
+def validate_plan_currency_alignment(
+    decision_intent: DecisionIntent, execution_plan: ExecutionPlan
+) -> None:
+    """Reject a decision/plan currency mismatch without conversion or I/O."""
+
+    if decision_intent.target_notional_currency != execution_plan.quote_currency:
+        raise ValueError("currency_conversion_not_authorized")
+
+
+def create_execution_plan(
+    decision_intent: DecisionIntent, /, **plan_values: Any
+) -> ExecutionPlan:
+    """Create a plan only when its supplied currency exactly matches the intent."""
+
+    if plan_values.get("quote_currency") != decision_intent.target_notional_currency:
+        raise ValueError("currency_conversion_not_authorized")
+    return ExecutionPlan(**plan_values)
 
 
 class OrderAttempt(_J1FrozenContract):
@@ -337,11 +404,24 @@ __all__ = [
     "OrderPreviewLine",
     "OrderBasketPreview",
     "OrderLifecycleEvent",
+    "TimingOwner",
+    "LaneStatus",
     "LaneState",
+    "LANE_STATUSES",
     "LANE_STATES",
+    "ActivationStatus",
+    "ACTIVATION_STATUSES",
+    "LaneRole",
+    "LANE_ROLES",
+    "SchedulerOwner",
+    "SCHEDULER_OWNERS",
+    "CurrencyAlignmentError",
+    "CURRENCY_ALIGNMENT_ERROR_CODES",
     "EvidenceTier",
     "EVIDENCE_TIERS",
     "DecisionIntent",
     "ExecutionPlan",
+    "validate_plan_currency_alignment",
+    "create_execution_plan",
     "OrderAttempt",
 ]

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -23,9 +23,17 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 CONTRACT_VERSION = "v1"
 
@@ -200,6 +208,118 @@ class OrderLifecycleEvent(BaseModel):
     warnings: list[str] = Field(default_factory=list)
 
 
+# ROB-1259 J1 — frozen vocabulary only. These definitions deliberately live in
+# the existing shared execution-contract leaf rather than creating a second
+# generic execution schema module. They do not select a broker, a profile, a
+# scheduler, or an order path.
+J1NonBlank = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+J1JsonObject = dict[str, Any]
+
+
+class LaneState(StrEnum):
+    """The complete ROB-1259 J1 lane-state allowlist."""
+
+    AUTO_ENABLED = "AUTO_ENABLED"
+    AUTO_READY = "AUTO_READY"
+    AUTO_READY_BLOCKED_BY_POLICY = "AUTO_READY_BLOCKED_BY_POLICY"
+    AUTO_READY_BLOCKED_BY_LIFECYCLE = "AUTO_READY_BLOCKED_BY_LIFECYCLE"
+    AUTO_READY_BLOCKED_BY_ACCOUNT_STATE = "AUTO_READY_BLOCKED_BY_ACCOUNT_STATE"
+    AUTO_READY_BLOCKED_BY_SCHEDULER = "AUTO_READY_BLOCKED_BY_SCHEDULER"
+    OBSERVATION_TEMPORARY = "OBSERVATION_TEMPORARY"
+    SHADOW_ONLY = "SHADOW_ONLY"
+    DISABLED_NO_STRATEGY = "DISABLED_NO_STRATEGY"
+    NOT_READY = "NOT_READY"
+    UNKNOWN = "UNKNOWN"
+
+
+LANE_STATES: frozenset[str] = frozenset(state.value for state in LaneState)
+
+
+class EvidenceTier(StrEnum):
+    """J0 audit claim tier: directly observed, reasoned, or not verified."""
+
+    FACT = "FACT"
+    INFERENCE = "INFERENCE"
+    UNVERIFIED = "UNVERIFIED"
+
+
+EVIDENCE_TIERS: frozenset[str] = frozenset(tier.value for tier in EvidenceTier)
+
+
+class _J1FrozenContract(BaseModel):
+    """Strict, side-effect-free base for the three ROB-1259 J1 records."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+
+class DecisionIntent(_J1FrozenContract):
+    """One stable policy/strategy decision before account-specific planning."""
+
+    decision_intent_id: J1NonBlank
+    policy_version: J1NonBlank
+    policy_version_hash: J1NonBlank
+    decision_timestamp: datetime
+    market_data_cutoff: datetime
+    symbol: J1NonBlank
+    side: Literal["buy", "sell"]
+    target_notional: Decimal = Field(gt=0, allow_inf_nan=False)
+    limit_policy: J1JsonObject
+    expiry_policy: J1JsonObject
+    rationale: J1NonBlank
+
+    @field_validator("decision_timestamp", "market_data_cutoff")
+    @classmethod
+    def _timestamps_must_be_timezone_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            raise ValueError("timestamps must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def _market_data_must_not_follow_the_decision(self) -> DecisionIntent:
+        if self.market_data_cutoff > self.decision_timestamp:
+            raise ValueError("market_data_cutoff must not be after decision_timestamp")
+        return self
+
+
+class ExecutionPlan(_J1FrozenContract):
+    """One account-specific plan derived from a DecisionIntent."""
+
+    execution_plan_id: J1NonBlank
+    decision_intent_id: J1NonBlank
+    lane_id: J1NonBlank
+    broker: J1NonBlank
+    account_profile: J1NonBlank
+    account_mode: J1NonBlank
+    normalized_symbol: J1NonBlank
+    quantity: Decimal = Field(gt=0, allow_inf_nan=False)
+    limit_price: Decimal | None
+    tick_rounding: J1JsonObject
+    session: J1NonBlank | None
+    time_in_force: J1NonBlank | None
+    min_order_validation: J1JsonObject
+    risk_caps: J1JsonObject
+
+    @field_validator("limit_price")
+    @classmethod
+    def _limit_price_must_be_positive_when_present(
+        cls, value: Decimal | None
+    ) -> Decimal | None:
+        if value is not None and (not value.is_finite() or value <= 0):
+            raise ValueError("limit_price must be finite and positive when present")
+        return value
+
+
+class OrderAttempt(_J1FrozenContract):
+    """One attempt identity; broker identifiers may be absent before acknowledgement."""
+
+    order_attempt_id: J1NonBlank
+    execution_plan_id: J1NonBlank
+    cycle_id: J1NonBlank
+    idempotency_key: J1NonBlank
+    broker_client_order_id: J1NonBlank | None
+    broker_order_id: J1NonBlank | None
+
+
 __all__ = [
     "CONTRACT_VERSION",
     "AccountMode",
@@ -217,4 +337,11 @@ __all__ = [
     "OrderPreviewLine",
     "OrderBasketPreview",
     "OrderLifecycleEvent",
+    "LaneState",
+    "LANE_STATES",
+    "EvidenceTier",
+    "EVIDENCE_TIERS",
+    "DecisionIntent",
+    "ExecutionPlan",
+    "OrderAttempt",
 ]

--- a/docs/contracts/rob-1259-mock-auto-integration-j1-freeze.md
+++ b/docs/contracts/rob-1259-mock-auto-integration-j1-freeze.md
@@ -11,7 +11,17 @@ Authority used for this freeze:
 - J0 verified audit SHA-256
   `7200bcb43af423ce9d1df3a593bc42330c9e3074003a01c1cabb4e7cd90cb69e`
   (§C lane matrix and §E2 split)
+- Signed operator addendum SHA-256
+  `5bf99507f7e1c7ccfa0255dfd784b716f72ed63364e68bdad0c45a5a9f3c5d04`
+  (D5 currency contract)
 - Repository base `fc990658547ba18196bd186e6ff4b06ff84e7f85`
+
+## Operator common header
+
+J1 does not select a profile, writer, cadence, cap, canary, or currency-rate
+behavior. When an exact literal or evidence is absent, the later owner must end
+in its applicable blocked or pending state rather than create a value. Only
+`orch-mock` may merge a verification-passing PR.
 
 ## Three-layer records
 
@@ -31,6 +41,7 @@ is not yet known.
 | `symbol` | non-blank decision symbol; where a DB symbol conversion applies, its canonical form remains `.`-separated |
 | `side` | `buy` or `sell` |
 | `target_notional` | finite, positive `Decimal` |
+| `target_notional_currency` | required `Literal["KRW", "USD", "USDT"]`; the unit of `target_notional` |
 | `limit_policy` | required opaque JSON object; detailed policy vocabulary belongs to a later owner |
 | `expiry_policy` | required opaque JSON object; detailed policy vocabulary belongs to a later owner |
 | `rationale` | non-blank text |
@@ -46,8 +57,9 @@ is not yet known.
 | `account_profile` | non-blank logical profile identifier |
 | `account_mode` | non-blank existing account-mode value |
 | `normalized_symbol` | non-blank broker-ready symbol; conversion remains owned by `app/core/symbol.py` where applicable |
-| `quantity` | finite, positive `Decimal` |
+| `quantity` | finite, positive `Decimal`; a share/base-asset quantity, not a currency amount |
 | `limit_price` | `null` or finite, positive `Decimal` |
+| `quote_currency` | required `Literal["KRW", "USD", "USDT"]`; the unit of `limit_price`, `quantity * price`, plan min-notional, and plan monetary caps without their own unit |
 | `tick_rounding` | required opaque JSON object |
 | `session` | non-blank string or `null` |
 | `time_in_force` | non-blank string or `null` |
@@ -70,9 +82,56 @@ or more account-specific `ExecutionPlan` records, and each `OrderAttempt`
 references exactly one plan. This contract does not prescribe persistence,
 fan-out, claim, submit, terminal-state, or recovery behavior.
 
+Each plan is independently identified and carries its own `lane_id`; J1 has no
+rollback or cancellation operation. A later mirror implementation must keep
+one lane's outcome separate from the others and record any divergence without
+using this vocabulary to cancel another plan.
+
+## Currency alignment and strict JSON
+
+`create_execution_plan(decision_intent, **plan_values)` is the pure J1
+creation boundary for an intent-derived plan. It checks
+`target_notional_currency` against the supplied `quote_currency` before
+constructing `ExecutionPlan`, so a mismatch creates no plan and raises exactly
+`currency_conversion_not_authorized`. The companion
+`validate_plan_currency_alignment(decision_intent, execution_plan)` protects
+an already materialized decision/plan pair. Neither function performs a
+conversion, rate lookup, broker call, or persistence operation. `KRW`, `USD`,
+and `USDT` remain distinct literals.
+
+`OrderAttempt` does not duplicate a currency; it inherits the plan context via
+`execution_plan_id`. J2A owns its later registry-specific quote-currency check
+and its distinct `lane_quote_currency_mismatch` result; the
+`CURRENCY_ALIGNMENT_ERROR_CODES` vocabulary contains both exact error strings,
+but no registry is added by J1.
+
+These frozen models are strict for Python inputs. For JSON serialized by
+`model_dump_json()`, the required deserialization path is
+`DecisionIntent.model_validate_json(payload)` or
+`ExecutionPlan.model_validate_json(payload)`. Callers must not pass a
+`json.loads()` dictionary to `model_validate()` as a substitute, because that
+would reject JSON timestamp/decimal representations under this strict contract.
+
+## Common control vocabulary
+
+`LaneStatus` is the canonical `lane_status` type. `LaneState` remains a
+backward-compatible alias, and `LANE_STATES` remains its historical set name.
+`ActivationStatus` is a separate type and currently has only the signed
+`READY_FOR_MOCK_DEPLOYMENT` value. Thus
+`AUTO_READY_BLOCKED_BY_SCHEDULER` remains a lane status, while
+`READY_FOR_MOCK_DEPLOYMENT` is not merged into it.
+
+`LaneRole` is a single `StrEnum` value, never a combined role string. Its signed
+vocabulary is `PRIMARY_AUTO`, `AUTO_MIRROR`, `BROKER_REGRESSION`, and
+`EXECUTION_AUTO`. `SchedulerOwner` separately uses exactly
+`taskiq|prefect|orch|manual|disabled`; `TimingOwner` is a distinct opaque owner
+type because J1 has no signed timing-owner value set. These are vocabulary types
+only: J1 does not add a registry or attach the fields to the three frozen
+records. J2A owns the registry surface that will use them.
+
 ## Lane state allowlist
 
-`LaneState` is the only J1 lane-state vocabulary:
+`LaneStatus` is the only J1 lane-status vocabulary:
 
 ```text
 AUTO_ENABLED
@@ -110,6 +169,16 @@ The matrix's account/profile split is preserved, particularly the two Spot
 Demo and the two Alpaca crypto rows. J1 does not merge them or change their
 state rationale.
 
+## Signed addendum expressibility check
+
+| Addendum constraint | J1 vocabulary / record support | Boundary retained |
+|---|---|---|
+| D1 Alpaca crypto remains unassigned and stops `NOT_READY` | `LaneStatus.NOT_READY` | J2A later records registry facts; J1 does not select a profile. |
+| D2 sidecar remains observation-only and recurring owner is disabled | `LaneStatus.OBSERVATION_TEMPORARY` and `SchedulerOwner.DISABLED` | No writer, cadence, or scheduler is attached by J1. |
+| D3 US/Kiwoom is `BROKER_REGRESSION`, not `AUTO_MIRROR` | distinct single `LaneRole` values express both states | The lane-specific allowed role is a later registry policy, not a J1 runtime check. |
+| D4 has no new recurring schedule | `LaneStatus.AUTO_READY_BLOCKED_BY_SCHEDULER` is separate from `ActivationStatus.READY_FOR_MOCK_DEPLOYMENT` | J1 adds neither scheduler code nor a cadence. |
+| D6 uses a limit plan with preserved sizing evidence | `target_notional`, `market_data_cutoff`, `quantity`, `limit_price`, `tick_rounding`, and `min_order_validation` hold the required values and opaque evidence | Exact venue step-size/source key grammar remains the later owner’s signed contract; J1 adds no speculative fields. |
+
 ## Evidence tier vocabulary
 
 `EvidenceTier` uses exactly these values:
@@ -145,6 +214,7 @@ not a claim that every occurrence has one shared meaning.
 | `idempotency_key` | 231 matching files. KIS's durable pre-send reservation is `app/models/review.py:592-613` and `app/services/order_send_intent_service.py:30-95`; paper intent has its own exact provenance-derived key at `app/services/brokers/paper/contracts.py:154-206`. | Reuse the field name on `OrderAttempt`, retaining current scope and uniqueness behavior. J1 does not claim global uniqueness or replace existing reservations. |
 | `approval_*` | 194 matching files. Existing approval material is ledger metadata in `app/models/review.py:454,551,709-712` and dedicated preview/confirmation behavior in `app/mcp_server/tooling/orders_kis_variants.py:487-496` and `app/mcp_server/tooling/orders_toss_variants.py:965-1118`. | Keep approval artifacts separate from decision/plan/attempt identity. No new approval field, token, or gate is created. |
 | Policy version/hash | `app/services/trading_policy_service.py:111-134` returns the current policy version with its existing short `content_hash`; paper validation also carries full hashes at `app/services/paper_validation/contracts.py:71-90`. | Retain `policy_version_hash` as an opaque, non-blank contract field so both existing representations remain usable. No new hash function or policy storage is added. |
+| `quote_currency` | Existing B0-X envelope/state vocabulary includes `scripts/b0x/envelope.py:28,48,85` and `scripts/b0x/state.py:73,82`; `scripts/b0x/kill_switch.py:163-184` rejects missing or mismatched values before comparing monetary quantities. | Reuse `quote_currency` exactly on `ExecutionPlan`; add the signed `target_notional_currency` only where it denotes the decision notional's unit. No second plan-currency abstraction is introduced. |
 | Existing decision/plan records | 16 matching files. `PaperCohortDecision` and `PaperCohortVenueIntent` are cohort-specific at `app/models/paper_cohort.py:287-467`; `PaperOrderRequest` and `VerifiedPaperOrderIntent` are paper-experiment boundary records at `app/services/brokers/paper/contracts.py:124-206`. Exact general classes named `DecisionIntent`, `ExecutionPlan`, and `OrderAttempt` were absent from the scan. | Add only the contract-minimum, broker-neutral types in the existing shared leaf. Existing specialized records remain untouched. |
 
 The additive boundary is explicit:

--- a/docs/contracts/rob-1259-mock-auto-integration-j1-freeze.md
+++ b/docs/contracts/rob-1259-mock-auto-integration-j1-freeze.md
@@ -1,0 +1,169 @@
+# ROB-1259 J1 — mock/paper/demo integration contract freeze
+
+This is a vocabulary-and-type contract only. It is implemented by the
+side-effect-free definitions in `app/schemas/execution_contracts.py`; it does
+not choose a physical account, register a scheduler, call a broker, or change
+an existing ledger.
+
+Authority used for this freeze:
+
+- Master Contract §3 (`contract-mock-auto-integration-20260815.md`)
+- J0 verified audit SHA-256
+  `7200bcb43af423ce9d1df3a593bc42330c9e3074003a01c1cabb4e7cd90cb69e`
+  (§C lane matrix and §E2 split)
+- Repository base `fc990658547ba18196bd186e6ff4b06ff84e7f85`
+
+## Three-layer records
+
+The records are strict, frozen Pydantic definitions. Every listed field is
+required; a nullable field must still be supplied explicitly as `null` when it
+is not yet known.
+
+### `DecisionIntent`
+
+| Field | Type / invariant |
+|---|---|
+| `decision_intent_id` | non-blank opaque identifier |
+| `policy_version` | non-blank policy version |
+| `policy_version_hash` | non-blank existing policy hash representation; J1 does not rehash or impose a digest length |
+| `decision_timestamp` | timezone-aware timestamp |
+| `market_data_cutoff` | timezone-aware timestamp, not after `decision_timestamp` |
+| `symbol` | non-blank decision symbol; where a DB symbol conversion applies, its canonical form remains `.`-separated |
+| `side` | `buy` or `sell` |
+| `target_notional` | finite, positive `Decimal` |
+| `limit_policy` | required opaque JSON object; detailed policy vocabulary belongs to a later owner |
+| `expiry_policy` | required opaque JSON object; detailed policy vocabulary belongs to a later owner |
+| `rationale` | non-blank text |
+
+### `ExecutionPlan`
+
+| Field | Type / invariant |
+|---|---|
+| `execution_plan_id` | non-blank opaque identifier |
+| `decision_intent_id` | non-blank parent identifier |
+| `lane_id` | non-blank lane identifier; its registry is a J2A responsibility |
+| `broker` | non-blank broker identifier |
+| `account_profile` | non-blank logical profile identifier |
+| `account_mode` | non-blank existing account-mode value |
+| `normalized_symbol` | non-blank broker-ready symbol; conversion remains owned by `app/core/symbol.py` where applicable |
+| `quantity` | finite, positive `Decimal` |
+| `limit_price` | `null` or finite, positive `Decimal` |
+| `tick_rounding` | required opaque JSON object |
+| `session` | non-blank string or `null` |
+| `time_in_force` | non-blank string or `null` |
+| `min_order_validation` | required opaque JSON object |
+| `risk_caps` | required opaque JSON object |
+
+### `OrderAttempt`
+
+| Field | Type / invariant |
+|---|---|
+| `order_attempt_id` | non-blank opaque identifier |
+| `execution_plan_id` | non-blank parent identifier |
+| `cycle_id` | non-blank existing cycle identity, with its current lane-owned derivation retained |
+| `idempotency_key` | non-blank existing deduplication identity, with its current scope retained |
+| `broker_client_order_id` | non-blank broker client ID or `null` before it is available |
+| `broker_order_id` | non-blank broker order ID or `null` before acknowledgement/readback |
+
+The containment relation is fixed: one stable `DecisionIntent` may produce one
+or more account-specific `ExecutionPlan` records, and each `OrderAttempt`
+references exactly one plan. This contract does not prescribe persistence,
+fan-out, claim, submit, terminal-state, or recovery behavior.
+
+## Lane state allowlist
+
+`LaneState` is the only J1 lane-state vocabulary:
+
+```text
+AUTO_ENABLED
+AUTO_READY
+AUTO_READY_BLOCKED_BY_POLICY
+AUTO_READY_BLOCKED_BY_LIFECYCLE
+AUTO_READY_BLOCKED_BY_ACCOUNT_STATE
+AUTO_READY_BLOCKED_BY_SCHEDULER
+OBSERVATION_TEMPORARY
+SHADOW_ONLY
+DISABLED_NO_STRATEGY
+NOT_READY
+UNKNOWN
+```
+
+J0 §C fit is exact. All 12 rows use an allowlisted value, and the snapshot has
+zero `AUTO_ENABLED` rows.
+
+| J0 lane/profile | Frozen state |
+|---|---|
+| KR/KIS mock | `OBSERVATION_TEMPORARY` |
+| KR/Kiwoom mock | `NOT_READY` |
+| US/KIS mock | `NOT_READY` |
+| US/Kiwoom mock | `NOT_READY` |
+| US/Alpaca paper default | `AUTO_READY_BLOCKED_BY_POLICY` |
+| US/Alpaca paper lab | `AUTO_READY_BLOCKED_BY_LIFECYCLE` |
+| Crypto/Binance Spot Demo — canonical paper cohort | `NOT_READY` |
+| Crypto/Binance Spot Demo — B0-X sidecar | `OBSERVATION_TEMPORARY` |
+| Crypto/Alpaca paper — canonical cohort/default account | `NOT_READY` |
+| Crypto/Alpaca paper — clean account profile | `NOT_READY` |
+| Crypto/Upbit synthetic shadow | `SHADOW_ONLY` |
+| Crypto/Binance Futures Demo | `DISABLED_NO_STRATEGY` |
+
+The matrix's account/profile split is preserved, particularly the two Spot
+Demo and the two Alpaca crypto rows. J1 does not merge them or change their
+state rationale.
+
+## Evidence tier vocabulary
+
+`EvidenceTier` uses exactly these values:
+
+| Value | Meaning |
+|---|---|
+| `FACT` | directly observed source evidence |
+| `INFERENCE` | conclusion drawn by combining direct facts |
+| `UNVERIFIED` | not established from the permitted evidence surface |
+
+J0 §G records its middle category as `INFERENCE`; that spelling is canonical
+here. The illustrative adjective `INFERRED` is not a second wire value, so a
+claim cannot split across two synonymous categories.
+
+`research_contracts/strategy_ownership_manifest.py:47-130` already has an
+`EvidenceStatus`/`EvidenceFact` pair, but it models a broader ownership-manifest
+authority lifecycle (`accepted`, `missing`, `draft`, `stale`, and more). It is
+not a J0 claim-tier type and importing it would break this shared schema leaf.
+The narrowly scoped `EvidenceTier` therefore adds the missing three-value
+audit vocabulary without replacing that manifest contract.
+
+## Reuse census and additive boundary
+
+The census scanned `app`, `scripts`, `tests`, `research_contracts`, and `docs`
+at the frozen base with whole-tree `rg` queries. Hit counts are file counts,
+not a claim that every occurrence has one shared meaning.
+
+| Existing vocabulary / object | Census result and anchors | J1 decision |
+|---|---|---|
+| Shared execution schema leaf | `app/schemas/execution_contracts.py:1-16`, existing `ExecutionReadiness` at `:128-146` and `OrderPreviewLine` at `:148-191` | Extend this leaf; do not create a competing generic schema module. |
+| `correlation_id` | 295 matching files. Existing lane-specific derivations include `app/services/paper_correlation.py:17-35`, `app/services/live_correlation.py:15-34`, `app/services/kis_mock_runner/correlation.py:8-25`, and `app/services/brokers/binance/demo_strategy_loop/correlation.py:14-33`; native ledger columns include `app/models/review.py:206,278,716,845`. | Preserve every native derivation and ledger column. No new J1 `correlation_id` field or derivation is introduced; later work may carry the existing value through additive metadata. |
+| `cycle_id` | 19 matching files. B0-X owns deterministic derivation in `scripts/b0x/derivation.py:158-170,230-280`; Kiwoom batch ownership uses it at `scripts/b0x/kr/kiwoom.py:875-1162`. | Reuse the name only on `OrderAttempt`; J1 deliberately does not impose a new cross-lane format. |
+| `idempotency_key` | 231 matching files. KIS's durable pre-send reservation is `app/models/review.py:592-613` and `app/services/order_send_intent_service.py:30-95`; paper intent has its own exact provenance-derived key at `app/services/brokers/paper/contracts.py:154-206`. | Reuse the field name on `OrderAttempt`, retaining current scope and uniqueness behavior. J1 does not claim global uniqueness or replace existing reservations. |
+| `approval_*` | 194 matching files. Existing approval material is ledger metadata in `app/models/review.py:454,551,709-712` and dedicated preview/confirmation behavior in `app/mcp_server/tooling/orders_kis_variants.py:487-496` and `app/mcp_server/tooling/orders_toss_variants.py:965-1118`. | Keep approval artifacts separate from decision/plan/attempt identity. No new approval field, token, or gate is created. |
+| Policy version/hash | `app/services/trading_policy_service.py:111-134` returns the current policy version with its existing short `content_hash`; paper validation also carries full hashes at `app/services/paper_validation/contracts.py:71-90`. | Retain `policy_version_hash` as an opaque, non-blank contract field so both existing representations remain usable. No new hash function or policy storage is added. |
+| Existing decision/plan records | 16 matching files. `PaperCohortDecision` and `PaperCohortVenueIntent` are cohort-specific at `app/models/paper_cohort.py:287-467`; `PaperOrderRequest` and `VerifiedPaperOrderIntent` are paper-experiment boundary records at `app/services/brokers/paper/contracts.py:124-206`. Exact general classes named `DecisionIntent`, `ExecutionPlan`, and `OrderAttempt` were absent from the scan. | Add only the contract-minimum, broker-neutral types in the existing shared leaf. Existing specialized records remain untouched. |
+
+The additive boundary is explicit:
+
+- No ORM model, migration, ledger column, JSONL format, repository, service,
+  router, task, scheduler registration, broker adapter, or configuration value
+  is changed by J1.
+- Existing correlation, idempotency, and approval data stay in their current
+  native storage. J1 supplies names and type shape for later consumers only.
+- No direct string symbol conversion is added. Existing `to_kis_symbol`,
+  `to_yahoo_symbol`, and `to_db_symbol` remain the conversion authority.
+- A broker identifier is never treated as fill evidence. It is nullable at the
+  attempt layer until the appropriate later acknowledgement/readback path has
+  evidence.
+
+## J0 §E2 hand-off boundary
+
+J1 supplies the state, three record shapes, evidence vocabulary, and the
+additive compatibility rule. It intentionally leaves J2A's physical
+account/profile registry and J2B's durable correlation/idempotency/capability
+work unimplemented. The later J3+ lane work remains responsible for its own
+claim, mutation, and recovery paths.

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -620,6 +620,73 @@ class TestRob1259FrozenContracts:
         with pytest.raises(ValidationError):
             self._attempt(unexpected="field")
 
+    @pytest.mark.parametrize(
+        ("factory_name", "field_name"),
+        [
+            ("_intent", "decision_intent_id"),
+            ("_intent", "policy_version"),
+            ("_intent", "policy_version_hash"),
+            ("_intent", "symbol"),
+            ("_intent", "rationale"),
+            ("_plan", "execution_plan_id"),
+            ("_plan", "decision_intent_id"),
+            ("_plan", "lane_id"),
+            ("_plan", "broker"),
+            ("_plan", "account_profile"),
+            ("_plan", "account_mode"),
+            ("_plan", "normalized_symbol"),
+            ("_plan", "session"),
+            ("_plan", "time_in_force"),
+            ("_attempt", "order_attempt_id"),
+            ("_attempt", "execution_plan_id"),
+            ("_attempt", "cycle_id"),
+            ("_attempt", "idempotency_key"),
+            ("_attempt", "broker_client_order_id"),
+            ("_attempt", "broker_order_id"),
+        ],
+    )
+    def test_j1_nonblank_values_reject_whitespace(self, factory_name, field_name):
+        factory = getattr(self, factory_name)
+
+        with pytest.raises(ValidationError):
+            factory(**{field_name: "   "})
+
+    @pytest.mark.parametrize("value", [Decimal("0"), Decimal("-0.01")])
+    def test_target_notional_must_be_strictly_positive(self, value):
+        with pytest.raises(ValidationError):
+            self._intent(target_notional=value)
+
+    @pytest.mark.parametrize("value", [Decimal("0"), Decimal("-1")])
+    def test_execution_plan_quantity_must_be_strictly_positive(self, value):
+        with pytest.raises(ValidationError):
+            self._plan(quantity=value)
+
+    @pytest.mark.parametrize(
+        ("factory_name", "field_name", "implicit_value"),
+        [
+            ("_intent", "target_notional", 100.0),
+            ("_plan", "quantity", 1.0),
+        ],
+    )
+    def test_contract_rejects_implicit_scalar_coercion(
+        self, factory_name, field_name, implicit_value
+    ):
+        factory = getattr(self, factory_name)
+
+        with pytest.raises(ValidationError):
+            factory(**{field_name: implicit_value})
+
+    def test_idempotency_key_is_required_for_every_attempt(self):
+        payload = self._attempt().model_dump()
+        del payload["idempotency_key"]
+
+        with pytest.raises(ValidationError, match="idempotency_key"):
+            ec.OrderAttempt(**payload)
+
+    def test_decision_side_is_limited_to_buy_or_sell(self):
+        with pytest.raises(ValidationError):
+            self._intent(side="hold")
+
     def test_decision_time_and_price_invariants_fail_closed(self):
         with pytest.raises(ValidationError, match="market_data_cutoff"):
             self._intent(

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -1,7 +1,9 @@
 """Tests for shared execution contracts (ROB-100)."""
 
+import json
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import Literal
 
 import pytest
 from pydantic import ValidationError
@@ -479,6 +481,7 @@ class TestRob1259FrozenContracts:
             "symbol": "BRK.B",
             "side": "buy",
             "target_notional": Decimal("100"),
+            "target_notional_currency": "USD",
             "limit_policy": {"order_type": "limit"},
             "expiry_policy": {"kind": "day"},
             "rationale": "frozen contract example",
@@ -498,6 +501,7 @@ class TestRob1259FrozenContracts:
             "normalized_symbol": "BRK.B",
             "quantity": Decimal("1"),
             "limit_price": Decimal("100"),
+            "quote_currency": "USD",
             "tick_rounding": {"increment": "0.01"},
             "session": "regular",
             "time_in_force": "day",
@@ -534,6 +538,30 @@ class TestRob1259FrozenContracts:
                 "DISABLED_NO_STRATEGY",
                 "NOT_READY",
                 "UNKNOWN",
+            }
+        )
+
+    def test_common_control_vocabularies_remain_separate(self):
+        assert ec.LaneStatus is ec.LaneState
+        assert ec.LaneStatus is not ec.ActivationStatus
+        assert ec.LANE_STATUSES == ec.LANE_STATES
+        assert ec.ACTIVATION_STATUSES == frozenset({"READY_FOR_MOCK_DEPLOYMENT"})
+        assert ec.LANE_ROLES == frozenset(
+            {
+                "PRIMARY_AUTO",
+                "AUTO_MIRROR",
+                "BROKER_REGRESSION",
+                "EXECUTION_AUTO",
+            }
+        )
+        assert ec.SCHEDULER_OWNERS == frozenset(
+            {"taskiq", "prefect", "orch", "manual", "disabled"}
+        )
+        assert ec.TimingOwner is not ec.SchedulerOwner
+        assert ec.CURRENCY_ALIGNMENT_ERROR_CODES == frozenset(
+            {
+                "currency_conversion_not_authorized",
+                "lane_quote_currency_mismatch",
             }
         )
 
@@ -576,6 +604,7 @@ class TestRob1259FrozenContracts:
             "symbol",
             "side",
             "target_notional",
+            "target_notional_currency",
             "limit_policy",
             "expiry_policy",
             "rationale",
@@ -590,6 +619,7 @@ class TestRob1259FrozenContracts:
             "normalized_symbol",
             "quantity",
             "limit_price",
+            "quote_currency",
             "tick_rounding",
             "session",
             "time_in_force",
@@ -604,6 +634,16 @@ class TestRob1259FrozenContracts:
             "broker_client_order_id",
             "broker_order_id",
         }
+
+    def test_currency_fields_use_the_signed_literals(self):
+        assert (
+            ec.DecisionIntent.model_fields["target_notional_currency"].annotation
+            == (Literal["KRW", "USD", "USDT"])
+        )
+        assert (
+            ec.ExecutionPlan.model_fields["quote_currency"].annotation
+            == (Literal["KRW", "USD", "USDT"])
+        )
 
     def test_records_are_strict_frozen_definitions(self):
         intent = self._intent()
@@ -686,6 +726,80 @@ class TestRob1259FrozenContracts:
     def test_decision_side_is_limited_to_buy_or_sell(self):
         with pytest.raises(ValidationError):
             self._intent(side="hold")
+
+    @pytest.mark.parametrize(
+        ("factory_name", "field_name"),
+        [
+            ("_intent", "target_notional_currency"),
+            ("_plan", "quote_currency"),
+        ],
+    )
+    @pytest.mark.parametrize("invalid_currency", [None, "", " ", " KRW", "krw", "EUR"])
+    def test_currency_fields_reject_invalid_values(
+        self, factory_name, field_name, invalid_currency
+    ):
+        factory = getattr(self, factory_name)
+
+        with pytest.raises(ValidationError, match=field_name):
+            factory(**{field_name: invalid_currency})
+
+    @pytest.mark.parametrize(
+        ("model_type", "factory_name", "field_name"),
+        [
+            (ec.DecisionIntent, "_intent", "target_notional_currency"),
+            (ec.ExecutionPlan, "_plan", "quote_currency"),
+        ],
+    )
+    def test_currency_fields_are_required(self, model_type, factory_name, field_name):
+        payload = getattr(self, factory_name)().model_dump()
+        del payload[field_name]
+
+        with pytest.raises(ValidationError, match=field_name):
+            model_type(**payload)
+
+    @pytest.mark.parametrize("currency", ["KRW", "USD", "USDT"])
+    def test_matching_currency_records_support_strict_json_round_trip(self, currency):
+        intent = self._intent(target_notional_currency=currency)
+        plan = self._plan(quote_currency=currency)
+        intent_json = intent.model_dump_json()
+        plan_json = plan.model_dump_json()
+
+        assert ec.DecisionIntent.model_validate_json(intent_json) == intent
+        assert ec.ExecutionPlan.model_validate_json(plan_json) == plan
+        ec.validate_plan_currency_alignment(intent, plan)
+        assert ec.create_execution_plan(intent, **plan.model_dump()) == plan
+
+        with pytest.raises(ValidationError):
+            ec.DecisionIntent.model_validate(json.loads(intent_json))
+        with pytest.raises(ValidationError):
+            ec.ExecutionPlan.model_validate(json.loads(plan_json))
+
+    @pytest.mark.parametrize(
+        ("intent_currency", "plan_currency"),
+        [
+            ("KRW", "USD"),
+            ("KRW", "USDT"),
+            ("USD", "KRW"),
+            ("USD", "USDT"),
+            ("USDT", "KRW"),
+            ("USDT", "USD"),
+        ],
+    )
+    def test_currency_mismatch_fails_closed_with_the_signed_error(
+        self, intent_currency, plan_currency
+    ):
+        intent = self._intent(target_notional_currency=intent_currency)
+        plan = self._plan(quote_currency=plan_currency)
+
+        with pytest.raises(ValueError) as excinfo:
+            ec.validate_plan_currency_alignment(intent, plan)
+
+        assert str(excinfo.value) == "currency_conversion_not_authorized"
+
+        with pytest.raises(ValueError) as creation_excinfo:
+            ec.create_execution_plan(intent, **plan.model_dump())
+
+        assert str(creation_excinfo.value) == "currency_conversion_not_authorized"
 
     def test_decision_time_and_price_invariants_fail_closed(self):
         with pytest.raises(ValidationError, match="market_data_cutoff"):

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -463,3 +463,184 @@ def test_cancelled_is_registered_terminal_state():
     assert "canceled" in ORDER_LIFECYCLE_STATES
     assert "canceled" in TERMINAL_LIFECYCLE_STATES
     assert is_terminal_state("canceled") is True
+
+
+class TestRob1259FrozenContracts:
+    """J1 vocabulary must remain definition-only and exact."""
+
+    @staticmethod
+    def _intent(**overrides):
+        payload = {
+            "decision_intent_id": "decision-1",
+            "policy_version": "policy-v1",
+            "policy_version_hash": "a" * 12,
+            "decision_timestamp": datetime(2026, 8, 15, 9, 0, tzinfo=UTC),
+            "market_data_cutoff": datetime(2026, 8, 15, 8, 59, tzinfo=UTC),
+            "symbol": "BRK.B",
+            "side": "buy",
+            "target_notional": Decimal("100"),
+            "limit_policy": {"order_type": "limit"},
+            "expiry_policy": {"kind": "day"},
+            "rationale": "frozen contract example",
+        }
+        payload.update(overrides)
+        return ec.DecisionIntent(**payload)
+
+    @staticmethod
+    def _plan(**overrides):
+        payload = {
+            "execution_plan_id": "plan-1",
+            "decision_intent_id": "decision-1",
+            "lane_id": "us-alpaca-paper-default",
+            "broker": "alpaca",
+            "account_profile": "default-paper",
+            "account_mode": "alpaca_paper",
+            "normalized_symbol": "BRK.B",
+            "quantity": Decimal("1"),
+            "limit_price": Decimal("100"),
+            "tick_rounding": {"increment": "0.01"},
+            "session": "regular",
+            "time_in_force": "day",
+            "min_order_validation": {"quote_required": True},
+            "risk_caps": {"max_notional": "100"},
+        }
+        payload.update(overrides)
+        return ec.ExecutionPlan(**payload)
+
+    @staticmethod
+    def _attempt(**overrides):
+        payload = {
+            "order_attempt_id": "attempt-1",
+            "execution_plan_id": "plan-1",
+            "cycle_id": "cycle-1",
+            "idempotency_key": "idempotency-1",
+            "broker_client_order_id": None,
+            "broker_order_id": None,
+        }
+        payload.update(overrides)
+        return ec.OrderAttempt(**payload)
+
+    def test_lane_states_exactly_match_the_j1_allowlist(self):
+        assert ec.LANE_STATES == frozenset(
+            {
+                "AUTO_ENABLED",
+                "AUTO_READY",
+                "AUTO_READY_BLOCKED_BY_POLICY",
+                "AUTO_READY_BLOCKED_BY_LIFECYCLE",
+                "AUTO_READY_BLOCKED_BY_ACCOUNT_STATE",
+                "AUTO_READY_BLOCKED_BY_SCHEDULER",
+                "OBSERVATION_TEMPORARY",
+                "SHADOW_ONLY",
+                "DISABLED_NO_STRATEGY",
+                "NOT_READY",
+                "UNKNOWN",
+            }
+        )
+
+    def test_j0_lane_matrix_fits_the_frozen_allowlist_with_no_enabled_lane(self):
+        j0_lane_states = {
+            "KR/KIS mock": "OBSERVATION_TEMPORARY",
+            "KR/Kiwoom mock": "NOT_READY",
+            "US/KIS mock": "NOT_READY",
+            "US/Kiwoom mock": "NOT_READY",
+            "US/Alpaca paper default": "AUTO_READY_BLOCKED_BY_POLICY",
+            "US/Alpaca paper lab": "AUTO_READY_BLOCKED_BY_LIFECYCLE",
+            "Crypto/Binance Spot Demo canonical paper cohort": "NOT_READY",
+            "Crypto/Binance Spot Demo B0-X sidecar": "OBSERVATION_TEMPORARY",
+            "Crypto/Alpaca paper canonical cohort/default account": "NOT_READY",
+            "Crypto/Alpaca paper clean account": "NOT_READY",
+            "Crypto/Upbit synthetic shadow": "SHADOW_ONLY",
+            "Crypto/Binance Futures Demo": "DISABLED_NO_STRATEGY",
+        }
+
+        assert set(j0_lane_states.values()) <= ec.LANE_STATES
+        assert (
+            sum(
+                state == ec.LaneState.AUTO_ENABLED.value
+                for state in j0_lane_states.values()
+            )
+            == 0
+        )
+
+    def test_evidence_tiers_match_j0_claim_categories(self):
+        assert ec.EVIDENCE_TIERS == frozenset({"FACT", "INFERENCE", "UNVERIFIED"})
+        assert ec.EvidenceTier.INFERENCE.value == "INFERENCE"
+
+    def test_three_tier_models_have_exact_minimum_fields(self):
+        assert set(ec.DecisionIntent.model_fields) == {
+            "decision_intent_id",
+            "policy_version",
+            "policy_version_hash",
+            "decision_timestamp",
+            "market_data_cutoff",
+            "symbol",
+            "side",
+            "target_notional",
+            "limit_policy",
+            "expiry_policy",
+            "rationale",
+        }
+        assert set(ec.ExecutionPlan.model_fields) == {
+            "execution_plan_id",
+            "decision_intent_id",
+            "lane_id",
+            "broker",
+            "account_profile",
+            "account_mode",
+            "normalized_symbol",
+            "quantity",
+            "limit_price",
+            "tick_rounding",
+            "session",
+            "time_in_force",
+            "min_order_validation",
+            "risk_caps",
+        }
+        assert set(ec.OrderAttempt.model_fields) == {
+            "order_attempt_id",
+            "execution_plan_id",
+            "cycle_id",
+            "idempotency_key",
+            "broker_client_order_id",
+            "broker_order_id",
+        }
+
+    def test_records_are_strict_frozen_definitions(self):
+        intent = self._intent()
+        plan = self._plan()
+        attempt = self._attempt()
+
+        with pytest.raises(ValidationError):
+            intent.symbol = "other"
+        with pytest.raises(ValidationError):
+            plan.broker = "other"
+        with pytest.raises(ValidationError):
+            attempt.cycle_id = "other"
+
+        with pytest.raises(ValidationError):
+            self._attempt(unexpected="field")
+
+    def test_decision_time_and_price_invariants_fail_closed(self):
+        with pytest.raises(ValidationError, match="market_data_cutoff"):
+            self._intent(
+                market_data_cutoff=datetime(2026, 8, 15, 9, 1, tzinfo=UTC),
+            )
+        with pytest.raises(ValidationError, match="timezone-aware"):
+            self._intent(decision_timestamp=datetime(2026, 8, 15, 9, 0))
+        with pytest.raises(ValidationError, match="limit_price"):
+            self._plan(limit_price=Decimal("0"))
+
+    def test_attempt_preserves_existing_correlation_and_approval_surfaces(self):
+        attempt = self._attempt(
+            broker_client_order_id="client-1",
+            broker_order_id="broker-1",
+        )
+        assert attempt.cycle_id == "cycle-1"
+        assert attempt.idempotency_key == "idempotency-1"
+        all_fields = (
+            set(ec.DecisionIntent.model_fields)
+            | set(ec.ExecutionPlan.model_fields)
+            | set(ec.OrderAttempt.model_fields)
+        )
+        assert "correlation_id" not in all_fields
+        assert "approval_hash" not in all_fields


### PR DESCRIPTION
## Summary
- Freeze DecisionIntent, ExecutionPlan, and OrderAttempt vocabulary in the shared execution schema leaf.
- Freeze the 11-state lane allowlist and FACT/INFERENCE/UNVERIFIED evidence tiers.
- Document the repository-wide reuse census and J0 §C / §E2 hand-off boundary.

## Safety scope
- Definition, documentation, and contract tests only.
- No ledger/model/migration, broker, scheduler, account, or configuration changes.

## Validation
- `uv run pytest tests/test_execution_contracts.py -v` — 47 passed
- `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v` — 3 passed
- `make lint` — passed
- `make test` — 19,643 passed, 13 skipped, 7 deselected; 3 existing research provider-config expectation failures outside this diff (listed in handoff report).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict execution-contract records for decision intents, execution plans, and order attempts.
  * Added standardized lane, activation, role, scheduler, currency-error, and evidence vocabularies.
  * Added validation for currencies, timestamps, pricing, positive values, required fields, and JSON-compatible data.
  * Added immutable records with protection against unexpected fields and unintended modifications.

* **Documentation**
  * Documented the frozen contract formats, validation rules, compatibility mappings, and supported boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->