### PR TITLE
ROB-1260: add account identity lane registry

### DIFF
--- a/app/services/mock_lane_registry.py
+++ b/app/services/mock_lane_registry.py
@@ -1,0 +1,1074 @@
+"""Fail-closed mock/paper/demo account identity registry (ROB-1260).
+
+This module is deliberately inert.  It performs no broker, database, scheduler,
+or credential I/O.  Canonical rows describe the evidence available at the J2A
+boundary; unavailable bindings stay present and blocked instead of being
+guessed or filtered out.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Final, Literal, Protocol
+from urllib.parse import urlsplit
+
+from app.schemas.execution_contracts import LaneStatus, SchedulerOwner
+
+QuoteCurrency = Literal["KRW", "USD", "USDT"]
+
+
+class AccountMode(StrEnum):
+    """Only non-live account modes are representable in this registry."""
+
+    MOCK = "mock"
+    PAPER = "paper"
+    DEMO = "demo"
+    SHADOW = "shadow"
+
+
+class EndpointClass(StrEnum):
+    """Endpoint classes intentionally omit a live value."""
+
+    MOCK = "mock"
+    PAPER = "paper"
+    DEMO = "demo"
+    SHADOW = "shadow"
+
+
+class RegistryRole(StrEnum):
+    """Single-value role vocabulary used by the lane registry."""
+
+    PRIMARY_AUTO = "PRIMARY_AUTO"
+    AUTO_MIRROR = "AUTO_MIRROR"
+    BROKER_REGRESSION = "BROKER_REGRESSION"
+    EXECUTION_AUTO = "EXECUTION_AUTO"
+    AUTO_CHALLENGER = "AUTO_CHALLENGER"
+    SHADOW_ONLY = "SHADOW_ONLY"
+
+
+class ActivationStatus(StrEnum):
+    """Activation is a separate axis from :class:`LaneStatus`."""
+
+    DISABLED = "DISABLED"
+    BLOCKED = "BLOCKED"
+    READY = "READY"
+    ENABLED = "ENABLED"
+    RUNTIME_ACCEPTANCE_PENDING = "RUNTIME_ACCEPTANCE_PENDING"
+    READY_FOR_MOCK_DEPLOYMENT = "READY_FOR_MOCK_DEPLOYMENT"
+
+
+class MissingBinding(StrEnum):
+    """Bindings that may not be synthesized at the J2A boundary."""
+
+    PHYSICAL_ACCOUNT_FINGERPRINT = "physical_account_fingerprint"
+    POLICY = "policy"
+    CAP = "cap"
+    OWNER = "owner"
+    CANARY = "canary"
+
+
+ACTIVATION_TRANSITION_GUARDS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "G1": (
+            "ENABLED 진입은 기존에 직접 증명된 cadence 보존 lane 에만. 신규 recurring\n"
+            "       schedule 이 필요하면 진입 금지 → "
+            "AUTO_READY_BLOCKED_BY_SCHEDULER (D4)"
+        ),
+        "G2": (
+            "READY_FOR_MOCK_DEPLOYMENT 는 종착 상태. shared production release 또는\n"
+            "       live restart 필요 시 여기서 정지, 자동 승격 경로 없음 "
+            "(운영자 결정 6)"
+        ),
+        "G3": (
+            "J8 canary 성공은 RUNTIME_ACCEPTANCE_PENDING → READY 까지만 이동시키며\n"
+            "       ENABLED 로 자동 전이시키지 않는다 (D4)"
+        ),
+    }
+)
+
+UNKNOWN_IDENTITY_RULE: Final[str] = (
+    "broker fingerprint 증거 부재 시 physical_account_id=null,\n"
+    "  identity_status=UNKNOWN, writer=false, auto=false. 행은 삭제하지 않는다."
+)
+MISSING_BINDING_RULE: Final[str] = (
+    "policy/cap/owner/canary 부재 시 행을 보존하고\n"
+    "  blocked|disabled + 사유. worker 는 값을 발명하지 않는다."
+)
+
+CANONICAL_LANE_IDS: Final[tuple[str, ...]] = (
+    "kr.kis.mock",
+    "kr.kiwoom.mock",
+    "us.kis.mock",
+    "us.kiwoom.mock",
+    "us.alpaca.paper.default",
+    "us.alpaca.paper.lab",
+    "crypto.binance.spot_demo.canonical",
+    "crypto.binance.spot_demo.b0x_sidecar",
+    "crypto.alpaca.paper.default",
+    "crypto.alpaca.paper.clean",
+    "crypto.upbit.shadow",
+    "crypto.binance.futures_demo",
+)
+
+LANE_QUOTE_CURRENCIES: Final[Mapping[str, QuoteCurrency]] = MappingProxyType(
+    {
+        "kr.kis.mock": "KRW",
+        "kr.kiwoom.mock": "KRW",
+        "us.kis.mock": "USD",
+        "us.kiwoom.mock": "USD",
+        "us.alpaca.paper.default": "USD",
+        "us.alpaca.paper.lab": "USD",
+        "crypto.binance.spot_demo.canonical": "USDT",
+        "crypto.binance.spot_demo.b0x_sidecar": "USDT",
+        "crypto.alpaca.paper.default": "USD",
+        "crypto.alpaca.paper.clean": "USD",
+        "crypto.upbit.shadow": "KRW",
+        "crypto.binance.futures_demo": "USDT",
+    }
+)
+
+# Symbolic namespace names only; credential values are never loaded here.
+LANE_CREDENTIAL_NAMESPACES: Final[Mapping[str, str | None]] = MappingProxyType(
+    {
+        "kr.kis.mock": "KIS_MOCK_*",
+        "kr.kiwoom.mock": "KIWOOM_MOCK_*",
+        "us.kis.mock": "KIS_MOCK_*",
+        "us.kiwoom.mock": "KIWOOM_MOCK_US_*",
+        "us.alpaca.paper.default": "ALPACA_PAPER_*",
+        "us.alpaca.paper.lab": "ALPACA_PAPER_LAB_*",
+        "crypto.binance.spot_demo.canonical": "BINANCE_SPOT_DEMO_API_*",
+        "crypto.binance.spot_demo.b0x_sidecar": "BINANCE_SPOT_DEMO_API_*",
+        "crypto.alpaca.paper.default": "ALPACA_PAPER_*",
+        "crypto.alpaca.paper.clean": "ALPACA_PAPER_CRYPTO_*",
+        "crypto.upbit.shadow": None,
+        "crypto.binance.futures_demo": "BINANCE_FUTURES_DEMO_API_*",
+    }
+)
+
+LANE_ALLOWED_HOSTS: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
+    {
+        "kr.kis.mock": ("openapivts.koreainvestment.com:29443",),
+        "kr.kiwoom.mock": ("mockapi.kiwoom.com",),
+        "us.kis.mock": ("openapivts.koreainvestment.com:29443",),
+        "us.kiwoom.mock": ("mockapi.kiwoom.com",),
+        "us.alpaca.paper.default": ("paper-api.alpaca.markets",),
+        "us.alpaca.paper.lab": ("paper-api.alpaca.markets",),
+        "crypto.binance.spot_demo.canonical": ("demo-api.binance.com",),
+        "crypto.binance.spot_demo.b0x_sidecar": ("demo-api.binance.com",),
+        "crypto.alpaca.paper.default": ("paper-api.alpaca.markets",),
+        "crypto.alpaca.paper.clean": ("paper-api.alpaca.markets",),
+        "crypto.upbit.shadow": (),
+        "crypto.binance.futures_demo": ("demo-fapi.binance.com",),
+    }
+)
+
+_FORBIDDEN_LIVE_HOSTS: Final[frozenset[str]] = frozenset(
+    {
+        "openapi.koreainvestment.com",
+        "openapi.koreainvestment.com:9443",
+        "api.kiwoom.com",
+        "api.alpaca.markets",
+        "data.alpaca.markets",
+        "api.binance.com",
+        "fapi.binance.com",
+        "api.upbit.com",
+    }
+)
+
+_MISSING_REQUIRED_BINDINGS: Final[tuple[MissingBinding, ...]] = (
+    MissingBinding.PHYSICAL_ACCOUNT_FINGERPRINT,
+    MissingBinding.POLICY,
+    MissingBinding.CAP,
+    MissingBinding.OWNER,
+    MissingBinding.CANARY,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LaneRegistryEntry:
+    """One preserved logical lane and its current physical-binding evidence."""
+
+    lane_id: str
+    market: str
+    broker: str
+    account_profile: str
+    profile_variant: str | None
+    account_mode: AccountMode
+    lane_type: AccountMode
+    quote_currency: QuoteCurrency
+    role: RegistryRole | None
+    role_pending_reason: str | None
+    role_on_policy_approval: RegistryRole | None
+    lane_status: LaneStatus
+    activation_status: ActivationStatus
+    activation_reason: str
+    policy_binding: str | None
+    execution_mode: str | None
+    scheduler_owner: SchedulerOwner | None
+    timing_owner: str | None
+    writer: bool
+    auto_order_enabled: bool
+    max_order_notional: Decimal | None
+    max_orders_per_session: int | None
+    max_open_orders: int | None
+    allowed_order_types: tuple[str, ...]
+    allowed_time_in_force: tuple[str, ...]
+    endpoint_class: EndpointClass
+    reconcile_required: bool | None
+    credential_namespace: str | None
+    allowed_hosts: tuple[str, ...]
+    physical_account_id: str | None = field(repr=False)
+    identity_status: str
+    fingerprint_evidence_ref: str | None = field(repr=False)
+    canary_binding: str | None
+    missing_bindings: tuple[MissingBinding, ...]
+
+    @property
+    def auto(self) -> bool:
+        """Exact short name used by the unknown-identity safety rule."""
+
+        return self.auto_order_enabled
+
+
+def _canonical_entry(
+    lane_id: str,
+    *,
+    market: str,
+    broker: str,
+    account_profile: str,
+    profile_variant: str | None,
+    account_mode: AccountMode,
+    role: RegistryRole | None,
+    role_pending_reason: str | None = None,
+    role_on_policy_approval: RegistryRole | None = None,
+    lane_status: LaneStatus,
+    activation_status: ActivationStatus,
+    scheduler_owner: SchedulerOwner | None = None,
+) -> LaneRegistryEntry:
+    return LaneRegistryEntry(
+        lane_id=lane_id,
+        market=market,
+        broker=broker,
+        account_profile=account_profile,
+        profile_variant=profile_variant,
+        account_mode=account_mode,
+        lane_type=account_mode,
+        quote_currency=LANE_QUOTE_CURRENCIES[lane_id],
+        role=role,
+        role_pending_reason=role_pending_reason,
+        role_on_policy_approval=role_on_policy_approval,
+        lane_status=lane_status,
+        activation_status=activation_status,
+        activation_reason=lane_status.value,
+        policy_binding=None,
+        execution_mode=None,
+        scheduler_owner=scheduler_owner,
+        timing_owner=None,
+        writer=False,
+        auto_order_enabled=False,
+        max_order_notional=None,
+        max_orders_per_session=None,
+        max_open_orders=None,
+        allowed_order_types=(),
+        allowed_time_in_force=(),
+        endpoint_class=EndpointClass(account_mode.value),
+        reconcile_required=None,
+        credential_namespace=LANE_CREDENTIAL_NAMESPACES[lane_id],
+        allowed_hosts=LANE_ALLOWED_HOSTS[lane_id],
+        physical_account_id=None,
+        identity_status="UNKNOWN",
+        fingerprint_evidence_ref=None,
+        canary_binding=None,
+        missing_bindings=_MISSING_REQUIRED_BINDINGS,
+    )
+
+
+CANONICAL_LANE_REGISTRY: Final[tuple[LaneRegistryEntry, ...]] = (
+    _canonical_entry(
+        "kr.kis.mock",
+        market="kr",
+        broker="kis",
+        account_profile="mock",
+        profile_variant=None,
+        account_mode=AccountMode.MOCK,
+        role=RegistryRole.AUTO_MIRROR,
+        lane_status=LaneStatus.OBSERVATION_TEMPORARY,
+        activation_status=ActivationStatus.BLOCKED,
+    ),
+    _canonical_entry(
+        "kr.kiwoom.mock",
+        market="kr",
+        broker="kiwoom",
+        account_profile="mock",
+        profile_variant=None,
+        account_mode=AccountMode.MOCK,
+        role=RegistryRole.PRIMARY_AUTO,
+        lane_status=LaneStatus.NOT_READY,
+        activation_status=ActivationStatus.BLOCKED,
+    ),
+    _canonical_entry(
+        "us.kis.mock",
+        market="us",
+        broker="kis",
+        account_profile="mock",
+        profile_variant=None,
+        account_mode=AccountMode.MOCK,
+        role=RegistryRole.AUTO_MIRROR,
+        lane_status=LaneStatus.NOT_READY,
+        activation_status=ActivationStatus.BLOCKED,
+    ),
+    _canonical_entry(
+        "us.kiwoom.mock",
+        market="us",
+        broker="kiwoom",
+        account_profile="mock",
+        profile_variant=None,
+        account_mode=AccountMode.MOCK,
+        role=RegistryRole.BROKER_REGRESSION,
+        lane_status=LaneStatus.NOT_READY,
+        activation_status=ActivationStatus.BLOCKED,
+    ),
+    _canonical_entry(
+        "us.alpaca.paper.default",
+        market="us",
+        broker="alpaca",
+        account_profile="paper",
+        profile_variant="default",
+        account_mode=AccountMode.PAPER,
+        role=RegistryRole.PRIMARY_AUTO,
+        lane_status=LaneStatus.AUTO_READY_BLOCKED_BY_POLICY,
+        activation_status=ActivationStatus.BLOCKED,
+    ),
+    _canonical_entry(
+        "us.alpaca.paper.lab",
+        market="us",
+        broker="alpaca",
+        account_profile="paper",
+        profile_variant="lab",
+        account_mode=AccountMode.PAPER,
+        role=None,
+        role_pending_reason="policy_absent",
+        role_on_policy_approval=RegistryRole.AUTO_CHALLENGER,
+        lane_status=LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE,
+        activation_status=ActivationStatus.BLOCKED,
+    ),
+    _canonical_entry(
+        "crypto.binance.spot_demo.canonical",
+        market="crypto",
+        broker="binance",
+        account_profile="spot_demo",
+        profile_variant="canonical",
+        account_mode=AccountMode.DEMO,
+        role=RegistryRole.PRIMARY_AUTO,
+        lane_status=LaneStatus.NOT_READY,
+        activation_status=ActivationStatus.BLOCKED,
+        scheduler_owner=SchedulerOwner.DISABLED,
+    ),
+    _canonical_entry(
+        "crypto.binance.spot_demo.b0x_sidecar",
+        market="crypto",
+        broker="binance",
+        account_profile="spot_demo",
+        profile_variant="b0x_sidecar",
+        account_mode=AccountMode.DEMO,
+        role=RegistryRole.SHADOW_ONLY,
+        lane_status=LaneStatus.OBSERVATION_TEMPORARY,
+        activation_status=ActivationStatus.DISABLED,
+        scheduler_owner=SchedulerOwner.DISABLED,
+    ),
+    _canonical_entry(
+        "crypto.alpaca.paper.default",
+        market="crypto",
+        broker="alpaca",
+        account_profile="paper",
+        profile_variant="default",
+        account_mode=AccountMode.PAPER,
+        role=RegistryRole.AUTO_MIRROR,
+        lane_status=LaneStatus.NOT_READY,
+        activation_status=ActivationStatus.DISABLED,
+    ),
+    _canonical_entry(
+        "crypto.alpaca.paper.clean",
+        market="crypto",
+        broker="alpaca",
+        account_profile="paper",
+        profile_variant="clean",
+        account_mode=AccountMode.PAPER,
+        role=RegistryRole.AUTO_MIRROR,
+        lane_status=LaneStatus.NOT_READY,
+        activation_status=ActivationStatus.DISABLED,
+    ),
+    _canonical_entry(
+        "crypto.upbit.shadow",
+        market="crypto",
+        broker="upbit",
+        account_profile="shadow",
+        profile_variant=None,
+        account_mode=AccountMode.SHADOW,
+        role=RegistryRole.SHADOW_ONLY,
+        lane_status=LaneStatus.SHADOW_ONLY,
+        activation_status=ActivationStatus.DISABLED,
+    ),
+    _canonical_entry(
+        "crypto.binance.futures_demo",
+        market="crypto",
+        broker="binance",
+        account_profile="futures_demo",
+        profile_variant=None,
+        account_mode=AccountMode.DEMO,
+        role=None,
+        lane_status=LaneStatus.DISABLED_NO_STRATEGY,
+        activation_status=ActivationStatus.DISABLED,
+        scheduler_owner=SchedulerOwner.DISABLED,
+    ),
+)
+
+_CANONICAL_BY_ID: Final[Mapping[str, LaneRegistryEntry]] = MappingProxyType(
+    {entry.lane_id: entry for entry in CANONICAL_LANE_REGISTRY}
+)
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class RegistryIssue:
+    code: str
+    lane_ids: tuple[str, ...]
+    detail: str
+
+
+class RegistryStartupError(RuntimeError):
+    """Raised before runtime construction when registry invariants fail."""
+
+    def __init__(self, issues: Iterable[RegistryIssue]) -> None:
+        self.issues = tuple(sorted(issues))
+        message = "; ".join(
+            f"{issue.code}[{','.join(issue.lane_ids)}]: {issue.detail}"
+            for issue in self.issues
+        )
+        super().__init__(message)
+
+
+class LaneGuardError(RuntimeError):
+    """Fail-closed pre-I/O rejection with a stable machine code."""
+
+    def __init__(self, code: str, *, lane_id: str) -> None:
+        self.code = code
+        self.lane_id = lane_id
+        super().__init__(f"{code}: lane={lane_id}")
+
+
+class ActivationTransitionBlocked(LaneGuardError):
+    """An activation transition rejected by one exact amendment guard."""
+
+    def __init__(self, code: str, *, lane_id: str, guard_id: str) -> None:
+        self.guard_id = guard_id
+        super().__init__(code, lane_id=lane_id)
+
+
+def mask_account_identifier(value: str | None) -> str | None:
+    """Return a non-reversible display value without exposing any identifier part."""
+
+    return None if value is None else "[MASKED]"
+
+
+def get_lane_registry_entry(lane_id: str) -> LaneRegistryEntry:
+    """Return blocked/disabled rows too; missing bindings never delete a lane."""
+
+    try:
+        return _CANONICAL_BY_ID[lane_id]
+    except KeyError as exc:
+        raise LaneGuardError("unknown_lane", lane_id=lane_id) from exc
+
+
+def _entry_issues(entry: LaneRegistryEntry) -> list[RegistryIssue]:
+    issues: list[RegistryIssue] = []
+    lane_ids = (entry.lane_id,)
+    expected_lane_id = ".".join(
+        part
+        for part in (
+            entry.market,
+            entry.broker,
+            entry.account_profile,
+            entry.profile_variant,
+        )
+        if part is not None
+    )
+    if entry.lane_id != expected_lane_id:
+        issues.append(
+            RegistryIssue(
+                "lane_id_components_mismatch",
+                lane_ids,
+                "market.broker.profile[.variant] must reconstruct lane_id",
+            )
+        )
+    if entry.quote_currency not in {"KRW", "USD", "USDT"}:
+        issues.append(
+            RegistryIssue("invalid_quote_currency", lane_ids, "allowed: KRW|USD|USDT")
+        )
+    if not isinstance(entry.role, RegistryRole | type(None)):
+        issues.append(
+            RegistryIssue("role_not_single_value", lane_ids, "role must be scalar")
+        )
+    if entry.role is None and entry.role_pending_reason is not None:
+        if not entry.role_pending_reason.strip():
+            issues.append(
+                RegistryIssue(
+                    "blank_role_pending_reason", lane_ids, "reason must be non-blank"
+                )
+            )
+    if entry.role is None and entry.role_on_policy_approval is not None:
+        if entry.role_pending_reason is None:
+            issues.append(
+                RegistryIssue(
+                    "role_future_reference_without_reason",
+                    lane_ids,
+                    "a future role reference requires a pending reason",
+                )
+            )
+    if entry.role is not None and (
+        entry.role_pending_reason is not None
+        or entry.role_on_policy_approval is not None
+    ):
+        issues.append(
+            RegistryIssue(
+                "active_role_has_pending_fields",
+                lane_ids,
+                "pending fields apply only while role is null",
+            )
+        )
+    valid_account_mode = isinstance(entry.account_mode, AccountMode)
+    valid_endpoint_class = isinstance(entry.endpoint_class, EndpointClass)
+    valid_lane_type = isinstance(entry.lane_type, AccountMode)
+    if not valid_account_mode:
+        code = (
+            "live_account_mode_forbidden"
+            if str(entry.account_mode).lower() == "live"
+            else "invalid_account_mode"
+        )
+        issues.append(
+            RegistryIssue(code, lane_ids, "only mock|paper|demo|shadow are allowed")
+        )
+    if not valid_endpoint_class:
+        issues.append(
+            RegistryIssue(
+                "invalid_endpoint_class",
+                lane_ids,
+                "only mock|paper|demo|shadow are allowed",
+            )
+        )
+    if not valid_lane_type:
+        issues.append(
+            RegistryIssue(
+                "invalid_lane_type",
+                lane_ids,
+                "lane_type must use the non-live account-mode vocabulary",
+            )
+        )
+    if valid_account_mode and valid_endpoint_class:
+        if entry.account_mode.value != entry.endpoint_class.value:
+            issues.append(
+                RegistryIssue(
+                    "endpoint_class_mode_mismatch",
+                    lane_ids,
+                    "endpoint class and non-live account mode must agree",
+                )
+            )
+    if valid_account_mode and valid_lane_type:
+        if entry.lane_type is not entry.account_mode:
+            issues.append(
+                RegistryIssue(
+                    "lane_type_mode_mismatch",
+                    lane_ids,
+                    "lane type and account mode must agree",
+                )
+            )
+    if entry.scheduler_owner is not None and entry.timing_owner is not None:
+        if entry.scheduler_owner.value == entry.timing_owner:
+            issues.append(
+                RegistryIssue(
+                    "scheduler_timing_owner_collapsed",
+                    lane_ids,
+                    "scheduler_owner and timing_owner are distinct bindings",
+                )
+            )
+    if entry.allowed_hosts != tuple(dict.fromkeys(entry.allowed_hosts)):
+        issues.append(
+            RegistryIssue(
+                "duplicate_allowed_host", lane_ids, "allowed hosts must be unique"
+            )
+        )
+    forbidden_hosts = sorted(set(entry.allowed_hosts) & _FORBIDDEN_LIVE_HOSTS)
+    if forbidden_hosts:
+        issues.append(
+            RegistryIssue(
+                "live_host_in_allowlist",
+                lane_ids,
+                "live hosts cannot be registered",
+            )
+        )
+    identity_unknown = (
+        entry.physical_account_id is None
+        or entry.fingerprint_evidence_ref is None
+        or entry.identity_status == "UNKNOWN"
+    )
+    if identity_unknown and not (
+        entry.physical_account_id is None
+        and entry.fingerprint_evidence_ref is None
+        and entry.identity_status == "UNKNOWN"
+        and entry.writer is False
+        and entry.auto is False
+    ):
+        issues.append(
+            RegistryIssue(
+                "unknown_identity_must_be_safe",
+                lane_ids,
+                "requires null/UNKNOWN with writer=false and auto=false",
+            )
+        )
+    identity_evidence_values = (
+        entry.physical_account_id,
+        entry.fingerprint_evidence_ref,
+        entry.identity_status,
+    )
+    if not identity_unknown and not all(
+        isinstance(value, str) and value.strip() for value in identity_evidence_values
+    ):
+        issues.append(
+            RegistryIssue(
+                "physical_account_identity_blank",
+                lane_ids,
+                "identity evidence fields must be non-blank",
+            )
+        )
+    if entry.missing_bindings:
+        if entry.activation_status not in {
+            ActivationStatus.BLOCKED,
+            ActivationStatus.DISABLED,
+        }:
+            issues.append(
+                RegistryIssue(
+                    "missing_binding_not_blocked",
+                    lane_ids,
+                    "missing bindings require blocked or disabled activation",
+                )
+            )
+        if not entry.activation_reason.strip():
+            issues.append(
+                RegistryIssue(
+                    "missing_binding_reason_absent",
+                    lane_ids,
+                    "blocked or disabled rows require a reason",
+                )
+            )
+    if entry.max_order_notional is not None and entry.max_order_notional <= 0:
+        issues.append(
+            RegistryIssue(
+                "invalid_max_order_notional",
+                lane_ids,
+                "a supplied cap must be positive",
+            )
+        )
+    for field_name, value in (
+        ("max_orders_per_session", entry.max_orders_per_session),
+        ("max_open_orders", entry.max_open_orders),
+    ):
+        if value is not None and value <= 0:
+            issues.append(
+                RegistryIssue(
+                    f"invalid_{field_name}",
+                    lane_ids,
+                    "a supplied cap must be positive",
+                )
+            )
+    if entry.auto:
+        required = (
+            entry.writer,
+            entry.activation_status is ActivationStatus.ENABLED,
+            not identity_unknown,
+            not entry.missing_bindings,
+            entry.policy_binding is not None,
+            entry.scheduler_owner not in {None, SchedulerOwner.DISABLED},
+            entry.max_order_notional is not None,
+            entry.max_orders_per_session is not None,
+            entry.max_open_orders is not None,
+            bool(entry.allowed_order_types),
+            bool(entry.allowed_time_in_force),
+            entry.reconcile_required is True,
+            entry.canary_binding is not None,
+            entry.credential_namespace is not None,
+            bool(entry.allowed_hosts),
+        )
+        if not all(required):
+            issues.append(
+                RegistryIssue(
+                    "auto_lane_missing_required_binding",
+                    lane_ids,
+                    "auto cannot be enabled without every signed binding",
+                )
+            )
+    return issues
+
+
+def _single_writer_issues(
+    entries: Iterable[LaneRegistryEntry],
+) -> list[RegistryIssue]:
+    writers_by_account: defaultdict[str, list[str]] = defaultdict(list)
+    for entry in entries:
+        if entry.writer and entry.physical_account_id is not None:
+            writers_by_account[entry.physical_account_id].append(entry.lane_id)
+    return [
+        RegistryIssue(
+            "physical_account_writer_conflict",
+            tuple(sorted(lane_ids)),
+            "more than one lane claims writer ownership for [MASKED]",
+        )
+        for lane_ids in writers_by_account.values()
+        if len(lane_ids) > 1
+    ]
+
+
+def assert_single_writer(entries: Iterable[LaneRegistryEntry]) -> None:
+    """Fail startup when two lanes claim the same physical-account writer."""
+
+    issues = _single_writer_issues(tuple(entries))
+    if issues:
+        raise RegistryStartupError(issues)
+
+
+def assert_registry_startup(
+    entries: Iterable[LaneRegistryEntry], *, require_canonical: bool = False
+) -> None:
+    """Validate registry structure and writer cardinality before client startup."""
+
+    materialized = tuple(entries)
+    issues: list[RegistryIssue] = []
+    lane_ids = tuple(entry.lane_id for entry in materialized)
+    if len(set(lane_ids)) != len(lane_ids):
+        issues.append(
+            RegistryIssue(
+                "duplicate_lane_id", tuple(sorted(lane_ids)), "lane ids must be unique"
+            )
+        )
+    if require_canonical and lane_ids != CANONICAL_LANE_IDS:
+        issues.append(
+            RegistryIssue(
+                "canonical_lane_ids_mismatch",
+                lane_ids,
+                "the 12 canonical lane ids and order are immutable",
+            )
+        )
+    for entry in materialized:
+        issues.extend(_entry_issues(entry))
+        if require_canonical:
+            expected_currency = LANE_QUOTE_CURRENCIES.get(entry.lane_id)
+            if expected_currency != entry.quote_currency:
+                issues.append(
+                    RegistryIssue(
+                        "lane_quote_currency_mismatch",
+                        (entry.lane_id,),
+                        "canonical registry currency differs",
+                    )
+                )
+            expected_namespace = LANE_CREDENTIAL_NAMESPACES.get(entry.lane_id)
+            if expected_namespace != entry.credential_namespace:
+                issues.append(
+                    RegistryIssue(
+                        "canonical_credential_namespace_mismatch",
+                        (entry.lane_id,),
+                        "credential namespace differs from repository evidence",
+                    )
+                )
+            expected_hosts = LANE_ALLOWED_HOSTS.get(entry.lane_id)
+            if expected_hosts != entry.allowed_hosts:
+                issues.append(
+                    RegistryIssue(
+                        "canonical_host_allowlist_mismatch",
+                        (entry.lane_id,),
+                        "host allowlist differs from repository evidence",
+                    )
+                )
+    issues.extend(_single_writer_issues(materialized))
+    if issues:
+        raise RegistryStartupError(issues)
+
+
+@dataclass(frozen=True, slots=True)
+class ActivationEvidence:
+    """Caller-supplied evidence; defaults do not authorize advancement."""
+
+    directly_proven_cadence_preserved: bool = False
+    requires_new_recurring_schedule: bool = False
+    shared_production_release_required: bool = False
+    live_restart_required: bool = False
+    j8_canary_succeeded: bool = False
+
+
+def transition_activation(
+    lane_id: str,
+    current: ActivationStatus,
+    target: ActivationStatus,
+    *,
+    evidence: ActivationEvidence = ActivationEvidence(),
+) -> ActivationStatus:
+    """Apply G1-G3 without selecting cadence, canary, or release behavior."""
+
+    if current is ActivationStatus.READY_FOR_MOCK_DEPLOYMENT:
+        if target is not current:
+            raise ActivationTransitionBlocked(
+                "ready_for_mock_deployment_terminal",
+                lane_id=lane_id,
+                guard_id="G2",
+            )
+        return current
+
+    release_stop = (
+        evidence.shared_production_release_required or evidence.live_restart_required
+    )
+    if release_stop:
+        if target is not ActivationStatus.READY_FOR_MOCK_DEPLOYMENT:
+            raise ActivationTransitionBlocked(
+                "ready_for_mock_deployment_required",
+                lane_id=lane_id,
+                guard_id="G2",
+            )
+        return target
+
+    if current is ActivationStatus.RUNTIME_ACCEPTANCE_PENDING:
+        if target is ActivationStatus.ENABLED:
+            raise ActivationTransitionBlocked(
+                "j8_canary_cannot_auto_enable", lane_id=lane_id, guard_id="G3"
+            )
+        if target is ActivationStatus.READY and not evidence.j8_canary_succeeded:
+            raise ActivationTransitionBlocked(
+                "j8_canary_evidence_required", lane_id=lane_id, guard_id="G3"
+            )
+    if evidence.j8_canary_succeeded and not (
+        current is ActivationStatus.RUNTIME_ACCEPTANCE_PENDING
+        and target is ActivationStatus.READY
+    ):
+        raise ActivationTransitionBlocked(
+            "j8_canary_transition_scope_violation",
+            lane_id=lane_id,
+            guard_id="G3",
+        )
+
+    if target is ActivationStatus.ENABLED:
+        if evidence.requires_new_recurring_schedule:
+            raise ActivationTransitionBlocked(
+                "AUTO_READY_BLOCKED_BY_SCHEDULER",
+                lane_id=lane_id,
+                guard_id="G1",
+            )
+        if not evidence.directly_proven_cadence_preserved:
+            raise ActivationTransitionBlocked(
+                "directly_proven_cadence_required",
+                lane_id=lane_id,
+                guard_id="G1",
+            )
+    return target
+
+
+class LaneCurrencyPlan(Protocol):
+    lane_id: str
+    quote_currency: str
+
+
+def assert_lane_quote_currency(
+    plan: LaneCurrencyPlan,
+    registry: Mapping[str, LaneRegistryEntry] = _CANONICAL_BY_ID,
+) -> LaneRegistryEntry:
+    """Reject a plan/registry mismatch before any broker boundary is reached."""
+
+    try:
+        entry = registry[plan.lane_id]
+    except KeyError as exc:
+        raise LaneGuardError("unknown_lane", lane_id=plan.lane_id) from exc
+    if plan.quote_currency != entry.quote_currency:
+        raise LaneGuardError("lane_quote_currency_mismatch", lane_id=plan.lane_id)
+    return entry
+
+
+def assert_mock_only_endpoint(entry: LaneRegistryEntry, endpoint_url: str) -> str:
+    """Return an exact allowlisted host or reject before client/network I/O."""
+
+    if not isinstance(entry.account_mode, AccountMode) or not isinstance(
+        entry.endpoint_class, EndpointClass
+    ):
+        raise LaneGuardError("live_account_mode_forbidden", lane_id=entry.lane_id)
+    if entry.account_mode is AccountMode.SHADOW:
+        raise LaneGuardError("shadow_broker_io_forbidden", lane_id=entry.lane_id)
+    try:
+        parsed = urlsplit(endpoint_url)
+        port = parsed.port
+    except ValueError as exc:
+        raise LaneGuardError("endpoint_url_invalid", lane_id=entry.lane_id) from exc
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise LaneGuardError("endpoint_url_invalid", lane_id=entry.lane_id)
+    host = parsed.hostname.lower()
+    netloc = host if port is None else f"{host}:{port}"
+    if netloc in _FORBIDDEN_LIVE_HOSTS or host in _FORBIDDEN_LIVE_HOSTS:
+        raise LaneGuardError("live_endpoint_forbidden", lane_id=entry.lane_id)
+    if netloc not in entry.allowed_hosts:
+        raise LaneGuardError("lane_endpoint_host_mismatch", lane_id=entry.lane_id)
+    return netloc
+
+
+def assert_credential_namespace(
+    entry: LaneRegistryEntry, credential_namespace: str
+) -> None:
+    """Reject fallback or cross-profile credential namespaces."""
+
+    if entry.credential_namespace is None:
+        raise LaneGuardError("credential_namespace_unbound", lane_id=entry.lane_id)
+    if credential_namespace != entry.credential_namespace:
+        raise LaneGuardError("credential_namespace_mismatch", lane_id=entry.lane_id)
+
+
+def assert_entry_execution_ready(entry: LaneRegistryEntry) -> None:
+    """Require every signed binding; registry roles never imply activation."""
+
+    if entry.activation_status is not ActivationStatus.ENABLED:
+        raise LaneGuardError("lane_activation_not_enabled", lane_id=entry.lane_id)
+    if not entry.writer or not entry.auto:
+        raise LaneGuardError("lane_writer_not_enabled", lane_id=entry.lane_id)
+    physical_account_id = entry.physical_account_id
+    fingerprint_evidence_ref = entry.fingerprint_evidence_ref
+    if not (
+        isinstance(physical_account_id, str)
+        and physical_account_id.strip()
+        and isinstance(fingerprint_evidence_ref, str)
+        and fingerprint_evidence_ref.strip()
+        and isinstance(entry.identity_status, str)
+        and entry.identity_status != "UNKNOWN"
+        and entry.identity_status.strip()
+    ):
+        raise LaneGuardError("physical_account_identity_unknown", lane_id=entry.lane_id)
+    if entry.missing_bindings:
+        raise LaneGuardError("lane_binding_incomplete", lane_id=entry.lane_id)
+    required_bindings = (
+        bool(entry.policy_binding and entry.policy_binding.strip()),
+        bool(entry.execution_mode and entry.execution_mode.strip()),
+        entry.scheduler_owner not in {None, SchedulerOwner.DISABLED},
+        entry.max_order_notional is not None and entry.max_order_notional > 0,
+        entry.max_orders_per_session is not None and entry.max_orders_per_session > 0,
+        entry.max_open_orders is not None and entry.max_open_orders > 0,
+        bool(entry.allowed_order_types),
+        bool(entry.allowed_time_in_force),
+        entry.reconcile_required is True,
+        bool(entry.credential_namespace and entry.credential_namespace.strip()),
+        bool(entry.allowed_hosts),
+        bool(entry.canary_binding and entry.canary_binding.strip()),
+    )
+    if not all(required_bindings):
+        raise LaneGuardError("lane_binding_incomplete", lane_id=entry.lane_id)
+
+
+async def guarded_broker_io[BrokerResult](
+    plan: LaneCurrencyPlan,
+    *,
+    endpoint_url: str,
+    credential_namespace: str,
+    broker_io: Callable[[], Awaitable[BrokerResult]],
+    registry: Mapping[str, LaneRegistryEntry] = _CANONICAL_BY_ID,
+) -> BrokerResult:
+    """Execute a supplied broker operation only after every J2A guard passes."""
+
+    entry = assert_lane_quote_currency(plan, registry)
+    assert_registry_startup(registry.values())
+    assert_mock_only_endpoint(entry, endpoint_url)
+    assert_credential_namespace(entry, credential_namespace)
+    assert_entry_execution_ready(entry)
+    return await broker_io()
+
+
+def guarded_client_factory[Client](
+    entry: LaneRegistryEntry,
+    *,
+    endpoint_url: str,
+    credential_namespace: str,
+    factory: Callable[[], Client],
+) -> Client:
+    """Reject live/mismatched construction before invoking a client factory."""
+
+    assert_mock_only_endpoint(entry, endpoint_url)
+    assert_credential_namespace(entry, credential_namespace)
+    assert_entry_execution_ready(entry)
+    return factory()
+
+
+@dataclass(frozen=True, slots=True)
+class LaneDivergence:
+    """A lane-scoped failure record that cannot cancel or roll back peers."""
+
+    primary_lane_id: str
+    divergent_lane_id: str
+    reason: str
+    rollback_other_lanes: bool = field(default=False, init=False)
+    cancel_other_lanes: bool = field(default=False, init=False)
+
+
+def record_mirror_divergence(
+    primary_lane_id: str, divergent_lane_id: str, reason: str
+) -> LaneDivergence:
+    """Record divergence without invoking either lane or mutating peer state."""
+
+    get_lane_registry_entry(primary_lane_id)
+    get_lane_registry_entry(divergent_lane_id)
+    if primary_lane_id == divergent_lane_id:
+        raise LaneGuardError(
+            "divergence_requires_distinct_lanes", lane_id=divergent_lane_id
+        )
+    normalized_reason = reason.strip()
+    if not normalized_reason:
+        raise LaneGuardError("divergence_reason_required", lane_id=divergent_lane_id)
+    return LaneDivergence(primary_lane_id, divergent_lane_id, normalized_reason)
+
+
+assert_registry_startup(CANONICAL_LANE_REGISTRY, require_canonical=True)
+
+
+__all__ = [
+    "ACTIVATION_TRANSITION_GUARDS",
+    "MISSING_BINDING_RULE",
+    "UNKNOWN_IDENTITY_RULE",
+    "AccountMode",
+    "ActivationEvidence",
+    "ActivationStatus",
+    "ActivationTransitionBlocked",
+    "CANONICAL_LANE_IDS",
+    "CANONICAL_LANE_REGISTRY",
+    "EndpointClass",
+    "LANE_ALLOWED_HOSTS",
+    "LANE_CREDENTIAL_NAMESPACES",
+    "LANE_QUOTE_CURRENCIES",
+    "LaneDivergence",
+    "LaneGuardError",
+    "LaneRegistryEntry",
+    "MissingBinding",
+    "RegistryIssue",
+    "RegistryRole",
+    "RegistryStartupError",
+    "assert_credential_namespace",
+    "assert_entry_execution_ready",
+    "assert_lane_quote_currency",
+    "assert_mock_only_endpoint",
+    "assert_registry_startup",
+    "assert_single_writer",
+    "get_lane_registry_entry",
+    "guarded_broker_io",
+    "guarded_client_factory",
+    "mask_account_identifier",
+    "record_mirror_divergence",
+    "transition_activation",
+]

--- a/app/services/mock_lane_registry.py
+++ b/app/services/mock_lane_registry.py
@@ -1,9 +1,10 @@
 """Fail-closed mock/paper/demo account identity registry (ROB-1260).
 
