### PR TITLE
ROB-1261: deterministic mock lineage correlation

### DIFF
--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -27,6 +27,9 @@ from app.services.brokers.alpaca.exceptions import (
     AlpacaPaperRequestError,
 )
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+from app.services.brokers.client_order_ids import (
+    ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -192,8 +195,11 @@ class PreviewOrderInput(BaseModel):
         stripped = v.strip()
         if not stripped:
             raise ValueError("client_order_id must not be blank")
-        if len(stripped) > 48:
-            raise ValueError("client_order_id must be <= 48 characters")
+        if len(stripped) > ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH:
+            raise ValueError(
+                "client_order_id must be <= "
+                f"{ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH} characters"
+            )
         return stripped
 
     @field_validator("asset_class")

--- a/app/services/brokers/alpaca/service.py
+++ b/app/services/brokers/alpaca/service.py
@@ -24,6 +24,10 @@ from app.services.brokers.alpaca.schemas import (
     Position,
 )
 from app.services.brokers.alpaca.transport import HTTPTransport, HttpxTransport
+from app.services.brokers.client_order_ids import (
+    BrokerClientIdTarget,
+    assert_broker_client_order_id,
+)
 
 
 class AlpacaPaperBrokerService:
@@ -198,6 +202,11 @@ class AlpacaPaperBrokerService:
 
     async def submit_order(self, request: OrderRequest) -> Order:
         body = request.model_dump(mode="json", exclude_none=True)
+        if request.client_order_id is not None:
+            assert_broker_client_order_id(
+                target=BrokerClientIdTarget.ALPACA_PAPER,
+                client_order_id=request.client_order_id,
+            )
         data = await self._request("POST", "/v2/orders", json=body)
         return Order.model_validate(data)
 
@@ -230,6 +239,10 @@ class AlpacaPaperBrokerService:
         Returns None when no order exists for the id (HTTP 404). Used only for
         crash-after-success reconciliation — this never mutates and never POSTs.
         """
+        assert_broker_client_order_id(
+            target=BrokerClientIdTarget.ALPACA_PAPER,
+            client_order_id=client_order_id,
+        )
         try:
             data = await self._request(
                 "GET",

--- a/app/services/brokers/binance/spot_demo/execution_client.py
+++ b/app/services/brokers/binance/spot_demo/execution_client.py
@@ -64,6 +64,10 @@ from app.services.brokers.binance.spot_demo.signing import (
     _sign_request_params,
 )
 from app.services.brokers.binance.spot_demo.transport import build_spot_demo_client
+from app.services.brokers.client_order_ids import (
+    BrokerClientIdTarget,
+    assert_broker_client_order_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -334,6 +338,10 @@ class BinanceSpotDemoExecutionClient:
                 qty=qty,
                 client_order_id=cid,
             )
+        assert_broker_client_order_id(
+            target=BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+            client_order_id=cid,
+        )
         params = self._build_order_params(
             symbol=symbol,
             side=side,
@@ -383,6 +391,10 @@ class BinanceSpotDemoExecutionClient:
                 qty=Decimal("0"),
                 client_order_id=client_order_id,
             )
+        assert_broker_client_order_id(
+            target=BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+            client_order_id=client_order_id,
+        )
         params = {
             "symbol": symbol,
             "origClientOrderId": client_order_id,
@@ -515,6 +527,10 @@ class BinanceSpotDemoExecutionClient:
         with order type (LIMIT vs STOP_*) and the ledger layer needs the
         full raw shape for state-machine decisions.
         """
+        assert_broker_client_order_id(
+            target=BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+            client_order_id=client_order_id,
+        )
         params = {
             "symbol": symbol,
             "origClientOrderId": client_order_id,

--- a/app/services/brokers/client_order_ids.py
+++ b/app/services/brokers/client_order_ids.py
@@ -63,21 +63,23 @@ BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 36
 ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 48
 
 BROKER_CLIENT_ORDER_ID_CONSTRAINTS: Final[
-    dict[BrokerClientIdTarget, BrokerClientOrderIdConstraint]
-] = {
-    BrokerClientIdTarget.TOSS: BrokerClientOrderIdConstraint(
-        max_length=TOSS_CLIENT_ORDER_ID_MAX_LENGTH,
-        allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
-    ),
-    BrokerClientIdTarget.BINANCE_SPOT_DEMO: BrokerClientOrderIdConstraint(
-        max_length=BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
-        allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
-    ),
-    BrokerClientIdTarget.ALPACA_PAPER: BrokerClientOrderIdConstraint(
-        max_length=ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
-        allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
-    ),
-}
+    Mapping[BrokerClientIdTarget, BrokerClientOrderIdConstraint]
+] = MappingProxyType(
+    {
+        BrokerClientIdTarget.TOSS: BrokerClientOrderIdConstraint(
+            max_length=TOSS_CLIENT_ORDER_ID_MAX_LENGTH,
+            allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
+        ),
+        BrokerClientIdTarget.BINANCE_SPOT_DEMO: BrokerClientOrderIdConstraint(
+            max_length=BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
+            allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
+        ),
+        BrokerClientIdTarget.ALPACA_PAPER: BrokerClientOrderIdConstraint(
+            max_length=ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
+            allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
+        ),
+    }
+)
 
 
 class BrokerClientOrderIdConstraintViolation(ValueError):

--- a/app/services/brokers/client_order_ids.py
+++ b/app/services/brokers/client_order_ids.py
@@ -8,8 +8,10 @@ transport boundary; it performs no network or persistence work.
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
+from types import MappingProxyType
 from typing import Final
 
 BROKER_CLIENT_ID_CONSTRAINT_VIOLATION: Final[str] = (
@@ -23,6 +25,20 @@ class BrokerClientIdTarget(StrEnum):
     TOSS = "toss"
     BINANCE_SPOT_DEMO = "binance_spot_demo"
     ALPACA_PAPER = "alpaca_paper"
+
+
+# These exact pairs are signed J2B contract inputs, not a dependency on the
+# later lane registry. The read-only map prevents runtime reconfiguration of
+# the factory's confirmed target boundary.
+BROKER_CLIENT_ID_TARGET_PLAN_BROKERS: Final[Mapping[BrokerClientIdTarget, str]] = (
+    MappingProxyType(
+        {
+            BrokerClientIdTarget.ALPACA_PAPER: "alpaca",
+            BrokerClientIdTarget.BINANCE_SPOT_DEMO: "binance",
+            BrokerClientIdTarget.TOSS: "toss",
+        }
+    )
+)
 
 
 @dataclass(frozen=True)
@@ -92,6 +108,7 @@ __all__ = [
     "BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH",
     "BROKER_CLIENT_ID_CONSTRAINT_VIOLATION",
     "BROKER_CLIENT_ORDER_ID_CONSTRAINTS",
+    "BROKER_CLIENT_ID_TARGET_PLAN_BROKERS",
     "BrokerClientIdTarget",
     "BrokerClientOrderIdConstraint",
     "BrokerClientOrderIdConstraintViolation",

--- a/app/services/brokers/client_order_ids.py
+++ b/app/services/brokers/client_order_ids.py
@@ -1,0 +1,102 @@
+"""Broker-facing client-order-ID constraints for mock/paper/demo lanes.
+
+The internal lineage identifiers remain full SHA-256 values.  This module
+holds only the bounded representation that is allowed to cross a broker
+transport boundary; it performs no network or persistence work.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final
+
+BROKER_CLIENT_ID_CONSTRAINT_VIOLATION: Final[str] = (
+    "broker_client_id_constraint_violation"
+)
+
+
+class BrokerClientIdTarget(StrEnum):
+    """Broker adapters with a confirmed client-order-ID boundary."""
+
+    TOSS = "toss"
+    BINANCE_SPOT_DEMO = "binance_spot_demo"
+    ALPACA_PAPER = "alpaca_paper"
+
+
+@dataclass(frozen=True)
+class BrokerClientOrderIdConstraint:
+    """The bounded, portable subset used by the corresponding adapter."""
+
+    max_length: int
+    allowed_pattern: re.Pattern[str]
+
+
+# Toss's existing submit boundary already pins 36 and this alphabet.  The
+# lineage factory emits the same portable subset for every supported target.
+_PORTABLE_CLIENT_ORDER_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"[A-Za-z0-9_-]+"
+)
+TOSS_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 36
+
+# The existing Spot Demo adapter and its submit tests retain the 36-character
+# boundary.  Explicitly centralizing it makes the pre-send assertion auditable.
+BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 36
+
+# Alpaca Paper's current POST /v2/orders contract permits client_order_id
+# values up to 128 characters.  We send the portable ASCII subset above.
+ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 128
+
+BROKER_CLIENT_ORDER_ID_CONSTRAINTS: Final[
+    dict[BrokerClientIdTarget, BrokerClientOrderIdConstraint]
+] = {
+    BrokerClientIdTarget.TOSS: BrokerClientOrderIdConstraint(
+        max_length=TOSS_CLIENT_ORDER_ID_MAX_LENGTH,
+        allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
+    ),
+    BrokerClientIdTarget.BINANCE_SPOT_DEMO: BrokerClientOrderIdConstraint(
+        max_length=BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
+        allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
+    ),
+    BrokerClientIdTarget.ALPACA_PAPER: BrokerClientOrderIdConstraint(
+        max_length=ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
+        allowed_pattern=_PORTABLE_CLIENT_ORDER_ID_PATTERN,
+    ),
+}
+
+
+class BrokerClientOrderIdConstraintViolation(ValueError):
+    """A broker-facing identifier cannot safely cross the send boundary."""
+
+    reason_code: Final[str] = BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+
+    def __init__(self, *, target: BrokerClientIdTarget) -> None:
+        super().__init__(f"{BROKER_CLIENT_ID_CONSTRAINT_VIOLATION}: {target.value}")
+
+
+def assert_broker_client_order_id(
+    *, target: BrokerClientIdTarget, client_order_id: str
+) -> None:
+    """Fail closed unless an ID fits the target's pre-send constraints."""
+
+    constraint = BROKER_CLIENT_ORDER_ID_CONSTRAINTS[target]
+    if (
+        not isinstance(client_order_id, str)
+        or len(client_order_id) > constraint.max_length
+        or constraint.allowed_pattern.fullmatch(client_order_id) is None
+    ):
+        raise BrokerClientOrderIdConstraintViolation(target=target)
+
+
+__all__ = [
+    "ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH",
+    "BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH",
+    "BROKER_CLIENT_ID_CONSTRAINT_VIOLATION",
+    "BROKER_CLIENT_ORDER_ID_CONSTRAINTS",
+    "BrokerClientIdTarget",
+    "BrokerClientOrderIdConstraint",
+    "BrokerClientOrderIdConstraintViolation",
+    "TOSS_CLIENT_ORDER_ID_MAX_LENGTH",
+    "assert_broker_client_order_id",
+]

--- a/app/services/brokers/client_order_ids.py
+++ b/app/services/brokers/client_order_ids.py
@@ -33,20 +33,18 @@ class BrokerClientOrderIdConstraint:
     allowed_pattern: re.Pattern[str]
 
 
-# Toss's existing submit boundary already pins 36 and this alphabet.  The
-# lineage factory emits the same portable subset for every supported target.
+# This intentionally conservative portable subset is derived from the Toss
+# boundary; it is not an assertion of Alpaca or Binance character constraints.
+# The lineage factory emits the same subset for every supported target.
 _PORTABLE_CLIENT_ORDER_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
     r"[A-Za-z0-9_-]+"
 )
 TOSS_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 36
 
-# The existing Spot Demo adapter and its submit tests retain the 36-character
-# boundary.  Explicitly centralizing it makes the pre-send assertion auditable.
 BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 36
 
-# Alpaca Paper's current POST /v2/orders contract permits client_order_id
-# values up to 128 characters.  We send the portable ASCII subset above.
-ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 128
+# Shared by the preview validator and the pre-send transport boundary.
+ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH: Final[int] = 48
 
 BROKER_CLIENT_ORDER_ID_CONSTRAINTS: Final[
     dict[BrokerClientIdTarget, BrokerClientOrderIdConstraint]

--- a/app/services/mock_integration/__init__.py
+++ b/app/services/mock_integration/__init__.py
@@ -1,0 +1,1 @@
+"""Pure mock/paper/demo integration building blocks (ROB-1261)."""

--- a/app/services/mock_integration/lineage.py
+++ b/app/services/mock_integration/lineage.py
@@ -1,0 +1,540 @@
+"""Server-generated lineage envelopes for mock/paper/demo execution.
+
+This module is deliberately pure: it creates immutable records, derives
+deterministic identifiers, and defines a persistence port.  It does not
+select a lane profile, persist a record, or call a broker.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated, Any, Final, Literal, Protocol, runtime_checkable
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    StringConstraints,
+    model_validator,
+)
+
+from app.schemas.execution_contracts import (
+    DecisionIntent,
+    ExecutionPlan,
+    OrderAttempt,
+)
+from app.services.brokers.client_order_ids import (
+    BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
+    BrokerClientIdTarget,
+    assert_broker_client_order_id,
+)
+
+_INTENT_V1_DOMAIN: Final[str] = "mock-intent-v1:"
+_PLAN_V1_DOMAIN: Final[str] = "mock-plan-v1:"
+_ATTEMPT_V1_DOMAIN: Final[str] = "mock-attempt-v1:"
+_IDEMPOTENCY_V1_DOMAIN: Final[str] = "mock-idempotency-v1:"
+
+# These tuples are a compatibility boundary, not a convenience list.  Add a
+# new domain version rather than changing either v1 input set.
+_INTENT_V1_HASH_FIELDS: Final[tuple[str, ...]] = (
+    "policy_version",
+    "policy_version_hash",
+    "decision_timestamp",
+    "market_data_cutoff",
+    "symbol",
+    "side",
+    "target_notional",
+    "target_notional_currency",
+    "limit_policy",
+    "expiry_policy",
+    "rationale",
+)
+_PLAN_V1_HASH_FIELDS: Final[tuple[str, ...]] = (
+    "decision_intent_id",
+    "lane_id",
+    "broker",
+    "account_profile",
+    "account_mode",
+    "normalized_symbol",
+    "quantity",
+    "limit_price",
+    "quote_currency",
+    "tick_rounding",
+    "session",
+    "time_in_force",
+    "min_order_validation",
+    "risk_caps",
+)
+
+
+class LineageReasonCode(StrEnum):
+    """Stable reason-code vocabulary for downstream aggregation."""
+
+    LINEAGE_PERSISTENCE_UNAVAILABLE = "lineage_persistence_unavailable"
+    CURRENCY_CONVERSION_NOT_AUTHORIZED = "currency_conversion_not_authorized"
+    LANE_QUOTE_CURRENCY_MISMATCH = "lane_quote_currency_mismatch"
+    BROKER_CLIENT_ID_CONSTRAINT_VIOLATION = BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+
+
+LINEAGE_REASON_CODES: Final[frozenset[str]] = frozenset(
+    reason.value for reason in LineageReasonCode
+)
+
+
+class CallerOwnedIdRejected(ValueError):
+    """A caller attempted to bypass the server-generated ID boundary."""
+
+
+class HashVersionUpgradeRequired(ValueError):
+    """A v1 model shape changed and must move to a new hash domain."""
+
+
+class LineagePersistenceUnavailable(RuntimeError):
+    """No future-owned persistence implementation was supplied."""
+
+    reason_code: Final[str] = LineageReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+
+    def __init__(self) -> None:
+        super().__init__(self.reason_code)
+
+
+LineageNonBlank = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+_Currency = Literal["KRW", "USD", "USDT"]
+
+
+class _LineageDraft(BaseModel):
+    """Strict server-factory input with no caller-owned identifier fields."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+
+class DecisionIntentDraft(_LineageDraft):
+    policy_version: LineageNonBlank
+    policy_version_hash: LineageNonBlank
+    decision_timestamp: datetime
+    market_data_cutoff: datetime
+    symbol: LineageNonBlank
+    side: Literal["buy", "sell"]
+    target_notional: Decimal = Field(gt=0, allow_inf_nan=False)
+    target_notional_currency: _Currency
+    limit_policy: dict[str, Any]
+    expiry_policy: dict[str, Any]
+    rationale: LineageNonBlank
+
+
+class ExecutionPlanDraft(_LineageDraft):
+    lane_id: LineageNonBlank
+    broker: LineageNonBlank
+    account_profile: LineageNonBlank
+    account_mode: LineageNonBlank
+    normalized_symbol: LineageNonBlank
+    quantity: Decimal = Field(gt=0, allow_inf_nan=False)
+    limit_price: Decimal | None
+    quote_currency: _Currency
+    tick_rounding: dict[str, Any]
+    session: LineageNonBlank | None
+    time_in_force: LineageNonBlank | None
+    min_order_validation: dict[str, Any]
+    risk_caps: dict[str, Any]
+
+
+class OrderAttemptDraft(_LineageDraft):
+    cycle_id: LineageNonBlank
+    attempt_seq: int = Field(ge=1)
+    lane_prefix: LineageNonBlank
+    broker_client_id_target: BrokerClientIdTarget
+
+
+class LineageEnvelope(_LineageDraft):
+    """Immutable one-plan lineage snapshot; mirror lanes receive separate ones."""
+
+    decision_intent: DecisionIntent
+    execution_plan: ExecutionPlan | None = None
+    order_attempt: OrderAttempt | None = None
+    attempt_seq: int | None = Field(default=None, ge=1)
+    lane_prefix: LineageNonBlank | None = None
+    broker_client_id_target: BrokerClientIdTarget | None = None
+
+    @model_validator(mode="after")
+    def _validate_containment(self) -> LineageEnvelope:
+        if self.decision_intent.decision_intent_id != derive_intent_v1_id(
+            self.decision_intent
+        ):
+            raise CallerOwnedIdRejected("decision_intent_id must be server-generated")
+        if (
+            self.execution_plan is not None
+            and self.execution_plan.decision_intent_id
+            != self.decision_intent.decision_intent_id
+        ):
+            raise ValueError("execution plan does not belong to decision intent")
+        if (
+            self.execution_plan is not None
+            and self.execution_plan.execution_plan_id
+            != derive_plan_v1_id(self.execution_plan)
+        ):
+            raise CallerOwnedIdRejected("execution_plan_id must be server-generated")
+        if self.order_attempt is not None:
+            if self.execution_plan is None:
+                raise ValueError("order attempt requires an execution plan")
+            if (
+                self.attempt_seq is None
+                or self.lane_prefix is None
+                or self.broker_client_id_target is None
+            ):
+                raise CallerOwnedIdRejected(
+                    "order attempt correlation metadata must be factory-generated"
+                )
+            if (
+                self.order_attempt.execution_plan_id
+                != self.execution_plan.execution_plan_id
+            ):
+                raise ValueError("order attempt does not belong to execution plan")
+            expected_attempt_id = derive_attempt_v1_id(
+                execution_plan_id=self.execution_plan.execution_plan_id,
+                cycle_id=self.order_attempt.cycle_id,
+                attempt_seq=self.attempt_seq,
+            )
+            if self.order_attempt.order_attempt_id != expected_attempt_id:
+                raise CallerOwnedIdRejected("order_attempt_id must be server-generated")
+            expected_idempotency_key = derive_idempotency_key(
+                execution_plan_id=self.execution_plan.execution_plan_id,
+                cycle_id=self.order_attempt.cycle_id,
+            )
+            if self.order_attempt.idempotency_key != expected_idempotency_key:
+                raise CallerOwnedIdRejected("idempotency_key must be server-generated")
+            expected_broker_client_order_id = derive_broker_client_order_id(
+                execution_plan_id=self.execution_plan.execution_plan_id,
+                cycle_id=self.order_attempt.cycle_id,
+                lane_prefix=self.lane_prefix,
+                target=self.broker_client_id_target,
+            )
+            if (
+                self.order_attempt.broker_client_order_id
+                != expected_broker_client_order_id
+            ):
+                raise CallerOwnedIdRejected(
+                    "broker_client_order_id must be server-generated"
+                )
+        elif any(
+            value is not None
+            for value in (
+                self.attempt_seq,
+                self.lane_prefix,
+                self.broker_client_id_target,
+            )
+        ):
+            raise ValueError("attempt metadata requires an order attempt")
+        return self
+
+
+@runtime_checkable
+class LineagePersistencePort(Protocol):
+    """Future lane-owned write boundary; no implementation lives in J2B."""
+
+    async def persist(self, envelope: LineageEnvelope, /) -> None:
+        """Persist an immutable lineage envelope in a later lane."""
+
+
+def require_lineage_persistence_port(
+    port: LineagePersistencePort | None, /
+) -> LineagePersistencePort:
+    """Fail closed when a later lane has not supplied its persistence port."""
+
+    if port is None or not isinstance(port, LineagePersistencePort):
+        raise LineagePersistenceUnavailable()
+    return port
+
+
+class _HashProjection(RootModel[dict[str, Any]]):
+    """A JSON-ready projection used solely as canonical hash input."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+
+def normalize_decimal(value: Decimal) -> str:
+    return format(value.normalize(), "f")
+
+
+def _normalize_decimal_values(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return normalize_decimal(value)
+    if isinstance(value, dict):
+        return {key: _normalize_decimal_values(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_decimal_values(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_normalize_decimal_values(item) for item in value)
+    return value
+
+
+def canonical_bytes(model: BaseModel) -> bytes:
+    return json.dumps(
+        model.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _require_frozen_v1_shape(
+    model: BaseModel,
+    *,
+    identifier_field: str,
+    hash_fields: tuple[str, ...],
+    next_domain: str,
+) -> None:
+    actual_fields = frozenset(type(model).model_fields)
+    expected_fields = frozenset((identifier_field, *hash_fields))
+    if actual_fields != expected_fields:
+        raise HashVersionUpgradeRequired(
+            f"v1 hash inputs changed; use {next_domain} for the revised model"
+        )
+
+
+def _projection_for(model: BaseModel, hash_fields: tuple[str, ...]) -> _HashProjection:
+    source = model.model_dump(mode="python")
+    return _HashProjection(
+        root=_normalize_decimal_values({field: source[field] for field in hash_fields})
+    )
+
+
+def _digest_projection(projection: _HashProjection) -> str:
+    return hashlib.sha256(canonical_bytes(projection)).hexdigest()
+
+
+def _digest_values(values: dict[str, Any]) -> str:
+    return _digest_projection(_HashProjection(root=_normalize_decimal_values(values)))
+
+
+def canonical_intent_v1_bytes(intent: DecisionIntent) -> bytes:
+    """Canonical v1 intent payload after the frozen-field projection."""
+
+    _require_frozen_v1_shape(
+        intent,
+        identifier_field="decision_intent_id",
+        hash_fields=_INTENT_V1_HASH_FIELDS,
+        next_domain="mock-intent-v2:",
+    )
+    return canonical_bytes(_projection_for(intent, _INTENT_V1_HASH_FIELDS))
+
+
+def canonical_plan_v1_bytes(plan: ExecutionPlan) -> bytes:
+    """Canonical v1 plan payload after the frozen-field projection."""
+
+    _require_frozen_v1_shape(
+        plan,
+        identifier_field="execution_plan_id",
+        hash_fields=_PLAN_V1_HASH_FIELDS,
+        next_domain="mock-plan-v2:",
+    )
+    return canonical_bytes(_projection_for(plan, _PLAN_V1_HASH_FIELDS))
+
+
+def derive_intent_v1_id(intent: DecisionIntent) -> str:
+    """Derive the full internal stable ID for a v1 decision intent."""
+
+    return f"{_INTENT_V1_DOMAIN}{hashlib.sha256(canonical_intent_v1_bytes(intent)).hexdigest()}"
+
+
+def derive_plan_v1_id(plan: ExecutionPlan) -> str:
+    """Derive the full internal stable ID for a v1 execution plan."""
+
+    return (
+        f"{_PLAN_V1_DOMAIN}{hashlib.sha256(canonical_plan_v1_bytes(plan)).hexdigest()}"
+    )
+
+
+def derive_idempotency_key(*, execution_plan_id: str, cycle_id: str) -> str:
+    """Derive retry-stable idempotency without an attempt sequence."""
+
+    digest = _digest_values(
+        {
+            "execution_plan_id": execution_plan_id,
+            "cycle_id": cycle_id,
+        }
+    )
+    return f"{_IDEMPOTENCY_V1_DOMAIN}{digest}"
+
+
+def derive_attempt_v1_id(
+    *, execution_plan_id: str, cycle_id: str, attempt_seq: int
+) -> str:
+    """Derive one unique internal attempt ID for each retry sequence."""
+
+    if (
+        isinstance(attempt_seq, bool)
+        or not isinstance(attempt_seq, int)
+        or attempt_seq < 1
+    ):
+        raise ValueError("attempt_seq must be a positive integer")
+    digest = _digest_values(
+        {
+            "execution_plan_id": execution_plan_id,
+            "cycle_id": cycle_id,
+            "attempt_seq": attempt_seq,
+        }
+    )
+    return f"{_ATTEMPT_V1_DOMAIN}{digest}"
+
+
+def derive_broker_client_order_id(
+    *,
+    execution_plan_id: str,
+    cycle_id: str,
+    lane_prefix: str,
+    target: BrokerClientIdTarget,
+) -> str:
+    """Create a bounded broker ID from the retry-stable internal digest."""
+
+    digest = _digest_values(
+        {
+            "execution_plan_id": execution_plan_id,
+            "cycle_id": cycle_id,
+        }
+    )
+    broker_client_id = f"{lane_prefix}-{digest[:24]}"
+    assert_broker_client_order_id(target=target, client_order_id=broker_client_id)
+    return broker_client_id
+
+
+def _require_exact_draft(value: object, expected_type: type[_LineageDraft]) -> None:
+    if type(value) is not expected_type:
+        raise CallerOwnedIdRejected("factory accepts only its ID-free draft type")
+
+
+class MockLineageFactory:
+    """The only construction surface that issues J2B lineage identifiers."""
+
+    def create_decision_intent(self, draft: DecisionIntentDraft, /) -> DecisionIntent:
+        _require_exact_draft(draft, DecisionIntentDraft)
+        provisional = DecisionIntent(
+            decision_intent_id="server-generated",
+            **draft.model_dump(mode="python"),
+        )
+        return provisional.model_copy(
+            update={"decision_intent_id": derive_intent_v1_id(provisional)}
+        )
+
+    def create_execution_plan(
+        self, decision_intent: DecisionIntent, draft: ExecutionPlanDraft, /
+    ) -> ExecutionPlan:
+        _require_exact_draft(draft, ExecutionPlanDraft)
+        self._require_server_intent(decision_intent)
+        if decision_intent.target_notional_currency != draft.quote_currency:
+            raise ValueError(LineageReasonCode.CURRENCY_CONVERSION_NOT_AUTHORIZED)
+        provisional = ExecutionPlan(
+            execution_plan_id="server-generated",
+            decision_intent_id=decision_intent.decision_intent_id,
+            **draft.model_dump(mode="python"),
+        )
+        return provisional.model_copy(
+            update={"execution_plan_id": derive_plan_v1_id(provisional)}
+        )
+
+    def create_order_attempt(
+        self, envelope: LineageEnvelope, draft: OrderAttemptDraft, /
+    ) -> OrderAttempt:
+        _require_exact_draft(draft, OrderAttemptDraft)
+        if type(envelope) is not LineageEnvelope:
+            raise CallerOwnedIdRejected(
+                "factory accepts only an immutable lineage envelope"
+            )
+        if envelope.execution_plan is None:
+            raise ValueError("order attempt requires a plan envelope")
+        execution_plan = envelope.execution_plan
+        self._require_server_plan(execution_plan)
+        idempotency_key = derive_idempotency_key(
+            execution_plan_id=execution_plan.execution_plan_id,
+            cycle_id=draft.cycle_id,
+        )
+        return OrderAttempt(
+            order_attempt_id=derive_attempt_v1_id(
+                execution_plan_id=execution_plan.execution_plan_id,
+                cycle_id=draft.cycle_id,
+                attempt_seq=draft.attempt_seq,
+            ),
+            execution_plan_id=execution_plan.execution_plan_id,
+            cycle_id=draft.cycle_id,
+            idempotency_key=idempotency_key,
+            broker_client_order_id=derive_broker_client_order_id(
+                execution_plan_id=execution_plan.execution_plan_id,
+                cycle_id=draft.cycle_id,
+                lane_prefix=draft.lane_prefix,
+                target=draft.broker_client_id_target,
+            ),
+            broker_order_id=None,
+        )
+
+    def create_intent_envelope(self, draft: DecisionIntentDraft, /) -> LineageEnvelope:
+        return LineageEnvelope(decision_intent=self.create_decision_intent(draft))
+
+    def create_plan_envelope(
+        self, decision_intent: DecisionIntent, draft: ExecutionPlanDraft, /
+    ) -> LineageEnvelope:
+        return LineageEnvelope(
+            decision_intent=decision_intent,
+            execution_plan=self.create_execution_plan(decision_intent, draft),
+        )
+
+    def create_attempt_envelope(
+        self, envelope: LineageEnvelope, draft: OrderAttemptDraft, /
+    ) -> LineageEnvelope:
+        if type(envelope) is not LineageEnvelope:
+            raise CallerOwnedIdRejected(
+                "factory accepts only an immutable lineage envelope"
+            )
+        if envelope.execution_plan is None:
+            raise ValueError("order attempt requires a plan envelope")
+        if envelope.order_attempt is not None:
+            raise ValueError("plan envelope already contains an order attempt")
+        return LineageEnvelope(
+            decision_intent=envelope.decision_intent,
+            execution_plan=envelope.execution_plan,
+            order_attempt=self.create_order_attempt(envelope, draft),
+            attempt_seq=draft.attempt_seq,
+            lane_prefix=draft.lane_prefix,
+            broker_client_id_target=draft.broker_client_id_target,
+        )
+
+    @staticmethod
+    def _require_server_intent(intent: DecisionIntent) -> None:
+        if intent.decision_intent_id != derive_intent_v1_id(intent):
+            raise CallerOwnedIdRejected("decision_intent_id must be server-generated")
+
+    @staticmethod
+    def _require_server_plan(plan: ExecutionPlan) -> None:
+        if plan.execution_plan_id != derive_plan_v1_id(plan):
+            raise CallerOwnedIdRejected("execution_plan_id must be server-generated")
+
+
+__all__ = [
+    "CallerOwnedIdRejected",
+    "DecisionIntentDraft",
+    "ExecutionPlanDraft",
+    "HashVersionUpgradeRequired",
+    "LINEAGE_REASON_CODES",
+    "LineageEnvelope",
+    "LineagePersistencePort",
+    "LineagePersistenceUnavailable",
+    "LineageReasonCode",
+    "MockLineageFactory",
+    "OrderAttemptDraft",
+    "_INTENT_V1_HASH_FIELDS",
+    "_PLAN_V1_HASH_FIELDS",
+    "canonical_bytes",
+    "canonical_intent_v1_bytes",
+    "canonical_plan_v1_bytes",
+    "derive_attempt_v1_id",
+    "derive_broker_client_order_id",
+    "derive_idempotency_key",
+    "derive_intent_v1_id",
+    "derive_plan_v1_id",
+    "normalize_decimal",
+    "require_lineage_persistence_port",
+]

--- a/app/services/mock_integration/lineage.py
+++ b/app/services/mock_integration/lineage.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from enum import StrEnum
 from typing import Annotated, Any, Final, Literal, Protocol, runtime_checkable
@@ -260,9 +260,17 @@ def normalize_decimal(value: Decimal) -> str:
     return format(value.normalize(), "f")
 
 
+def normalize_datetime(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("datetime must be timezone-aware")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
 def _normalize_decimal_values(value: Any) -> Any:
     if isinstance(value, Decimal):
         return normalize_decimal(value)
+    if isinstance(value, datetime):
+        return normalize_datetime(value)
     if isinstance(value, dict):
         return {key: _normalize_decimal_values(item) for key, item in value.items()}
     if isinstance(value, list):
@@ -536,5 +544,6 @@ __all__ = [
     "derive_intent_v1_id",
     "derive_plan_v1_id",
     "normalize_decimal",
+    "normalize_datetime",
     "require_lineage_persistence_port",
 ]

--- a/app/services/mock_integration/lineage.py
+++ b/app/services/mock_integration/lineage.py
@@ -30,6 +30,7 @@ from app.schemas.execution_contracts import (
 )
 from app.services.brokers.client_order_ids import (
     BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
+    BROKER_CLIENT_ID_TARGET_PLAN_BROKERS,
     BrokerClientIdTarget,
     assert_broker_client_order_id,
 )
@@ -38,6 +39,12 @@ _INTENT_V1_DOMAIN: Final[str] = "mock-intent-v1:"
 _PLAN_V1_DOMAIN: Final[str] = "mock-plan-v1:"
 _ATTEMPT_V1_DOMAIN: Final[str] = "mock-attempt-v1:"
 _IDEMPOTENCY_V1_DOMAIN: Final[str] = "mock-idempotency-v1:"
+BROKER_CLIENT_ID_TARGET_MISMATCH: Final[str] = "broker_client_id_target_mismatch"
+BROKER_ORDER_ID_CONFLICT: Final[str] = "broker_order_id_conflict"
+# This is derived from the confirmed target map, not a broker-registry allowlist.
+_BROKERS_REQUIRING_NATIVE_CLIENT_ID: Final[frozenset[str]] = frozenset(
+    BROKER_CLIENT_ID_TARGET_PLAN_BROKERS.values()
+)
 
 # These tuples are a compatibility boundary, not a convenience list.  Add a
 # new domain version rather than changing either v1 input set.
@@ -79,6 +86,8 @@ class LineageReasonCode(StrEnum):
     CURRENCY_CONVERSION_NOT_AUTHORIZED = "currency_conversion_not_authorized"
     LANE_QUOTE_CURRENCY_MISMATCH = "lane_quote_currency_mismatch"
     BROKER_CLIENT_ID_CONSTRAINT_VIOLATION = BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+    BROKER_CLIENT_ID_TARGET_MISMATCH = BROKER_CLIENT_ID_TARGET_MISMATCH
+    BROKER_ORDER_ID_CONFLICT = BROKER_ORDER_ID_CONFLICT
 
 
 LINEAGE_REASON_CODES: Final[frozenset[str]] = frozenset(
@@ -88,6 +97,24 @@ LINEAGE_REASON_CODES: Final[frozenset[str]] = frozenset(
 
 class CallerOwnedIdRejected(ValueError):
     """A caller attempted to bypass the server-generated ID boundary."""
+
+
+class BrokerClientIdTargetMismatch(ValueError):
+    """A client-ID target does not belong to the execution-plan broker."""
+
+    reason_code: Final[str] = BROKER_CLIENT_ID_TARGET_MISMATCH
+
+    def __init__(self) -> None:
+        super().__init__(self.reason_code)
+
+
+class BrokerOrderIdConflict(ValueError):
+    """A later acknowledgement conflicts with the immutable broker ID."""
+
+    reason_code: Final[str] = BROKER_ORDER_ID_CONFLICT
+
+    def __init__(self) -> None:
+        super().__init__(self.reason_code)
 
 
 class HashVersionUpgradeRequired(ValueError):
@@ -146,8 +173,16 @@ class ExecutionPlanDraft(_LineageDraft):
 class OrderAttemptDraft(_LineageDraft):
     cycle_id: LineageNonBlank
     attempt_seq: int = Field(ge=1)
-    lane_prefix: LineageNonBlank
-    broker_client_id_target: BrokerClientIdTarget
+    lane_prefix: LineageNonBlank | None
+    broker_client_id_target: BrokerClientIdTarget | None
+
+    @model_validator(mode="after")
+    def _require_broker_client_id_pair(self) -> OrderAttemptDraft:
+        if (self.lane_prefix is None) != (self.broker_client_id_target is None):
+            raise ValueError(
+                "lane_prefix and broker_client_id_target must be both set or both None"
+            )
+        return self
 
 
 class LineageEnvelope(_LineageDraft):
@@ -181,14 +216,18 @@ class LineageEnvelope(_LineageDraft):
         if self.order_attempt is not None:
             if self.execution_plan is None:
                 raise ValueError("order attempt requires an execution plan")
-            if (
-                self.attempt_seq is None
-                or self.lane_prefix is None
-                or self.broker_client_id_target is None
-            ):
+            if self.attempt_seq is None:
                 raise CallerOwnedIdRejected(
                     "order attempt correlation metadata must be factory-generated"
                 )
+            if (self.lane_prefix is None) != (self.broker_client_id_target is None):
+                raise CallerOwnedIdRejected(
+                    "broker client ID metadata must be both set or both None"
+                )
+            _require_broker_client_id_target_matches_plan(
+                self.execution_plan,
+                self.broker_client_id_target,
+            )
             if (
                 self.order_attempt.execution_plan_id
                 != self.execution_plan.execution_plan_id
@@ -207,19 +246,34 @@ class LineageEnvelope(_LineageDraft):
             )
             if self.order_attempt.idempotency_key != expected_idempotency_key:
                 raise CallerOwnedIdRejected("idempotency_key must be server-generated")
-            expected_broker_client_order_id = derive_broker_client_order_id(
-                execution_plan_id=self.execution_plan.execution_plan_id,
-                cycle_id=self.order_attempt.cycle_id,
-                lane_prefix=self.lane_prefix,
-                target=self.broker_client_id_target,
-            )
-            if (
-                self.order_attempt.broker_client_order_id
-                != expected_broker_client_order_id
-            ):
-                raise CallerOwnedIdRejected(
-                    "broker_client_order_id must be server-generated"
+            if self.order_attempt.broker_order_id is not None:
+                normalized_broker_order_id = _normalize_broker_order_id(
+                    self.order_attempt.broker_order_id
                 )
+                if self.order_attempt.broker_order_id != normalized_broker_order_id:
+                    raise CallerOwnedIdRejected(
+                        "broker_order_id must be strip-normalized"
+                    )
+            if self.lane_prefix is None:
+                if self.order_attempt.broker_client_order_id is not None:
+                    raise CallerOwnedIdRejected(
+                        "broker_client_order_id must be absent without a native client ID"
+                    )
+            else:
+                assert self.broker_client_id_target is not None
+                expected_broker_client_order_id = derive_broker_client_order_id(
+                    execution_plan_id=self.execution_plan.execution_plan_id,
+                    cycle_id=self.order_attempt.cycle_id,
+                    lane_prefix=self.lane_prefix,
+                    target=self.broker_client_id_target,
+                )
+                if (
+                    self.order_attempt.broker_client_order_id
+                    != expected_broker_client_order_id
+                ):
+                    raise CallerOwnedIdRejected(
+                        "broker_client_order_id must be server-generated"
+                    )
         elif any(
             value is not None
             for value in (
@@ -411,6 +465,40 @@ def derive_broker_client_order_id(
     return broker_client_id
 
 
+def _require_broker_client_id_target_matches_plan(
+    plan: ExecutionPlan,
+    target: BrokerClientIdTarget | None,
+) -> None:
+    if target is None:
+        if plan.broker in _BROKERS_REQUIRING_NATIVE_CLIENT_ID:
+            raise BrokerClientIdTargetMismatch()
+        return
+    if BROKER_CLIENT_ID_TARGET_PLAN_BROKERS[target] != plan.broker:
+        raise BrokerClientIdTargetMismatch()
+
+
+def _normalize_broker_order_id(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("broker_order_id must be a non-empty string")
+    normalized_broker_order_id = value.strip()
+    if not normalized_broker_order_id:
+        raise ValueError("broker_order_id must be a non-empty string")
+    return normalized_broker_order_id
+
+
+def _revalidate_lineage_envelope(envelope: LineageEnvelope) -> LineageEnvelope:
+    """Reconstruct an envelope so containment validators run on every ACK."""
+
+    return LineageEnvelope(
+        decision_intent=envelope.decision_intent,
+        execution_plan=envelope.execution_plan,
+        order_attempt=envelope.order_attempt,
+        attempt_seq=envelope.attempt_seq,
+        lane_prefix=envelope.lane_prefix,
+        broker_client_id_target=envelope.broker_client_id_target,
+    )
+
+
 def _require_exact_draft(value: object, expected_type: type[_LineageDraft]) -> None:
     if type(value) is not expected_type:
         raise CallerOwnedIdRejected("factory accepts only its ID-free draft type")
@@ -457,10 +545,23 @@ class MockLineageFactory:
             raise ValueError("order attempt requires a plan envelope")
         execution_plan = envelope.execution_plan
         self._require_server_plan(execution_plan)
+        _require_broker_client_id_target_matches_plan(
+            execution_plan,
+            draft.broker_client_id_target,
+        )
         idempotency_key = derive_idempotency_key(
             execution_plan_id=execution_plan.execution_plan_id,
             cycle_id=draft.cycle_id,
         )
+        broker_client_order_id: str | None = None
+        if draft.lane_prefix is not None:
+            assert draft.broker_client_id_target is not None
+            broker_client_order_id = derive_broker_client_order_id(
+                execution_plan_id=execution_plan.execution_plan_id,
+                cycle_id=draft.cycle_id,
+                lane_prefix=draft.lane_prefix,
+                target=draft.broker_client_id_target,
+            )
         return OrderAttempt(
             order_attempt_id=derive_attempt_v1_id(
                 execution_plan_id=execution_plan.execution_plan_id,
@@ -470,13 +571,49 @@ class MockLineageFactory:
             execution_plan_id=execution_plan.execution_plan_id,
             cycle_id=draft.cycle_id,
             idempotency_key=idempotency_key,
-            broker_client_order_id=derive_broker_client_order_id(
-                execution_plan_id=execution_plan.execution_plan_id,
-                cycle_id=draft.cycle_id,
-                lane_prefix=draft.lane_prefix,
-                target=draft.broker_client_id_target,
-            ),
+            broker_client_order_id=broker_client_order_id,
             broker_order_id=None,
+        )
+
+    def acknowledge_order_attempt(
+        self, envelope: LineageEnvelope, broker_order_id: str
+    ) -> LineageEnvelope:
+        """Attach one broker-supplied order ID without parsing native responses."""
+
+        if type(envelope) is not LineageEnvelope:
+            raise CallerOwnedIdRejected(
+                "factory accepts only an immutable lineage envelope"
+            )
+        validated_envelope = _revalidate_lineage_envelope(envelope)
+        if (
+            validated_envelope.order_attempt is None
+            or validated_envelope.execution_plan is None
+        ):
+            raise ValueError("acknowledgement requires an order attempt envelope")
+        _require_broker_client_id_target_matches_plan(
+            validated_envelope.execution_plan,
+            validated_envelope.broker_client_id_target,
+        )
+        normalized_broker_order_id = _normalize_broker_order_id(broker_order_id)
+        existing_broker_order_id = validated_envelope.order_attempt.broker_order_id
+        if existing_broker_order_id is not None:
+            if existing_broker_order_id != _normalize_broker_order_id(
+                existing_broker_order_id
+            ):
+                raise CallerOwnedIdRejected("broker_order_id must be strip-normalized")
+            if existing_broker_order_id == normalized_broker_order_id:
+                return envelope
+            raise BrokerOrderIdConflict()
+        acknowledged_attempt = validated_envelope.order_attempt.model_copy(
+            update={"broker_order_id": normalized_broker_order_id}
+        )
+        return LineageEnvelope(
+            decision_intent=validated_envelope.decision_intent,
+            execution_plan=validated_envelope.execution_plan,
+            order_attempt=acknowledged_attempt,
+            attempt_seq=validated_envelope.attempt_seq,
+            lane_prefix=validated_envelope.lane_prefix,
+            broker_client_id_target=validated_envelope.broker_client_id_target,
         )
 
     def create_intent_envelope(self, draft: DecisionIntentDraft, /) -> LineageEnvelope:
@@ -522,6 +659,10 @@ class MockLineageFactory:
 
 
 __all__ = [
+    "BROKER_CLIENT_ID_TARGET_MISMATCH",
+    "BROKER_ORDER_ID_CONFLICT",
+    "BrokerClientIdTargetMismatch",
+    "BrokerOrderIdConflict",
     "CallerOwnedIdRejected",
     "DecisionIntentDraft",
     "ExecutionPlanDraft",

--- a/tests/services/brokers/binance/spot_demo/test_execution_client_submit_cancel.py
+++ b/tests/services/brokers/binance/spot_demo/test_execution_client_submit_cancel.py
@@ -25,6 +25,10 @@ from app.services.brokers.binance.spot_demo.execution_client import (
     BinanceSpotDemoExecutionClient,
     SpotDemoDryRunResult,
 )
+from app.services.brokers.client_order_ids import (
+    BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
+    BrokerClientOrderIdConstraintViolation,
+)
 
 _SPOT_DEMO_BASE = "https://demo-api.binance.com"
 
@@ -62,6 +66,26 @@ async def test_submit_order_default_returns_dry_run(
     assert result.order_type == "MARKET"
     assert result.client_order_id == "test-cid-default"
     # No HTTP dispatched.
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_order_id", ["x" * 37, "unsafe.id"])
+async def test_submit_rejects_invalid_client_order_id_before_http(
+    client: BinanceSpotDemoExecutionClient, httpx_mock, client_order_id: str
+) -> None:
+    """The client ID is checked immediately before the signed POST boundary."""
+    with pytest.raises(BrokerClientOrderIdConstraintViolation) as error:
+        await client.submit_order(
+            symbol="BTCUSDT",
+            side="BUY",
+            order_type="MARKET",
+            qty=Decimal("0.0001"),
+            client_order_id=client_order_id,
+            confirm=True,
+        )
+
+    assert error.value.reason_code == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
     assert httpx_mock.get_requests() == []
 
 

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -138,6 +138,13 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         "app/services/alpaca_paper_order_application.py",
         "app/services/brokers/alpaca/paper_adapter.py",
         "app/services/brokers/capabilities.py",
+        # ROB-1261 — shared broker-client-ID constraint vocabulary. It records
+        # bounded identifier rules consumed by existing adapters, but contains
+        # no Binance HTTP/WS, signing, credential, or endpoint behavior.
+        "app/services/brokers/client_order_ids.py",
+        # ROB-1261 — lane registry holds declarative lane/string facts only;
+        # it contains no Binance HTTP/WS, signing, credential, or endpoint behavior.
+        "app/services/mock_lane_registry.py",
         # ROB-1196 — declarative execution-outcome mapping table. Binance
         # appears only in broker/status/source-locator strings; this file has
         # no HTTP/WS, signing, credential, client, endpoint, or mutation code.

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -142,8 +142,9 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # bounded identifier rules consumed by existing adapters, but contains
         # no Binance HTTP/WS, signing, credential, or endpoint behavior.
         "app/services/brokers/client_order_ids.py",
-        # ROB-1261 — lane registry holds declarative lane/string facts only;
-        # it contains no Binance HTTP/WS, signing, credential, or endpoint behavior.
+        # ROB-1261 — lane registry performs string-level host/URL endpoint and
+        # credential-namespace safety validation before I/O. It has no HTTP/WS
+        # client, signing, secret-load, or broker-I/O surface.
         "app/services/mock_lane_registry.py",
         # ROB-1196 — declarative execution-outcome mapping table. Binance
         # appears only in broker/status/source-locator strings; this file has

--- a/tests/services/mock_integration/test_lineage.py
+++ b/tests/services/mock_integration/test_lineage.py
@@ -1,0 +1,418 @@
+"""ROB-1261 deterministic intent/plan/attempt lineage tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.execution_contracts import DecisionIntent, ExecutionPlan
+from app.services.brokers.client_order_ids import (
+    ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
+    BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
+    BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
+    TOSS_CLIENT_ORDER_ID_MAX_LENGTH,
+    BrokerClientIdTarget,
+    BrokerClientOrderIdConstraintViolation,
+    assert_broker_client_order_id,
+)
+from app.services.mock_integration import lineage
+from app.services.mock_integration.lineage import (
+    CallerOwnedIdRejected,
+    DecisionIntentDraft,
+    ExecutionPlanDraft,
+    HashVersionUpgradeRequired,
+    LineagePersistenceUnavailable,
+    LineageReasonCode,
+    MockLineageFactory,
+    OrderAttemptDraft,
+    canonical_bytes,
+    require_lineage_persistence_port,
+)
+
+
+def _intent_draft(**overrides: object) -> DecisionIntentDraft:
+    values: dict[str, object] = {
+        "policy_version": "policy-v1",
+        "policy_version_hash": "a" * 12,
+        "decision_timestamp": datetime(2026, 8, 15, 9, 0, tzinfo=UTC),
+        "market_data_cutoff": datetime(2026, 8, 15, 8, 59, tzinfo=UTC),
+        "symbol": "BRK.B",
+        "side": "buy",
+        "target_notional": Decimal("1"),
+        "target_notional_currency": "USD",
+        "limit_policy": {"order_type": "limit"},
+        "expiry_policy": {"kind": "day"},
+        "rationale": "한국어 canonical fixture",
+    }
+    values.update(overrides)
+    return DecisionIntentDraft(**values)
+
+
+def _plan_draft(**overrides: object) -> ExecutionPlanDraft:
+    values: dict[str, object] = {
+        "lane_id": "us.alpaca.paper.default",
+        "broker": "alpaca",
+        "account_profile": "default-paper",
+        "account_mode": "alpaca_paper",
+        "normalized_symbol": "BRK.B",
+        "quantity": Decimal("1"),
+        "limit_price": Decimal("1"),
+        "quote_currency": "USD",
+        "tick_rounding": {"increment": "0.01"},
+        "session": "regular",
+        "time_in_force": "day",
+        "min_order_validation": {"quote_required": True},
+        "risk_caps": {"max_notional": "1"},
+    }
+    values.update(overrides)
+    return ExecutionPlanDraft(**values)
+
+
+def _attempt_draft(**overrides: object) -> OrderAttemptDraft:
+    values: dict[str, object] = {
+        "cycle_id": "cycle-20260815-1",
+        "attempt_seq": 1,
+        "lane_prefix": "alpaca",
+        "broker_client_id_target": BrokerClientIdTarget.ALPACA_PAPER,
+    }
+    values.update(overrides)
+    return OrderAttemptDraft(**values)
+
+
+def _issued_intent_and_plan(
+    *,
+    intent_overrides: dict[str, object] | None = None,
+    plan_overrides: dict[str, object] | None = None,
+) -> tuple[MockLineageFactory, DecisionIntent, ExecutionPlan]:
+    factory = MockLineageFactory()
+    intent = factory.create_decision_intent(_intent_draft(**(intent_overrides or {})))
+    plan = factory.create_execution_plan(intent, _plan_draft(**(plan_overrides or {})))
+    return factory, intent, plan
+
+
+def test_factory_rejects_caller_owned_identifier_fields() -> None:
+    factory = MockLineageFactory()
+    draft = _intent_draft()
+
+    with pytest.raises(ValidationError, match="decision_intent_id"):
+        DecisionIntentDraft(
+            **draft.model_dump(mode="python"),
+            decision_intent_id="caller-owned",
+        )
+    with pytest.raises(TypeError, match="decision_intent_id"):
+        factory.create_decision_intent(draft, decision_intent_id="caller-owned")
+
+    forged = DecisionIntent(
+        decision_intent_id="caller-owned",
+        **draft.model_dump(mode="python"),
+    )
+    with pytest.raises(CallerOwnedIdRejected, match="server-generated"):
+        factory.create_execution_plan(forged, _plan_draft())
+    with pytest.raises(ValidationError, match="server-generated"):
+        lineage.LineageEnvelope(decision_intent=forged)
+
+
+def test_every_server_factory_draft_forbids_caller_owned_ids() -> None:
+    with pytest.raises(ValidationError, match="execution_plan_id"):
+        ExecutionPlanDraft(
+            **_plan_draft().model_dump(mode="python"),
+            execution_plan_id="caller-owned",
+        )
+    with pytest.raises(ValidationError, match="decision_intent_id"):
+        ExecutionPlanDraft(
+            **_plan_draft().model_dump(mode="python"),
+            decision_intent_id="caller-owned",
+        )
+    with pytest.raises(ValidationError, match="order_attempt_id"):
+        OrderAttemptDraft(
+            **_attempt_draft().model_dump(mode="python"),
+            order_attempt_id="caller-owned",
+        )
+    with pytest.raises(ValidationError, match="idempotency_key"):
+        OrderAttemptDraft(
+            **_attempt_draft().model_dump(mode="python"),
+            idempotency_key="caller-owned",
+        )
+    with pytest.raises(ValidationError, match="broker_client_order_id"):
+        OrderAttemptDraft(
+            **_attempt_draft().model_dump(mode="python"),
+            broker_client_order_id="caller-owned",
+        )
+
+
+def test_server_factory_generates_a_full_internal_id_and_immutable_envelope() -> None:
+    factory = MockLineageFactory()
+    envelope = factory.create_intent_envelope(_intent_draft())
+
+    prefix, digest = envelope.decision_intent.decision_intent_id.split(":", 1)
+    assert prefix == "mock-intent-v1"
+    assert len(digest) == 64
+    with pytest.raises(ValidationError):
+        envelope.decision_intent = envelope.decision_intent
+
+
+def test_canonical_json_is_sorted_utf8_and_round_trips() -> None:
+    _, intent, _ = _issued_intent_and_plan()
+
+    canonical = canonical_bytes(intent)
+
+    assert b", " not in canonical
+    assert b"\\u" not in canonical
+    assert "한국어".encode() in canonical
+    assert json.loads(canonical)["decision_intent_id"] == intent.decision_intent_id
+    assert DecisionIntent.model_validate_json(canonical) == intent
+
+
+@pytest.mark.parametrize("value", [Decimal("1"), Decimal("1.0"), Decimal("1.000")])
+def test_decimal_golden_values_produce_the_same_intent_hash(value: Decimal) -> None:
+    factory = MockLineageFactory()
+    intent = factory.create_decision_intent(_intent_draft(target_notional=value))
+
+    assert intent.decision_intent_id == (
+        "mock-intent-v1:"
+        "6b58bec1ac89e262cda8a301a0c01e33432f26e80d5dce8c0a7401c6a5f4a1ea"
+    )
+
+
+@pytest.mark.parametrize("value", [Decimal("1"), Decimal("1.0"), Decimal("1.000")])
+def test_decimal_golden_values_produce_the_same_plan_hash(value: Decimal) -> None:
+    factory = MockLineageFactory()
+    intent = factory.create_decision_intent(_intent_draft())
+    plan = factory.create_execution_plan(
+        intent,
+        _plan_draft(quantity=value, limit_price=value),
+    )
+
+    assert plan.execution_plan_id == (
+        "mock-plan-v1:b9ac4cfe41a996714d5969efda2c222d16c42579b42900853ac1c88160960077"
+    )
+
+
+def test_v1_hash_allowlists_are_exact_and_field_additions_require_v2() -> None:
+    assert lineage._INTENT_V1_HASH_FIELDS == (
+        "policy_version",
+        "policy_version_hash",
+        "decision_timestamp",
+        "market_data_cutoff",
+        "symbol",
+        "side",
+        "target_notional",
+        "target_notional_currency",
+        "limit_policy",
+        "expiry_policy",
+        "rationale",
+    )
+    assert lineage._PLAN_V1_HASH_FIELDS == (
+        "decision_intent_id",
+        "lane_id",
+        "broker",
+        "account_profile",
+        "account_mode",
+        "normalized_symbol",
+        "quantity",
+        "limit_price",
+        "quote_currency",
+        "tick_rounding",
+        "session",
+        "time_in_force",
+        "min_order_validation",
+        "risk_caps",
+    )
+
+    class IntentWithNewField(DecisionIntent):
+        new_hash_input: str
+
+    class PlanWithNewField(ExecutionPlan):
+        new_hash_input: str
+
+    _, intent, plan = _issued_intent_and_plan()
+    extended_intent = IntentWithNewField(
+        **intent.model_dump(mode="python"),
+        new_hash_input="v2-required",
+    )
+    extended_plan = PlanWithNewField(
+        **plan.model_dump(mode="python"),
+        new_hash_input="v2-required",
+    )
+
+    with pytest.raises(HashVersionUpgradeRequired, match="mock-intent-v2"):
+        lineage.derive_intent_v1_id(extended_intent)
+    with pytest.raises(HashVersionUpgradeRequired, match="mock-plan-v2"):
+        lineage.derive_plan_v1_id(extended_plan)
+
+
+def test_attempt_sequence_changes_only_the_attempt_identity() -> None:
+    factory, intent, plan = _issued_intent_and_plan()
+    envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+    first = factory.create_order_attempt(envelope, _attempt_draft(attempt_seq=1))
+    retry = factory.create_order_attempt(envelope, _attempt_draft(attempt_seq=2))
+
+    assert first.order_attempt_id != retry.order_attempt_id
+    assert first.idempotency_key == retry.idempotency_key
+    assert first.broker_client_order_id == retry.broker_client_order_id
+    assert ":1" not in first.idempotency_key
+    assert ":2" not in retry.idempotency_key
+
+
+@pytest.mark.parametrize(
+    ("field_name", "replacement"),
+    [
+        ("order_attempt_id", "caller-owned"),
+        ("idempotency_key", "caller-owned"),
+        ("broker_client_order_id", "caller-owned"),
+    ],
+)
+def test_attempt_envelope_rejects_caller_owned_identifiers(
+    field_name: str, replacement: str
+) -> None:
+    factory, intent, plan = _issued_intent_and_plan()
+    plan_envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+    draft = _attempt_draft()
+    issued = factory.create_order_attempt(plan_envelope, draft)
+    forged = issued.model_copy(update={field_name: replacement})
+
+    with pytest.raises(ValidationError, match="server-generated"):
+        lineage.LineageEnvelope(
+            decision_intent=intent,
+            execution_plan=plan,
+            order_attempt=forged,
+            attempt_seq=draft.attempt_seq,
+            lane_prefix=draft.lane_prefix,
+            broker_client_id_target=draft.broker_client_id_target,
+        )
+
+
+def test_factory_attempt_envelope_carries_only_derived_correlation() -> None:
+    factory, intent, plan = _issued_intent_and_plan()
+    plan_envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+    draft = _attempt_draft()
+
+    envelope = factory.create_attempt_envelope(plan_envelope, draft)
+
+    assert envelope.order_attempt is not None
+    assert envelope.attempt_seq == draft.attempt_seq
+    assert envelope.lane_prefix == draft.lane_prefix
+    assert envelope.broker_client_id_target == draft.broker_client_id_target
+
+
+def test_broker_client_id_is_shorter_than_the_internal_digest() -> None:
+    factory, intent, plan = _issued_intent_and_plan()
+    envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+    attempt = factory.create_order_attempt(
+        envelope,
+        _attempt_draft(
+            broker_client_id_target=BrokerClientIdTarget.TOSS,
+            lane_prefix="tosprop",
+        ),
+    )
+
+    assert attempt.broker_client_order_id is not None
+    attempt_digest = attempt.order_attempt_id.split(":", 1)[1]
+    assert len(attempt_digest) == 64
+    internal_digest = attempt.idempotency_key.split(":", 1)[1]
+    assert len(internal_digest) == 64
+    assert attempt.broker_client_order_id == f"tosprop-{internal_digest[:24]}"
+    assert len(attempt.broker_client_order_id) <= TOSS_CLIENT_ORDER_ID_MAX_LENGTH
+    assert attempt_digest not in attempt.broker_client_order_id
+    assert internal_digest not in attempt.broker_client_order_id
+
+
+def test_generated_broker_client_id_fails_closed_when_it_exceeds_target_limit() -> None:
+    factory, intent, plan = _issued_intent_and_plan()
+    envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+
+    with pytest.raises(BrokerClientOrderIdConstraintViolation) as error:
+        factory.create_order_attempt(
+            envelope,
+            _attempt_draft(
+                lane_prefix="x" * 12,
+                broker_client_id_target=BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+            ),
+        )
+
+    assert error.value.reason_code == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+
+
+@pytest.mark.parametrize(
+    ("target", "maximum"),
+    [
+        (BrokerClientIdTarget.TOSS, TOSS_CLIENT_ORDER_ID_MAX_LENGTH),
+        (
+            BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+            BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
+        ),
+        (BrokerClientIdTarget.ALPACA_PAPER, ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH),
+    ],
+)
+def test_broker_client_id_constraints_fail_closed(
+    target: BrokerClientIdTarget, maximum: int
+) -> None:
+    assert_broker_client_order_id(target=target, client_order_id="lane-0123456789")
+
+    with pytest.raises(BrokerClientOrderIdConstraintViolation) as length_error:
+        assert_broker_client_order_id(
+            target=target, client_order_id="a" * (maximum + 1)
+        )
+    assert length_error.value.reason_code == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+
+    with pytest.raises(BrokerClientOrderIdConstraintViolation) as charset_error:
+        assert_broker_client_order_id(target=target, client_order_id="unsafe.id")
+    assert charset_error.value.reason_code == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+
+
+def test_reason_code_dictionary_contains_persistence_broker_and_d5_codes() -> None:
+    assert lineage.LINEAGE_REASON_CODES == {
+        "lineage_persistence_unavailable",
+        "currency_conversion_not_authorized",
+        "lane_quote_currency_mismatch",
+        "broker_client_id_constraint_violation",
+    }
+    assert (
+        LineageReasonCode.BROKER_CLIENT_ID_CONSTRAINT_VIOLATION.value
+        == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+    )
+
+
+def test_persistence_requires_a_future_owned_port_without_implementing_storage() -> (
+    None
+):
+    with pytest.raises(LineagePersistenceUnavailable) as unavailable:
+        require_lineage_persistence_port(None)
+    assert unavailable.value.reason_code == "lineage_persistence_unavailable"
+
+    class FuturePort:
+        async def persist(self, envelope, /) -> None:  # type: ignore[no-untyped-def]
+            del envelope
+
+    port = FuturePort()
+    assert require_lineage_persistence_port(port) is port
+
+
+def test_currency_mismatch_fails_before_plan_issuance() -> None:
+    factory = MockLineageFactory()
+    intent = factory.create_decision_intent(
+        _intent_draft(target_notional_currency="USD")
+    )
+
+    with pytest.raises(ValueError) as error:
+        factory.create_execution_plan(intent, _plan_draft(quote_currency="KRW"))
+    assert str(error.value) == "currency_conversion_not_authorized"

--- a/tests/services/mock_integration/test_lineage.py
+++ b/tests/services/mock_integration/test_lineage.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from decimal import Decimal
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
 from pydantic import ValidationError
 
-from app.schemas.execution_contracts import DecisionIntent, ExecutionPlan
+from app.schemas.execution_contracts import DecisionIntent, ExecutionPlan, OrderAttempt
 from app.services.brokers.client_order_ids import (
     ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
     BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
     BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
+    BROKER_CLIENT_ID_TARGET_PLAN_BROKERS,
     TOSS_CLIENT_ORDER_ID_MAX_LENGTH,
     BrokerClientIdTarget,
     BrokerClientOrderIdConstraintViolation,
@@ -22,6 +24,10 @@ from app.services.brokers.client_order_ids import (
 )
 from app.services.mock_integration import lineage
 from app.services.mock_integration.lineage import (
+    BROKER_CLIENT_ID_TARGET_MISMATCH,
+    BROKER_ORDER_ID_CONFLICT,
+    BrokerClientIdTargetMismatch,
+    BrokerOrderIdConflict,
     CallerOwnedIdRejected,
     DecisionIntentDraft,
     ExecutionPlanDraft,
@@ -360,8 +366,469 @@ def test_factory_attempt_envelope_carries_only_derived_correlation() -> None:
     assert envelope.broker_client_id_target == draft.broker_client_id_target
 
 
-def test_broker_client_id_is_shorter_than_the_internal_digest() -> None:
+def test_order_attempt_draft_requires_a_complete_broker_client_id_pair() -> None:
+    required_values = _attempt_draft().model_dump(mode="python")
+    del required_values["lane_prefix"]
+    del required_values["broker_client_id_target"]
+
+    with pytest.raises(ValidationError, match="lane_prefix"):
+        OrderAttemptDraft(**required_values)
+    with pytest.raises(ValidationError, match="both set or both None"):
+        _attempt_draft(lane_prefix="kis", broker_client_id_target=None)
+    with pytest.raises(ValidationError, match="both set or both None"):
+        _attempt_draft(
+            lane_prefix=None,
+            broker_client_id_target=BrokerClientIdTarget.TOSS,
+        )
+
+    assert (
+        _attempt_draft(
+            lane_prefix=None,
+            broker_client_id_target=None,
+        ).lane_prefix
+        is None
+    )
+    assert _attempt_draft().broker_client_id_target is BrokerClientIdTarget.ALPACA_PAPER
+
+
+def test_broker_client_id_target_remains_the_three_confirmed_targets() -> None:
+    assert tuple(BrokerClientIdTarget) == (
+        BrokerClientIdTarget.TOSS,
+        BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+        BrokerClientIdTarget.ALPACA_PAPER,
+    )
+
+
+def test_broker_client_id_target_plan_broker_map_is_read_only() -> None:
+    with pytest.raises(TypeError):
+        BROKER_CLIENT_ID_TARGET_PLAN_BROKERS[BrokerClientIdTarget.TOSS] = "mutated"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("plan_broker", "target", "matches"),
+    [
+        pytest.param("toss", BrokerClientIdTarget.TOSS, True, id="toss-matches"),
+        pytest.param(
+            "binance",
+            BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+            True,
+            id="binance-spot-demo-matches-binance",
+        ),
+        pytest.param(
+            "alpaca",
+            BrokerClientIdTarget.ALPACA_PAPER,
+            True,
+            id="alpaca-matches",
+        ),
+        pytest.param("toss", BrokerClientIdTarget.BINANCE_SPOT_DEMO, False),
+        pytest.param("toss", BrokerClientIdTarget.ALPACA_PAPER, False),
+        pytest.param("binance", BrokerClientIdTarget.TOSS, False),
+        pytest.param("binance", BrokerClientIdTarget.ALPACA_PAPER, False),
+        pytest.param("alpaca", BrokerClientIdTarget.TOSS, False),
+        pytest.param("alpaca", BrokerClientIdTarget.BINANCE_SPOT_DEMO, False),
+    ],
+)
+def test_factory_enforces_broker_client_id_target_plan_broker_matrix(
+    plan_broker: str,
+    target: BrokerClientIdTarget,
+    matches: bool,
+) -> None:
+    factory, intent, plan = _issued_intent_and_plan(
+        plan_overrides={"broker": plan_broker}
+    )
+    plan_envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+
+    if matches:
+        attempt = factory.create_order_attempt(
+            plan_envelope,
+            _attempt_draft(lane_prefix="lane", broker_client_id_target=target),
+        )
+        assert attempt.broker_client_order_id is not None
+    else:
+        with pytest.raises(BrokerClientIdTargetMismatch) as error:
+            factory.create_order_attempt(
+                plan_envelope,
+                _attempt_draft(lane_prefix="lane", broker_client_id_target=target),
+            )
+        assert error.value.reason_code == BROKER_CLIENT_ID_TARGET_MISMATCH
+        assert str(error.value) == "broker_client_id_target_mismatch"
+
+
+def test_factory_rejects_kis_plan_with_alpaca_target() -> None:
+    factory, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": "kis"})
+    plan_envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+
+    with pytest.raises(BrokerClientIdTargetMismatch) as error:
+        factory.create_order_attempt(
+            plan_envelope,
+            _attempt_draft(
+                lane_prefix="lane",
+                broker_client_id_target=BrokerClientIdTarget.ALPACA_PAPER,
+            ),
+        )
+
+    assert error.value.reason_code == "broker_client_id_target_mismatch"
+
+
+@pytest.mark.parametrize("broker", ("toss", "alpaca", "binance"))
+def test_factory_rejects_a_none_pair_for_each_confirmed_broker(broker: str) -> None:
+    factory, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": broker})
+    plan_envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+
+    with pytest.raises(BrokerClientIdTargetMismatch) as error:
+        factory.create_order_attempt(
+            plan_envelope,
+            _attempt_draft(lane_prefix=None, broker_client_id_target=None),
+        )
+
+    assert error.value.reason_code == BROKER_CLIENT_ID_TARGET_MISMATCH
+
+
+def test_factory_allows_a_none_pair_for_an_unconfirmed_broker() -> None:
+    factory, intent, plan = _issued_intent_and_plan(
+        plan_overrides={"broker": "unknown-broker"}
+    )
+    envelope = factory.create_attempt_envelope(
+        lineage.LineageEnvelope(
+            decision_intent=intent,
+            execution_plan=plan,
+        ),
+        _attempt_draft(lane_prefix=None, broker_client_id_target=None),
+    )
+
+    assert envelope.order_attempt is not None
+    assert envelope.order_attempt.broker_client_order_id is None
+
+
+@pytest.mark.parametrize("broker", ("kis", "kiwoom"))
+@pytest.mark.parametrize("target", tuple(BrokerClientIdTarget))
+def test_factory_rejects_a_confirmed_target_for_kr_brokers(
+    broker: str,
+    target: BrokerClientIdTarget,
+) -> None:
+    factory, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": broker})
+    plan_envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+
+    with pytest.raises(BrokerClientIdTargetMismatch) as error:
+        factory.create_order_attempt(
+            plan_envelope,
+            _attempt_draft(lane_prefix="lane", broker_client_id_target=target),
+        )
+
+    assert error.value.reason_code == BROKER_CLIENT_ID_TARGET_MISMATCH
+
+
+def test_target_mismatch_is_rejected_before_broker_client_id_derivation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    factory, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": "kis"})
+    plan_envelope = lineage.LineageEnvelope(
+        decision_intent=intent,
+        execution_plan=plan,
+    )
+
+    def broker_id_derivation_must_not_run(**_: object) -> str:
+        raise AssertionError("broker client ID derivation ran after a target mismatch")
+
+    monkeypatch.setattr(
+        lineage,
+        "derive_broker_client_order_id",
+        broker_id_derivation_must_not_run,
+    )
+
+    with pytest.raises(BrokerClientIdTargetMismatch) as error:
+        factory.create_order_attempt(
+            plan_envelope,
+            _attempt_draft(
+                lane_prefix="lane",
+                broker_client_id_target=BrokerClientIdTarget.ALPACA_PAPER,
+            ),
+        )
+
+    assert error.value.reason_code == "broker_client_id_target_mismatch"
+
+
+def _none_pair_envelope(
+    *, broker: str = "kis"
+) -> tuple[MockLineageFactory, lineage.LineageEnvelope]:
+    factory, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": broker})
+    return factory, factory.create_attempt_envelope(
+        lineage.LineageEnvelope(
+            decision_intent=intent,
+            execution_plan=plan,
+        ),
+        _attempt_draft(lane_prefix=None, broker_client_id_target=None),
+    )
+
+
+def _self_consistent_attempt(
+    plan: ExecutionPlan,
+    *,
+    lane_prefix: str | None,
+    target: BrokerClientIdTarget | None,
+) -> OrderAttempt:
+    cycle_id = "forged-cycle-1"
+    attempt_seq = 1
+    broker_client_order_id: str | None = None
+    if lane_prefix is not None:
+        assert target is not None
+        broker_client_order_id = lineage.derive_broker_client_order_id(
+            execution_plan_id=plan.execution_plan_id,
+            cycle_id=cycle_id,
+            lane_prefix=lane_prefix,
+            target=target,
+        )
+    return OrderAttempt(
+        order_attempt_id=lineage.derive_attempt_v1_id(
+            execution_plan_id=plan.execution_plan_id,
+            cycle_id=cycle_id,
+            attempt_seq=attempt_seq,
+        ),
+        execution_plan_id=plan.execution_plan_id,
+        cycle_id=cycle_id,
+        idempotency_key=lineage.derive_idempotency_key(
+            execution_plan_id=plan.execution_plan_id,
+            cycle_id=cycle_id,
+        ),
+        broker_client_order_id=broker_client_order_id,
+        broker_order_id=None,
+    )
+
+
+@pytest.mark.parametrize("broker", ("kis", "kiwoom"))
+def test_none_pair_preserves_internal_correlation_and_round_trips(broker: str) -> None:
+    _, envelope = _none_pair_envelope(broker=broker)
+    assert envelope.execution_plan is not None
+    assert envelope.execution_plan.broker == broker
+    assert envelope.order_attempt is not None
+    attempt = envelope.order_attempt
+
+    assert attempt.order_attempt_id.startswith("mock-attempt-v1:")
+    assert attempt.idempotency_key.startswith("mock-idempotency-v1:")
+    assert attempt.broker_client_order_id is None
+    assert attempt.broker_order_id is None
+    canonical = canonical_bytes(attempt)
+    round_tripped = OrderAttempt.model_validate_json(canonical)
+    assert round_tripped == attempt
+    assert canonical_bytes(round_tripped) == canonical
+
+
+@pytest.mark.parametrize("broker", ("kis", "kiwoom"))
+def test_acknowledge_order_attempt_sets_a_broker_order_id_once(broker: str) -> None:
+    factory, envelope = _none_pair_envelope(broker=broker)
+
+    acknowledged = factory.acknowledge_order_attempt(envelope, "  id-1  ")
+
+    assert acknowledged is not envelope
+    assert acknowledged.order_attempt is not None
+    assert acknowledged.order_attempt.broker_order_id == "id-1"
+    assert acknowledged.order_attempt.broker_client_order_id is None
+
+
+def test_acknowledge_order_attempt_replays_the_same_broker_order_id_as_a_no_op() -> (
+    None
+):
+    factory, envelope = _none_pair_envelope()
+    acknowledged = factory.acknowledge_order_attempt(envelope, "  id-1  ")
+
+    replayed = factory.acknowledge_order_attempt(acknowledged, "id-1")
+
+    assert replayed is acknowledged
+
+
+def test_acknowledge_order_attempt_revalidates_same_id_replay_before_returning() -> (
+    None
+):
+    factory, envelope = _none_pair_envelope()
+    acknowledged = factory.acknowledge_order_attempt(envelope, "id-1")
+    assert acknowledged.execution_plan is not None
+    assert acknowledged.order_attempt is not None
+
+    forged_attempt_seq = acknowledged.model_copy(update={"attempt_seq": 2})
+    forged_idempotency_key = acknowledged.model_copy(
+        update={
+            "order_attempt": acknowledged.order_attempt.model_copy(
+                update={"idempotency_key": "caller-owned"}
+            )
+        }
+    )
+    forged_plan_correlation = acknowledged.model_copy(
+        update={
+            "execution_plan": acknowledged.execution_plan.model_copy(
+                update={"decision_intent_id": "caller-owned"}
+            )
+        }
+    )
+
+    for forged_envelope in (
+        forged_attempt_seq,
+        forged_idempotency_key,
+        forged_plan_correlation,
+    ):
+        with pytest.raises(ValidationError):
+            factory.acknowledge_order_attempt(forged_envelope, "id-1")
+
+
+def test_acknowledge_order_attempt_rejects_a_conflicting_broker_order_id() -> None:
+    factory, envelope = _none_pair_envelope()
+    acknowledged = factory.acknowledge_order_attempt(envelope, "  id-1  ")
+
+    with pytest.raises(BrokerOrderIdConflict) as error:
+        factory.acknowledge_order_attempt(acknowledged, "  id-2  ")
+
+    assert error.value.reason_code == BROKER_ORDER_ID_CONFLICT
+    assert str(error.value) == "broker_order_id_conflict"
+
+
+@pytest.mark.parametrize("broker_order_id", ("", "   "))
+def test_acknowledge_order_attempt_rejects_an_empty_normalized_broker_order_id(
+    broker_order_id: str,
+) -> None:
+    factory, envelope = _none_pair_envelope()
+
+    with pytest.raises(ValueError, match="non-empty"):
+        factory.acknowledge_order_attempt(envelope, broker_order_id)
+
+
+def test_acknowledge_order_attempt_accepts_a_confirmed_client_id_pair() -> None:
     factory, intent, plan = _issued_intent_and_plan()
+    envelope = factory.create_attempt_envelope(
+        lineage.LineageEnvelope(decision_intent=intent, execution_plan=plan),
+        _attempt_draft(),
+    )
+
+    acknowledged = factory.acknowledge_order_attempt(envelope, "broker-ack-1")
+
+    assert acknowledged.order_attempt is not None
+    assert acknowledged.order_attempt.broker_order_id == "broker-ack-1"
+
+
+def test_common_lineage_source_has_no_native_ack_field_parser() -> None:
+    source = Path(lineage.__file__).read_text(encoding="utf-8")
+
+    assert "od" + "no" not in source
+    assert "order_" + "no" not in source
+
+
+def test_acknowledge_order_attempt_rejects_a_model_copy_normalization_bypass() -> None:
+    factory, envelope = _none_pair_envelope()
+    assert envelope.order_attempt is not None
+    forged_attempt = envelope.order_attempt.model_copy(
+        update={"broker_order_id": "  id-1  "}
+    )
+
+    with pytest.raises(ValidationError, match="strip-normalized"):
+        lineage.LineageEnvelope(
+            decision_intent=envelope.decision_intent,
+            execution_plan=envelope.execution_plan,
+            order_attempt=forged_attempt,
+            attempt_seq=envelope.attempt_seq,
+            lane_prefix=envelope.lane_prefix,
+            broker_client_id_target=envelope.broker_client_id_target,
+        )
+
+    unvalidated_envelope = lineage.LineageEnvelope.model_construct(
+        decision_intent=envelope.decision_intent,
+        execution_plan=envelope.execution_plan,
+        order_attempt=forged_attempt,
+        attempt_seq=envelope.attempt_seq,
+        lane_prefix=envelope.lane_prefix,
+        broker_client_id_target=envelope.broker_client_id_target,
+    )
+    with pytest.raises(ValidationError, match="strip-normalized"):
+        factory.acknowledge_order_attempt(unvalidated_envelope, "id-1")
+
+
+@pytest.mark.parametrize("broker", ("toss", "alpaca", "binance"))
+def test_envelope_rejects_a_self_consistent_none_pair_for_confirmed_brokers(
+    broker: str,
+) -> None:
+    _, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": broker})
+
+    with pytest.raises(ValidationError, match=BROKER_CLIENT_ID_TARGET_MISMATCH):
+        lineage.LineageEnvelope(
+            decision_intent=intent,
+            execution_plan=plan,
+            order_attempt=_self_consistent_attempt(
+                plan,
+                lane_prefix=None,
+                target=None,
+            ),
+            attempt_seq=1,
+            lane_prefix=None,
+            broker_client_id_target=None,
+        )
+
+
+def test_envelope_rejects_a_self_consistent_mismatched_broker_target() -> None:
+    _, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": "kis"})
+
+    with pytest.raises(ValidationError, match=BROKER_CLIENT_ID_TARGET_MISMATCH):
+        lineage.LineageEnvelope(
+            decision_intent=intent,
+            execution_plan=plan,
+            order_attempt=_self_consistent_attempt(
+                plan,
+                lane_prefix="lane",
+                target=BrokerClientIdTarget.ALPACA_PAPER,
+            ),
+            attempt_seq=1,
+            lane_prefix="lane",
+            broker_client_id_target=BrokerClientIdTarget.ALPACA_PAPER,
+        )
+
+
+def test_acknowledge_order_attempt_rejects_an_unvalidated_confirmed_none_pair() -> None:
+    factory, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": "alpaca"})
+    unvalidated_envelope = lineage.LineageEnvelope.model_construct(
+        decision_intent=intent,
+        execution_plan=plan,
+        order_attempt=_self_consistent_attempt(
+            plan,
+            lane_prefix=None,
+            target=None,
+        ),
+        attempt_seq=1,
+        lane_prefix=None,
+        broker_client_id_target=None,
+    )
+
+    with pytest.raises(ValidationError, match=BROKER_CLIENT_ID_TARGET_MISMATCH):
+        factory.acknowledge_order_attempt(unvalidated_envelope, "broker-ack-1")
+
+
+def test_none_pair_rejects_a_broker_client_order_id_value() -> None:
+    _, envelope = _none_pair_envelope()
+    assert envelope.order_attempt is not None
+    forged = envelope.order_attempt.model_copy(
+        update={"broker_client_order_id": "must-not-be-present"}
+    )
+
+    with pytest.raises(ValidationError, match="broker_client_order_id"):
+        lineage.LineageEnvelope(
+            decision_intent=envelope.decision_intent,
+            execution_plan=envelope.execution_plan,
+            order_attempt=forged,
+            attempt_seq=envelope.attempt_seq,
+            lane_prefix=None,
+            broker_client_id_target=None,
+        )
+
+
+def test_broker_client_id_is_shorter_than_the_internal_digest() -> None:
+    factory, intent, plan = _issued_intent_and_plan(plan_overrides={"broker": "toss"})
     envelope = lineage.LineageEnvelope(
         decision_intent=intent,
         execution_plan=plan,
@@ -386,7 +853,9 @@ def test_broker_client_id_is_shorter_than_the_internal_digest() -> None:
 
 
 def test_generated_broker_client_id_fails_closed_when_it_exceeds_target_limit() -> None:
-    factory, intent, plan = _issued_intent_and_plan()
+    factory, intent, plan = _issued_intent_and_plan(
+        plan_overrides={"broker": "binance"}
+    )
     envelope = lineage.LineageEnvelope(
         decision_intent=intent,
         execution_plan=plan,
@@ -437,11 +906,14 @@ def test_reason_code_dictionary_contains_persistence_broker_and_d5_codes() -> No
         "currency_conversion_not_authorized",
         "lane_quote_currency_mismatch",
         "broker_client_id_constraint_violation",
+        "broker_client_id_target_mismatch",
+        "broker_order_id_conflict",
     }
     assert (
         LineageReasonCode.BROKER_CLIENT_ID_CONSTRAINT_VIOLATION.value
         == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
     )
+    assert LineageReasonCode.BROKER_ORDER_ID_CONFLICT.value == BROKER_ORDER_ID_CONFLICT
 
 
 def test_persistence_requires_a_future_owned_port_without_implementing_storage() -> (

--- a/tests/services/mock_integration/test_lineage.py
+++ b/tests/services/mock_integration/test_lineage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from decimal import Decimal
+from zoneinfo import ZoneInfo
 
 import pytest
 from pydantic import ValidationError
@@ -30,6 +31,7 @@ from app.services.mock_integration.lineage import (
     MockLineageFactory,
     OrderAttemptDraft,
     canonical_bytes,
+    normalize_datetime,
     require_lineage_persistence_port,
 )
 
@@ -165,6 +167,56 @@ def test_canonical_json_is_sorted_utf8_and_round_trips() -> None:
     assert "한국어".encode() in canonical
     assert json.loads(canonical)["decision_intent_id"] == intent.decision_intent_id
     assert DecisionIntent.model_validate_json(canonical) == intent
+
+
+def test_datetime_golden_values_produce_the_same_intent_hash_for_one_instant() -> None:
+    factory = MockLineageFactory()
+    kst = ZoneInfo("Asia/Seoul")
+    eastern_time = ZoneInfo("America/New_York")
+    representations = (
+        (
+            datetime(2026, 8, 15, 9, 0, tzinfo=UTC),
+            datetime(2026, 8, 15, 8, 59, tzinfo=UTC),
+        ),
+        (
+            datetime(2026, 8, 15, 18, 0, tzinfo=kst),
+            datetime(2026, 8, 15, 17, 59, tzinfo=kst),
+        ),
+        (
+            datetime(2026, 8, 15, 5, 0, tzinfo=eastern_time),
+            datetime(2026, 8, 15, 4, 59, tzinfo=eastern_time),
+        ),
+    )
+
+    intent_ids = [
+        factory.create_decision_intent(
+            _intent_draft(
+                decision_timestamp=decision_timestamp,
+                market_data_cutoff=market_data_cutoff,
+            )
+        ).decision_intent_id
+        for decision_timestamp, market_data_cutoff in representations
+    ]
+    different_instant_id = factory.create_decision_intent(
+        _intent_draft(
+            decision_timestamp=datetime(2026, 8, 15, 9, 1, tzinfo=UTC),
+            market_data_cutoff=datetime(2026, 8, 15, 9, 0, tzinfo=UTC),
+        )
+    ).decision_intent_id
+
+    assert intent_ids[0] == intent_ids[1] == intent_ids[2]
+    assert different_instant_id != intent_ids[0]
+
+
+def test_naive_datetime_is_rejected_before_hashing() -> None:
+    naive = datetime(2026, 8, 15, 9, 0)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        normalize_datetime(naive)
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        MockLineageFactory().create_decision_intent(
+            _intent_draft(decision_timestamp=naive)
+        )
 
 
 @pytest.mark.parametrize("value", [Decimal("1"), Decimal("1.0"), Decimal("1.000")])

--- a/tests/services/mock_integration/test_lineage.py
+++ b/tests/services/mock_integration/test_lineage.py
@@ -17,6 +17,7 @@ from app.services.brokers.client_order_ids import (
     BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
     BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
     BROKER_CLIENT_ID_TARGET_PLAN_BROKERS,
+    BROKER_CLIENT_ORDER_ID_CONSTRAINTS,
     TOSS_CLIENT_ORDER_ID_MAX_LENGTH,
     BrokerClientIdTarget,
     BrokerClientOrderIdConstraintViolation,
@@ -402,6 +403,18 @@ def test_broker_client_id_target_remains_the_three_confirmed_targets() -> None:
 def test_broker_client_id_target_plan_broker_map_is_read_only() -> None:
     with pytest.raises(TypeError):
         BROKER_CLIENT_ID_TARGET_PLAN_BROKERS[BrokerClientIdTarget.TOSS] = "mutated"  # type: ignore[index]
+
+
+def test_broker_client_order_id_constraints_map_rejects_in_place_mutation() -> None:
+    target = BrokerClientIdTarget.TOSS
+    original_constraint = BROKER_CLIENT_ORDER_ID_CONSTRAINTS[target]
+
+    with pytest.raises(TypeError):
+        BROKER_CLIENT_ORDER_ID_CONSTRAINTS[target] = original_constraint  # type: ignore[index]
+    with pytest.raises(TypeError):
+        del BROKER_CLIENT_ORDER_ID_CONSTRAINTS[target]  # type: ignore[index]
+
+    assert BROKER_CLIENT_ORDER_ID_CONSTRAINTS[target] is original_constraint
 
 
 @pytest.mark.parametrize(

--- a/tests/test_alpaca_paper_service_methods.py
+++ b/tests/test_alpaca_paper_service_methods.py
@@ -15,6 +15,10 @@ from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
 from app.services.brokers.alpaca.schemas import OrderRequest
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
 from app.services.brokers.alpaca.transport import HTTPTransport
+from app.services.brokers.client_order_ids import (
+    BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
+    BrokerClientOrderIdConstraintViolation,
+)
 
 
 def _make_response(data: Any, status_code: int = 200) -> httpx.Response:
@@ -219,6 +223,44 @@ async def test_submit_order_marshals_request():
     assert body["qty"] == "10"
     assert body["limit_price"] == pytest.approx("150.00")
     assert order.id == "order-001"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_order_id", ["x" * 129, "unsafe.id"])
+async def test_submit_order_rejects_invalid_client_id_before_transport(
+    client_order_id: str,
+):
+    transport = _mock_transport(ORDER_DATA)
+    svc = _make_service(transport)
+    request = OrderRequest(
+        symbol="AAPL",
+        qty=Decimal("10"),
+        side="buy",
+        type="limit",
+        time_in_force="day",
+        limit_price=Decimal("150.00"),
+        client_order_id=client_order_id,
+    )
+
+    with pytest.raises(BrokerClientOrderIdConstraintViolation) as error:
+        await svc.submit_order(request)
+
+    assert error.value.reason_code == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+    transport.request.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_by_client_order_id_rejects_invalid_id_before_transport():
+    transport = _mock_transport(ORDER_DATA)
+    svc = _make_service(transport)
+
+    with pytest.raises(BrokerClientOrderIdConstraintViolation) as error:
+        await svc.get_order_by_client_order_id("x" * 129)
+
+    assert error.value.reason_code == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
+    transport.request.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/test_alpaca_paper_service_methods.py
+++ b/tests/test_alpaca_paper_service_methods.py
@@ -16,6 +16,7 @@ from app.services.brokers.alpaca.schemas import OrderRequest
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
 from app.services.brokers.alpaca.transport import HTTPTransport
 from app.services.brokers.client_order_ids import (
+    ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
     BROKER_CLIENT_ID_CONSTRAINT_VIOLATION,
     BrokerClientOrderIdConstraintViolation,
 )
@@ -227,7 +228,28 @@ async def test_submit_order_marshals_request():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-@pytest.mark.parametrize("client_order_id", ["x" * 129, "unsafe.id"])
+async def test_submit_order_allows_exact_alpaca_client_id_limit_to_transport():
+    assert ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH == 48
+    transport = _mock_transport(ORDER_DATA)
+    svc = _make_service(transport)
+    request = OrderRequest(
+        symbol="AAPL",
+        qty=Decimal("10"),
+        side="buy",
+        type="limit",
+        time_in_force="day",
+        limit_price=Decimal("150.00"),
+        client_order_id="x" * 48,
+    )
+
+    await svc.submit_order(request)
+
+    transport.request.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_order_id", ["x" * 49, "unsafe.id"])
 async def test_submit_order_rejects_invalid_client_id_before_transport(
     client_order_id: str,
 ):
@@ -257,7 +279,7 @@ async def test_get_by_client_order_id_rejects_invalid_id_before_transport():
     svc = _make_service(transport)
 
     with pytest.raises(BrokerClientOrderIdConstraintViolation) as error:
-        await svc.get_order_by_client_order_id("x" * 129)
+        await svc.get_order_by_client_order_id("x" * 49)
 
     assert error.value.reason_code == BROKER_CLIENT_ID_CONSTRAINT_VIOLATION
     transport.request.assert_not_called()

--- a/tests/test_mcp_alpaca_paper_tools.py
+++ b/tests/test_mcp_alpaca_paper_tools.py
@@ -35,6 +35,9 @@ from app.services.brokers.alpaca.schemas import (
     Order,
     Position,
 )
+from app.services.brokers.client_order_ids import (
+    ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH,
+)
 from tests._mcp_tooling_support import DummyMCP
 
 
@@ -569,6 +572,25 @@ async def test_preview_rejects_blank_symbol(
             symbol="   ", side="buy", type="market", qty=Decimal("1")
         )
     assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_accepts_exact_shared_client_order_id_limit(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    assert ALPACA_PAPER_CLIENT_ORDER_ID_MAX_LENGTH == 48
+
+    payload = await alpaca_paper_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        qty=Decimal("1"),
+        client_order_id="x" * 48,
+    )
+
+    assert payload["order_request"]["client_order_id"] == "x" * 48
+    assert fake_preview_service.calls
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Adds strict server-generated intent, plan, and attempt lineage IDs; canonical hashing; persistence port only; and broker-facing client-ID assertions. Includes the two exact audit allow-list entries required for the shared lane registry and client-ID vocabulary. Verification: targeted suite 152 passed; lint passed; full suite had 19,743 passed, 13 skipped, 7 deselected, and 3 unrelated KR backfill expectation failures. No migration, persistence implementation, or broker I/O was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent client-order-ID validation for Alpaca Paper, Binance Spot Demo, and Toss integrations.
  * Invalid IDs are rejected before requests are sent, with clear constraint-related errors.
  * Added deterministic lineage tracking for mock, paper, and demo execution flows, including order attempts, acknowledgements, retries, and conflict detection.

* **Bug Fixes**
  * Alpaca Paper previews now enforce the same client-order-ID length limit as order submission and lookup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->