### PR TITLE
fix(ROB-1276): correct false-green Binance audit allowlist comment

### DIFF
--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -142,9 +142,11 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # bounded identifier rules consumed by existing adapters, but contains
         # no Binance HTTP/WS, signing, credential, or endpoint behavior.
         "app/services/brokers/client_order_ids.py",
-        # ROB-1261 — lane registry performs string-level host/URL endpoint and
-        # credential-namespace safety validation before I/O. It has no HTTP/WS
-        # client, signing, secret-load, or broker-I/O surface.
+        # ROB-1261/ROB-1260 — the lane registry performs static validation of
+        # caller-declared host/URL and symbolic credential-namespace strings, then may
+        # invoke opaque caller-owned callbacks. It defines no Binance HTTP/WS transport,
+        # signing, credential-value load, or direct endpoint call; actual transport
+        # host/profile revalidation remains broker-owned.
         "app/services/mock_lane_registry.py",
         # ROB-1196 — declarative execution-outcome mapping table. Binance
         # appears only in broker/status/source-locator strings; this file has


### PR DESCRIPTION
## Summary
- The `tests/services/brokers/binance/test_audit_no_signed_endpoints.py` allowlist comment for `app/services/mock_lane_registry.py` claimed the registry has "no ... broker-I/O surface". `guarded_broker_io`/`guarded_client_factory` (ROB-1260/mock_lane_registry.py:1233-1286) invoke caller-owned opaque callbacks after static validation, so that phrasing made the audit green under a false explanation.
- Replaced the comment (3 lines → 5 lines) with wording that states both true facts: the registry defines no Binance HTTP/WS transport/signing/credential-value-load/direct-endpoint-call, and it does expose guarded opaque-callback invocation. Allowlist entry itself is unchanged (still allow-listed).
- Scope: exactly one file, comment-only change. No allowlist entries added/removed, no other comments touched, no test logic changed.

## Test plan
- [x] `pytest tests/services/brokers/binance/test_audit_no_signed_endpoints.py` — 3 passed (confirms the AST audit still enforces no-signed-endpoint-surface / no-API-key-header-constant invariants)
- [x] Mutant proof: temporarily injected `def cancel_order(...)` into `app/services/brokers/binance/rest_client.py` (public adapter, outside isolated signed sub-packages) → `test_no_signed_endpoint_surface_in_binance_public_package` FAILED as expected → reverted (`git diff` on that file empty afterward)
- [x] `pytest tests/services/brokers/binance/` — 710 passed
- [x] `ruff check` / `ruff format --check` (app/ tests/ research/ scripts/) — pass
- [x] `ty check app/ --error-on-warning` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)