-This module is deliberately inert.  It performs no broker, database, scheduler,
-or credential I/O.  Canonical rows describe the evidence available at the J2A
-boundary; unavailable bindings stay present and blocked instead of being
-guessed or filtered out.
+This module defines no broker transport, database, scheduler, signing, or
+credential-value I/O. Canonical rows describe the evidence available at the
+J2A boundary; unavailable bindings stay present and blocked instead of being
+guessed or filtered out. Guarded helpers validate caller declarations before
+invoking opaque callbacks, but do not bind those declarations to a transport.
 """
 
 from __future__ import annotations
@@ -18,6 +19,10 @@ from typing import Final, Literal, Protocol
 from urllib.parse import urlsplit
 
 from app.schemas.execution_contracts import LaneStatus, SchedulerOwner
+from app.services.mock_integration.lineage import (
+    BROKER_CLIENT_ID_TARGET_MISMATCH,
+    LineageEnvelope,
+)
 
 QuoteCurrency = Literal["KRW", "USD", "USDT"]
 
@@ -72,6 +77,21 @@ class MissingBinding(StrEnum):
     CANARY = "canary"
 
 
+@dataclass(frozen=True, slots=True)
+class PolicyBinding:
+    """In-memory exact policy identity; neither field may be blank."""
+
+    policy_version: str
+    policy_version_hash: str
+
+    def __post_init__(self) -> None:
+        if not all(
+            isinstance(value, str) and bool(value.strip())
+            for value in (self.policy_version, self.policy_version_hash)
+        ):
+            raise ValueError("lane_binding_incomplete")
+
+
 ACTIVATION_TRANSITION_GUARDS: Final[Mapping[str, str]] = MappingProxyType(
     {
         "G1": (
@@ -98,6 +118,27 @@ UNKNOWN_IDENTITY_RULE: Final[str] = (
 MISSING_BINDING_RULE: Final[str] = (
     "policy/cap/owner/canary 부재 시 행을 보존하고\n"
     "  blocked|disabled + 사유. worker 는 값을 발명하지 않는다."
+)
+
+R2_REJECT_CODES: Final[frozenset[str]] = frozenset(
+    {
+        "lane_signed_restriction_violation",
+        "lane_recurring_not_authorized",
+        "canonical_lane_identity_mismatch",
+        "invalid_scheduler_owner",
+        "invalid_timing_owner",
+        "physical_account_writer_conflict",
+        "canonical_lane_ids_mismatch",
+        "canonical_credential_namespace_mismatch",
+        "canonical_host_allowlist_mismatch",
+        "lane_broker_mismatch",
+        "lane_account_profile_mismatch",
+        "lane_account_mode_mismatch",
+        "lane_policy_binding_mismatch",
+        "lane_binding_incomplete",
+        BROKER_CLIENT_ID_TARGET_MISMATCH,
+        "lane_quote_currency_mismatch",
+    }
 )
 
 CANONICAL_LANE_IDS: Final[tuple[str, ...]] = (
@@ -188,6 +229,46 @@ _MISSING_REQUIRED_BINDINGS: Final[tuple[MissingBinding, ...]] = (
     MissingBinding.CANARY,
 )
 
+_SIGNED_WRITER_FALSE_LANES: Final[frozenset[str]] = frozenset(
+    {
+        "crypto.alpaca.paper.default",
+        "crypto.alpaca.paper.clean",
+        "crypto.binance.spot_demo.b0x_sidecar",
+        "crypto.binance.futures_demo",
+    }
+)
+_NON_AUTONOMOUS_ROLES: Final[frozenset[RegistryRole | None]] = frozenset(
+    {None, RegistryRole.BROKER_REGRESSION, RegistryRole.SHADOW_ONLY}
+)
+_SIGNED_LANE_STATUS_ALLOWLISTS: Final[Mapping[str, frozenset[LaneStatus]]] = (
+    MappingProxyType(
+        {
+            "us.alpaca.paper.default": frozenset(
+                {LaneStatus.AUTO_READY_BLOCKED_BY_POLICY}
+            ),
+            "us.alpaca.paper.lab": frozenset(
+                {LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE}
+            ),
+            "us.kis.mock": frozenset({LaneStatus.NOT_READY}),
+            "us.kiwoom.mock": frozenset({LaneStatus.NOT_READY}),
+            "crypto.binance.spot_demo.canonical": frozenset(
+                {
+                    LaneStatus.NOT_READY,
+                    LaneStatus.AUTO_READY_BLOCKED_BY_POLICY,
+                    LaneStatus.AUTO_READY_BLOCKED_BY_SCHEDULER,
+                }
+            ),
+            "crypto.binance.spot_demo.b0x_sidecar": frozenset(
+                {LaneStatus.OBSERVATION_TEMPORARY}
+            ),
+            "crypto.alpaca.paper.default": frozenset({LaneStatus.NOT_READY}),
+            "crypto.alpaca.paper.clean": frozenset({LaneStatus.NOT_READY}),
+            "crypto.upbit.shadow": frozenset({LaneStatus.SHADOW_ONLY}),
+            "crypto.binance.futures_demo": frozenset({LaneStatus.DISABLED_NO_STRATEGY}),
+        }
+    )
+)
+
 
 @dataclass(frozen=True, slots=True)
 class LaneRegistryEntry:
@@ -207,7 +288,7 @@ class LaneRegistryEntry:
     lane_status: LaneStatus
     activation_status: ActivationStatus
     activation_reason: str
-    policy_binding: str | None
+    policy_binding: PolicyBinding | None
     execution_mode: str | None
     scheduler_owner: SchedulerOwner | None
     timing_owner: str | None
@@ -432,6 +513,22 @@ _CANONICAL_BY_ID: Final[Mapping[str, LaneRegistryEntry]] = MappingProxyType(
     {entry.lane_id: entry for entry in CANONICAL_LANE_REGISTRY}
 )
 
+_IMMUTABLE_IDENTITY_FIELDS: Final[tuple[str, ...]] = (
+    "market",
+    "broker",
+    "account_profile",
+    "profile_variant",
+    "account_mode",
+    "lane_type",
+    "quote_currency",
+    "role",
+    "role_pending_reason",
+    "role_on_policy_approval",
+    "endpoint_class",
+    "credential_namespace",
+    "allowed_hosts",
+)
+
 
 @dataclass(frozen=True, slots=True, order=True)
 class RegistryIssue:
@@ -455,10 +552,11 @@ class RegistryStartupError(RuntimeError):
 class LaneGuardError(RuntimeError):
     """Fail-closed pre-I/O rejection with a stable machine code."""
 
-    def __init__(self, code: str, *, lane_id: str) -> None:
+    def __init__(self, code: str, *, lane_id: str | None = None) -> None:
         self.code = code
         self.lane_id = lane_id
-        super().__init__(f"{code}: lane={lane_id}")
+        lane_suffix = "" if lane_id is None else f": lane={lane_id}"
+        super().__init__(f"{code}{lane_suffix}")
 
 
 class ActivationTransitionBlocked(LaneGuardError):
@@ -482,6 +580,25 @@ def get_lane_registry_entry(lane_id: str) -> LaneRegistryEntry:
         return _CANONICAL_BY_ID[lane_id]
     except KeyError as exc:
         raise LaneGuardError("unknown_lane", lane_id=lane_id) from exc
+
+
+def _violates_signed_lane_restriction(entry: LaneRegistryEntry) -> bool:
+    enabled_or_autonomous = (
+        entry.writer
+        or entry.auto
+        or entry.activation_status is ActivationStatus.ENABLED
+    )
+    if entry.lane_id in _SIGNED_WRITER_FALSE_LANES and enabled_or_autonomous:
+        return True
+    if entry.role in _NON_AUTONOMOUS_ROLES and enabled_or_autonomous:
+        return True
+    allowed_statuses = _SIGNED_LANE_STATUS_ALLOWLISTS.get(entry.lane_id)
+    if allowed_statuses is None:
+        return False
+    return (
+        entry.lane_status not in allowed_statuses
+        or entry.activation_status is ActivationStatus.ENABLED
+    )
 
 
 def _entry_issues(entry: LaneRegistryEntry) -> list[RegistryIssue]:
@@ -586,15 +703,52 @@ def _entry_issues(entry: LaneRegistryEntry) -> list[RegistryIssue]:
                     "lane type and account mode must agree",
                 )
             )
-    if entry.scheduler_owner is not None and entry.timing_owner is not None:
-        if entry.scheduler_owner.value == entry.timing_owner:
-            issues.append(
-                RegistryIssue(
-                    "scheduler_timing_owner_collapsed",
-                    lane_ids,
-                    "scheduler_owner and timing_owner are distinct bindings",
-                )
+    valid_scheduler_owner = isinstance(
+        entry.scheduler_owner, SchedulerOwner | type(None)
+    )
+    if not valid_scheduler_owner:
+        issues.append(
+            RegistryIssue(
+                "invalid_scheduler_owner",
+                lane_ids,
+                "scheduler_owner must be SchedulerOwner or null",
             )
+        )
+    valid_timing_owner = entry.timing_owner is None or (
+        isinstance(entry.timing_owner, str) and bool(entry.timing_owner.strip())
+    )
+    if not valid_timing_owner:
+        issues.append(
+            RegistryIssue(
+                "invalid_timing_owner",
+                lane_ids,
+                "timing_owner must be a nonblank string or null",
+            )
+        )
+    if (
+        valid_scheduler_owner
+        and valid_timing_owner
+        and entry.scheduler_owner is not None
+        and entry.timing_owner is not None
+        and entry.scheduler_owner.value == entry.timing_owner
+    ):
+        issues.append(
+            RegistryIssue(
+                "invalid_timing_owner",
+                lane_ids,
+                "scheduler_owner and timing_owner are distinct bindings",
+            )
+        )
+    if entry.policy_binding is not None and not isinstance(
+        entry.policy_binding, PolicyBinding
+    ):
+        issues.append(
+            RegistryIssue(
+                "lane_binding_incomplete",
+                lane_ids,
+                "policy_binding must be a complete PolicyBinding",
+            )
+        )
     if entry.allowed_hosts != tuple(dict.fromkeys(entry.allowed_hosts)):
         issues.append(
             RegistryIssue(
@@ -687,7 +841,6 @@ def _entry_issues(entry: LaneRegistryEntry) -> list[RegistryIssue]:
     if entry.auto:
         required = (
             entry.writer,
-            entry.activation_status is ActivationStatus.ENABLED,
             not identity_unknown,
             not entry.missing_bindings,
             entry.policy_binding is not None,
@@ -710,6 +863,14 @@ def _entry_issues(entry: LaneRegistryEntry) -> list[RegistryIssue]:
                     "auto cannot be enabled without every signed binding",
                 )
             )
+    if _violates_signed_lane_restriction(entry):
+        issues.append(
+            RegistryIssue(
+                "lane_signed_restriction_violation",
+                lane_ids,
+                "signed lane writer, role, status, and activation facts are immutable",
+            )
+        )
     return issues
 
 
@@ -791,6 +952,18 @@ def assert_registry_startup(
                         "host allowlist differs from repository evidence",
                     )
                 )
+            canonical_entry = _CANONICAL_BY_ID.get(entry.lane_id)
+            if canonical_entry is not None and any(
+                getattr(entry, field_name) != getattr(canonical_entry, field_name)
+                for field_name in _IMMUTABLE_IDENTITY_FIELDS
+            ):
+                issues.append(
+                    RegistryIssue(
+                        "canonical_lane_identity_mismatch",
+                        (entry.lane_id,),
+                        "one or more of the 13 immutable identity fields differ",
+                    )
+                )
     issues.extend(_single_writer_issues(materialized))
     if issues:
         raise RegistryStartupError(issues)
@@ -815,6 +988,22 @@ def transition_activation(
     evidence: ActivationEvidence = ActivationEvidence(),
 ) -> ActivationStatus:
     """Apply G1-G3 without selecting cadence, canary, or release behavior."""
+
+    canonical_entry = _CANONICAL_BY_ID.get(lane_id)
+    if (
+        target is ActivationStatus.ENABLED
+        and canonical_entry is not None
+        and (
+            lane_id in _SIGNED_WRITER_FALSE_LANES
+            or lane_id in _SIGNED_LANE_STATUS_ALLOWLISTS
+            or canonical_entry.role in _NON_AUTONOMOUS_ROLES
+        )
+    ):
+        raise ActivationTransitionBlocked(
+            "lane_signed_restriction_violation",
+            lane_id=lane_id,
+            guard_id="B2",
+        )
 
     if current is ActivationStatus.READY_FOR_MOCK_DEPLOYMENT:
         if target is not current:
@@ -877,6 +1066,22 @@ class LaneCurrencyPlan(Protocol):
     quote_currency: str
 
 
+type RegistrySource = Mapping[str, LaneRegistryEntry] | Iterable[LaneRegistryEntry]
+
+
+def _validated_registry(
+    registry: RegistrySource | None = None,
+) -> Mapping[str, LaneRegistryEntry]:
+    if registry is None:
+        entries = CANONICAL_LANE_REGISTRY
+    elif isinstance(registry, Mapping):
+        entries = tuple(registry.values())
+    else:
+        entries = tuple(registry)
+    assert_registry_startup(entries, require_canonical=True)
+    return MappingProxyType({entry.lane_id: entry for entry in entries})
+
+
 def assert_lane_quote_currency(
     plan: LaneCurrencyPlan,
     registry: Mapping[str, LaneRegistryEntry] = _CANONICAL_BY_ID,
@@ -892,8 +1097,40 @@ def assert_lane_quote_currency(
     return entry
 
 
+def assert_lineage_registry_binding(
+    envelope: LineageEnvelope,
+    registry: RegistrySource | None = None,
+) -> LaneRegistryEntry:
+    """Compare one exact J2B factory lineage to the canonical in-memory registry."""
+
+    validated_registry = _validated_registry(registry)
+    if type(envelope) is not LineageEnvelope or envelope.execution_plan is None:
+        raise LaneGuardError("lane_binding_incomplete")
+    plan = envelope.execution_plan
+    entry = assert_lane_quote_currency(plan, validated_registry)
+    if plan.broker != entry.broker:
+        raise LaneGuardError("lane_broker_mismatch", lane_id=plan.lane_id)
+    if plan.account_profile != entry.account_profile:
+        raise LaneGuardError("lane_account_profile_mismatch", lane_id=plan.lane_id)
+    if plan.account_mode != entry.account_mode.value:
+        raise LaneGuardError("lane_account_mode_mismatch", lane_id=plan.lane_id)
+    policy_binding = entry.policy_binding
+    if (
+        not isinstance(policy_binding, PolicyBinding)
+        or MissingBinding.POLICY in entry.missing_bindings
+    ):
+        raise LaneGuardError("lane_binding_incomplete", lane_id=plan.lane_id)
+    intent_policy_binding = PolicyBinding(
+        envelope.decision_intent.policy_version,
+        envelope.decision_intent.policy_version_hash,
+    )
+    if intent_policy_binding != policy_binding:
+        raise LaneGuardError("lane_policy_binding_mismatch", lane_id=plan.lane_id)
+    return entry
+
+
 def assert_mock_only_endpoint(entry: LaneRegistryEntry, endpoint_url: str) -> str:
-    """Return an exact allowlisted host or reject before client/network I/O."""
+    """Validate one caller-declared HTTPS endpoint string against its lane."""
 
     if not isinstance(entry.account_mode, AccountMode) or not isinstance(
         entry.endpoint_class, EndpointClass
@@ -927,7 +1164,7 @@ def assert_mock_only_endpoint(entry: LaneRegistryEntry, endpoint_url: str) -> st
 def assert_credential_namespace(
     entry: LaneRegistryEntry, credential_namespace: str
 ) -> None:
-    """Reject fallback or cross-profile credential namespaces."""
+    """Validate one caller-declared symbolic credential namespace."""
 
     if entry.credential_namespace is None:
         raise LaneGuardError("credential_namespace_unbound", lane_id=entry.lane_id)
@@ -938,6 +1175,8 @@ def assert_credential_namespace(
 def assert_entry_execution_ready(entry: LaneRegistryEntry) -> None:
     """Require every signed binding; registry roles never imply activation."""
 
+    if _violates_signed_lane_restriction(entry):
+        raise LaneGuardError("lane_signed_restriction_violation", lane_id=entry.lane_id)
     if entry.activation_status is not ActivationStatus.ENABLED:
         raise LaneGuardError("lane_activation_not_enabled", lane_id=entry.lane_id)
     if not entry.writer or not entry.auto:
@@ -957,9 +1196,10 @@ def assert_entry_execution_ready(entry: LaneRegistryEntry) -> None:
     if entry.missing_bindings:
         raise LaneGuardError("lane_binding_incomplete", lane_id=entry.lane_id)
     required_bindings = (
-        bool(entry.policy_binding and entry.policy_binding.strip()),
+        isinstance(entry.policy_binding, PolicyBinding),
         bool(entry.execution_mode and entry.execution_mode.strip()),
-        entry.scheduler_owner not in {None, SchedulerOwner.DISABLED},
+        isinstance(entry.scheduler_owner, SchedulerOwner)
+        and entry.scheduler_owner is not SchedulerOwner.DISABLED,
         entry.max_order_notional is not None and entry.max_order_notional > 0,
         entry.max_orders_per_session is not None and entry.max_orders_per_session > 0,
         entry.max_open_orders is not None and entry.max_open_orders > 0,
@@ -974,18 +1214,44 @@ def assert_entry_execution_ready(entry: LaneRegistryEntry) -> None:
         raise LaneGuardError("lane_binding_incomplete", lane_id=entry.lane_id)
 
 
+def assert_recurring_authorized(
+    entry: LaneRegistryEntry,
+    *,
+    recurring_requested: bool,
+    bounded_canary: bool = False,
+) -> None:
+    """Require both signed states; bounded canary evidence grants no recurrence."""
+
+    if recurring_requested and (
+        bounded_canary
+        or entry.lane_status is not LaneStatus.AUTO_ENABLED
+        or entry.activation_status is not ActivationStatus.ENABLED
+    ):
+        raise LaneGuardError("lane_recurring_not_authorized", lane_id=entry.lane_id)
+
+
 async def guarded_broker_io[BrokerResult](
-    plan: LaneCurrencyPlan,
+    envelope: LineageEnvelope,
     *,
     endpoint_url: str,
     credential_namespace: str,
     broker_io: Callable[[], Awaitable[BrokerResult]],
-    registry: Mapping[str, LaneRegistryEntry] = _CANONICAL_BY_ID,
+    registry: RegistrySource | None = None,
+    recurring_requested: bool = False,
+    bounded_canary: bool = False,
 ) -> BrokerResult:
-    """Execute a supplied broker operation only after every J2A guard passes."""
+    """Validate declared strings, then invoke an opaque caller-owned callback.
 
-    entry = assert_lane_quote_currency(plan, registry)
-    assert_registry_startup(registry.values())
+    This inert helper does not bind the declarations to the callback's actual
+    transport. Each broker transport must revalidate its real host and profile.
+    """
+
+    entry = assert_lineage_registry_binding(envelope, registry)
+    assert_recurring_authorized(
+        entry,
+        recurring_requested=recurring_requested,
+        bounded_canary=bounded_canary,
+    )
     assert_mock_only_endpoint(entry, endpoint_url)
     assert_credential_namespace(entry, credential_namespace)
     assert_entry_execution_ready(entry)
@@ -993,14 +1259,27 @@ async def guarded_broker_io[BrokerResult](
 
 
 def guarded_client_factory[Client](
-    entry: LaneRegistryEntry,
+    envelope: LineageEnvelope,
     *,
     endpoint_url: str,
     credential_namespace: str,
     factory: Callable[[], Client],
+    registry: RegistrySource | None = None,
+    recurring_requested: bool = False,
+    bounded_canary: bool = False,
 ) -> Client:
-    """Reject live/mismatched construction before invoking a client factory."""
+    """Validate declared strings, then invoke an opaque caller-owned factory.
 
+    This inert helper cannot prove which transport the returned client uses.
+    Transport-level host and profile validation remains broker-owned.
+    """
+
+    entry = assert_lineage_registry_binding(envelope, registry)
+    assert_recurring_authorized(
+        entry,
+        recurring_requested=recurring_requested,
+        bounded_canary=bounded_canary,
+    )
     assert_mock_only_endpoint(entry, endpoint_url)
     assert_credential_namespace(entry, credential_namespace)
     assert_entry_execution_ready(entry)
@@ -1041,6 +1320,7 @@ assert_registry_startup(CANONICAL_LANE_REGISTRY, require_canonical=True)
 __all__ = [
     "ACTIVATION_TRANSITION_GUARDS",
     "MISSING_BINDING_RULE",
+    "R2_REJECT_CODES",
     "UNKNOWN_IDENTITY_RULE",
     "AccountMode",
     "ActivationEvidence",
@@ -1056,13 +1336,16 @@ __all__ = [
     "LaneGuardError",
     "LaneRegistryEntry",
     "MissingBinding",
+    "PolicyBinding",
     "RegistryIssue",
     "RegistryRole",
     "RegistryStartupError",
     "assert_credential_namespace",
     "assert_entry_execution_ready",
     "assert_lane_quote_currency",
+    "assert_lineage_registry_binding",
     "assert_mock_only_endpoint",
+    "assert_recurring_authorized",
     "assert_registry_startup",
     "assert_single_writer",
     "get_lane_registry_entry",

--- a/docs/contracts/rob-1260-account-identity-registry.md
+++ b/docs/contracts/rob-1260-account-identity-registry.md
@@ -56,6 +56,23 @@ ownership. Errors identify lanes but render the account as `[MASKED]`. Both
 guarded helpers run this full canonical/global validation; a caller-supplied
 mapping cannot replace or weaken the signed identity facts.
 
+### Scheduler-owner absence is not binding authority
+
+J5, J6, and J8 consumers must treat both `scheduler_owner=None` and
+`scheduler_owner=DISABLED` as mutation-ineligible in the current registry.
+`None` means that the owner is absent; it does not authorize a downstream stage
+to choose or bind a new owner. A row with `None` retains
+`MissingBinding.OWNER`, remains blocked, and cannot enter the broker-mutation
+path. `DISABLED` is likewise not an eligible scheduler owner.
+
+The three Binance rows (`crypto.binance.spot_demo.canonical`,
+`crypto.binance.spot_demo.b0x_sidecar`, and
+`crypto.binance.futures_demo`) use `DISABLED` because the repository contains no
+Binance demo scheduler registration. That value is an evidence-backed absence,
+not an arbitrary owner assignment or permission for a later stage to invent
+one. Downstream consumers must preserve the row's blocked or disabled state
+until separately approved, exact owner evidence exists.
+
 `PolicyBinding(policy_version, policy_version_hash)` is frozen, nonblank, and
 in-memory only. No model, database column, or migration is added. A real J2B
 `LineageEnvelope` is compared exactly before any opaque callback or factory:

--- a/docs/contracts/rob-1260-account-identity-registry.md
+++ b/docs/contracts/rob-1260-account-identity-registry.md
@@ -1,7 +1,9 @@
 # ROB-1260 — account identity and lane registry contract
 
-Status: **inert and fail-closed**. This contract performs no broker, database,
-scheduler, deployment, or credential I/O. It adds no schema or migration.
+Status: **inert and fail-closed**. This contract defines no broker transport,
+database, scheduler, deployment, signing, or credential-value I/O. Its helpers
+may invoke opaque caller callbacks after static validation. It adds no schema or
+migration.
 
 Authority:
 
@@ -11,6 +13,7 @@ Authority:
 - J2 preflight SHA-256
   `71513c149a265c94f286c401fa5e56667e52a9888007a9f224d9ff6de2bdeab7`
 - J1 merge base `5d63d60239ea98ed83459071892f6304323b1742`
+- J2B merge `094ab2d59d6f2bf5fc3df4efa43bb5d412221ffd`
 
 The implementation is `app/services/mock_lane_registry.py`. It intentionally
 does not modify J2B's intent, plan, attempt, ID, canonical-JSON, or hash
@@ -35,34 +38,56 @@ the row as reasons. They are never used as a reason to omit the lane.
 | `crypto.binance.spot_demo.b0x_sidecar` | USDT | `SHADOW_ONLY` | `OBSERVATION_TEMPORARY` | `DISABLED` | `BINANCE_SPOT_DEMO_API_*` | `demo-api.binance.com` |
 | `crypto.alpaca.paper.default` | USD | `AUTO_MIRROR` | `NOT_READY` | `DISABLED` | `ALPACA_PAPER_*` | `paper-api.alpaca.markets` |
 | `crypto.alpaca.paper.clean` | USD | `AUTO_MIRROR` | `NOT_READY` | `DISABLED` | `ALPACA_PAPER_CRYPTO_*` | `paper-api.alpaca.markets` |
-| `crypto.upbit.shadow` | KRW | `SHADOW_ONLY` | `SHADOW_ONLY` | `DISABLED` | none | none; broker I/O is structurally rejected |
+| `crypto.upbit.shadow` | KRW | `SHADOW_ONLY` | `SHADOW_ONLY` | `DISABLED` | none | none; the declared callback path is rejected |
 | `crypto.binance.futures_demo` | USDT | `null` | `DISABLED_NO_STRATEGY` | `DISABLED` | `BINANCE_FUTURES_DEMO_API_*` | `demo-fapi.binance.com` |
 
 The host and namespace columns record repository literals only. They do not
 prove which physical account a credential keyset reaches. That proof requires a
 separate broker fingerprint and evidence reference.
 
-## Startup and pre-I/O assertions
+## Canonical startup and lineage binding
 
-`assert_registry_startup` verifies immutable lane identity, non-live modes,
-separate lane/activation states, preserved blocked rows, safe unknown identity,
-and exact host/namespace bindings. `assert_single_writer` groups opaque physical
+`assert_registry_startup` verifies the ordered 12-row registry, the exact
+13-field identity subset, non-live modes, strict scheduler/timing owner types,
+preserved blocked rows, safe unknown identity, signed lane restrictions, and
+exact host/namespace bindings. `assert_single_writer` groups opaque physical
 account IDs internally and fails startup if more than one lane claims writer
-ownership. Errors identify lanes but render the account as `[MASKED]`.
+ownership. Errors identify lanes but render the account as `[MASKED]`. Both
+guarded helpers run this full canonical/global validation; a caller-supplied
+mapping cannot replace or weaken the signed identity facts.
 
-The guarded broker boundary applies checks in this order:
+`PolicyBinding(policy_version, policy_version_hash)` is frozen, nonblank, and
+in-memory only. No model, database column, or migration is added. A real J2B
+`LineageEnvelope` is compared exactly before any opaque callback or factory:
 
-1. resolve the exact lane;
-2. compare the plan and registry quote currency, raising exactly
-   `lane_quote_currency_mismatch` on disagreement;
-3. reject shadow, live, malformed, or non-allowlisted endpoints;
-4. require the exact credential namespace;
-5. require `ENABLED`, a single evidenced writer, `auto=true`, and every signed
-   policy/cap/owner/canary/reconcile binding;
-6. only then invoke the supplied broker callback.
+1. validate the full canonical registry and global writer cardinality;
+2. resolve the exact registered `lane_id`;
+3. compare quote currency, broker, account profile, and exact
+   `mock|paper|demo|shadow` account mode;
+4. compare the intent policy version/hash to the registry `PolicyBinding`;
+5. enforce immutable signed lane and recurring rules;
+6. validate the caller-declared host and symbolic credential namespace;
+7. require complete known-identity execution evidence;
+8. only then invoke the supplied opaque callback or factory.
 
-Current canonical rows cannot reach step 6. The tests use callback spies and
-perform no network operation.
+Current canonical rows cannot reach step 8. Tests use counter-only callbacks and
+perform no network operation. KIS and Kiwoom attempt envelopes with J2B's
+`lane_prefix=None` and `broker_client_id_target=None` pass only when their plan
+binds to a fully evidenced registered lane. An unregistered broker may receive
+internal J2B IDs, but J2A stops it at the existing `unknown_lane` lookup. J2A
+does not add broker targets or reproduce J2B's confirmed-target rejection.
+
+## Static declared-string helper limitation
+
+`guarded_broker_io` and `guarded_client_factory` validate caller-declared
+endpoint and namespace strings. Their callbacks are opaque and zero-argument;
+these helpers do not prove that the actual callback transport consumes those
+declarations. Real host/profile validation at each broker send boundary is a
+J3+ transport responsibility.
+
+The registry contains symbolic Binance host/namespace facts, URL parsing,
+live-host rejection, and pre-I/O declared-string checks. It contains no Binance
+HTTP/WS transport, signing, credential-value loading, or actual endpoint call.
 
 ## Activation guards
 
@@ -79,6 +104,13 @@ READY_FOR_MOCK_DEPLOYMENT`.
   live restart stops there with no automatic promotion.
 - G3: J8 canary success can move only
   `RUNTIME_ACCEPTANCE_PENDING -> READY`, never directly to `ENABLED`.
+
+In addition, signed writer-false, `SHADOW_ONLY`, role-null,
+`BROKER_REGRESSION`, and lane-status ceilings remain enforced after a physical
+identity and every dynamic binding become known. Recurring authorization
+requires both `lane_status=AUTO_ENABLED` and `activation_status=ENABLED`.
+Satisfying only one state fails with `lane_recurring_not_authorized`; bounded
+canary evidence is a separate path and never supplies recurring authority.
 
 ## Lane independence
 

--- a/docs/contracts/rob-1260-account-identity-registry.md
+++ b/docs/contracts/rob-1260-account-identity-registry.md
@@ -1,0 +1,87 @@
+# ROB-1260 — account identity and lane registry contract
+
+Status: **inert and fail-closed**. This contract performs no broker, database,
+scheduler, deployment, or credential I/O. It adds no schema or migration.
+
+Authority:
+
+- Linear ROB-1260 description
+- operator addendum SHA-256
+  `5bf99507f7e1c7ccfa0255dfd784b716f72ed63364e68bdad0c45a5a9f3c5d04`
+- J2 preflight SHA-256
+  `71513c149a265c94f286c401fa5e56667e52a9888007a9f224d9ff6de2bdeab7`
+- J1 merge base `5d63d60239ea98ed83459071892f6304323b1742`
+
+The implementation is `app/services/mock_lane_registry.py`. It intentionally
+does not modify J2B's intent, plan, attempt, ID, canonical-JSON, or hash
+surfaces.
+
+## Canonical registry snapshot
+
+Every physical identity is currently `physical_account_id=null` and
+`identity_status=UNKNOWN`; consequently every row has `writer=false` and
+`auto=false`. Missing policy, cap, physical owner, and canary bindings remain on
+the row as reasons. They are never used as a reason to omit the lane.
+
+| `lane_id` | quote | role | lane status | activation | credential namespace | exact host allowlist |
+|---|---|---|---|---|---|---|
+| `kr.kis.mock` | KRW | `AUTO_MIRROR` | `OBSERVATION_TEMPORARY` | `BLOCKED` | `KIS_MOCK_*` | `openapivts.koreainvestment.com:29443` |
+| `kr.kiwoom.mock` | KRW | `PRIMARY_AUTO` | `NOT_READY` | `BLOCKED` | `KIWOOM_MOCK_*` | `mockapi.kiwoom.com` |
+| `us.kis.mock` | USD | `AUTO_MIRROR` | `NOT_READY` | `BLOCKED` | `KIS_MOCK_*` | `openapivts.koreainvestment.com:29443` |
+| `us.kiwoom.mock` | USD | `BROKER_REGRESSION` | `NOT_READY` | `BLOCKED` | `KIWOOM_MOCK_US_*` | `mockapi.kiwoom.com` |
+| `us.alpaca.paper.default` | USD | `PRIMARY_AUTO` | `AUTO_READY_BLOCKED_BY_POLICY` | `BLOCKED` | `ALPACA_PAPER_*` | `paper-api.alpaca.markets` |
+| `us.alpaca.paper.lab` | USD | `null` (`policy_absent`; future reference `AUTO_CHALLENGER`) | `AUTO_READY_BLOCKED_BY_LIFECYCLE` | `BLOCKED` | `ALPACA_PAPER_LAB_*` | `paper-api.alpaca.markets` |
+| `crypto.binance.spot_demo.canonical` | USDT | `PRIMARY_AUTO` | `NOT_READY` | `BLOCKED` | `BINANCE_SPOT_DEMO_API_*` | `demo-api.binance.com` |
+| `crypto.binance.spot_demo.b0x_sidecar` | USDT | `SHADOW_ONLY` | `OBSERVATION_TEMPORARY` | `DISABLED` | `BINANCE_SPOT_DEMO_API_*` | `demo-api.binance.com` |
+| `crypto.alpaca.paper.default` | USD | `AUTO_MIRROR` | `NOT_READY` | `DISABLED` | `ALPACA_PAPER_*` | `paper-api.alpaca.markets` |
+| `crypto.alpaca.paper.clean` | USD | `AUTO_MIRROR` | `NOT_READY` | `DISABLED` | `ALPACA_PAPER_CRYPTO_*` | `paper-api.alpaca.markets` |
+| `crypto.upbit.shadow` | KRW | `SHADOW_ONLY` | `SHADOW_ONLY` | `DISABLED` | none | none; broker I/O is structurally rejected |
+| `crypto.binance.futures_demo` | USDT | `null` | `DISABLED_NO_STRATEGY` | `DISABLED` | `BINANCE_FUTURES_DEMO_API_*` | `demo-fapi.binance.com` |
+
+The host and namespace columns record repository literals only. They do not
+prove which physical account a credential keyset reaches. That proof requires a
+separate broker fingerprint and evidence reference.
+
+## Startup and pre-I/O assertions
+
+`assert_registry_startup` verifies immutable lane identity, non-live modes,
+separate lane/activation states, preserved blocked rows, safe unknown identity,
+and exact host/namespace bindings. `assert_single_writer` groups opaque physical
+account IDs internally and fails startup if more than one lane claims writer
+ownership. Errors identify lanes but render the account as `[MASKED]`.
+
+The guarded broker boundary applies checks in this order:
+
+1. resolve the exact lane;
+2. compare the plan and registry quote currency, raising exactly
+   `lane_quote_currency_mismatch` on disagreement;
+3. reject shadow, live, malformed, or non-allowlisted endpoints;
+4. require the exact credential namespace;
+5. require `ENABLED`, a single evidenced writer, `auto=true`, and every signed
+   policy/cap/owner/canary/reconcile binding;
+6. only then invoke the supplied broker callback.
+
+Current canonical rows cannot reach step 6. The tests use callback spies and
+perform no network operation.
+
+## Activation guards
+
+The activation enum is exactly:
+
+`DISABLED | BLOCKED | READY | ENABLED | RUNTIME_ACCEPTANCE_PENDING |
+READY_FOR_MOCK_DEPLOYMENT`.
+
+`transition_activation` enforces all three signed rules:
+
+- G1: `ENABLED` requires directly proven preservation of an existing cadence;
+  a new recurring schedule ends in `AUTO_READY_BLOCKED_BY_SCHEDULER`.
+- G2: `READY_FOR_MOCK_DEPLOYMENT` is terminal. A shared production release or
+  live restart stops there with no automatic promotion.
+- G3: J8 canary success can move only
+  `RUNTIME_ACCEPTANCE_PENDING -> READY`, never directly to `ENABLED`.
+
+## Lane independence
+
+`record_mirror_divergence` creates an immutable lane-scoped record whose peer
+rollback and peer cancellation fields are fixed to `false`. It performs no
+broker or ledger operation.

--- a/tests/test_mock_lane_registry.py
+++ b/tests/test_mock_lane_registry.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.execution_contracts import LaneStatus, SchedulerOwner
+from app.services import mock_lane_registry as registry
+
+
+def _by_id() -> dict[str, registry.LaneRegistryEntry]:
+    return {entry.lane_id: entry for entry in registry.CANONICAL_LANE_REGISTRY}
+
+
+def _issue_codes(exc: registry.RegistryStartupError) -> set[str]:
+    return {issue.code for issue in exc.issues}
+
+
+def test_canonical_lane_ids_and_quote_currencies_are_exact() -> None:
+    expected = (
+        ("kr.kis.mock", "KRW"),
+        ("kr.kiwoom.mock", "KRW"),
+        ("us.kis.mock", "USD"),
+        ("us.kiwoom.mock", "USD"),
+        ("us.alpaca.paper.default", "USD"),
+        ("us.alpaca.paper.lab", "USD"),
+        ("crypto.binance.spot_demo.canonical", "USDT"),
+        ("crypto.binance.spot_demo.b0x_sidecar", "USDT"),
+        ("crypto.alpaca.paper.default", "USD"),
+        ("crypto.alpaca.paper.clean", "USD"),
+        ("crypto.upbit.shadow", "KRW"),
+        ("crypto.binance.futures_demo", "USDT"),
+    )
+
+    assert (
+        tuple(
+            (entry.lane_id, entry.quote_currency)
+            for entry in registry.CANONICAL_LANE_REGISTRY
+        )
+        == expected
+    )
+    assert registry.CANONICAL_LANE_IDS == tuple(lane_id for lane_id, _ in expected)
+    assert tuple(registry.LANE_QUOTE_CURRENCIES.items()) == expected
+
+
+def test_canonical_roles_and_hard_writer_literals_are_exact() -> None:
+    rows = _by_id()
+
+    assert rows["kr.kis.mock"].role is registry.RegistryRole.AUTO_MIRROR
+    assert rows["kr.kiwoom.mock"].role is registry.RegistryRole.PRIMARY_AUTO
+    assert rows["us.kis.mock"].role is registry.RegistryRole.AUTO_MIRROR
+    assert rows["us.kiwoom.mock"].role is registry.RegistryRole.BROKER_REGRESSION
+    assert rows["us.alpaca.paper.default"].role is registry.RegistryRole.PRIMARY_AUTO
+
+    lab = rows["us.alpaca.paper.lab"]
+    assert lab.role is None
+    assert lab.role_pending_reason == "policy_absent"
+    assert lab.role_on_policy_approval is registry.RegistryRole.AUTO_CHALLENGER
+
+    canonical = rows["crypto.binance.spot_demo.canonical"]
+    assert canonical.role is registry.RegistryRole.PRIMARY_AUTO
+
+    sidecar = rows["crypto.binance.spot_demo.b0x_sidecar"]
+    assert sidecar.role is registry.RegistryRole.SHADOW_ONLY
+    assert sidecar.writer is False
+
+    for lane_id in (
+        "crypto.alpaca.paper.default",
+        "crypto.alpaca.paper.clean",
+    ):
+        assert rows[lane_id].role is registry.RegistryRole.AUTO_MIRROR
+        assert rows[lane_id].writer is False
+
+    assert rows["crypto.upbit.shadow"].role is registry.RegistryRole.SHADOW_ONLY
+
+    futures = rows["crypto.binance.futures_demo"]
+    assert futures.role is None
+    assert futures.writer is False
+    assert futures.lane_status is LaneStatus.DISABLED_NO_STRATEGY
+
+
+def test_activation_enum_is_exact_and_separate_from_lane_status() -> None:
+    assert tuple(status.value for status in registry.ActivationStatus) == (
+        "DISABLED",
+        "BLOCKED",
+        "READY",
+        "ENABLED",
+        "RUNTIME_ACCEPTANCE_PENDING",
+        "READY_FOR_MOCK_DEPLOYMENT",
+    )
+    for entry in registry.CANONICAL_LANE_REGISTRY:
+        assert isinstance(entry.lane_status, LaneStatus)
+        assert isinstance(entry.activation_status, registry.ActivationStatus)
+        assert type(entry.lane_status) is not type(entry.activation_status)
+
+
+def test_amendment_rule_and_guard_literals_are_verbatim() -> None:
+    assert dict(registry.ACTIVATION_TRANSITION_GUARDS) == {
+        "G1": (
+            "ENABLED 진입은 기존에 직접 증명된 cadence 보존 lane 에만. 신규 recurring\n"
+            "       schedule 이 필요하면 진입 금지 → "
+            "AUTO_READY_BLOCKED_BY_SCHEDULER (D4)"
+        ),
+        "G2": (
+            "READY_FOR_MOCK_DEPLOYMENT 는 종착 상태. shared production release 또는\n"
+            "       live restart 필요 시 여기서 정지, 자동 승격 경로 없음 "
+            "(운영자 결정 6)"
+        ),
+        "G3": (
+            "J8 canary 성공은 RUNTIME_ACCEPTANCE_PENDING → READY 까지만 이동시키며\n"
+            "       ENABLED 로 자동 전이시키지 않는다 (D4)"
+        ),
+    }
+    assert registry.UNKNOWN_IDENTITY_RULE == (
+        "broker fingerprint 증거 부재 시 physical_account_id=null,\n"
+        "  identity_status=UNKNOWN, writer=false, auto=false. 행은 삭제하지 않는다."
+    )
+    assert registry.MISSING_BINDING_RULE == (
+        "policy/cap/owner/canary 부재 시 행을 보존하고\n"
+        "  blocked|disabled + 사유. worker 는 값을 발명하지 않는다."
+    )
+
+
+def test_g1_rejects_new_recurring_schedule_and_missing_cadence_proof() -> None:
+    lane_id = "kr.kiwoom.mock"
+    with pytest.raises(registry.ActivationTransitionBlocked) as new_schedule:
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.READY,
+            registry.ActivationStatus.ENABLED,
+            evidence=registry.ActivationEvidence(
+                directly_proven_cadence_preserved=True,
+                requires_new_recurring_schedule=True,
+            ),
+        )
+    assert new_schedule.value.guard_id == "G1"
+    assert new_schedule.value.code == "AUTO_READY_BLOCKED_BY_SCHEDULER"
+
+    with pytest.raises(registry.ActivationTransitionBlocked) as no_proof:
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.READY,
+            registry.ActivationStatus.ENABLED,
+        )
+    assert no_proof.value.guard_id == "G1"
+    assert no_proof.value.code == "directly_proven_cadence_required"
+
+    assert (
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.READY,
+            registry.ActivationStatus.ENABLED,
+            evidence=registry.ActivationEvidence(
+                directly_proven_cadence_preserved=True
+            ),
+        )
+        is registry.ActivationStatus.ENABLED
+    )
+
+
+def test_g2_stops_at_ready_for_mock_deployment() -> None:
+    lane_id = "us.alpaca.paper.default"
+    release_evidence = registry.ActivationEvidence(
+        shared_production_release_required=True
+    )
+
+    assert (
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.BLOCKED,
+            registry.ActivationStatus.READY_FOR_MOCK_DEPLOYMENT,
+            evidence=release_evidence,
+        )
+        is registry.ActivationStatus.READY_FOR_MOCK_DEPLOYMENT
+    )
+
+    with pytest.raises(registry.ActivationTransitionBlocked) as skipped_stop:
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.BLOCKED,
+            registry.ActivationStatus.ENABLED,
+            evidence=release_evidence,
+        )
+    assert skipped_stop.value.guard_id == "G2"
+
+    with pytest.raises(registry.ActivationTransitionBlocked) as terminal:
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.READY_FOR_MOCK_DEPLOYMENT,
+            registry.ActivationStatus.READY,
+        )
+    assert terminal.value.guard_id == "G2"
+    assert terminal.value.code == "ready_for_mock_deployment_terminal"
+
+
+def test_g3_canary_moves_pending_to_ready_only() -> None:
+    lane_id = "crypto.binance.spot_demo.canonical"
+    canary_evidence = registry.ActivationEvidence(j8_canary_succeeded=True)
+
+    assert (
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.RUNTIME_ACCEPTANCE_PENDING,
+            registry.ActivationStatus.READY,
+            evidence=canary_evidence,
+        )
+        is registry.ActivationStatus.READY
+    )
+
+    with pytest.raises(registry.ActivationTransitionBlocked) as enabled:
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.RUNTIME_ACCEPTANCE_PENDING,
+            registry.ActivationStatus.ENABLED,
+            evidence=canary_evidence,
+        )
+    assert enabled.value.guard_id == "G3"
+    assert enabled.value.code == "j8_canary_cannot_auto_enable"
+
+    with pytest.raises(registry.ActivationTransitionBlocked) as missing:
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.RUNTIME_ACCEPTANCE_PENDING,
+            registry.ActivationStatus.READY,
+        )
+    assert missing.value.guard_id == "G3"
+    assert missing.value.code == "j8_canary_evidence_required"
+
+
+def test_unknown_fingerprint_rows_are_safe_and_preserved() -> None:
+    assert len(registry.CANONICAL_LANE_REGISTRY) == 12
+    for entry in registry.CANONICAL_LANE_REGISTRY:
+        assert entry.physical_account_id is None
+        assert entry.fingerprint_evidence_ref is None
+        assert entry.identity_status == "UNKNOWN"
+        assert entry.writer is False
+        assert entry.auto is False
+        assert registry.get_lane_registry_entry(entry.lane_id) is entry
+
+
+@pytest.mark.parametrize(
+    "changes",
+    (
+        {"writer": True},
+        {"auto_order_enabled": True},
+        {"physical_account_id": "opaque-test-id"},
+    ),
+)
+def test_unknown_identity_mutants_fail_closed(changes: dict[str, object]) -> None:
+    mutant = replace(registry.CANONICAL_LANE_REGISTRY[0], **changes)
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        registry.assert_registry_startup((mutant,))
+
+    assert "unknown_identity_must_be_safe" in _issue_codes(exc_info.value)
+
+
+def test_missing_bindings_keep_rows_blocked_or_disabled_with_reasons() -> None:
+    required_missing = {
+        registry.MissingBinding.PHYSICAL_ACCOUNT_FINGERPRINT,
+        registry.MissingBinding.POLICY,
+        registry.MissingBinding.CAP,
+        registry.MissingBinding.OWNER,
+        registry.MissingBinding.CANARY,
+    }
+
+    assert (
+        tuple(entry.lane_id for entry in registry.CANONICAL_LANE_REGISTRY)
+        == registry.CANONICAL_LANE_IDS
+    )
+    for entry in registry.CANONICAL_LANE_REGISTRY:
+        assert set(entry.missing_bindings) == required_missing
+        assert entry.activation_status in {
+            registry.ActivationStatus.BLOCKED,
+            registry.ActivationStatus.DISABLED,
+        }
+        assert entry.activation_reason
+        assert entry.policy_binding is None
+        assert entry.max_order_notional is None
+        assert entry.canary_binding is None
+
+
+def test_missing_binding_reason_is_required_once() -> None:
+    mutant = replace(registry.CANONICAL_LANE_REGISTRY[0], activation_reason="")
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        registry.assert_registry_startup((mutant,))
+
+    matching = [
+        issue
+        for issue in exc_info.value.issues
+        if issue.code == "missing_binding_reason_absent"
+    ]
+    assert len(matching) == 1
+
+
+def test_live_account_mode_is_not_representable_or_dispatchable() -> None:
+    mutant = replace(
+        registry.CANONICAL_LANE_REGISTRY[0],
+        account_mode="live",
+        lane_type="live",
+        endpoint_class="live",
+    )
+
+    with pytest.raises(registry.RegistryStartupError) as startup:
+        registry.assert_registry_startup((mutant,))
+    assert "live_account_mode_forbidden" in _issue_codes(startup.value)
+
+    with pytest.raises(registry.LaneGuardError) as dispatch:
+        registry.assert_mock_only_endpoint(
+            mutant, "https://openapi.koreainvestment.com:9443"
+        )
+    assert dispatch.value.code == "live_account_mode_forbidden"
+
+
+def test_canonical_registry_passes_startup_assertion() -> None:
+    registry.assert_registry_startup(
+        registry.CANONICAL_LANE_REGISTRY, require_canonical=True
+    )
+
+
+def test_same_physical_account_two_writers_fail_without_identifier_leak() -> None:
+    raw_identifier = "opaque-account-id-that-must-not-appear"
+    first = replace(
+        registry.CANONICAL_LANE_REGISTRY[0],
+        physical_account_id=raw_identifier,
+        writer=True,
+    )
+    second = replace(
+        registry.CANONICAL_LANE_REGISTRY[1],
+        physical_account_id=raw_identifier,
+        writer=True,
+    )
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        registry.assert_single_writer((first, second))
+
+    assert _issue_codes(exc_info.value) == {"physical_account_writer_conflict"}
+    assert raw_identifier not in str(exc_info.value)
+    assert "[MASKED]" in str(exc_info.value)
+    assert registry.mask_account_identifier(raw_identifier) == "[MASKED]"
+    assert registry.mask_account_identifier(None) is None
+    assert raw_identifier not in repr(first)
+
+
+def test_scheduler_owner_and_timing_owner_cannot_collapse() -> None:
+    mutant = replace(
+        registry.CANONICAL_LANE_REGISTRY[0],
+        scheduler_owner=SchedulerOwner.MANUAL,
+        timing_owner="manual",
+    )
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        registry.assert_registry_startup((mutant,))
+
+    assert "scheduler_timing_owner_collapsed" in _issue_codes(exc_info.value)
+
+
+def test_credential_namespaces_and_host_allowlists_are_exact() -> None:
+    assert dict(registry.LANE_CREDENTIAL_NAMESPACES) == {
+        "kr.kis.mock": "KIS_MOCK_*",
+        "kr.kiwoom.mock": "KIWOOM_MOCK_*",
+        "us.kis.mock": "KIS_MOCK_*",
+        "us.kiwoom.mock": "KIWOOM_MOCK_US_*",
+        "us.alpaca.paper.default": "ALPACA_PAPER_*",
+        "us.alpaca.paper.lab": "ALPACA_PAPER_LAB_*",
+        "crypto.binance.spot_demo.canonical": "BINANCE_SPOT_DEMO_API_*",
+        "crypto.binance.spot_demo.b0x_sidecar": "BINANCE_SPOT_DEMO_API_*",
+        "crypto.alpaca.paper.default": "ALPACA_PAPER_*",
+        "crypto.alpaca.paper.clean": "ALPACA_PAPER_CRYPTO_*",
+        "crypto.upbit.shadow": None,
+        "crypto.binance.futures_demo": "BINANCE_FUTURES_DEMO_API_*",
+    }
+    assert dict(registry.LANE_ALLOWED_HOSTS) == {
+        "kr.kis.mock": ("openapivts.koreainvestment.com:29443",),
+        "kr.kiwoom.mock": ("mockapi.kiwoom.com",),
+        "us.kis.mock": ("openapivts.koreainvestment.com:29443",),
+        "us.kiwoom.mock": ("mockapi.kiwoom.com",),
+        "us.alpaca.paper.default": ("paper-api.alpaca.markets",),
+        "us.alpaca.paper.lab": ("paper-api.alpaca.markets",),
+        "crypto.binance.spot_demo.canonical": ("demo-api.binance.com",),
+        "crypto.binance.spot_demo.b0x_sidecar": ("demo-api.binance.com",),
+        "crypto.alpaca.paper.default": ("paper-api.alpaca.markets",),
+        "crypto.alpaca.paper.clean": ("paper-api.alpaca.markets",),
+        "crypto.upbit.shadow": (),
+        "crypto.binance.futures_demo": ("demo-fapi.binance.com",),
+    }
+
+
+@pytest.mark.asyncio
+async def test_currency_mismatch_blocks_before_broker_io() -> None:
+    called = False
+
+    async def broker_io() -> None:
+        nonlocal called
+        called = True
+
+    plan = SimpleNamespace(lane_id="kr.kiwoom.mock", quote_currency="USD")
+    with pytest.raises(registry.LaneGuardError) as exc_info:
+        await registry.guarded_broker_io(
+            plan,
+            endpoint_url="https://mockapi.kiwoom.com",
+            credential_namespace="KIWOOM_MOCK_*",
+            broker_io=broker_io,
+        )
+
+    assert exc_info.value.code == "lane_quote_currency_mismatch"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_live_endpoint_and_namespace_mismatch_block_before_broker_io() -> None:
+    called = False
+
+    async def broker_io() -> None:
+        nonlocal called
+        called = True
+
+    plan = SimpleNamespace(lane_id="kr.kiwoom.mock", quote_currency="KRW")
+    with pytest.raises(registry.LaneGuardError) as live:
+        await registry.guarded_broker_io(
+            plan,
+            endpoint_url="https://api.kiwoom.com",
+            credential_namespace="KIWOOM_MOCK_*",
+            broker_io=broker_io,
+        )
+    assert live.value.code == "live_endpoint_forbidden"
+
+    with pytest.raises(registry.LaneGuardError) as namespace:
+        await registry.guarded_broker_io(
+            plan,
+            endpoint_url="https://mockapi.kiwoom.com",
+            credential_namespace="KIWOOM_MOCK_US_*",
+            broker_io=broker_io,
+        )
+    assert namespace.value.code == "credential_namespace_mismatch"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_current_blocked_row_never_reaches_broker_io() -> None:
+    called = False
+
+    async def broker_io() -> None:
+        nonlocal called
+        called = True
+
+    plan = SimpleNamespace(lane_id="kr.kiwoom.mock", quote_currency="KRW")
+    with pytest.raises(registry.LaneGuardError) as exc_info:
+        await registry.guarded_broker_io(
+            plan,
+            endpoint_url="https://mockapi.kiwoom.com",
+            credential_namespace="KIWOOM_MOCK_*",
+            broker_io=broker_io,
+        )
+
+    assert exc_info.value.code == "lane_activation_not_enabled"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_broker_boundary_rechecks_single_writer_registry() -> None:
+    called = False
+    physical_account_id = "opaque-test-account"
+
+    async def broker_io() -> None:
+        nonlocal called
+        called = True
+
+    first = replace(
+        registry.CANONICAL_LANE_REGISTRY[0],
+        physical_account_id=physical_account_id,
+        writer=True,
+    )
+    second = replace(
+        registry.CANONICAL_LANE_REGISTRY[1],
+        physical_account_id=physical_account_id,
+        writer=True,
+    )
+    plan = SimpleNamespace(lane_id=first.lane_id, quote_currency="KRW")
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        await registry.guarded_broker_io(
+            plan,
+            endpoint_url="https://openapivts.koreainvestment.com:29443",
+            credential_namespace="KIS_MOCK_*",
+            broker_io=broker_io,
+            registry={first.lane_id: first, second.lane_id: second},
+        )
+
+    assert "physical_account_writer_conflict" in _issue_codes(exc_info.value)
+    assert called is False
+
+
+def test_live_client_factory_and_near_miss_host_are_never_invoked() -> None:
+    entry = registry.get_lane_registry_entry("kr.kiwoom.mock")
+    called = False
+
+    def factory() -> object:
+        nonlocal called
+        called = True
+        return object()
+
+    with pytest.raises(registry.LaneGuardError) as live:
+        registry.guarded_client_factory(
+            entry,
+            endpoint_url="https://api.kiwoom.com",
+            credential_namespace="KIWOOM_MOCK_*",
+            factory=factory,
+        )
+    assert live.value.code == "live_endpoint_forbidden"
+
+    with pytest.raises(registry.LaneGuardError) as near_miss:
+        registry.guarded_client_factory(
+            entry,
+            endpoint_url="https://mockapi.kiwoom.com.evil.test",
+            credential_namespace="KIWOOM_MOCK_*",
+            factory=factory,
+        )
+    assert near_miss.value.code == "lane_endpoint_host_mismatch"
+    assert called is False
+
+
+def test_shadow_lane_structurally_rejects_broker_io() -> None:
+    shadow = registry.get_lane_registry_entry("crypto.upbit.shadow")
+
+    with pytest.raises(registry.LaneGuardError) as exc_info:
+        registry.assert_mock_only_endpoint(shadow, "https://api.upbit.com")
+
+    assert exc_info.value.code == "shadow_broker_io_forbidden"
+
+
+def test_mirror_failure_is_record_only_without_peer_rollback_or_cancel() -> None:
+    divergence = registry.record_mirror_divergence(
+        "us.alpaca.paper.default",
+        "us.kis.mock",
+        "mirror execution failed",
+    )
+
+    assert divergence.primary_lane_id == "us.alpaca.paper.default"
+    assert divergence.divergent_lane_id == "us.kis.mock"
+    assert divergence.reason == "mirror execution failed"
+    assert divergence.rollback_other_lanes is False
+    assert divergence.cancel_other_lanes is False

--- a/tests/test_mock_lane_registry.py
+++ b/tests/test_mock_lane_registry.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import replace
-from types import SimpleNamespace
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
 
 import pytest
 
 from app.schemas.execution_contracts import LaneStatus, SchedulerOwner
 from app.services import mock_lane_registry as registry
+from app.services.mock_integration import lineage
+from app.services.mock_integration.lineage import (
+    DecisionIntentDraft,
+    ExecutionPlanDraft,
+    LineageEnvelope,
+    MockLineageFactory,
+    OrderAttemptDraft,
+)
 
 
 def _by_id() -> dict[str, registry.LaneRegistryEntry]:
@@ -15,6 +26,197 @@ def _by_id() -> dict[str, registry.LaneRegistryEntry]:
 
 def _issue_codes(exc: registry.RegistryStartupError) -> set[str]:
     return {issue.code for issue in exc.issues}
+
+
+def test_registry_stays_free_of_transport_signing_and_secret_value_loading() -> None:
+    source_path = Path(registry.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    forbidden_modules = {
+        "aiohttp",
+        "dotenv",
+        "hashlib",
+        "hmac",
+        "http.client",
+        "httpx",
+        "os",
+        "pydantic_settings",
+        "requests",
+        "socket",
+        "urllib.request",
+        "websockets",
+    }
+    imported_modules: set[str] = set()
+    called_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.add(node.module)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            called_names.add(node.func.id)
+
+    assert imported_modules.isdisjoint(forbidden_modules)
+    assert called_names.isdisjoint({"open"})
+
+
+def _lineage_envelope(
+    lane_id: str,
+    *,
+    intent_overrides: dict[str, object] | None = None,
+    plan_overrides: dict[str, object] | None = None,
+) -> tuple[MockLineageFactory, LineageEnvelope]:
+    entry = _by_id()[lane_id]
+    intent_values: dict[str, object] = {
+        "policy_version": "test-policy-v1",
+        "policy_version_hash": "test-policy-hash-v1",
+        "decision_timestamp": datetime(2026, 8, 16, 0, 0, tzinfo=UTC),
+        "market_data_cutoff": datetime(2026, 8, 15, 23, 59, tzinfo=UTC),
+        "symbol": "BRK.B",
+        "side": "buy",
+        "target_notional": Decimal("1"),
+        "target_notional_currency": entry.quote_currency,
+        "limit_policy": {"order_type": "limit"},
+        "expiry_policy": {"kind": "day"},
+        "rationale": "test-only registry binding",
+    }
+    intent_values.update(intent_overrides or {})
+    plan_values: dict[str, object] = {
+        "lane_id": lane_id,
+        "broker": entry.broker,
+        "account_profile": entry.account_profile,
+        "account_mode": entry.account_mode.value,
+        "normalized_symbol": "BRK.B",
+        "quantity": Decimal("1"),
+        "limit_price": Decimal("1"),
+        "quote_currency": entry.quote_currency,
+        "tick_rounding": {"increment": "0.01"},
+        "session": "regular",
+        "time_in_force": "day",
+        "min_order_validation": {"quote_required": True},
+        "risk_caps": {"max_notional": "1"},
+    }
+    plan_values.update(plan_overrides or {})
+    factory = MockLineageFactory()
+    intent = factory.create_decision_intent(DecisionIntentDraft(**intent_values))
+    return factory, factory.create_plan_envelope(
+        intent,
+        ExecutionPlanDraft(**plan_values),
+    )
+
+
+def _registry_replacing(
+    replacement: registry.LaneRegistryEntry,
+) -> tuple[registry.LaneRegistryEntry, ...]:
+    return tuple(
+        replacement if entry.lane_id == replacement.lane_id else entry
+        for entry in registry.CANONICAL_LANE_REGISTRY
+    )
+
+
+def _policy_bound_entry(
+    envelope: LineageEnvelope,
+    lane_id: str,
+) -> registry.LaneRegistryEntry:
+    return replace(
+        _by_id()[lane_id],
+        policy_binding=registry.PolicyBinding(
+            envelope.decision_intent.policy_version,
+            envelope.decision_intent.policy_version_hash,
+        ),
+        missing_bindings=tuple(
+            binding
+            for binding in _by_id()[lane_id].missing_bindings
+            if binding is not registry.MissingBinding.POLICY
+        ),
+    )
+
+
+def _fully_bound_entry(
+    envelope: LineageEnvelope,
+    lane_id: str,
+    **overrides: object,
+) -> registry.LaneRegistryEntry:
+    values: dict[str, object] = {
+        "lane_status": LaneStatus.AUTO_ENABLED,
+        "activation_status": registry.ActivationStatus.ENABLED,
+        "activation_reason": "test-only fully bound fixture",
+        "policy_binding": registry.PolicyBinding(
+            envelope.decision_intent.policy_version,
+            envelope.decision_intent.policy_version_hash,
+        ),
+        "execution_mode": "test-only-bounded",
+        "scheduler_owner": SchedulerOwner.MANUAL,
+        "timing_owner": "test-only-timing",
+        "writer": True,
+        "auto_order_enabled": True,
+        "max_order_notional": Decimal("1"),
+        "max_orders_per_session": 1,
+        "max_open_orders": 1,
+        "allowed_order_types": ("limit",),
+        "allowed_time_in_force": ("day",),
+        "reconcile_required": True,
+        "physical_account_id": f"opaque-test-{lane_id}",
+        "identity_status": "KNOWN",
+        "fingerprint_evidence_ref": "test-only-fingerprint",
+        "canary_binding": "test-only-bounded-canary",
+        "missing_bindings": (),
+    }
+    values.update(overrides)
+    return replace(_by_id()[lane_id], **values)
+
+
+async def _assert_both_boundaries_reject(
+    envelope: LineageEnvelope,
+    snapshot: tuple[registry.LaneRegistryEntry, ...],
+    *,
+    reason: str,
+    endpoint_url: str,
+    credential_namespace: str,
+    recurring_requested: bool = False,
+    bounded_canary: bool = False,
+) -> None:
+    broker_calls = 0
+    factory_calls = 0
+
+    async def broker_io() -> None:
+        nonlocal broker_calls
+        broker_calls += 1
+
+    def factory() -> object:
+        nonlocal factory_calls
+        factory_calls += 1
+        return object()
+
+    with pytest.raises((registry.LaneGuardError, registry.RegistryStartupError)) as io:
+        await registry.guarded_broker_io(
+            envelope,
+            endpoint_url=endpoint_url,
+            credential_namespace=credential_namespace,
+            broker_io=broker_io,
+            registry=snapshot,
+            recurring_requested=recurring_requested,
+            bounded_canary=bounded_canary,
+        )
+    with pytest.raises(
+        (registry.LaneGuardError, registry.RegistryStartupError)
+    ) as client:
+        registry.guarded_client_factory(
+            envelope,
+            endpoint_url=endpoint_url,
+            credential_namespace=credential_namespace,
+            factory=factory,
+            registry=snapshot,
+            recurring_requested=recurring_requested,
+            bounded_canary=bounded_canary,
+        )
+
+    for error in (io.value, client.value):
+        if isinstance(error, registry.LaneGuardError):
+            assert error.code == reason
+        else:
+            assert reason in _issue_codes(error)
+    assert broker_calls == 0
+    assert factory_calls == 0
 
 
 def test_canonical_lane_ids_and_quote_currencies_are_exact() -> None:
@@ -122,6 +324,28 @@ def test_amendment_rule_and_guard_literals_are_verbatim() -> None:
     )
 
 
+def test_r2_reject_code_allowlist_is_exact_and_consumes_j2b_literal() -> None:
+    assert registry.R2_REJECT_CODES == {
+        "lane_signed_restriction_violation",
+        "lane_recurring_not_authorized",
+        "canonical_lane_identity_mismatch",
+        "invalid_scheduler_owner",
+        "invalid_timing_owner",
+        "physical_account_writer_conflict",
+        "canonical_lane_ids_mismatch",
+        "canonical_credential_namespace_mismatch",
+        "canonical_host_allowlist_mismatch",
+        "lane_broker_mismatch",
+        "lane_account_profile_mismatch",
+        "lane_account_mode_mismatch",
+        "lane_policy_binding_mismatch",
+        "lane_binding_incomplete",
+        lineage.BROKER_CLIENT_ID_TARGET_MISMATCH,
+        "lane_quote_currency_mismatch",
+    }
+    assert "unknown_lane" not in registry.R2_REJECT_CODES
+
+
 def test_g1_rejects_new_recurring_schedule_and_missing_cadence_proof() -> None:
     lane_id = "kr.kiwoom.mock"
     with pytest.raises(registry.ActivationTransitionBlocked) as new_schedule:
@@ -160,7 +384,7 @@ def test_g1_rejects_new_recurring_schedule_and_missing_cadence_proof() -> None:
 
 
 def test_g2_stops_at_ready_for_mock_deployment() -> None:
-    lane_id = "us.alpaca.paper.default"
+    lane_id = "kr.kiwoom.mock"
     release_evidence = registry.ActivationEvidence(
         shared_production_release_required=True
     )
@@ -195,7 +419,7 @@ def test_g2_stops_at_ready_for_mock_deployment() -> None:
 
 
 def test_g3_canary_moves_pending_to_ready_only() -> None:
-    lane_id = "crypto.binance.spot_demo.canonical"
+    lane_id = "kr.kiwoom.mock"
     canary_evidence = registry.ActivationEvidence(j8_canary_succeeded=True)
 
     assert (
@@ -226,6 +450,100 @@ def test_g3_canary_moves_pending_to_ready_only() -> None:
         )
     assert missing.value.guard_id == "G3"
     assert missing.value.code == "j8_canary_evidence_required"
+
+
+@pytest.mark.parametrize(
+    "lane_id",
+    (
+        "us.alpaca.paper.default",
+        "us.alpaca.paper.lab",
+        "us.kis.mock",
+        "us.kiwoom.mock",
+        "crypto.binance.spot_demo.canonical",
+        "crypto.binance.spot_demo.b0x_sidecar",
+        "crypto.alpaca.paper.default",
+        "crypto.alpaca.paper.clean",
+        "crypto.upbit.shadow",
+        "crypto.binance.futures_demo",
+    ),
+)
+def test_fully_bound_signed_lane_promotion_is_immutable(lane_id: str) -> None:
+    _, envelope = _lineage_envelope(lane_id)
+    mutant = _fully_bound_entry(envelope, lane_id)
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        registry.assert_registry_startup(
+            _registry_replacing(mutant), require_canonical=True
+        )
+
+    assert "lane_signed_restriction_violation" in _issue_codes(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "lane_id",
+    (
+        "us.alpaca.paper.default",
+        "us.alpaca.paper.lab",
+        "us.kiwoom.mock",
+        "crypto.binance.spot_demo.canonical",
+        "crypto.binance.spot_demo.b0x_sidecar",
+        "crypto.alpaca.paper.default",
+        "crypto.alpaca.paper.clean",
+        "crypto.upbit.shadow",
+        "crypto.binance.futures_demo",
+    ),
+)
+def test_signed_lane_cannot_transition_to_enabled(lane_id: str) -> None:
+    with pytest.raises(registry.ActivationTransitionBlocked) as exc_info:
+        registry.transition_activation(
+            lane_id,
+            registry.ActivationStatus.READY,
+            registry.ActivationStatus.ENABLED,
+            evidence=registry.ActivationEvidence(
+                directly_proven_cadence_preserved=True
+            ),
+        )
+
+    assert exc_info.value.code == "lane_signed_restriction_violation"
+    assert exc_info.value.guard_id == "B2"
+
+
+def test_recurring_requires_lane_and_activation_enabled_together() -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    both_enabled = _fully_bound_entry(envelope, "kr.kiwoom.mock")
+    lane_only = replace(
+        both_enabled,
+        activation_status=registry.ActivationStatus.READY,
+    )
+    activation_only = replace(both_enabled, lane_status=LaneStatus.NOT_READY)
+
+    for one_sided in (lane_only, activation_only):
+        with pytest.raises(registry.LaneGuardError) as exc_info:
+            registry.assert_recurring_authorized(
+                one_sided,
+                recurring_requested=True,
+            )
+        assert exc_info.value.code == "lane_recurring_not_authorized"
+
+    registry.assert_recurring_authorized(both_enabled, recurring_requested=True)
+
+
+def test_bounded_canary_does_not_authorize_recurring() -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    entry = _fully_bound_entry(envelope, "kr.kiwoom.mock")
+
+    registry.assert_recurring_authorized(
+        entry,
+        recurring_requested=False,
+        bounded_canary=True,
+    )
+    with pytest.raises(registry.LaneGuardError) as exc_info:
+        registry.assert_recurring_authorized(
+            entry,
+            recurring_requested=True,
+            bounded_canary=True,
+        )
+    assert exc_info.value.code == "lane_recurring_not_authorized"
 
 
 def test_unknown_fingerprint_rows_are_safe_and_preserved() -> None:
@@ -320,6 +638,44 @@ def test_canonical_registry_passes_startup_assertion() -> None:
     )
 
 
+def test_startup_default_and_explicit_false_accept_full_canonical_registry() -> None:
+    assert (
+        registry.assert_registry_startup(
+            registry.CANONICAL_LANE_REGISTRY, require_canonical=False
+        )
+        is None
+    )
+    assert registry.assert_registry_startup(registry.CANONICAL_LANE_REGISTRY) is None
+
+
+def test_startup_default_and_explicit_false_skip_canonical_only_checks() -> None:
+    custom = replace(
+        registry.CANONICAL_LANE_REGISTRY[0],
+        lane_id="kr.custom.mock",
+        broker="custom",
+        credential_namespace="CUSTOM_MOCK_*",
+        allowed_hosts=("mock.custom.invalid",),
+    )
+    identity_mismatch = replace(
+        registry.CANONICAL_LANE_REGISTRY[1],
+        role=registry.RegistryRole.AUTO_MIRROR,
+    )
+    assert registry.assert_registry_startup((custom,), require_canonical=False) is None
+    assert registry.assert_registry_startup((custom,)) is None
+
+    with pytest.raises(registry.RegistryStartupError) as strict:
+        registry.assert_registry_startup(
+            (custom, identity_mismatch), require_canonical=True
+        )
+    assert {
+        "canonical_lane_ids_mismatch",
+        "canonical_lane_identity_mismatch",
+        "lane_quote_currency_mismatch",
+        "canonical_credential_namespace_mismatch",
+        "canonical_host_allowlist_mismatch",
+    } <= _issue_codes(strict.value)
+
+
 def test_same_physical_account_two_writers_fail_without_identifier_leak() -> None:
     raw_identifier = "opaque-account-id-that-must-not-appear"
     first = replace(
@@ -354,7 +710,35 @@ def test_scheduler_owner_and_timing_owner_cannot_collapse() -> None:
     with pytest.raises(registry.RegistryStartupError) as exc_info:
         registry.assert_registry_startup((mutant,))
 
-    assert "scheduler_timing_owner_collapsed" in _issue_codes(exc_info.value)
+    assert "invalid_timing_owner" in _issue_codes(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "reason"),
+    (
+        ("scheduler_owner", "manual", "invalid_scheduler_owner"),
+        ("timing_owner", "   ", "invalid_timing_owner"),
+        ("timing_owner", 17, "invalid_timing_owner"),
+    ),
+)
+def test_owner_types_are_strict(field_name: str, value: object, reason: str) -> None:
+    mutant = replace(
+        registry.CANONICAL_LANE_REGISTRY[0],
+        **{field_name: value},
+    )
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        registry.assert_registry_startup((mutant,))
+
+    assert reason in _issue_codes(exc_info.value)
+
+
+@pytest.mark.parametrize(("version", "version_hash"), (("", "hash"), ("v1", " ")))
+def test_policy_binding_fields_must_be_nonblank(
+    version: str, version_hash: str
+) -> None:
+    with pytest.raises(ValueError, match="^lane_binding_incomplete$"):
+        registry.PolicyBinding(version, version_hash)
 
 
 def test_credential_namespaces_and_host_allowlists_are_exact() -> None:
@@ -388,138 +772,463 @@ def test_credential_namespaces_and_host_allowlists_are_exact() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value", "reason"),
+    (
+        (
+            "credential_namespace",
+            "CHANGED_*",
+            "canonical_credential_namespace_mismatch",
+        ),
+        (
+            "allowed_hosts",
+            ("changed.invalid",),
+            "canonical_host_allowlist_mismatch",
+        ),
+    ),
+)
+def test_retained_canonical_binding_reasons_remain_exact(
+    field_name: str,
+    value: object,
+    reason: str,
+) -> None:
+    mutant = replace(_by_id()["kr.kiwoom.mock"], **{field_name: value})
+
+    with pytest.raises(registry.RegistryStartupError) as exc_info:
+        registry.assert_registry_startup(
+            _registry_replacing(mutant), require_canonical=True
+        )
+
+    assert reason in _issue_codes(exc_info.value)
+
+
 @pytest.mark.asyncio
 async def test_currency_mismatch_blocks_before_broker_io() -> None:
-    called = False
+    _, envelope = _lineage_envelope(
+        "kr.kiwoom.mock",
+        intent_overrides={"target_notional_currency": "USD"},
+        plan_overrides={"quote_currency": "USD"},
+    )
+    await _assert_both_boundaries_reject(
+        envelope,
+        registry.CANONICAL_LANE_REGISTRY,
+        reason="lane_quote_currency_mismatch",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
 
-    async def broker_io() -> None:
-        nonlocal called
-        called = True
 
-    plan = SimpleNamespace(lane_id="kr.kiwoom.mock", quote_currency="USD")
-    with pytest.raises(registry.LaneGuardError) as exc_info:
-        await registry.guarded_broker_io(
-            plan,
-            endpoint_url="https://mockapi.kiwoom.com",
-            credential_namespace="KIWOOM_MOCK_*",
-            broker_io=broker_io,
-        )
+def test_factory_derived_alpaca_paper_binding_uses_exact_canonical_values() -> None:
+    _, envelope = _lineage_envelope("us.alpaca.paper.default")
+    assert envelope.execution_plan is not None
+    entry = _policy_bound_entry(envelope, "us.alpaca.paper.default")
 
-    assert exc_info.value.code == "lane_quote_currency_mismatch"
-    assert called is False
+    resolved = registry.assert_lineage_registry_binding(
+        envelope,
+        _registry_replacing(entry),
+    )
+
+    assert envelope.decision_intent.decision_intent_id.startswith("mock-intent-v1:")
+    assert envelope.execution_plan.execution_plan_id.startswith("mock-plan-v1:")
+    assert envelope.execution_plan.account_profile == "paper"
+    assert envelope.execution_plan.account_mode == "paper"
+    assert resolved is entry
 
 
 @pytest.mark.asyncio
-async def test_live_endpoint_and_namespace_mismatch_block_before_broker_io() -> None:
-    called = False
+@pytest.mark.parametrize(
+    ("field_name", "value", "reason"),
+    (
+        ("broker", "other-broker", "lane_broker_mismatch"),
+        ("account_profile", "other-profile", "lane_account_profile_mismatch"),
+        ("account_mode", "alpaca_paper", "lane_account_mode_mismatch"),
+    ),
+)
+async def test_lineage_plan_identity_mismatch_rejects_both_boundaries(
+    field_name: str,
+    value: str,
+    reason: str,
+) -> None:
+    _, envelope = _lineage_envelope(
+        "kr.kiwoom.mock",
+        plan_overrides={field_name: value},
+    )
+    entry = _policy_bound_entry(envelope, "kr.kiwoom.mock")
 
-    async def broker_io() -> None:
-        nonlocal called
-        called = True
+    await _assert_both_boundaries_reject(
+        envelope,
+        _registry_replacing(entry),
+        reason=reason,
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
 
-    plan = SimpleNamespace(lane_id="kr.kiwoom.mock", quote_currency="KRW")
-    with pytest.raises(registry.LaneGuardError) as live:
-        await registry.guarded_broker_io(
-            plan,
-            endpoint_url="https://api.kiwoom.com",
-            credential_namespace="KIWOOM_MOCK_*",
-            broker_io=broker_io,
-        )
-    assert live.value.code == "live_endpoint_forbidden"
 
-    with pytest.raises(registry.LaneGuardError) as namespace:
-        await registry.guarded_broker_io(
-            plan,
-            endpoint_url="https://mockapi.kiwoom.com",
-            credential_namespace="KIWOOM_MOCK_US_*",
-            broker_io=broker_io,
-        )
-    assert namespace.value.code == "credential_namespace_mismatch"
-    assert called is False
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("intent_overrides", "policy_binding"),
+    (
+        (
+            {"policy_version": "changed-policy"},
+            registry.PolicyBinding("expected-policy", "test-policy-hash-v1"),
+        ),
+        (
+            {"policy_version_hash": "changed-hash"},
+            registry.PolicyBinding("test-policy-v1", "expected-hash"),
+        ),
+    ),
+)
+async def test_lineage_policy_mismatch_rejects_both_boundaries(
+    intent_overrides: dict[str, object],
+    policy_binding: registry.PolicyBinding,
+) -> None:
+    _, envelope = _lineage_envelope(
+        "kr.kiwoom.mock",
+        intent_overrides=intent_overrides,
+    )
+    entry = replace(
+        _policy_bound_entry(envelope, "kr.kiwoom.mock"),
+        policy_binding=policy_binding,
+    )
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        _registry_replacing(entry),
+        reason="lane_policy_binding_mismatch",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
+
+
+@pytest.mark.asyncio
+async def test_absent_policy_binding_keeps_existing_incomplete_reason() -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        registry.CANONICAL_LANE_REGISTRY,
+        reason="lane_binding_incomplete",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
+
+
+@pytest.mark.asyncio
+async def test_declared_endpoint_and_namespace_reject_before_opaque_callbacks() -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    entry = _policy_bound_entry(envelope, "kr.kiwoom.mock")
+    snapshot = _registry_replacing(entry)
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        snapshot,
+        reason="live_endpoint_forbidden",
+        endpoint_url="https://api.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
+    await _assert_both_boundaries_reject(
+        envelope,
+        snapshot,
+        reason="credential_namespace_mismatch",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_US_*",
+    )
 
 
 @pytest.mark.asyncio
 async def test_current_blocked_row_never_reaches_broker_io() -> None:
-    called = False
+    called = 0
 
     async def broker_io() -> None:
         nonlocal called
-        called = True
+        called += 1
 
-    plan = SimpleNamespace(lane_id="kr.kiwoom.mock", quote_currency="KRW")
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    entry = _policy_bound_entry(envelope, "kr.kiwoom.mock")
     with pytest.raises(registry.LaneGuardError) as exc_info:
         await registry.guarded_broker_io(
-            plan,
+            envelope,
             endpoint_url="https://mockapi.kiwoom.com",
             credential_namespace="KIWOOM_MOCK_*",
             broker_io=broker_io,
+            registry=_registry_replacing(entry),
         )
 
     assert exc_info.value.code == "lane_activation_not_enabled"
-    assert called is False
+    assert called == 0
 
 
 @pytest.mark.asyncio
 async def test_broker_boundary_rechecks_single_writer_registry() -> None:
-    called = False
     physical_account_id = "opaque-test-account"
-
-    async def broker_io() -> None:
-        nonlocal called
-        called = True
-
-    first = replace(
-        registry.CANONICAL_LANE_REGISTRY[0],
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    first = _fully_bound_entry(
+        envelope,
+        "kr.kis.mock",
         physical_account_id=physical_account_id,
-        writer=True,
     )
-    second = replace(
-        registry.CANONICAL_LANE_REGISTRY[1],
+    second = _fully_bound_entry(
+        envelope,
+        "kr.kiwoom.mock",
         physical_account_id=physical_account_id,
-        writer=True,
     )
-    plan = SimpleNamespace(lane_id=first.lane_id, quote_currency="KRW")
+    replacements = {first.lane_id: first, second.lane_id: second}
+    snapshot = tuple(
+        replacements.get(entry.lane_id, entry)
+        for entry in registry.CANONICAL_LANE_REGISTRY
+    )
 
-    with pytest.raises(registry.RegistryStartupError) as exc_info:
+    await _assert_both_boundaries_reject(
+        envelope,
+        snapshot,
+        reason="physical_account_writer_conflict",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    (
+        ("market", "changed"),
+        ("broker", "changed"),
+        ("account_profile", "changed"),
+        ("profile_variant", "changed"),
+        ("account_mode", registry.AccountMode.PAPER),
+        ("lane_type", registry.AccountMode.PAPER),
+        ("quote_currency", "USD"),
+        ("role", registry.RegistryRole.AUTO_MIRROR),
+        ("role_pending_reason", "changed"),
+        ("role_on_policy_approval", registry.RegistryRole.AUTO_CHALLENGER),
+        ("endpoint_class", registry.EndpointClass.PAPER),
+        ("credential_namespace", "CHANGED_*"),
+        ("allowed_hosts", ("changed.invalid",)),
+    ),
+)
+async def test_all_13_canonical_identity_fields_are_immutable_at_both_boundaries(
+    field_name: str,
+    value: object,
+) -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    mutant = replace(_by_id()["kr.kiwoom.mock"], **{field_name: value})
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        _registry_replacing(mutant),
+        reason="canonical_lane_identity_mismatch",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
+
+
+@pytest.mark.asyncio
+async def test_custom_registry_cannot_bypass_canonical_lane_set() -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    custom = replace(
+        _by_id()["kr.kis.mock"],
+        lane_id="kr.custom.mock",
+        broker="custom",
+    )
+    snapshot = (custom, *registry.CANONICAL_LANE_REGISTRY[1:])
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        snapshot,
+        reason="canonical_lane_ids_mismatch",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field_name", "value", "reason"),
+    (
+        ("scheduler_owner", "manual", "invalid_scheduler_owner"),
+        ("timing_owner", " ", "invalid_timing_owner"),
+    ),
+)
+async def test_invalid_owner_types_reject_both_boundaries_without_calls(
+    field_name: str,
+    value: object,
+    reason: str,
+) -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    mutant = replace(_by_id()["kr.kiwoom.mock"], **{field_name: value})
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        _registry_replacing(mutant),
+        reason=reason,
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fully_bound_signed_restriction_rejects_both_boundaries() -> None:
+    _, envelope = _lineage_envelope("crypto.alpaca.paper.default")
+    mutant = _fully_bound_entry(envelope, "crypto.alpaca.paper.default")
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        _registry_replacing(mutant),
+        reason="lane_signed_restriction_violation",
+        endpoint_url="https://paper-api.alpaca.markets",
+        credential_namespace="ALPACA_PAPER_*",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("lane_status", "activation_status"),
+    (
+        (LaneStatus.AUTO_ENABLED, registry.ActivationStatus.READY),
+        (LaneStatus.NOT_READY, registry.ActivationStatus.ENABLED),
+    ),
+)
+async def test_one_sided_recurring_state_rejects_both_boundaries(
+    lane_status: LaneStatus,
+    activation_status: registry.ActivationStatus,
+) -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    mutant = _fully_bound_entry(
+        envelope,
+        "kr.kiwoom.mock",
+        lane_status=lane_status,
+        activation_status=activation_status,
+    )
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        _registry_replacing(mutant),
+        reason="lane_recurring_not_authorized",
+        endpoint_url="https://mockapi.kiwoom.com",
+        credential_namespace="KIWOOM_MOCK_*",
+        recurring_requested=True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("lane_id", "endpoint_url", "credential_namespace"),
+    (
+        (
+            "kr.kis.mock",
+            "https://openapivts.koreainvestment.com:29443",
+            "KIS_MOCK_*",
+        ),
+        ("kr.kiwoom.mock", "https://mockapi.kiwoom.com", "KIWOOM_MOCK_*"),
+    ),
+)
+async def test_kis_and_kiwoom_none_client_id_pair_pass_exact_registered_binding(
+    lane_id: str,
+    endpoint_url: str,
+    credential_namespace: str,
+) -> None:
+    factory, plan_envelope = _lineage_envelope(lane_id)
+    envelope = factory.create_attempt_envelope(
+        plan_envelope,
+        OrderAttemptDraft(
+            cycle_id=f"test-cycle-{lane_id}",
+            attempt_seq=1,
+            lane_prefix=None,
+            broker_client_id_target=None,
+        ),
+    )
+    entry = _fully_bound_entry(envelope, lane_id)
+    snapshot = _registry_replacing(entry)
+    broker_calls = 0
+    factory_calls = 0
+
+    async def broker_io() -> str:
+        nonlocal broker_calls
+        broker_calls += 1
+        return "broker-ok"
+
+    def client_factory() -> str:
+        nonlocal factory_calls
+        factory_calls += 1
+        return "factory-ok"
+
+    assert envelope.order_attempt is not None
+    assert envelope.order_attempt.broker_client_order_id is None
+    assert (
         await registry.guarded_broker_io(
-            plan,
-            endpoint_url="https://openapivts.koreainvestment.com:29443",
-            credential_namespace="KIS_MOCK_*",
+            envelope,
+            endpoint_url=endpoint_url,
+            credential_namespace=credential_namespace,
             broker_io=broker_io,
-            registry={first.lane_id: first, second.lane_id: second},
+            registry=snapshot,
         )
+        == "broker-ok"
+    )
+    assert (
+        registry.guarded_client_factory(
+            envelope,
+            endpoint_url=endpoint_url,
+            credential_namespace=credential_namespace,
+            factory=client_factory,
+            registry=snapshot,
+        )
+        == "factory-ok"
+    )
+    assert broker_calls == 1
+    assert factory_calls == 1
 
-    assert "physical_account_writer_conflict" in _issue_codes(exc_info.value)
-    assert called is False
+
+@pytest.mark.asyncio
+async def test_unknown_broker_none_client_id_pair_stops_at_existing_unknown_lane() -> (
+    None
+):
+    factory, plan_envelope = _lineage_envelope(
+        "kr.kis.mock",
+        plan_overrides={
+            "lane_id": "kr.unregistered.mock",
+            "broker": "unregistered",
+        },
+    )
+    envelope = factory.create_attempt_envelope(
+        plan_envelope,
+        OrderAttemptDraft(
+            cycle_id="test-cycle-unregistered",
+            attempt_seq=1,
+            lane_prefix=None,
+            broker_client_id_target=None,
+        ),
+    )
+    registered_entry = _fully_bound_entry(envelope, "kr.kis.mock")
+
+    await _assert_both_boundaries_reject(
+        envelope,
+        _registry_replacing(registered_entry),
+        reason="unknown_lane",
+        endpoint_url="https://openapivts.koreainvestment.com:29443",
+        credential_namespace="KIS_MOCK_*",
+    )
 
 
-def test_live_client_factory_and_near_miss_host_are_never_invoked() -> None:
-    entry = registry.get_lane_registry_entry("kr.kiwoom.mock")
-    called = False
+def test_declared_near_miss_host_rejects_before_opaque_factory() -> None:
+    _, envelope = _lineage_envelope("kr.kiwoom.mock")
+    entry = _policy_bound_entry(envelope, "kr.kiwoom.mock")
+    called = 0
 
     def factory() -> object:
         nonlocal called
-        called = True
+        called += 1
         return object()
-
-    with pytest.raises(registry.LaneGuardError) as live:
-        registry.guarded_client_factory(
-            entry,
-            endpoint_url="https://api.kiwoom.com",
-            credential_namespace="KIWOOM_MOCK_*",
-            factory=factory,
-        )
-    assert live.value.code == "live_endpoint_forbidden"
 
     with pytest.raises(registry.LaneGuardError) as near_miss:
         registry.guarded_client_factory(
-            entry,
+            envelope,
             endpoint_url="https://mockapi.kiwoom.com.evil.test",
             credential_namespace="KIWOOM_MOCK_*",
             factory=factory,
+            registry=_registry_replacing(entry),
         )
     assert near_miss.value.code == "lane_endpoint_host_mismatch"
-    assert called is False
+    assert called == 0
 
 
 def test_shadow_lane_structurally_rejects_broker_io() -> None:


### PR DESCRIPTION
## Summary
- add an inert, fail-closed 12-lane account identity registry
- encode exact roles, quote currencies, activation enum/guards, and unknown-identity preservation rules
- enforce masked single-writer startup checks and currency/endpoint/credential gates before broker callbacks
- add the ROB-1260 contract and focused guard tests

## Verification
- `uv run pytest tests/test_mock_lane_registry.py -q`: 25 passed
- `make lint`: Ruff, format check, and ty passed
- `make test`: 19740 passed, 13 skipped, 7 deselected, 4 failed
  - one expected integration-order audit failure remains until the J2B-owned allowlist from ROB-1261 lands
  - three existing dotenv-isolation failures were attributed without exposing values; the same inputs fail closed with `ValidationError` from a dotenv-free working directory

## Integration order
The J2B-owned Binance audit test is intentionally untouched. Merge ROB-1261 first, then rebase this branch on fresh merged main and rerun focused, audit, and full attribution before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fail-closed registry for mock, paper, demo, and shadow trading lanes.
  * Added safeguards for lane identity, currencies, endpoints, credentials, activation, recurring orders, and broker access.
  * Added immutable evidence and mirror-divergence recording.

* **Bug Fixes**
  * Prevented invalid, incomplete, or unauthorized lane configurations from reaching broker or client operations.
  * Enforced restrictions for unknown identities, unsupported hosts, signed lanes, and missing ownership.

* **Documentation**
  * Added the account identity and lane registry contract.

* **Tests**
  * Added comprehensive coverage for validation, activation, access guards, and divergence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->