### PR TITLE
ROB-1262 J3A: broker-neutral mock coordination port (lease/fence)

### DIFF
--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -503,9 +503,17 @@ def _hold_view(hold: UnreleasedAuthorityHold) -> UnreleasedAuthorityHold:
 
 
 def authority_hold_history() -> tuple[UnreleasedAuthorityHold, ...]:
-    """Immutable evidence: every hold ever recorded, in order, including resolved."""
+    """Every hold ever recorded, in order, including resolved ones.
 
-    return tuple(_AUTHORITY_HOLD_HISTORY)
+    Projected through the same :func:`_hold_view` the active view uses, because
+    the contract says reachability is recomputed on every read. Returning the
+    raw stored record here would let one ``hold_id`` report ``True`` from
+    :func:`unreleased_authority_holds` and ``False`` from this function at the
+    same instant — a contradiction an operator has no way to adjudicate.
+    A resolved hold has no retained owner, so it projects to not-recoverable.
+    """
+
+    return tuple(_hold_view(hold) for hold in _AUTHORITY_HOLD_HISTORY)
 
 
 def unreleased_authority_holds() -> tuple[UnreleasedAuthorityHold, ...]:
@@ -2118,8 +2126,11 @@ def _validated_callback_result(
             "mock mutation callback returned a non-MutationCertainty certainty"
         )
     broker_order_id = result.broker_order_id
+    # ``type(...) is str`` on purpose: a ``str`` subclass can override ``strip``
+    # and raise from inside validation — after a possible send and before either
+    # durable write. Exact type first means no dispatch to caller code at all.
     if broker_order_id is not None and (
-        not isinstance(broker_order_id, str) or not broker_order_id.strip()
+        type(broker_order_id) is not str or not broker_order_id.strip()
     ):
         return None, TypeError(
             "mock mutation callback returned a non-string broker order id"
@@ -2310,7 +2321,13 @@ async def coordinate_mock_order_mutation(
     # The coordinated section is over: a captured scope must stop working.
     gate.active = False
     if callback_error is None:
-        result, callback_error = _validated_callback_result(result)
+        try:
+            result, callback_error = _validated_callback_result(result)
+        except BaseException as exc:
+            # Belt and braces: validation is contained as well as non-dispatching.
+            # Anything raised here happens after the callback may have sent, so
+            # it is uncertainty that must reach the durable writes, not an escape.
+            result, callback_error = None, exc
 
     factory = lineage_factory if lineage_factory is not None else MockLineageFactory()
     evidence_envelope = envelope
@@ -2324,9 +2341,11 @@ async def coordinate_mock_order_mutation(
             evidence_envelope = factory.acknowledge_order_attempt(
                 envelope, result.broker_order_id
             )
-        except Exception as exc:
-            # A malformed or conflicting broker order id is transport
+        except BaseException as exc:
+            # A malformed or conflicting broker order id — or a cancellation
+            # landing inside the acknowledgement helper — is transport
             # uncertainty, not a reason to escape before recording the unknown.
+            # The original exception is re-delivered after the AND gate closes.
             ack_error = exc
             evidence_envelope = envelope
 

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -1725,8 +1725,12 @@ class TerminalClaimEvidence:
     Every field defaults to absent, so a default-constructed instance authorizes
     nothing.  Unknown results, anomalies, a broker rejection without proven
     absence, and a partial fill with an unknown remainder all fail to set these
-    flags — which is exactly why they retain the claim and keep the account
-    blocked until a human resolves them.  Nothing releases a claim automatically.
+    flags — which is exactly why they retain the claim until a human resolves
+    them.  Retention is scoped to this exact send lineage: it prevents that
+    logical send from being replayed, and says nothing on its own about whether
+    unrelated plans may proceed.  Whether the *account* is blocked is answered by
+    :class:`AccountUncertaintyGatePort`, which this dataclass neither receives nor
+    consults.  Nothing releases a claim automatically.
     """
 
     lane_native_terminal_evidence: bool = False
@@ -2104,7 +2108,9 @@ class _HeldCoordination:
     queue, **not** a durable state store, and it has no TTL, janitor, takeover,
     automatic retry, claim deletion, or scheduler.  Process death may end the
     ephemeral DB session, but the durable binary reservation survives and keeps
-    blocking a successor, which is the property that actually matters.
+    preventing a replay of that exact send lineage, which is the property that
+    actually matters.  It does not decide whether a successor may run some
+    *other* plan — that is the uncertainty authority's answer, not this map's.
     """
 
     hold_id: str

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -364,16 +364,21 @@ class SqlAlchemyLockAuthority:
                 raise BackendSessionTerminationUnproven(
                     "the backend is still present in pg_stat_activity"
                 )
+            # Absence is proven *here*. The receipt is built before any cleanup
+            # so that a cancellation during a close cannot erase a proof we
+            # already hold and manufacture a false active hold.
+            receipt = BackendTerminationReceipt(
+                backend_pid=expected_pid, owner_token=owner_token, terminated=True
+            )
         finally:
             # Only the *observer* is disposable on every path. Closing the owner
             # connection here would return a still-locked backend to the pool on
             # exactly the paths where termination was NOT proven.
             await _close_quietly(observer)
-        # Proven gone: only now may the owner connection be released.
+        # Proven gone: only now may the owner connection be released, and a
+        # failure doing so is reported without invalidating the receipt.
         await _close_quietly(self._connection)
-        return BackendTerminationReceipt(
-            backend_pid=expected_pid, owner_token=owner_token, terminated=True
-        )
+        return receipt
 
     def can_prove_backend_session_termination(self) -> bool:
         """Without an independent observer, termination can never be proven."""
@@ -386,7 +391,9 @@ async def _close_quietly(closeable: Any) -> None:
 
     try:
         await closeable.close()
-    except Exception:
+    except BaseException:
+        # Including a cancellation: a cleanup failure is never allowed to
+        # invalidate a proof that was already established.
         pass
 
 
@@ -464,6 +471,7 @@ _ACTIVE_AUTHORITY_HOLDS: dict[str, UnreleasedAuthorityHold] = {}
 _RETAINED_AUTHORITIES: dict[str, _RetainedAuthority] = {}
 
 _HOLD_ID_ALLOCATION_ATTEMPTS: Final[int] = 8
+_QUARANTINE_SEQUENCE = 0
 
 
 def _hold_view(hold: UnreleasedAuthorityHold) -> UnreleasedAuthorityHold:
@@ -477,10 +485,17 @@ def _hold_view(hold: UnreleasedAuthorityHold) -> UnreleasedAuthorityHold:
 
     retained = _RETAINED_AUTHORITIES.get(hold.hold_id)
     owner = retained.owner if retained is not None else None
+    # The two reasons a release is refused are a permanent coordination seal
+    # (public paths) and missing durable evidence (every path, owner included).
+    # The flag must be the negation of both, or it reports a retry that cannot
+    # happen. Deliberately *not* consulted: whether private machinery still
+    # exists — a sealed lease has no supported retry, and saying otherwise would
+    # imply a recovery API that this epoch does not have.
     recoverable = (
         isinstance(owner, PostgresAdvisoryKeysetLease)
         and not owner.coordination_sealed
         and not owner.released
+        and hold.durable_evidence_written
     )
     if recoverable == hold.recoverable_in_process:
         return hold
@@ -570,7 +585,17 @@ def _allocate_hold_id() -> str:
         candidate = f"hold:{secrets.token_hex(8)}"
         if not _hold_id_in_use(candidate):
             return candidate
-    raise CoordinationError(CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE)
+    # Exhaustion must never leave a newly unsafe authority unreachable, so fall
+    # back to a quarantine id derived from a monotonic counter rather than
+    # raising. It cannot collide (the random ids never take this shape) and it
+    # never overwrites an existing owner, so the victim of the collision storm
+    # is untouched while the intruder still gets retained.
+    global _QUARANTINE_SEQUENCE
+    while True:
+        _QUARANTINE_SEQUENCE += 1
+        candidate = f"hold:quarantine:{_QUARANTINE_SEQUENCE:012d}"
+        if not _hold_id_in_use(candidate):
+            return candidate
 
 
 def _resolve_authority_hold(
@@ -859,15 +884,19 @@ class PostgresAdvisoryKeysetLease:
     There is no TTL and no takeover, and a pool return is neither of those.
 
     A lease whose post-send durable evidence never landed is not releasable at
-    all: :meth:`retain_authority` marks it, and every subsequent ``release`` —
-    including one driven by the exact grant obtained from public introspection —
-    fails closed with ``lineage_persistence_unavailable``.
+    all: ``_retain_authority`` marks it, and every subsequent ``release`` fails
+    closed with ``lineage_persistence_unavailable``.  Public introspection yields
+    capability-free snapshots only — no lease, no grant, no connection — so there
+    is no public route to a release in the first place.
 
     Release is also cancellation-safe.  The whole re-attest → reverse unlock →
     close sequence runs as a retained task, and the lease is marked released only
-    after that sequence proves an allowed outcome.  A release that is interrupted
-    or fails leaves the lease recoverable by the exact grant, while stale or
-    foreign grants keep being rejected.
+    after that sequence proves an allowed outcome.  Whether an interrupted or
+    failed release can be retried depends on who owns it: an unsealed standalone
+    owner still holding its exact private lease/grant can retry, while a
+    coordination-sealed lease and a partial-acquisition rollback have no
+    in-process recovery API in this epoch.  Stale or foreign grants are always
+    rejected.
     """
 
     __slots__ = (
@@ -1041,9 +1070,10 @@ class PostgresAdvisoryKeysetLease:
         **entire** active lifetime — while the callback runs, while either
         durable write is in flight, during a cancellation-retained wait, and
         while an acknowledgement anomaly is being recorded.  Holding the exact
-        grant from public introspection does not change that: seeing a lease is
-        not owning it, and the window in which a release would be most damaging
-        is precisely the window in which nothing is yet known.
+        grant does not change that: seeing that an account is stuck and being
+        able to unstick it are different rights, and the window in which a
+        release would be most damaging is precisely the window in which nothing
+        is yet known.
         """
 
         self._require_grant(expected_grant)
@@ -1094,7 +1124,8 @@ class PostgresAdvisoryKeysetLease:
         cancellation = await _await_retained_task(task)
         error = _task_error(task)
         if error is not None:
-            # Recoverable by the exact grant; stale/foreign grants still fail.
+            # An unsealed owner may retry with this exact grant; a sealed one
+            # cannot, and stale or foreign grants never can.
             self._release_task = None
             raise error
         self._released = True
@@ -1200,6 +1231,11 @@ class PostgresAdvisoryKeysetLease:
             termination_proven=False,
             durable_evidence_written=True,
             connection=self._connection,
+            # A sealed lease already has an opaque id an operator is following;
+            # allocating a second one here would split one stuck authority
+            # across two ids with no public way to join them. An unsealed lease
+            # has no such id, so it keeps a fresh allocation.
+            hold_id=self._coordination_hold_id,
         )
 
 
@@ -1290,7 +1326,23 @@ async def acquire_physical_account_lease(
                 connection, acquired, grant, in_flight=tuple(in_flight)
             )
         )
-        await _await_retained_task(rollback)
+        rollback_cancellation = await _await_retained_task(rollback)
+        if _task_error(rollback) is not None:
+            # The rollback itself failed, so nothing proved this connection is
+            # safe and nothing may have retained it. Retain it here rather than
+            # letting it fall out of scope with a key possibly still held.
+            _record_unreleased_authority(
+                grant,
+                owner=connection,
+                reason_code=CoordinationReasonCode.LEASE_LOST,
+                termination_proven=False,
+                durable_evidence_written=True,
+                connection=connection,
+            )
+        if rollback_cancellation is not None:
+            # A cancellation that arrived while the rollback was still running is
+            # re-delivered now that a safe outcome exists — never before it.
+            raise rollback_cancellation
         raise
 
     return PostgresAdvisoryKeysetLease(connection=connection, grant=grant)
@@ -1489,6 +1541,25 @@ class TerminalClaimEvidence:
     authoritative_absence_proven: bool = False
 
     @property
+    def exact_booleans(self) -> bool:
+        """Every field is a real ``bool``, not merely something truthy.
+
+        The string ``"false"`` is truthy. So is ``"0"``. Accepting either here
+        would let a mistyped field authorize the deletion of the durable claim
+        that is the entire account block.
+        """
+
+        return all(
+            value is True or value is False
+            for value in (
+                self.lane_native_terminal_evidence,
+                self.account_position_reconciled,
+                self.remainder_known,
+                self.authoritative_absence_proven,
+            )
+        )
+
+    @property
     def authorizes_release(self) -> bool:
         if self.authoritative_absence_proven:
             return self.account_position_reconciled
@@ -1497,6 +1568,18 @@ class TerminalClaimEvidence:
             and self.account_position_reconciled
             and self.remainder_known
         )
+
+
+def _terminal_evidence_authorizes(evidence: TerminalClaimEvidence) -> bool:
+    """The release predicate, recomputed from exact booleans and not overridable."""
+
+    if evidence.authoritative_absence_proven is True:
+        return evidence.account_position_reconciled is True
+    return (
+        evidence.lane_native_terminal_evidence is True
+        and evidence.account_position_reconciled is True
+        and evidence.remainder_known is True
+    )
 
 
 class DurableSendClaimAdapter:
@@ -1558,7 +1641,14 @@ class DurableSendClaimAdapter:
         an evidence-less release cannot happen even by accident.
         """
 
-        if not evidence.authorizes_release:
+        # Checked here rather than trusting the property alone: a subclass can
+        # override `authorizes_release`, and this adapter is the last thing
+        # between a caller's claim of evidence and a durable delete.
+        if (
+            type(evidence) is not TerminalClaimEvidence
+            or not evidence.exact_booleans
+            or not _terminal_evidence_authorizes(evidence)
+        ):
             raise CoordinationError(CoordinationReasonCode.TERMINAL_EVIDENCE_REQUIRED)
         return int(
             await self._intents.release_if_matches(
@@ -1659,7 +1749,45 @@ class MutationCallbackResult:
     broker_order_id: str | None = None
 
 
-type MockMutationCallback = Callable[[], Awaitable[MutationCallbackResult]]
+class _ScopeGate:
+    """Liveness flag for one coordinated section; not reachable from the view."""
+
+    __slots__ = ("active",)
+
+    def __init__(self) -> None:
+        self.active = True
+
+
+class CoordinationScope:
+    """What a lane callback receives: one operation, and no capability at all.
+
+    A broker callback can await account truth, a token refresh, or rate limiting
+    after it is entered, and a same-cycle batch can contain several POSTs. The
+    coordinator's single pre-callback attestation is therefore neither temporally
+    nor semantically sufficient — J3B and J3C must re-assert immediately before
+    **every** send.
+
+    So this exposes exactly one coroutine. It carries no lease, grant,
+    connection, backend PID, owner token, key, hold id, release, or termination —
+    reading the state and changing it are different rights, and only the first is
+    handed out. It also stops working once its coordinated section ends, so a
+    captured scope cannot assert against a finished lease.
+    """
+
+    __slots__ = ("_assert",)
+
+    def __init__(self, assert_owned: Callable[[], Awaitable[None]]) -> None:
+        self._assert = assert_owned
+
+    async def assert_owned(self) -> None:
+        """Re-prove ownership *and* the pinned lane binding. Call before each send."""
+
+        await self._assert()
+
+
+type MockMutationCallback = Callable[
+    [CoordinationScope], Awaitable[MutationCallbackResult]
+]
 
 
 class DispatchEvidenceKind(StrEnum):
@@ -1805,10 +1933,11 @@ class _HeldCoordination:
 _HELD_COORDINATION: dict[str, _HeldCoordination] = {}
 
 # The release rights for each held lease. Deliberately module-private with no
-# accessor: ``HeldCoordination`` publishes the lease and the grant so operators
-# and later lanes can *see* what is stuck, and neither of those is enough to
-# release it. Capability identity cannot be reconstructed from the public
-# handle, so a generic caller cannot forge one.
+# accessor. Public introspection returns ``HeldCoordinationSnapshot`` objects,
+# which carry no lease, grant, connection, PID, owner token, or callable — so
+# operators and later lanes can see *what* is stuck without being able to
+# unstick it. Capability identity cannot be reconstructed from anything public,
+# so a generic caller cannot forge one.
 _COORDINATION_RELEASE_CAPABILITIES: dict[str, object] = {}
 
 
@@ -1967,6 +2096,37 @@ def _callback_outcome(
     return task.result(), None
 
 
+def _validated_callback_result(
+    result: object,
+) -> tuple[MutationCallbackResult | None, BaseException | None]:
+    """Accept only the exact supported result shape.
+
+    A type annotation is not a runtime guarantee. A raw-string certainty slips
+    past every ``is MutationCertainty.X`` branch and lands in the durable record
+    misclassified as an acknowledgement; a dict or a stray integer raises on
+    attribute access *after* a possible send but before either mandatory write.
+    Both become typed uncertainty instead.
+    """
+
+    if type(result) is not MutationCallbackResult:
+        return None, TypeError(
+            f"mock mutation callback returned {type(result).__name__}, "
+            "expected MutationCallbackResult"
+        )
+    if not isinstance(result.certainty, MutationCertainty):
+        return None, TypeError(
+            "mock mutation callback returned a non-MutationCertainty certainty"
+        )
+    broker_order_id = result.broker_order_id
+    if broker_order_id is not None and (
+        not isinstance(broker_order_id, str) or not broker_order_id.strip()
+    ):
+        return None, TypeError(
+            "mock mutation callback returned a non-string broker order id"
+        )
+    return result, None
+
+
 def _required_persistence(
     persistence: LineagePersistencePort | None,
 ) -> LineagePersistencePort:
@@ -1976,6 +2136,26 @@ def _required_persistence(
         raise CoordinationError(
             CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
         ) from exc
+
+
+def _require_pinned_entry(
+    envelope: LineageEnvelope,
+    registry: RegistrySource | None,
+    pinned: LaneRegistryEntry,
+) -> LaneRegistryEntry:
+    """Re-validate, then require the *same* entry that authority was derived from.
+
+    ``RegistrySource`` accepts any mapping or iterable and re-materializes it on
+    every call, so a registry mutated during an awaited reserve could validate a
+    different physical account on the second look while the callback proceeds
+    behind the first account's lease and claim. Full entry equality is the
+    conservative comparison: any authority-relevant drift fails.
+    """
+
+    entry = _validated_entry(envelope, registry)
+    if entry != pinned:
+        raise LaneGuardError("canonical_lane_identity_mismatch", lane_id=pinned.lane_id)
+    return entry
 
 
 def _validated_entry(
@@ -2072,17 +2252,17 @@ async def coordinate_mock_order_mutation(
             side=envelope.decision_intent.side,
         )
         await lease.assert_owned(grant)
-        _validated_entry(envelope, registry)
-        # Strong handle first, callback task second: between these two lines
-        # there is no order in flight, and after them nothing can drop the
-        # authority implicitly.
+        _require_pinned_entry(envelope, registry, entry)
+        # Strong handle first, callback second: between these two lines there is
+        # no order in flight, and after them nothing can drop the authority
+        # implicitly.
         held = _register_held_coordination(
             lease=lease, grant=grant, claim=claim, envelope=envelope
         )
-        task: asyncio.Task[MutationCallbackResult] = asyncio.ensure_future(mutation())
     except BaseException:
-        # Nothing is in flight: the callback never started. The durable claim,
-        # if taken, stays put — absence of send is not proven here.
+        # Genuinely pre-callback: the callable was never invoked, so nothing can
+        # be in flight. The durable claim, if taken, stays put — absence of send
+        # is not proven here.
         if held is None:
             await _release_lease_quietly(lease, grant)
         else:
@@ -2094,8 +2274,43 @@ async def coordinate_mock_order_mutation(
             CoordinationReasonCode.DURABLE_CLAIM_CONFLICT, lane_id=entry.lane_id
         )
 
-    outer_cancellation = await _await_retained_task(task)
-    result, callback_error = _callback_outcome(task)
+    # Everything from here is post-invocation. A supplied callable can run a
+    # synchronous broker SDK prelude and *then* raise, or return a non-awaitable;
+    # neither is "the callback never started", because an order may already have
+    # gone out. Both take the durable-evidence path.
+    gate = _ScopeGate()
+
+    async def _assert_scope_owned() -> None:
+        if not gate.active:
+            raise CoordinationError(
+                CoordinationReasonCode.LEASE_LOST, lane_id=entry.lane_id
+            )
+        await lease.assert_owned(grant)
+        _require_pinned_entry(envelope, registry, entry)
+
+    task: asyncio.Task[MutationCallbackResult] | None = None
+    invocation_error: BaseException | None = None
+    try:
+        started = mutation(CoordinationScope(_assert_scope_owned))
+        if not isinstance(started, Awaitable):
+            raise TypeError(
+                "mock mutation callback did not return an awaitable; the send "
+                "may already have happened synchronously"
+            )
+        task = asyncio.ensure_future(started)
+    except BaseException as exc:
+        invocation_error = exc
+
+    if task is None:
+        outer_cancellation = None
+        result, callback_error = None, invocation_error
+    else:
+        outer_cancellation = await _await_retained_task(task)
+        result, callback_error = _callback_outcome(task)
+    # The coordinated section is over: a captured scope must stop working.
+    gate.active = False
+    if callback_error is None:
+        result, callback_error = _validated_callback_result(result)
 
     factory = lineage_factory if lineage_factory is not None else MockLineageFactory()
     evidence_envelope = envelope
@@ -2246,6 +2461,7 @@ __all__ = [
     "ClaimFollowupRequest",
     "CoordinatedMutationResult",
     "CoordinationError",
+    "CoordinationScope",
     "CoordinationReasonCode",
     "DispatchEvidence",
     "DispatchEvidenceKind",

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -488,12 +488,19 @@ def _hold_view(hold: UnreleasedAuthorityHold) -> UnreleasedAuthorityHold:
     process — and there is deliberately no recovery API to add one.
     """
 
-    # Cross-generation aliasing is prevented at the source, in
-    # :func:`_allocate_hold_id`, which never reissues an id. An identity check
-    # here was tried and removed: ``lease.unreleased_authority_hold`` already
-    # returns a *view*, so comparing object identity made this function answer
-    # differently for the same hold depending on whether it was re-viewed. One
-    # load-bearing guard beats two that disagree.
+    # Live truth is projected onto a record only when that record *is* the exact
+    # object the active map currently holds under that id. Looking the id up as a
+    # string would let a retired generation's history row borrow a later owner's
+    # recoverability. Every production caller views a *raw* record — the history
+    # list, the active map, and ``unreleased_authority_hold`` via ``self._hold``
+    # — so identity is the right comparison, and re-viewing a projection is not
+    # a supported call.
+    if _ACTIVE_AUTHORITY_HOLDS.get(hold.hold_id) is not hold:
+        return (
+            hold
+            if hold.recoverable_in_process is False
+            else replace(hold, recoverable_in_process=False)
+        )
     retained = _RETAINED_AUTHORITIES.get(hold.hold_id)
     owner = retained.owner if retained is not None else None
     # The two reasons a release is refused are a permanent coordination seal
@@ -618,6 +625,21 @@ def _allocate_hold_id() -> str:
         if not _hold_id_in_use(candidate):
             _ISSUED_HOLD_IDS.add(candidate)
             return candidate
+
+
+def _authority_already_retained(*, owner: object, grant: AdvisoryLeaseGrant) -> bool:
+    """Is this exact connection+grant already held in the retained map?
+
+    The rollback helper may retain an authority and then fail on its way out.
+    The caller's fallback must notice that, or one stuck account is recorded
+    twice and every count that follows -- holds, successors, operator triage --
+    is wrong.
+    """
+
+    return any(
+        entry.owner is owner and entry.grant is grant
+        for entry in _RETAINED_AUTHORITIES.values()
+    )
 
 
 def _resolve_authority_hold(
@@ -854,6 +876,7 @@ def _record_unreleased_authority(
     durable_evidence_written: bool,
     connection: LockAuthorityConnection | None = None,
     hold_id: str | None = None,
+    capability: object | None = None,
 ) -> UnreleasedAuthorityHold:
     """Record a hold, never overwriting one that belongs to somebody else."""
 
@@ -870,6 +893,33 @@ def _record_unreleased_authority(
         if foreign:
             # A supplied id that belongs to another owner is refused outright;
             # adopting it would let this hold delete that one during recovery.
+            raise CoordinationError(
+                CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE, hold_id=hold_id
+            )
+        # A non-``None`` id is **not** a caller-selected id. It is a
+        # same-generation handoff: the coordination handle that already owns this
+        # id telling the authority record to share it, so one stuck account keeps
+        # one opaque thread for an operator. Everything else is refused *here*,
+        # before the history append and the map assignment below — a rejection
+        # that happens after recording is not a rejection.
+        handoff = (
+            # (1) issued exactly once by the allocator, and never retired from
+            #     the process-lifetime set — successful coordinations included.
+            hold_id in _ISSUED_HOLD_IDS
+            # (2) an exact still-live preallocated coordination handle.
+            and held is not None
+            # (3) owned by this very lease, and sealed with this very capability.
+            and held.lease is owner
+            and (
+                capability is None
+                or _COORDINATION_RELEASE_CAPABILITIES.get(hold_id) is capability
+            )
+            # (4) the first authority transition for that id, ever.
+            and retained is None
+            and hold_id not in _ACTIVE_AUTHORITY_HOLDS
+            and not any(row.hold_id == hold_id for row in _AUTHORITY_HOLD_HISTORY)
+        )
+        if not handoff:
             raise CoordinationError(
                 CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE, hold_id=hold_id
             )
@@ -1065,6 +1115,7 @@ class PostgresAdvisoryKeysetLease:
             durable_evidence_written=durable_evidence_written,
             connection=self._connection,
             hold_id=hold_id,
+            capability=capability,
         )
         self._hold = hold
         return hold
@@ -1351,10 +1402,15 @@ async def acquire_physical_account_lease(
         rollback_cancellation = await _await_retained_task(rollback)
         rollback_error = _task_error(rollback)
         rollback_interruption = rollback.result() if rollback_error is None else None
-        if rollback_error is not None:
+        if rollback_error is not None and not _authority_already_retained(
+            owner=connection, grant=grant
+        ):
             # The rollback itself failed, so nothing proved this connection is
             # safe and nothing may have retained it. Retain it here rather than
-            # letting it fall out of scope with a key possibly still held.
+            # letting it fall out of scope with a key possibly still held --
+            # unless the helper already retained this exact authority before
+            # raising, in which case a second record would double-count one
+            # stuck account.
             _record_unreleased_authority(
                 grant,
                 owner=connection,
@@ -2352,9 +2408,12 @@ async def coordinate_mock_order_mutation(
     except BaseException as exc:
         invocation_error = exc
 
+    # Established before outcome access so that a failure *during* that access
+    # cannot decide the value: whether the caller cancelled us is an orthogonal
+    # fact, and once observed it is never unobserved.
+    outer_cancellation: asyncio.CancelledError | None = None
     try:
         if task is None:
-            outer_cancellation = None
             result, callback_error = None, invocation_error
         else:
             try:
@@ -2362,8 +2421,11 @@ async def coordinate_mock_order_mutation(
                 result, callback_error = _callback_outcome(task)
             except BaseException as exc:
                 # Reading the outcome happens after a possible send, so a failure
-                # there is uncertainty, not an escape.
-                outer_cancellation, result, callback_error = None, None, exc
+                # there is uncertainty, not an escape. It replaces the *result*
+                # only — clearing the cancellation fact here would write
+                # ``outer_cancellation_requested=False`` into durable evidence
+                # for a send the caller demonstrably asked to stop.
+                result, callback_error = None, exc
     finally:
         # In a ``finally`` so no path — including an outcome-access failure —
         # leaves a live scope behind for a captured reference to keep using.

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -627,18 +627,32 @@ def _allocate_hold_id() -> str:
             return candidate
 
 
-def _authority_already_retained(*, owner: object, grant: AdvisoryLeaseGrant) -> bool:
-    """Is this exact connection+grant already held in the retained map?
+def _authority_already_retained(
+    *,
+    owner: object,
+    grant: AdvisoryLeaseGrant,
+    connection: LockAuthorityConnection,
+) -> bool:
+    """Is *this exact* authority already recorded, with a live active record?
 
     The rollback helper may retain an authority and then fail on its way out.
     The caller's fallback must notice that, or one stuck account is recorded
     twice and every count that follows -- holds, successors, operator triage --
     is wrong.
+
+    Owner and grant alone are not enough. A row carrying the right owner and
+    grant but a *different* connection describes a different physical session,
+    so accepting it would suppress the safe fallback and leave the real
+    connection unrooted. The corresponding active record must exist too: a
+    retained row with no active hold is not a recorded authority.
     """
 
     return any(
-        entry.owner is owner and entry.grant is grant
-        for entry in _RETAINED_AUTHORITIES.values()
+        entry.owner is owner
+        and entry.grant is grant
+        and entry.connection is connection
+        and _ACTIVE_AUTHORITY_HOLDS.get(hold_id) is not None
+        for hold_id, entry in _RETAINED_AUTHORITIES.items()
     )
 
 
@@ -760,7 +774,12 @@ def ordered_advisory_keyset(keys: Sequence[int]) -> tuple[int, ...]:
     return tuple(sorted(set(keys)))
 
 
-@dataclass(frozen=True, slots=True)
+# ``weakref_slot`` only adds ``__weakref__`` to the generated slots: the grant
+# stays frozen, slotted, immutable, and out of ``__all__``. It exists so a test
+# can hold a non-owning witness to the exact original grant and prove the
+# module-private retained map is the only thing keeping it alive. An id() read
+# afterwards cannot prove that — it only re-reads the object the map still holds.
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class AdvisoryLeaseGrant:
     """Immutable proof of one successful ordered-keyset acquisition.
 
@@ -908,12 +927,16 @@ def _record_unreleased_authority(
             hold_id in _ISSUED_HOLD_IDS
             # (2) an exact still-live preallocated coordination handle.
             and held is not None
-            # (3) owned by this very lease, and sealed with this very capability.
+            # (3) the same generation, proved on all four identities: the lease
+            #     recording it, the grant it was acquired under, the connection
+            #     that actually holds the keys, and the private release
+            #     capability it was sealed with. Any one differing means this is
+            #     not that handle's authority record, and an id is not a right.
             and held.lease is owner
-            and (
-                capability is None
-                or _COORDINATION_RELEASE_CAPABILITIES.get(hold_id) is capability
-            )
+            and held.grant is grant
+            and (connection is None or connection is held.lease._connection)
+            and capability is not None
+            and _COORDINATION_RELEASE_CAPABILITIES.get(hold_id) is capability
             # (4) the first authority transition for that id, ever.
             and retained is None
             and hold_id not in _ACTIVE_AUTHORITY_HOLDS
@@ -1309,6 +1332,10 @@ class PostgresAdvisoryKeysetLease:
             # across two ids with no public way to join them. An unsealed lease
             # has no such id, so it keeps a fresh allocation.
             hold_id=self._coordination_hold_id,
+            # ...and the id alone is not the right to use it. The record gate
+            # demands the exact capability this lease was sealed with, so a
+            # supplied id cannot be adopted by anything that lacks it.
+            capability=self._release_capability,
         )
 
 
@@ -1403,7 +1430,7 @@ async def acquire_physical_account_lease(
         rollback_error = _task_error(rollback)
         rollback_interruption = rollback.result() if rollback_error is None else None
         if rollback_error is not None and not _authority_already_retained(
-            owner=connection, grant=grant
+            owner=connection, grant=grant, connection=connection
         ):
             # The rollback itself failed, so nothing proved this connection is
             # safe and nothing may have retained it. Retain it here rather than

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -1,0 +1,1919 @@
+"""ROB-1262 J3A — broker-neutral mock/paper/demo coordination port.
+
+One physical mock/paper/demo account is coordinated by four separable pieces: an
+authoritative PostgreSQL **session** advisory lease, a durable **binary** send
+reservation, lane-owned **durable evidence** ports, and an **injected** mutation
+callback.  This module owns none of the broker transport those pieces protect.
+
+NOT BROKER-ENFORCED FENCING — statement 1 of 3 (see also
+:class:`PostgresAdvisoryKeysetLease` and the lane matrix in
+``docs/contracts/rob-1262-coordination-port.md``).  The lease coordinates
+processes *inside this repository only*.  Every lane in
+:data:`LANE_FENCING_MATRIX` maps to :data:`FENCING_NOT_BROKER_ENFORCED` because
+no broker on that list accepts a fencing token: an out-of-repo process, a stale
+deployment, or a human at a broker console reaches the same account without ever
+contending for this lease.  Reading "the lease is held, therefore the broker will
+reject everyone else" is the most expensive available misreading of this module.
+
+Three distinctions this module refuses to blur:
+
+* **A pool return is not a backend-session termination.**  Returning or closing a
+  pooled connection leaves the backend — and every advisory lock whose unlock
+  could not be *proven* — alive.  :class:`LockAuthorityConnection` therefore
+  requires a real ``terminate_backend_session`` that raises unless severance is
+  positively demonstrated, and an authority without one is rejected before any
+  lock is taken.
+* **A lease release is not a claim release.**  The lease is ephemeral process
+  coordination; the durable claim is the account block.  Only
+  :meth:`DurableSendClaimAdapter.release_with_terminal_evidence` removes a claim.
+* **Cleanup is not permitted while the outcome is unknown.**  If the durable
+  evidence of what happened to a dispatch cannot be written, this process keeps
+  the writer authority and records an auditable
+  :class:`UnreleasedAuthorityHold` rather than handing the account to a
+  successor that would mutate it blind.
+
+Deliberate absences, each covered by a static test:
+
+* no clock — no TTL, no heartbeat, no local-clock expiry, no automatic takeover;
+* no file lock — a DB authority failure is fail-closed, never a file fallback
+  (the existing KIS PID file stays a later J3B *diagnostic* seam, not authority);
+* no broker transport, socket, signing implementation, or credential-value load;
+* no lifecycle/hold/retry/queue state — ``review.order_send_intents`` stays a
+  binary reservation, and lifecycle evidence belongs to lane-native services.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import secrets
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any, Final, Protocol, runtime_checkable
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from app.services.mock_integration.lineage import (
+    LineageEnvelope,
+    LineagePersistencePort,
+    LineagePersistenceUnavailable,
+    LineageReasonCode,
+    MockLineageFactory,
+    require_lineage_persistence_port,
+)
+from app.services.mock_lane_registry import (
+    CANONICAL_LANE_IDS,
+    LaneGuardError,
+    LaneRegistryEntry,
+    RegistrySource,
+    assert_entry_execution_ready,
+    assert_lineage_registry_binding,
+)
+from app.services.order_send_intent_service import DuplicateOrderIntent
+
+# --------------------------------------------------------------------------
+# Reason codes
+# --------------------------------------------------------------------------
+
+
+class CoordinationReasonCode(StrEnum):
+    """The complete J3A reason-code vocabulary; no free-form alternatives.
+
+    ``LINEAGE_PERSISTENCE_UNAVAILABLE`` reuses J2B's exact literal instead of
+    redefining it.  J2B's :class:`~app.services.mock_integration.lineage.LineageReasonCode`
+    is never modified or overloaded from here.
+    """
+
+    LOCK_AUTHORITY_UNAVAILABLE = "lock_authority_unavailable"
+    LEASE_CONTENDED = "lease_contended"
+    LEASE_LOST = "lease_lost"
+    LEASE_EVENT_LOOP_MISMATCH = "lease_event_loop_mismatch"
+    DURABLE_CLAIM_CONFLICT = "durable_claim_conflict"
+    LINEAGE_PERSISTENCE_UNAVAILABLE = (
+        LineageReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE.value
+    )
+    TERMINAL_EVIDENCE_REQUIRED = "terminal_evidence_required"
+    CLAIM_FOLLOWUP_NOT_AUTHORIZED = "claim_followup_not_authorized"
+
+
+COORDINATION_REASON_CODES: Final[frozenset[str]] = frozenset(
+    reason.value for reason in CoordinationReasonCode
+)
+
+
+class CoordinationError(RuntimeError):
+    """Fail-closed coordination rejection carrying one stable machine code.
+
+    The message never contains a physical account identifier; only the derived
+    opaque scope or the lane id may accompany it.
+    """
+
+    def __init__(
+        self,
+        reason_code: CoordinationReasonCode,
+        *,
+        lane_id: str | None = None,
+        hold_id: str | None = None,
+    ) -> None:
+        self.reason_code = reason_code
+        self.lane_id = lane_id
+        # Only the opaque hold id is ever exposed: never the account identity,
+        # the advisory key, or the backend PID.
+        self.hold_id = hold_id
+        parts = [reason_code.value]
+        if lane_id is not None:
+            parts.append(f"lane={lane_id}")
+        if hold_id is not None:
+            parts.append(f"hold={hold_id}")
+        super().__init__(": ".join(parts))
+
+
+class BackendSessionTerminationUnproven(RuntimeError):
+    """A backend session could not be *proven* to have ended.
+
+    This is not a reason code and never becomes one: it is the internal signal
+    that a lock may still be held by a surviving backend, which the caller turns
+    into an :class:`UnreleasedAuthorityHold`.
+    """
+
+
+# --------------------------------------------------------------------------
+# Not-broker-enforced fencing (statement 2 of 3 lives on the lease class)
+# --------------------------------------------------------------------------
+
+FENCING_NOT_BROKER_ENFORCED: Final[str] = "not_broker_enforced"
+
+NOT_BROKER_ENFORCED_FENCING_STATEMENT: Final[str] = (
+    "The J3A physical-account lease is process coordination only. It is NOT "
+    "broker-enforced fencing: no lane broker rejects a request because another "
+    "process holds this lease."
+)
+
+# One row per canonical J2A lane. There is intentionally no per-lane exception:
+# a lane that later gains real broker-side fencing must add its own evidence
+# rather than silently reinterpreting this matrix.
+LANE_FENCING_MATRIX: Final[Mapping[str, str]] = MappingProxyType(
+    dict.fromkeys(CANONICAL_LANE_IDS, FENCING_NOT_BROKER_ENFORCED)
+)
+
+# There is no TTL, no heartbeat, and no janitor. A durable claim is removed only
+# by an evidence-gated ``release_if_matches``; nothing in this process deletes a
+# claim because time passed.
+AUTOMATIC_CLAIM_RELEASE_AVAILABLE: Final[bool] = False
+LEASE_TTL_SECONDS: Final[None] = None
+
+
+# --------------------------------------------------------------------------
+# B-1 — opaque physical-account scope derived from canonical J2A identity
+# --------------------------------------------------------------------------
+
+_PHYSICAL_ACCOUNT_SCOPE_V1_DOMAIN: Final[bytes] = b"mock-physical-account-v1\0"
+_PHYSICAL_ACCOUNT_SCOPE_V1_PREFIX: Final[str] = "mockpa:v1:"
+
+
+@dataclass(frozen=True, slots=True)
+class PhysicalAccountScope:
+    """Opaque, non-reversible coordination identity for one physical account.
+
+    Both fields are SHA-256 derivatives.  The raw ``physical_account_id`` is
+    never stored here, so this record is safe to repr, log, and serialize.
+    """
+
+    claim_account_scope: str
+    advisory_key: int
+
+
+def _derive_physical_account_scope(physical_account_id: str) -> PhysicalAccountScope:
+    """Apply the pinned derivation to already-canonical J2A identity bytes.
+
+    No local alias, case, whitespace, broker, market, or profile normalization is
+    applied: the caller must already hold canonical J2A identity bytes.
+    """
+
+    digest = hashlib.sha256(
+        _PHYSICAL_ACCOUNT_SCOPE_V1_DOMAIN + physical_account_id.encode("utf-8")
+    ).digest()
+    return PhysicalAccountScope(
+        claim_account_scope=_PHYSICAL_ACCOUNT_SCOPE_V1_PREFIX + digest.hex(),
+        advisory_key=int.from_bytes(digest[:8], byteorder="big", signed=True),
+    )
+
+
+def physical_account_scope_for_entry(entry: LaneRegistryEntry) -> PhysicalAccountScope:
+    """Derive the coordination scope from one identity-known J2A registry entry.
+
+    A caller-supplied scope string is never accepted: the only input is the
+    canonical ``physical_account_id`` of a validated registry entry.  Unknown or
+    blank identity fails here, before any lease, persistence, reservation, or
+    callback work is attempted.
+    """
+
+    physical_account_id = entry.physical_account_id
+    if (
+        not isinstance(physical_account_id, str)
+        or not physical_account_id.strip()
+        or not isinstance(entry.identity_status, str)
+        or entry.identity_status == "UNKNOWN"
+        or not entry.identity_status.strip()
+    ):
+        raise LaneGuardError("physical_account_identity_unknown", lane_id=entry.lane_id)
+    return _derive_physical_account_scope(physical_account_id)
+
+
+# --------------------------------------------------------------------------
+# B-5 / B-7 — PostgreSQL session advisory lease over an ordered keyset
+# --------------------------------------------------------------------------
+
+_SESSION_IDENTITY_SQL: Final[str] = (
+    "SELECT pg_backend_pid() AS backend_pid, "
+    "(SELECT oid FROM pg_database WHERE datname = current_database())::bigint "
+    "AS database_oid"
+)
+_TRY_ADVISORY_LOCK_SQL: Final[str] = (
+    "SELECT pg_try_advisory_lock(CAST(:key AS bigint)) AS acquired"
+)
+_ADVISORY_UNLOCK_SQL: Final[str] = (
+    "SELECT pg_advisory_unlock(CAST(:key AS bigint)) AS released"
+)
+_OWNED_ADVISORY_ROWS_SQL: Final[str] = (
+    "SELECT locktype, mode, granted, database::bigint AS database_oid, pid, "
+    "objsubid, classid::bigint AS classid, objid::bigint AS objid "
+    "FROM pg_locks WHERE locktype = 'advisory' AND pid = :pid"
+)
+_TERMINATE_BACKEND_SQL: Final[str] = (
+    "SELECT pg_terminate_backend(CAST(:pid AS integer)) AS terminated"
+)
+_BACKEND_ALIVE_SQL: Final[str] = (
+    "SELECT count(*) AS alive FROM pg_stat_activity WHERE pid = CAST(:pid AS integer)"
+)
+
+_ADVISORY_LOCKTYPE: Final[str] = "advisory"
+_ADVISORY_EXCLUSIVE_MODE: Final[str] = "ExclusiveLock"
+# A bigint advisory key occupies one (classid, objid) pair with objsubid = 1.
+# The two-int32 form uses objsubid = 2 and is a different lock space.
+_BIGINT_ADVISORY_OBJSUBID: Final[int] = 1
+
+
+@dataclass(frozen=True, slots=True)
+class BackendTerminationReceipt:
+    """Positive, immutable proof that one exact backend session was ended.
+
+    A receipt is only meaningful when it is bound to the *exact* PID and owner
+    token of the acquisition it claims to have terminated.  A ``close()``, a
+    pool return, or an ambiguous driver error produces no receipt at all — those
+    are silence, not proof, and silence is never accepted as a release.
+    """
+
+    backend_pid: int
+    owner_token: str
+    terminated: bool
+
+
+@runtime_checkable
+class LockAuthorityConnection(Protocol):
+    """The dedicated session that *is* the lock authority.
+
+    Deliberately narrow: a pooled ``AsyncSession``, a transparently reconnecting
+    wrapper, or a file handle cannot satisfy the ownership attestation below.
+
+    ``terminate_backend_session`` is part of the contract, not an optimisation.
+    When an unlock cannot be *proven*, the only remaining way to guarantee the
+    advisory lock is gone is to end the backend session that holds it.  Closing
+    or returning a pooled connection does not do that.  An implementation must
+    return a :class:`BackendTerminationReceipt` bound to the exact ``expected_pid``
+    and ``owner_token``, or **raise** — silently reporting success here would hand
+    a successor an account that is still locked by a live backend.
+    """
+
+    async def execute(self, statement: Any, parameters: Any = None, /) -> Any: ...
+
+    async def commit(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+    def can_prove_backend_session_termination(self) -> bool: ...
+
+    async def terminate_backend_session(
+        self, *, expected_pid: int, owner_token: str
+    ) -> BackendTerminationReceipt: ...
+
+
+type LockAuthorityConnectionFactory = Callable[[], Awaitable[LockAuthorityConnection]]
+
+
+class SqlAlchemyLockAuthority:
+    """Adapts one **dedicated** SQLAlchemy ``AsyncConnection`` to the authority.
+
+    The constructor accepts nothing else on purpose: an ``AsyncSession``, a
+    sessionmaker, or any pooled facade is rejected rather than quietly treated as
+    a dedicated session.
+
+    ``terminate_backend_session`` proves the result from an **independent
+    observer session**: it runs ``pg_terminate_backend`` against the exact PID and
+    then confirms that PID is absent from ``pg_stat_activity``.  Self-termination
+    from the dying connection is deliberately not used, because the driver error
+    it produces is *ambiguous* — it looks identical to a network blip — and an
+    ambiguous error is not a receipt.  Without an observer factory this adapter
+    honestly reports that it cannot prove termination.
+    """
+
+    __slots__ = ("_connection", "_observer_factory")
+
+    def __init__(
+        self,
+        connection: AsyncConnection,
+        *,
+        observer_factory: Callable[[], Awaitable[AsyncConnection]] | None = None,
+    ) -> None:
+        if not isinstance(connection, AsyncConnection):
+            raise CoordinationError(CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE)
+        self._connection = connection
+        self._observer_factory = observer_factory
+
+    async def execute(self, statement: Any, parameters: Any = None, /) -> Any:
+        return await self._connection.execute(statement, parameters)
+
+    async def commit(self) -> None:
+        await self._connection.commit()
+
+    async def close(self) -> None:
+        await self._connection.close()
+
+    async def terminate_backend_session(
+        self, *, expected_pid: int, owner_token: str
+    ) -> BackendTerminationReceipt:
+        if self._observer_factory is None:
+            raise BackendSessionTerminationUnproven(
+                "no independent observer session is available to prove termination"
+            )
+        observer = await self._observer_factory()
+        try:
+            # The boolean is informational: it is false both when the PID never
+            # existed and when it had already gone. Absence from
+            # ``pg_stat_activity`` is the decisive proof, and it is the only
+            # thing this treats as one.
+            await observer.execute(text(_TERMINATE_BACKEND_SQL), {"pid": expected_pid})
+            alive = await observer.execute(
+                text(_BACKEND_ALIVE_SQL), {"pid": expected_pid}
+            )
+            if int(alive.scalar_one()) != 0:
+                raise BackendSessionTerminationUnproven(
+                    "the backend is still present in pg_stat_activity"
+                )
+        finally:
+            # Only the *observer* is disposable on every path. Closing the owner
+            # connection here would return a still-locked backend to the pool on
+            # exactly the paths where termination was NOT proven.
+            await _close_quietly(observer)
+        # Proven gone: only now may the owner connection be released.
+        await _close_quietly(self._connection)
+        return BackendTerminationReceipt(
+            backend_pid=expected_pid, owner_token=owner_token, terminated=True
+        )
+
+    def can_prove_backend_session_termination(self) -> bool:
+        """Without an independent observer, termination can never be proven."""
+
+        return self._observer_factory is not None
+
+
+async def _close_quietly(closeable: Any) -> None:
+    """Close something that is provably not holding a lock we still need."""
+
+    try:
+        await closeable.close()
+    except Exception:
+        pass
+
+
+def supports_backend_session_termination(connection: object) -> bool:
+    """True only when the authority *asserts* it can end its backend session.
+
+    The presence of a ``terminate_backend_session`` method is not capability:
+    an adapter with no independent observer would sail through a callable check,
+    take the locks, and only then discover it can never prove termination.  So
+    the authority must also answer ``can_prove_backend_session_termination()``
+    affirmatively, and it is asked before a single statement is issued.
+    """
+
+    if not callable(getattr(connection, "terminate_backend_session", None)):
+        return False
+    prover = getattr(connection, "can_prove_backend_session_termination", None)
+    if not callable(prover):
+        return False
+    try:
+        return bool(prover())
+    except Exception:
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class UnreleasedAuthorityHold:
+    """An advisory lease this process could **not** prove it released.
+
+    Its existence is the audit trail: the physical-account writer authority is
+    still held (or may be), so no successor may safely mutate that account.  It
+    is reachable through :func:`unreleased_authority_holds` and through the
+    owning lease — never left to a garbage collector or a pooled ``close()``
+    side effect to resolve, and never expired by a clock.
+    """
+
+    hold_id: str
+    keys: tuple[int, ...]
+    backend_pid: int
+    database_oid: int
+    connection_token: str
+    reason_code: CoordinationReasonCode
+    termination_proven: bool
+    durable_evidence_written: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _RetainedAuthority:
+    """A strong reference to the *actual* connection an unproven hold describes.
+
+    Recording metadata alone would let a garbage collection or a pool return
+    quietly drop the very authority the metadata claims is still held.  This
+    keeps the real dedicated connection, together with the exact grant identity,
+    reachable for as long as the hold stands.
+
+    It is a lifetime guard only: no TTL, no janitor, no retry, no takeover, no
+    scheduler, and no reason code of its own.
+    """
+
+    hold_id: str
+    connection: LockAuthorityConnection
+    grant: AdvisoryLeaseGrant
+
+
+# History is immutable evidence: every hold ever recorded, resolved or not.
+# The active views are the honest answer to "what is unresolved right now".
+# Reporting a resolved hold as unresolved is as much a defect as the reverse.
+_AUTHORITY_HOLD_HISTORY: list[UnreleasedAuthorityHold] = []
+_ACTIVE_AUTHORITY_HOLDS: dict[str, UnreleasedAuthorityHold] = {}
+_RETAINED_AUTHORITIES: dict[str, _RetainedAuthority] = {}
+
+
+def authority_hold_history() -> tuple[UnreleasedAuthorityHold, ...]:
+    """Immutable evidence: every hold ever recorded, in order, including resolved."""
+
+    return tuple(_AUTHORITY_HOLD_HISTORY)
+
+
+def unreleased_authority_holds() -> tuple[UnreleasedAuthorityHold, ...]:
+    """The authorities that are unresolved **right now**, in recording order."""
+
+    return tuple(_ACTIVE_AUTHORITY_HOLDS.values())
+
+
+def retained_authority_connections() -> Mapping[str, _RetainedAuthority]:
+    """The still-reachable connections behind every *active* unproven hold."""
+
+    return MappingProxyType(dict(_RETAINED_AUTHORITIES))
+
+
+def _resolve_authority_hold(hold: UnreleasedAuthorityHold | None) -> None:
+    """Drop exactly this hold's active entries, both of them, in one step.
+
+    Only ever called after a proven full unlock or a positive termination
+    receipt.  A foreign or stale hold id matches nothing and therefore clears
+    nothing, and an ambiguous or failed recovery never reaches here at all.
+    History is untouched.
+    """
+
+    if hold is None:
+        return
+    _ACTIVE_AUTHORITY_HOLDS.pop(hold.hold_id, None)
+    _RETAINED_AUTHORITIES.pop(hold.hold_id, None)
+
+
+def split_advisory_key(key: int) -> tuple[int, int]:
+    """Reconstruct the unsigned ``(classid, objid)`` halves of a signed key.
+
+    ``pg_locks`` stores the two 32-bit halves as unsigned oids, so a negative
+    signed bigint key never equals ``objid``.  Comparing the signed key directly
+    against ``objid`` is the classic silent-ownership bug this exists to prevent.
+    """
+
+    unsigned_key = key & ((1 << 64) - 1)
+    return unsigned_key >> 32, unsigned_key & 0xFFFFFFFF
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryLockRow:
+    """One observed ``pg_locks`` row, projected to the fields that matter."""
+
+    locktype: str
+    mode: str
+    granted: bool
+    database_oid: int
+    pid: int
+    objsubid: int
+    classid: int
+    objid: int
+
+
+def row_proves_ownership(
+    row: AdvisoryLockRow, *, key: int, backend_pid: int, database_oid: int
+) -> bool:
+    """Every predicate must hold; a partial match is not ownership."""
+
+    classid, objid = split_advisory_key(key)
+    return (
+        row.locktype == _ADVISORY_LOCKTYPE
+        and row.mode == _ADVISORY_EXCLUSIVE_MODE
+        and row.granted is True
+        and row.database_oid == database_oid
+        and row.pid == backend_pid
+        and row.objsubid == _BIGINT_ADVISORY_OBJSUBID
+        and row.classid == classid
+        and row.objid == objid
+    )
+
+
+def _rows_prove_full_keyset(
+    rows: Sequence[AdvisoryLockRow],
+    *,
+    keys: Sequence[int],
+    backend_pid: int,
+    database_oid: int,
+) -> bool:
+    return all(
+        any(
+            row_proves_ownership(
+                row, key=key, backend_pid=backend_pid, database_oid=database_oid
+            )
+            for row in rows
+        )
+        for key in keys
+    )
+
+
+def ordered_advisory_keyset(keys: Sequence[int]) -> tuple[int, ...]:
+    """De-duplicate, then sort by a deterministic global numeric order.
+
+    A stable acquisition order across every caller is what prevents two
+    multi-key holders from deadlocking on each other's partial keysets.
+    """
+
+    return tuple(sorted(set(keys)))
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryLeaseGrant:
+    """Immutable proof of one successful ordered-keyset acquisition.
+
+    This carries the *complete* identity of the acquisition — full keyset,
+    backend PID, database oid, a per-acquisition owner token, and the event loop
+    the session is bound to.  Both :meth:`PostgresAdvisoryKeysetLease.assert_owned`
+    and :meth:`PostgresAdvisoryKeysetLease.release` require the caller to hand
+    this exact grant back, so a stale grant or a copied token cannot drive
+    either one.
+    """
+
+    keys: tuple[int, ...]
+    backend_pid: int
+    database_oid: int
+    connection_token: str
+    event_loop: asyncio.AbstractEventLoop
+
+
+async def _read_session_identity(
+    connection: LockAuthorityConnection,
+) -> tuple[int, int]:
+    result = await connection.execute(text(_SESSION_IDENTITY_SQL))
+    row = result.mappings().one()
+    return int(row["backend_pid"]), int(row["database_oid"])
+
+
+async def _read_owned_advisory_rows(
+    connection: LockAuthorityConnection, backend_pid: int
+) -> tuple[AdvisoryLockRow, ...]:
+    result = await connection.execute(
+        text(_OWNED_ADVISORY_ROWS_SQL), {"pid": backend_pid}
+    )
+    return tuple(
+        AdvisoryLockRow(
+            locktype=str(row["locktype"]),
+            mode=str(row["mode"]),
+            granted=bool(row["granted"]),
+            database_oid=int(row["database_oid"]),
+            pid=int(row["pid"]),
+            objsubid=int(row["objsubid"]),
+            classid=int(row["classid"]),
+            objid=int(row["objid"]),
+        )
+        for row in result.mappings().all()
+    )
+
+
+async def _attest_full_ownership(
+    connection: LockAuthorityConnection,
+    *,
+    keys: Sequence[int],
+    backend_pid: int,
+    database_oid: int,
+) -> bool:
+    """Re-read the session identity and prove every exact ``pg_locks`` row."""
+
+    attested_pid, attested_database_oid = await _read_session_identity(connection)
+    if attested_pid != backend_pid or attested_database_oid != database_oid:
+        return False
+    rows = await _read_owned_advisory_rows(connection, backend_pid)
+    return _rows_prove_full_keyset(
+        rows, keys=keys, backend_pid=backend_pid, database_oid=database_oid
+    )
+
+
+async def _unlock_proven(connection: LockAuthorityConnection, key: int) -> bool:
+    """Unlock one key and return what PostgreSQL actually reported.
+
+    ``pg_advisory_unlock`` returns false when this session does not hold the
+    key.  Recording an unlock without checking that boolean is how a release
+    starts lying about keys it never let go of.
+    """
+
+    result = await connection.execute(text(_ADVISORY_UNLOCK_SQL), {"key": key})
+    return bool(result.scalar_one())
+
+
+async def _terminate_authority(
+    connection: LockAuthorityConnection, grant: AdvisoryLeaseGrant
+) -> BackendTerminationReceipt | None:
+    """End the backend session and return a receipt only when it is *proven*.
+
+    A pool return is never accepted as termination, an ambiguous driver error is
+    never converted into success, and a receipt that does not match this exact
+    acquisition's PID and owner token is discarded.  The caller records an
+    :class:`UnreleasedAuthorityHold` for every one of those cases.
+    """
+
+    try:
+        receipt = await connection.terminate_backend_session(
+            expected_pid=grant.backend_pid, owner_token=grant.connection_token
+        )
+    except Exception:
+        return None
+    if (
+        not isinstance(receipt, BackendTerminationReceipt)
+        or receipt.terminated is not True
+        or receipt.backend_pid != grant.backend_pid
+        or receipt.owner_token != grant.connection_token
+    ):
+        return None
+    return receipt
+
+
+def _record_unreleased_authority(
+    grant: AdvisoryLeaseGrant,
+    *,
+    reason_code: CoordinationReasonCode,
+    termination_proven: bool,
+    durable_evidence_written: bool,
+    connection: LockAuthorityConnection | None = None,
+    hold_id: str | None = None,
+) -> UnreleasedAuthorityHold:
+    hold = UnreleasedAuthorityHold(
+        hold_id=hold_id or f"hold:{secrets.token_hex(8)}",
+        keys=grant.keys,
+        backend_pid=grant.backend_pid,
+        database_oid=grant.database_oid,
+        connection_token=grant.connection_token,
+        reason_code=reason_code,
+        termination_proven=termination_proven,
+        durable_evidence_written=durable_evidence_written,
+    )
+    _AUTHORITY_HOLD_HISTORY.append(hold)
+    _ACTIVE_AUTHORITY_HOLDS[hold.hold_id] = hold
+    if connection is not None:
+        _RETAINED_AUTHORITIES[hold.hold_id] = _RetainedAuthority(
+            hold_id=hold.hold_id, connection=connection, grant=grant
+        )
+    return hold
+
+
+class PostgresAdvisoryKeysetLease:
+    """A dedicated PostgreSQL session holding an ordered advisory keyset.
+
+    NOT BROKER-ENFORCED FENCING — statement 2 of 3.  Holding this lease proves
+    that no *other holder of this same lease* is mutating the account.  It proves
+    nothing about the broker: the broker never sees the lease, so a process that
+    does not take it (an old deployment, an operator console, another repository)
+    is unaffected.  See :data:`NOT_BROKER_ENFORCED_FENCING_STATEMENT` and the
+    lane matrix in ``docs/contracts/rob-1262-coordination-port.md``.
+
+    Release is exactly two things: an **attested** owner/key-matched
+    ``pg_advisory_unlock``, or a **proven** termination of this backend session.
+    There is no TTL and no takeover, and a pool return is neither of those.
+
+    A lease whose post-send durable evidence never landed is not releasable at
+    all: :meth:`retain_authority` marks it, and every subsequent ``release`` —
+    including one driven by the exact grant obtained from public introspection —
+    fails closed with ``lineage_persistence_unavailable``.
+
+    Release is also cancellation-safe.  The whole re-attest → reverse unlock →
+    close sequence runs as a retained task, and the lease is marked released only
+    after that sequence proves an allowed outcome.  A release that is interrupted
+    or fails leaves the lease recoverable by the exact grant, while stale or
+    foreign grants keep being rejected.
+    """
+
+    __slots__ = (
+        "_connection",
+        "_grant",
+        "_hold",
+        "_release_task",
+        "_released",
+        "_termination_receipt",
+        "_unlocked_keys",
+    )
+
+    def __init__(
+        self,
+        *,
+        connection: LockAuthorityConnection,
+        grant: AdvisoryLeaseGrant,
+    ) -> None:
+        self._connection = connection
+        self._grant = grant
+        self._released = False
+        self._unlocked_keys: tuple[int, ...] = ()
+        self._release_task: asyncio.Task[None] | None = None
+        self._hold: UnreleasedAuthorityHold | None = None
+        self._termination_receipt: BackendTerminationReceipt | None = None
+
+    @property
+    def grant(self) -> AdvisoryLeaseGrant:
+        return self._grant
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    @property
+    def unlocked_keys(self) -> tuple[int, ...]:
+        """Keys PostgreSQL *confirmed* it released, in call order, once each."""
+
+        return self._unlocked_keys
+
+    @property
+    def unreleased_authority_hold(self) -> UnreleasedAuthorityHold | None:
+        """Set when this lease could not be proven released."""
+
+        return self._hold
+
+    @property
+    def termination_receipt(self) -> BackendTerminationReceipt | None:
+        """The positive receipt, when release fell back to a proven termination."""
+
+        return self._termination_receipt
+
+    def _require_grant(self, expected_grant: AdvisoryLeaseGrant) -> None:
+        if asyncio.get_running_loop() is not self._grant.event_loop:
+            raise CoordinationError(CoordinationReasonCode.LEASE_EVENT_LOOP_MISMATCH)
+        if (
+            expected_grant is not self._grant
+            or expected_grant.connection_token != self._grant.connection_token
+            or expected_grant.event_loop is not self._grant.event_loop
+            or expected_grant.keys != self._grant.keys
+            or expected_grant.backend_pid != self._grant.backend_pid
+            or expected_grant.database_oid != self._grant.database_oid
+        ):
+            raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
+
+    async def assert_owned(self, expected_grant: AdvisoryLeaseGrant) -> None:
+        """Re-prove ownership immediately before every mutation.
+
+        There is no heartbeat, so this is a *use-time* check: an idle lease is
+        never assumed to still be held.  A transparently reconnected connection
+        lands on a new backend PID and therefore owns nothing.
+        """
+
+        self._require_grant(expected_grant)
+        if self._released:
+            raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
+        try:
+            attested = await _attest_full_ownership(
+                self._connection,
+                keys=self._grant.keys,
+                backend_pid=self._grant.backend_pid,
+                database_oid=self._grant.database_oid,
+            )
+        except Exception as exc:
+            raise CoordinationError(
+                CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+            ) from exc
+        if not attested:
+            raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
+
+    def retain_authority(
+        self,
+        *,
+        reason_code: CoordinationReasonCode,
+        durable_evidence_written: bool,
+        hold_id: str | None = None,
+    ) -> UnreleasedAuthorityHold:
+        """Deliberately keep the writer authority and record why.
+
+        Used when the durable evidence of a dispatch could not be written: a
+        successor must not receive this account while nobody knows whether an
+        order went out.  The hold is explicit and auditable, and is never
+        resolved by a timer.
+        """
+
+        hold = _record_unreleased_authority(
+            self._grant,
+            reason_code=reason_code,
+            termination_proven=False,
+            durable_evidence_written=durable_evidence_written,
+            connection=self._connection,
+            hold_id=hold_id,
+        )
+        self._hold = hold
+        return hold
+
+    async def release(self, expected_grant: AdvisoryLeaseGrant) -> None:
+        """Re-attest, then unlock each key in reverse order, proving every one.
+
+        A normal release is *attested unlock, then close*.  If ownership cannot
+        be re-attested, or PostgreSQL reports ``false`` for any unlock, the lock
+        state is unknown — so this ends the backend session instead of quietly
+        closing a pooled connection and calling that a release, and if even that
+        cannot be proven it records an :class:`UnreleasedAuthorityHold`.
+        """
+
+        self._require_grant(expected_grant)
+        hold = self._hold
+        if hold is not None and not hold.durable_evidence_written:
+            # The post-send AND gate never closed, so nobody knows whether an
+            # order went out. Surrendering the advisory lock here would let an
+            # old or non-claim-aware writer mutate the account concurrently, and
+            # holding the exact grant does not make that safe. Public
+            # introspection may still *see* this lease; it may not release it.
+            # There is deliberately no recovery API in this epoch: process
+            # termination ends the ephemeral session, while the durable binary
+            # claim survives and keeps blocking a successor's repost.
+            raise CoordinationError(
+                CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+                hold_id=hold.hold_id,
+            )
+        if self._released:
+            return
+
+        if self._release_task is None:
+            self._release_task = asyncio.ensure_future(self._release_impl())
+        task = self._release_task
+        cancellation = await _await_retained_task(task)
+        error = _task_error(task)
+        if error is not None:
+            # Recoverable by the exact grant; stale/foreign grants still fail.
+            self._release_task = None
+            raise error
+        self._released = True
+        if cancellation is not None:
+            raise cancellation
+
+    async def _release_impl(self) -> None:
+        try:
+            attested = await _attest_full_ownership(
+                self._connection,
+                keys=self._grant.keys,
+                backend_pid=self._grant.backend_pid,
+                database_oid=self._grant.database_oid,
+            )
+        except Exception as exc:
+            await self._terminate_or_hold(CoordinationReasonCode.LEASE_LOST)
+            raise CoordinationError(
+                CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+            ) from exc
+        if not attested:
+            await self._terminate_or_hold(CoordinationReasonCode.LEASE_LOST)
+            raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
+
+        confirmed: list[int] = []
+        try:
+            for key in reversed(self._grant.keys):
+                if not await _unlock_proven(self._connection, key):
+                    raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
+                confirmed.append(key)
+        except CoordinationError:
+            self._unlocked_keys = tuple(confirmed)
+            await self._terminate_or_hold(CoordinationReasonCode.LEASE_LOST)
+            raise
+        except Exception as exc:
+            self._unlocked_keys = tuple(confirmed)
+            await self._terminate_or_hold(
+                CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+            )
+            raise CoordinationError(
+                CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+            ) from exc
+
+        self._unlocked_keys = tuple(confirmed)
+        await self._connection.close()
+        # Proven full reverse unlock: any hold this lease left behind on an
+        # earlier attempt is now genuinely resolved.
+        self._resolve_own_hold()
+
+    def _resolve_own_hold(self) -> None:
+        _resolve_authority_hold(self._hold)
+        self._hold = None
+
+    async def _terminate_or_hold(self, reason_code: CoordinationReasonCode) -> None:
+        receipt = await _terminate_authority(self._connection, self._grant)
+        if receipt is not None:
+            # The exact backend is provably gone, so every advisory key it held
+            # is gone with it. That is an allowed release outcome even though the
+            # caller still sees the failure that forced it.
+            self._termination_receipt = receipt
+            self._released = True
+            # A positive receipt resolves any hold from an earlier attempt.
+            self._resolve_own_hold()
+            return
+        if self._hold is not None:
+            # One lease is one authority: a repeat failure is the *same*
+            # unresolved hold, not a second one accumulating in the active view.
+            return
+        self._hold = _record_unreleased_authority(
+            self._grant,
+            reason_code=reason_code,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=self._connection,
+        )
+
+
+async def acquire_physical_account_lease(
+    *,
+    keys: Sequence[int],
+    connection_factory: LockAuthorityConnectionFactory,
+) -> PostgresAdvisoryKeysetLease:
+    """Acquire an ordered advisory keyset on one dedicated session.
+
+    The sequence is fixed: verify the authority can really terminate its own
+    backend, retain the backend PID, ``pg_try_advisory_lock`` each key in
+    deterministic order, cross an **explicit COMMIT** boundary, then re-read the
+    PID and prove every exact ``pg_locks`` row in the new transaction.  A
+    transaction pooler that hands the next statement to a different backend fails
+    that attestation instead of silently downgrading a session lock.
+
+    Contention yields ``lease_contended``.  Any unattested or failed authority —
+    including one that cannot terminate its own backend session — yields
+    ``lock_authority_unavailable``.  Neither leaves a key provably held.
+    """
+
+    loop = asyncio.get_running_loop()
+    ordered_keys = ordered_advisory_keyset(keys)
+    if not ordered_keys:
+        raise CoordinationError(CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE)
+
+    connection = await _open_lock_authority(connection_factory)
+
+    # The exact session identity is read BEFORE the first lock attempt. Every
+    # rollback, hold, and termination request downstream needs the real backend
+    # PID; a zero placeholder would ask PostgreSQL to terminate backend 0 and
+    # leave the actual lock held.
+    try:
+        backend_pid, database_oid = await _read_session_identity(connection)
+    except Exception as exc:
+        # No key has been requested yet, so nothing can be held: closing is both
+        # safe and the only thing left to do.
+        await _close_quietly(connection)
+        raise CoordinationError(
+            CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+        ) from exc
+
+    grant = AdvisoryLeaseGrant(
+        keys=ordered_keys,
+        backend_pid=backend_pid,
+        database_oid=database_oid,
+        connection_token=f"lockconn:{secrets.token_hex(8)}",
+        event_loop=loop,
+    )
+    acquired: list[int] = []
+    # A key is marked in flight *before* the statement is dispatched and cleared
+    # only once a definite answer comes back. Anything still listed here has an
+    # unknown owner: PostgreSQL may have granted it before the client-side await
+    # failed, exactly like a broker submit that times out locally after the
+    # remote mutation already happened.
+    in_flight: list[int] = []
+    try:
+        await _acquire_attested_keyset(connection, grant, acquired, in_flight)
+    except BaseException:
+        await _rollback_partial_acquisition(
+            connection, acquired, grant, in_flight=tuple(in_flight)
+        )
+        raise
+
+    return PostgresAdvisoryKeysetLease(connection=connection, grant=grant)
+
+
+async def _open_lock_authority(
+    connection_factory: LockAuthorityConnectionFactory,
+) -> LockAuthorityConnection:
+    try:
+        connection = await connection_factory()
+    except Exception as exc:
+        raise CoordinationError(
+            CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+        ) from exc
+    if not supports_backend_session_termination(connection):
+        # No lock is held yet, so closing is safe here — and it is the only
+        # thing this object is actually able to do.
+        try:
+            await connection.close()
+        except Exception:
+            pass
+        raise CoordinationError(CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE)
+    return connection
+
+
+async def _acquire_attested_keyset(
+    connection: LockAuthorityConnection,
+    grant: AdvisoryLeaseGrant,
+    acquired: list[int],
+    in_flight: list[int],
+) -> None:
+    backend_pid = grant.backend_pid
+    database_oid = grant.database_oid
+    ordered_keys = grant.keys
+    try:
+        for key in ordered_keys:
+            in_flight.append(key)
+            result = await connection.execute(
+                text(_TRY_ADVISORY_LOCK_SQL), {"key": key}
+            )
+            # Only an explicit, definite ``False`` proves this key was not
+            # granted. Any raise or cancellation between dispatch and here
+            # leaves the key marked in flight, because local silence is not
+            # evidence that the server did nothing.
+            if not bool(result.scalar_one()):
+                in_flight.remove(key)
+                raise CoordinationError(CoordinationReasonCode.LEASE_CONTENDED)
+            in_flight.remove(key)
+            acquired.append(key)
+        # Explicit COMMIT boundary: everything after this runs in a new
+        # transaction, which is exactly where a transaction pooler would move us
+        # to a different backend session.
+        await connection.commit()
+        attested = await _attest_full_ownership(
+            connection,
+            keys=ordered_keys,
+            backend_pid=backend_pid,
+            database_oid=database_oid,
+        )
+    except CoordinationError:
+        raise
+    except Exception as exc:
+        raise CoordinationError(
+            CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+        ) from exc
+    if not attested:
+        raise CoordinationError(CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE)
+
+
+async def _rollback_partial_acquisition(
+    connection: LockAuthorityConnection,
+    acquired: Sequence[int],
+    grant: AdvisoryLeaseGrant,
+    *,
+    in_flight: Sequence[int] = (),
+) -> None:
+    """Unlock every already-acquired key in reverse order, proving each one.
+
+    If any unlock cannot be proven, the session is terminated rather than
+    closed: an unproven advisory lock on a surviving backend is exactly the
+    stuck-account state this module exists to avoid.  If termination itself
+    cannot be proven, that becomes an auditable hold rather than silence.
+
+    When a key was still **in flight**, its ownership is unknown rather than
+    absent, so the confirmed-only unlock path and the ordinary close are both
+    off limits: this demands a positive exact-PID termination receipt, and
+    failing that retains the real connection under an auditable hold.
+    """
+
+    if in_flight:
+        if await _terminate_authority(connection, grant) is not None:
+            return
+        _record_unreleased_authority(
+            grant,
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=connection,
+        )
+        return
+
+    proven = True
+    try:
+        for key in reversed(tuple(acquired)):
+            if not await _unlock_proven(connection, key):
+                proven = False
+                break
+    except Exception:
+        proven = False
+    if proven:
+        await connection.close()
+        return
+    if await _terminate_authority(connection, grant) is None:
+        # Metadata alone would let a GC pass or a pool return drop the very
+        # authority it claims is still held, so the real connection is retained.
+        _record_unreleased_authority(
+            grant,
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=connection,
+        )
+
+
+# --------------------------------------------------------------------------
+# B-4 — durable binary send reservation (adapter, never a state machine)
+# --------------------------------------------------------------------------
+
+
+@runtime_checkable
+class OrderSendIntentReservationPort(Protocol):
+    """The exact binary-reservation surface J3A consumes.
+
+    ``release`` is intentionally absent.  The unrestricted delete is never part
+    of this port, so no coordination path can reach it; only the evidence-gated
+    ``release_if_matches`` below may remove a claim.
+    """
+
+    async def has_reservations(self, *, account_scope: str) -> bool: ...
+
+    async def reserve(
+        self,
+        *,
+        account_scope: str,
+        idempotency_key: str,
+        symbol: str | None = None,
+        side: str | None = None,
+        conflicting_key_sides: tuple[tuple[str, str], ...] = (),
+    ) -> int: ...
+
+    async def list_reservations(self, *, account_scope: str) -> Sequence[Any]: ...
+
+    async def release_if_matches(
+        self,
+        *,
+        account_scope: str,
+        row_id: int,
+        idempotency_key: str,
+        side: str | None,
+    ) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class DurableClaim:
+    """One binary reservation row observed before external I/O.
+
+    This is a claim, not a lifecycle record: there is no state, no hold field,
+    no retry counter, and no broker order id.  Its mere existence is the
+    account-wide block.
+    """
+
+    row_id: int
+    claim_account_scope: str
+    idempotency_key: str
+    side: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalClaimEvidence:
+    """The evidence a lane must present before a claim may be deleted.
+
+    Every field defaults to absent, so a default-constructed instance authorizes
+    nothing.  Unknown results, anomalies, a broker rejection without proven
+    absence, and a partial fill with an unknown remainder all fail to set these
+    flags — which is exactly why they retain the claim and keep the account
+    blocked until a human resolves them.  Nothing releases a claim automatically.
+    """
+
+    lane_native_terminal_evidence: bool = False
+    account_position_reconciled: bool = False
+    remainder_known: bool = False
+    authoritative_absence_proven: bool = False
+
+    @property
+    def authorizes_release(self) -> bool:
+        if self.authoritative_absence_proven:
+            return self.account_position_reconciled
+        return (
+            self.lane_native_terminal_evidence
+            and self.account_position_reconciled
+            and self.remainder_known
+        )
+
+
+class DurableSendClaimAdapter:
+    """Adapts the existing binary reservation service to J3A coordination.
+
+    The underlying ``OrderSendIntentService`` is imported and adapted, never
+    edited into a state machine: its schema holds only binary claim facts and
+    this adapter adds none.
+    """
+
+    __slots__ = ("_intents",)
+
+    def __init__(self, intents: OrderSendIntentReservationPort) -> None:
+        self._intents = intents
+
+    async def account_has_unresolved_claim(self, scope: PhysicalAccountScope) -> bool:
+        """Any unresolved reservation blocks every new order on the account."""
+
+        return bool(
+            await self._intents.has_reservations(
+                account_scope=scope.claim_account_scope
+            )
+        )
+
+    async def reserve(
+        self,
+        *,
+        scope: PhysicalAccountScope,
+        idempotency_key: str,
+        symbol: str | None = None,
+        side: str | None = None,
+    ) -> DurableClaim:
+        """Insert and commit the binary claim before any broker callback runs."""
+
+        try:
+            row_id = await self._intents.reserve(
+                account_scope=scope.claim_account_scope,
+                idempotency_key=idempotency_key,
+                symbol=symbol,
+                side=side,
+            )
+        except DuplicateOrderIntent as exc:
+            raise CoordinationError(
+                CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+            ) from exc
+        return DurableClaim(
+            row_id=row_id,
+            claim_account_scope=scope.claim_account_scope,
+            idempotency_key=idempotency_key,
+            side=side,
+        )
+
+    async def release_with_terminal_evidence(
+        self, claim: DurableClaim, evidence: TerminalClaimEvidence
+    ) -> int:
+        """Delete the exact claim row only after terminal + reconcile evidence.
+
+        Without sufficient evidence this raises before touching the database, so
+        an evidence-less release cannot happen even by accident.
+        """
+
+        if not evidence.authorizes_release:
+            raise CoordinationError(CoordinationReasonCode.TERMINAL_EVIDENCE_REQUIRED)
+        return int(
+            await self._intents.release_if_matches(
+                account_scope=claim.claim_account_scope,
+                row_id=claim.row_id,
+                idempotency_key=claim.idempotency_key,
+                side=claim.side,
+            )
+        )
+
+
+# --------------------------------------------------------------------------
+# B-10 — follow-up capability representation only; never an authorization
+# --------------------------------------------------------------------------
+
+CLAIM_FOLLOWUP_OPERATIONS: Final[frozenset[str]] = frozenset({"cancel", "reduce"})
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimFollowupRequest:
+    """What a later lane claims to hold before a cancel/reduce follow-up."""
+
+    operation: str
+    lane_capability_supports_operation: bool = False
+    attributed_native_order_id: str | None = None
+    known_remainder: Decimal | None = None
+    fresh_guards_passed: bool = False
+    lease_ownership_verified: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimFollowupCapability:
+    """A capability description — deliberately not an authorization.
+
+    ``authorizes_broker_mutation`` and ``releases_durable_claim`` are structural
+    ``False``: they cannot be constructed as ``True``.  Whether a follow-up is
+    actually permitted, and what transport performs it, stays with J3B/J3C.
+    """
+
+    operation: str
+    capability_present: bool
+    reason_code: CoordinationReasonCode | None
+    authorizes_broker_mutation: bool = field(default=False, init=False)
+    releases_durable_claim: bool = field(default=False, init=False)
+
+
+def describe_claim_followup(request: ClaimFollowupRequest) -> ClaimFollowupCapability:
+    """Report whether every follow-up precondition is present.
+
+    Increasing quantity, changing symbol, or creating a new order under the same
+    claim is not describable here: only ``cancel`` and ``reduce`` are operations
+    at all.  Any missing element yields ``claim_followup_not_authorized`` and the
+    reservation is retained either way.
+    """
+
+    capability_present = (
+        request.operation in CLAIM_FOLLOWUP_OPERATIONS
+        and request.lane_capability_supports_operation
+        and isinstance(request.attributed_native_order_id, str)
+        and bool(request.attributed_native_order_id.strip())
+        and request.known_remainder is not None
+        and request.fresh_guards_passed
+        and request.lease_ownership_verified
+    )
+    return ClaimFollowupCapability(
+        operation=request.operation,
+        capability_present=capability_present,
+        reason_code=(
+            None
+            if capability_present
+            else CoordinationReasonCode.CLAIM_FOLLOWUP_NOT_AUTHORIZED
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# B-6 — coordinated mutation with an injected callback + durable evidence
+# --------------------------------------------------------------------------
+
+
+class MutationCertainty(StrEnum):
+    """Whether the transport reached a definite answer or a definite unknown."""
+
+    DEFINITIVE = "definitive"
+    UNCERTAIN = "uncertain"
+
+
+@dataclass(frozen=True, slots=True)
+class MutationCallbackResult:
+    """What a lane's injected callback reports back.
+
+    ``broker_order_id`` is the value the *lane* already extracted from its native
+    response; J3A parses no broker payload and only hands it to J2B's
+    acknowledgement helper.
+    """
+
+    certainty: MutationCertainty
+    broker_order_id: str | None = None
+
+
+type MockMutationCallback = Callable[[], Awaitable[MutationCallbackResult]]
+
+
+class DispatchEvidenceKind(StrEnum):
+    """What this process actually learned about one dispatch.
+
+    This is an *evidence* vocabulary, not a reason-code vocabulary: it never
+    overlaps :class:`CoordinationReasonCode` and carries no broker state. It
+    exists so that "we do not know whether the order went out" is a typed,
+    durable fact rather than an inference from a missing field.
+    """
+
+    ACKNOWLEDGED = "acknowledged"
+    DEFINITIVE_WITHOUT_BROKER_ID = "definitive_without_broker_id"
+    LANE_REPORTED_UNCERTAIN = "lane_reported_uncertain"
+    CALLBACK_FAILED = "callback_failed"
+    ACK_ATTACHMENT_FAILED = "ack_attachment_failed"
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchEvidence:
+    """Immutable record of exactly what this process learned about one dispatch.
+
+    Every outcome is durably persisted before any cleanup runs:
+
+    1. a definitive acknowledgement (``ACKNOWLEDGED``);
+    2. a definitive uncertainty reported by the lane
+       (``LANE_REPORTED_UNCERTAIN``);
+    3. a callback failure (``CALLBACK_FAILED``) — uncertain, because the write
+       may well have reached the broker;
+    4. a broker order id that could not be normalized or attached
+       (``ACK_ATTACHMENT_FAILED``) — also uncertain, and never recorded as a
+       success just because the transport returned.
+
+    An outer cancellation is orthogonal to all of them and is recorded by
+    ``outer_cancellation_requested``: cancelling the *caller* says nothing about
+    what the *transport* did, so it never overwrites the kind.
+
+    The lineage correlation fields make this record self-describing at rest: a
+    later reconciler can tie the unknown back to its exact intent, plan, and
+    attempt without reading this process's memory.  There is no free-form broker
+    state and no reason code here — native lifecycle detail belongs to the lane's
+    own service, and the durable claim referenced here remains the account block
+    until evidence-gated release.
+    """
+
+    envelope: LineageEnvelope
+    kind: DispatchEvidenceKind
+    certainty: MutationCertainty
+    broker_order_id: str | None
+    callback_failed: bool
+    ack_attachment_failed: bool
+    outer_cancellation_requested: bool
+    decision_intent_id: str
+    execution_plan_id: str
+    order_attempt_id: str
+    cycle_id: str
+    attempt_seq: int | None
+    claim_account_scope: str
+    claim_row_id: int
+    idempotency_key: str
+
+
+def _dispatch_evidence_kind(
+    result: MutationCallbackResult | None,
+    callback_error: BaseException | None,
+    ack_error: BaseException | None,
+) -> DispatchEvidenceKind:
+    if callback_error is not None or result is None:
+        return DispatchEvidenceKind.CALLBACK_FAILED
+    if ack_error is not None:
+        return DispatchEvidenceKind.ACK_ATTACHMENT_FAILED
+    if result.certainty is MutationCertainty.UNCERTAIN:
+        return DispatchEvidenceKind.LANE_REPORTED_UNCERTAIN
+    if result.broker_order_id is None:
+        return DispatchEvidenceKind.DEFINITIVE_WITHOUT_BROKER_ID
+    return DispatchEvidenceKind.ACKNOWLEDGED
+
+
+@runtime_checkable
+class DispatchEvidencePort(Protocol):
+    """Lane-owned durable write boundary for dispatch evidence.
+
+    J3A supplies no implementation: a lane wires this to its existing native
+    lifecycle service.  ``review.order_send_intents`` is explicitly *not* an
+    acceptable target — it is a binary reservation, not a state store.
+    """
+
+    async def persist_dispatch_evidence(
+        self, evidence: DispatchEvidence, /
+    ) -> None: ...
+
+
+def require_dispatch_evidence_port(
+    port: DispatchEvidencePort | None, /
+) -> DispatchEvidencePort:
+    """Fail closed when a lane has not supplied its dispatch-evidence port."""
+
+    if port is None or not isinstance(port, DispatchEvidencePort):
+        raise CoordinationError(CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE)
+    return port
+
+
+@dataclass(frozen=True, slots=True)
+class HeldCoordination:
+    """A strong handle on coordination authority that is currently in use.
+
+    Created the instant the durable binary reservation is committed and *before*
+    the broker callback task exists, so there is no window in which an exception
+    unwinding, a garbage collection, or a pool return can quietly drop the
+    authority for an order that may already be on the wire.
+
+    This map is a lifetime and safety guard, nothing more.  It is **not** a retry
+    queue, **not** a durable state store, and it has no TTL, janitor, takeover,
+    automatic retry, claim deletion, or scheduler.  Process death may end the
+    ephemeral DB session, but the durable binary reservation survives and keeps
+    blocking a successor, which is the property that actually matters.
+    """
+
+    hold_id: str
+    lease: PostgresAdvisoryKeysetLease
+    grant: AdvisoryLeaseGrant
+    claim: DurableClaim
+    envelope: LineageEnvelope
+
+
+# Strong references, keyed by the opaque hold id and nothing else.
+_HELD_COORDINATION: dict[str, HeldCoordination] = {}
+
+
+def held_coordinations() -> Mapping[str, HeldCoordination]:
+    """Every coordination authority this process is still holding."""
+
+    return MappingProxyType(dict(_HELD_COORDINATION))
+
+
+def held_coordination(hold_id: str) -> HeldCoordination | None:
+    """Look one held authority up by its opaque id."""
+
+    return _HELD_COORDINATION.get(hold_id)
+
+
+def _register_held_coordination(
+    *,
+    lease: PostgresAdvisoryKeysetLease,
+    grant: AdvisoryLeaseGrant,
+    claim: DurableClaim,
+    envelope: LineageEnvelope,
+) -> HeldCoordination:
+    held = HeldCoordination(
+        hold_id=f"hold:{secrets.token_hex(8)}",
+        lease=lease,
+        grant=grant,
+        claim=claim,
+        envelope=envelope,
+    )
+    _HELD_COORDINATION[held.hold_id] = held
+    return held
+
+
+async def _release_and_unregister(held: HeldCoordination) -> None:
+    """Drop the handle only after an allowed release outcome is proven."""
+
+    await held.lease.release(held.grant)
+    _HELD_COORDINATION.pop(held.hold_id, None)
+
+
+async def _release_and_unregister_quietly(held: HeldCoordination) -> None:
+    """Release on an already-failing path; keep the handle if unproven."""
+
+    try:
+        await _release_and_unregister(held)
+    except CoordinationError:
+        pass
+
+
+@dataclass(frozen=True, slots=True)
+class CoordinatedMutationResult:
+    """Outcome of one coordinated mutation; the durable claim is still held."""
+
+    envelope: LineageEnvelope
+    scope: PhysicalAccountScope
+    claim: DurableClaim
+    certainty: MutationCertainty
+    evidence: DispatchEvidence
+    lease_grant: AdvisoryLeaseGrant
+
+
+async def _await_retained_task(
+    task: asyncio.Task[Any],
+) -> asyncio.CancelledError | None:
+    """Wait for a retained task without ever cancelling it.
+
+    ``asyncio.shield`` alone is not enough: it lets the outer awaiter raise
+    ``CancelledError`` while the inner socket write — or the evidence write that
+    proves what happened to it, or the unlock sequence that gives up the
+    account — continues, after which a naive ``finally`` would release the lease
+    and reservation on an order that may well have reached the broker.  So the
+    outer cancellation is captured and the retained task is awaited to a definite
+    result first.
+    """
+
+    outer_cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            outer_cancellation = outer_cancellation or exc
+            if task.done():
+                break
+        except BaseException:
+            # The retained task itself failed; ``task`` now carries it.
+            break
+    return outer_cancellation
+
+
+def _task_error(task: asyncio.Task[Any]) -> BaseException | None:
+    if task.cancelled():
+        return asyncio.CancelledError()
+    return task.exception()
+
+
+async def _run_retained(
+    make_awaitable: Callable[[], Awaitable[Any]],
+) -> tuple[BaseException | None, asyncio.CancelledError | None]:
+    """Start, retain, and fully await one durable write."""
+
+    try:
+        task: asyncio.Task[Any] = asyncio.ensure_future(make_awaitable())
+    except BaseException as exc:
+        return exc, None
+    cancellation = await _await_retained_task(task)
+    return _task_error(task), cancellation
+
+
+def _callback_outcome(
+    task: asyncio.Task[MutationCallbackResult],
+) -> tuple[MutationCallbackResult | None, BaseException | None]:
+    if task.cancelled():
+        return None, asyncio.CancelledError()
+    callback_error = task.exception()
+    if callback_error is not None:
+        return None, callback_error
+    return task.result(), None
+
+
+def _required_persistence(
+    persistence: LineagePersistencePort | None,
+) -> LineagePersistencePort:
+    try:
+        return require_lineage_persistence_port(persistence)
+    except LineagePersistenceUnavailable as exc:
+        raise CoordinationError(
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+        ) from exc
+
+
+def _validated_entry(
+    envelope: LineageEnvelope, registry: RegistrySource | None
+) -> LaneRegistryEntry:
+    entry = assert_lineage_registry_binding(envelope, registry)
+    assert_entry_execution_ready(entry)
+    if envelope.order_attempt is None:
+        raise LaneGuardError("lane_binding_incomplete", lane_id=entry.lane_id)
+    return entry
+
+
+async def coordinate_mock_order_mutation(
+    *,
+    envelope: LineageEnvelope,
+    persistence: LineagePersistencePort | None,
+    dispatch_evidence: DispatchEvidencePort | None,
+    claims: DurableSendClaimAdapter,
+    connection_factory: LockAuthorityConnectionFactory,
+    mutation: MockMutationCallback,
+    registry: RegistrySource | None = None,
+    lineage_factory: MockLineageFactory | None = None,
+    additional_advisory_keys: Sequence[int] = (),
+) -> CoordinatedMutationResult:
+    """Run one mutation behind the full J3A coordination order.
+
+    The order is load-bearing, not stylistic::
+
+        1. canonical J2A lane/identity/policy validation
+        2. require BOTH lane-supplied durable write ports
+        3. persist the immutable envelope — and abort here if the caller was
+           cancelled, rather than proceeding to a lease, a claim, and a send
+        4. acquire the authoritative physical-account lease
+        5. check account-wide unresolved reservations
+        6. reserve and COMMIT the binary claim
+        7. re-assert lease ownership and re-run the lane guards
+        8. invoke the injected callback, retained against cancellation
+        9. persist the ACK/uncertainty envelope AND the typed dispatch evidence,
+           both retained against cancellation
+       10. release the lease **only if** step 9 was durable — otherwise keep the
+           writer authority and record an :class:`UnreleasedAuthorityHold`
+
+    Steps 1-3 run before any lock is taken so a rejected plan never contends.
+    Step 6 commits before step 8 so a crash mid-send leaves a durable claim.
+    Step 9 completes before step 10 so the lease is never surrendered while a
+    transport — or the evidence that describes it — is still in flight.  The
+    durable claim is never released here: only
+    :meth:`DurableSendClaimAdapter.release_with_terminal_evidence` may remove it.
+
+    ``additional_advisory_keys`` is how a later broker lane supplies its own
+    extra keys (for example a legacy compatibility key).  J3A never chooses them.
+    """
+
+    entry = _validated_entry(envelope, registry)
+    # Both are proven present by ``_validated_entry`` above.
+    order_attempt = envelope.order_attempt
+    execution_plan = envelope.execution_plan
+    if order_attempt is None or execution_plan is None:  # pragma: no cover
+        raise LaneGuardError("lane_binding_incomplete", lane_id=entry.lane_id)
+
+    scope = physical_account_scope_for_entry(entry)
+    port = _required_persistence(persistence)
+    evidence_port = require_dispatch_evidence_port(dispatch_evidence)
+
+    persist_error, persist_cancellation = await _run_retained(
+        lambda: port.persist(envelope)
+    )
+    if persist_error is not None:
+        raise CoordinationError(
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+            lane_id=entry.lane_id,
+        ) from persist_error
+    if persist_cancellation is not None:
+        # Pre-send cancellation. The mandatory persist finished, and we stop
+        # here: no lease, no reservation, and above all no broker callback.
+        raise persist_cancellation
+
+    lease = await acquire_physical_account_lease(
+        keys=(scope.advisory_key, *additional_advisory_keys),
+        connection_factory=connection_factory,
+    )
+    grant = lease.grant
+    claim: DurableClaim | None = None
+    held: HeldCoordination | None = None
+    try:
+        if await claims.account_has_unresolved_claim(scope):
+            raise CoordinationError(
+                CoordinationReasonCode.DURABLE_CLAIM_CONFLICT, lane_id=entry.lane_id
+            )
+        claim = await claims.reserve(
+            scope=scope,
+            idempotency_key=order_attempt.idempotency_key,
+            symbol=execution_plan.normalized_symbol,
+            side=envelope.decision_intent.side,
+        )
+        await lease.assert_owned(grant)
+        _validated_entry(envelope, registry)
+        # Strong handle first, callback task second: between these two lines
+        # there is no order in flight, and after them nothing can drop the
+        # authority implicitly.
+        held = _register_held_coordination(
+            lease=lease, grant=grant, claim=claim, envelope=envelope
+        )
+        task: asyncio.Task[MutationCallbackResult] = asyncio.ensure_future(mutation())
+    except BaseException:
+        # Nothing is in flight: the callback never started. The durable claim,
+        # if taken, stays put — absence of send is not proven here.
+        if held is None:
+            await _release_lease_quietly(lease, grant)
+        else:
+            await _release_and_unregister_quietly(held)
+        raise
+
+    if claim is None:  # pragma: no cover - the try block either reserves or raises
+        raise CoordinationError(
+            CoordinationReasonCode.DURABLE_CLAIM_CONFLICT, lane_id=entry.lane_id
+        )
+
+    outer_cancellation = await _await_retained_task(task)
+    result, callback_error = _callback_outcome(task)
+
+    factory = lineage_factory if lineage_factory is not None else MockLineageFactory()
+    evidence_envelope = envelope
+    ack_error: BaseException | None = None
+    if (
+        result is not None
+        and result.certainty is MutationCertainty.DEFINITIVE
+        and result.broker_order_id is not None
+    ):
+        try:
+            evidence_envelope = factory.acknowledge_order_attempt(
+                envelope, result.broker_order_id
+            )
+        except Exception as exc:
+            # A malformed or conflicting broker order id is transport
+            # uncertainty, not a reason to escape before recording the unknown.
+            ack_error = exc
+            evidence_envelope = envelope
+
+    kind = _dispatch_evidence_kind(result, callback_error, ack_error)
+    evidence = DispatchEvidence(
+        envelope=evidence_envelope,
+        kind=kind,
+        # A failed callback or an unusable acknowledgement is an *uncertainty*:
+        # the write may already have landed at the broker.
+        certainty=(
+            MutationCertainty.UNCERTAIN
+            if (result is None or ack_error is not None)
+            else result.certainty
+        ),
+        broker_order_id=(
+            result.broker_order_id
+            if (result is not None and ack_error is None)
+            else None
+        ),
+        callback_failed=callback_error is not None,
+        ack_attachment_failed=ack_error is not None,
+        outer_cancellation_requested=outer_cancellation is not None,
+        decision_intent_id=envelope.decision_intent.decision_intent_id,
+        execution_plan_id=execution_plan.execution_plan_id,
+        order_attempt_id=order_attempt.order_attempt_id,
+        cycle_id=order_attempt.cycle_id,
+        attempt_seq=envelope.attempt_seq,
+        claim_account_scope=claim.claim_account_scope,
+        claim_row_id=claim.row_id,
+        idempotency_key=claim.idempotency_key,
+    )
+
+    envelope_error, envelope_cancellation = await _run_retained(
+        lambda: port.persist(evidence_envelope)
+    )
+    evidence_error, evidence_cancellation = await _run_retained(
+        lambda: evidence_port.persist_dispatch_evidence(evidence)
+    )
+    outer_cancellation = (
+        outer_cancellation or envelope_cancellation or evidence_cancellation
+    )
+    durable_write_error = envelope_error or evidence_error
+
+    if durable_write_error is not None:
+        # The AND gate did not close: nobody knows whether an order went out, so
+        # the writer authority is deliberately kept, the strong handle stays in
+        # the map, no key is unlocked, and the connection is not returned. The
+        # reservation stays unresolved and no successor may safely mutate this
+        # physical account. A lane may later finish the durable write with this
+        # exact handle and grant; J3A schedules nothing.
+        # One stuck authority, one opaque id: the coordination handle and the
+        # authority hold share it so an operator follows a single thread.
+        lease.retain_authority(
+            reason_code=CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+            durable_evidence_written=False,
+            hold_id=held.hold_id if held is not None else None,
+        )
+        raise CoordinationError(
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+            lane_id=entry.lane_id,
+            hold_id=held.hold_id if held is not None else None,
+        ) from durable_write_error
+
+    # Both durable receipts are in, so the ephemeral lease may be surrendered
+    # and the strong handle dropped. The durable claim stays regardless.
+    if held is None:  # pragma: no cover - registered before the callback task
+        await lease.release(grant)
+    else:
+        await _release_and_unregister(held)
+
+    if ack_error is not None:
+        raise ack_error
+    if callback_error is not None:
+        raise callback_error
+    if outer_cancellation is not None:
+        raise outer_cancellation
+    if result is None:  # pragma: no cover - no error implies a result
+        raise CoordinationError(
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+            lane_id=entry.lane_id,
+        )
+    return CoordinatedMutationResult(
+        envelope=evidence_envelope,
+        scope=scope,
+        claim=claim,
+        certainty=result.certainty,
+        evidence=evidence,
+        lease_grant=grant,
+    )
+
+
+async def _release_lease_quietly(
+    lease: PostgresAdvisoryKeysetLease, grant: AdvisoryLeaseGrant
+) -> None:
+    """Release on an already-failing path without masking the original error.
+
+    A lease that cannot be proven released here has already either terminated
+    its backend or recorded an :class:`UnreleasedAuthorityHold`, so the lock is
+    never silently abandoned.
+    """
+
+    try:
+        await lease.release(grant)
+    except CoordinationError:
+        pass
+
+
+__all__ = [
+    "AUTOMATIC_CLAIM_RELEASE_AVAILABLE",
+    "CLAIM_FOLLOWUP_OPERATIONS",
+    "COORDINATION_REASON_CODES",
+    "FENCING_NOT_BROKER_ENFORCED",
+    "LANE_FENCING_MATRIX",
+    "LEASE_TTL_SECONDS",
+    "NOT_BROKER_ENFORCED_FENCING_STATEMENT",
+    "AdvisoryLeaseGrant",
+    "AdvisoryLockRow",
+    "BackendSessionTerminationUnproven",
+    "BackendTerminationReceipt",
+    "ClaimFollowupCapability",
+    "ClaimFollowupRequest",
+    "CoordinatedMutationResult",
+    "CoordinationError",
+    "CoordinationReasonCode",
+    "DispatchEvidence",
+    "DispatchEvidenceKind",
+    "DispatchEvidencePort",
+    "DurableClaim",
+    "DurableSendClaimAdapter",
+    "HeldCoordination",
+    "LockAuthorityConnection",
+    "MockMutationCallback",
+    "MutationCallbackResult",
+    "MutationCertainty",
+    "OrderSendIntentReservationPort",
+    "PhysicalAccountScope",
+    "PostgresAdvisoryKeysetLease",
+    "SqlAlchemyLockAuthority",
+    "TerminalClaimEvidence",
+    "UnreleasedAuthorityHold",
+    "acquire_physical_account_lease",
+    "coordinate_mock_order_mutation",
+    "describe_claim_followup",
+    "held_coordination",
+    "held_coordinations",
+    "ordered_advisory_keyset",
+    "physical_account_scope_for_entry",
+    "require_dispatch_evidence_port",
+    "row_proves_ownership",
+    "split_advisory_key",
+    "supports_backend_session_termination",
+    "authority_hold_history",
+    "retained_authority_connections",
+    "unreleased_authority_holds",
+]

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -23,9 +23,13 @@ Three distinctions this module refuses to blur:
   requires a real ``terminate_backend_session`` that raises unless severance is
   positively demonstrated, and an authority without one is rejected before any
   lock is taken.
-* **A lease release is not a claim release.**  The lease is ephemeral process
-  coordination; the durable claim is the account block.  Only
-  :meth:`DurableSendClaimAdapter.release_with_terminal_evidence` removes a claim.
+* **A lease release is not a claim release.**  They have distinct lifetimes: the
+  lease is ephemeral process coordination over a broker-mutation critical
+  section, while the claim is durable proof that one exact send lineage was
+  attempted.  Once both post-send writes have committed, the lease may be
+  released while the claim remains.  Only
+  :meth:`DurableSendClaimAdapter.release_with_terminal_evidence` removes a claim,
+  and backend termination is never evidence for it.
 * **Cleanup is not permitted while the outcome is unknown.**  If the durable
   evidence of what happened to a dispatch cannot be written, this process keeps
   the writer authority and records an auditable
@@ -364,9 +368,19 @@ class SqlAlchemyLockAuthority:
                 raise BackendSessionTerminationUnproven(
                     "the backend is still present in pg_stat_activity"
                 )
-            # Absence is proven *here*. The receipt is built before any cleanup
-            # so that a cancellation during a close cannot erase a proof we
-            # already hold and manufacture a false active hold.
+            # Absence is proven *here*, and the receipt is built here — before
+            # either close — so the proof never depends on cleanup succeeding.
+            #
+            # Be precise about what carries that guarantee today: it is
+            # ``_close_quietly`` being total, not this ordering. It swallows
+            # BaseException around its only await, so a cancellation during a
+            # close cannot propagate and could not erase a receipt built after
+            # it either. Building first is therefore defence in depth — it keeps
+            # the proof correct if cleanup ever stops being total — and it reads
+            # in causal order. A mutant that moves this construction after both
+            # closes is provably indistinguishable on the current shape; the
+            # load-bearing property is the one below it, that no receipt exists
+            # until absence has been proven.
             receipt = BackendTerminationReceipt(
                 backend_pid=expected_pid, owner_token=owner_token, terminated=True
             )
@@ -1614,6 +1628,48 @@ async def _rollback_partial_acquisition(
 
 
 @runtime_checkable
+class AccountUncertaintyGatePort(Protocol):
+    """Whether any prior mutation outcome on this physical account is unresolved.
+
+    This is a *different question* from "has this exact send been made before",
+    and conflating the two is the defect this port exists to remove. A durable
+    binary claim answers only the second: it is keyed to one immutable send
+    lineage and prevents replay of that logical send. It is not an
+    account-lifecycle mutex, and its mere existence says nothing about whether an
+    earlier order's outcome is known.
+
+    An account-wide block is warranted only while a prior outcome remains
+    *uncorrelated or uncertain* — including the absence of a durably attributed
+    native broker order id and immutable ACK. A durably ACK-correlated open order
+    is a tracked position, not an unknown, and it does not by itself stop an
+    unrelated execution plan.
+
+    J3A does not implement this. Read-only and broker-neutral by construction:
+    the aggregation of lane-native evidence into a physical-account answer
+    belongs to the lane that owns that evidence. Nothing here reads back from a
+    broker, retries, queues, or keeps state.
+    """
+
+    async def has_unresolved_account_uncertainty(
+        self, *, claim_account_scope: str
+    ) -> bool: ...
+
+
+def require_account_uncertainty_gate(
+    gate: AccountUncertaintyGatePort | None, /
+) -> AccountUncertaintyGatePort:
+    """Fail closed when a lane has not supplied its uncertainty authority.
+
+    Checked before the lease is taken: a coordinator that cannot ask whether the
+    account is settled must not acquire authority, reserve, or send.
+    """
+
+    if gate is None or not isinstance(gate, AccountUncertaintyGatePort):
+        raise CoordinationError(CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE)
+    return gate
+
+
+@runtime_checkable
 class OrderSendIntentReservationPort(Protocol):
     """The exact binary-reservation surface J3A consumes.
 
@@ -1621,8 +1677,6 @@ class OrderSendIntentReservationPort(Protocol):
     of this port, so no coordination path can reach it; only the evidence-gated
     ``release_if_matches`` below may remove a claim.
     """
-
-    async def has_reservations(self, *, account_scope: str) -> bool: ...
 
     async def reserve(
         self,
@@ -1651,8 +1705,11 @@ class DurableClaim:
     """One binary reservation row observed before external I/O.
 
     This is a claim, not a lifecycle record: there is no state, no hold field,
-    no retry counter, and no broker order id.  Its mere existence is the
-    account-wide block.
+    no retry counter, and no broker order id.  It is keyed to the exact immutable
+    send lineage and prevents replay of *that* logical send — nothing more.  Its
+    existence says nothing about whether some earlier order's outcome is known,
+    so it is not an account-wide block; that question belongs to
+    :class:`AccountUncertaintyGatePort`.
     """
 
     row_id: int
@@ -1682,8 +1739,8 @@ class TerminalClaimEvidence:
         """Every field is a real ``bool``, not merely something truthy.
 
         The string ``"false"`` is truthy. So is ``"0"``. Accepting either here
-        would let a mistyped field authorize the deletion of the durable claim
-        that is the entire account block.
+        would let a mistyped field authorize the deletion of the durable proof
+        that this exact send lineage was attempted.
         """
 
         return all(
@@ -1731,15 +1788,6 @@ class DurableSendClaimAdapter:
 
     def __init__(self, intents: OrderSendIntentReservationPort) -> None:
         self._intents = intents
-
-    async def account_has_unresolved_claim(self, scope: PhysicalAccountScope) -> bool:
-        """Any unresolved reservation blocks every new order on the account."""
-
-        return bool(
-            await self._intents.has_reservations(
-                account_scope=scope.claim_account_scope
-            )
-        )
 
     async def reserve(
         self,
@@ -1966,8 +2014,8 @@ class DispatchEvidence:
     later reconciler can tie the unknown back to its exact intent, plan, and
     attempt without reading this process's memory.  There is no free-form broker
     state and no reason code here — native lifecycle detail belongs to the lane's
-    own service, and the durable claim referenced here remains the account block
-    until evidence-gated release.
+    own service, and the durable claim referenced here remains recorded against
+    that exact lineage until evidence-gated release.
     """
 
     envelope: LineageEnvelope
@@ -2313,11 +2361,51 @@ def _validated_entry(
     return entry
 
 
+async def _account_uncertainty(
+    gate: AccountUncertaintyGatePort, scope: PhysicalAccountScope
+) -> tuple[bool, BaseException | None, asyncio.CancelledError | None]:
+    """Ask the authority, and accept only an exact ``bool``.
+
+    A truthy string, a stray integer, or ``None`` are not answers to "is this
+    account settled"; treating them as one would decide a broker-safety question
+    by accident. Anything other than ``True``/``False`` — and any raised
+    exception — fails closed as unavailability, before any reservation or send.
+
+    The call is retained the same way the durable writes are, so a cancellation
+    arriving mid-question cannot leave the question half-asked.
+    """
+
+    answered: list[object] = []
+
+    async def ask() -> None:
+        answered.append(
+            await gate.has_unresolved_account_uncertainty(
+                claim_account_scope=scope.claim_account_scope
+            )
+        )
+
+    error, cancellation = await _run_retained(ask)
+    if error is not None or cancellation is not None:
+        return False, error, cancellation
+    answer = answered[0] if answered else None
+    if answer is not True and answer is not False:
+        return (
+            False,
+            TypeError(
+                "account uncertainty gate returned "
+                f"{type(answer).__name__}, expected exactly bool"
+            ),
+            None,
+        )
+    return answer, None, None
+
+
 async def coordinate_mock_order_mutation(
     *,
     envelope: LineageEnvelope,
     persistence: LineagePersistencePort | None,
     dispatch_evidence: DispatchEvidencePort | None,
+    uncertainty_gate: AccountUncertaintyGatePort | None,
     claims: DurableSendClaimAdapter,
     connection_factory: LockAuthorityConnectionFactory,
     mutation: MockMutationCallback,
@@ -2334,7 +2422,8 @@ async def coordinate_mock_order_mutation(
         3. persist the immutable envelope — and abort here if the caller was
            cancelled, rather than proceeding to a lease, a claim, and a send
         4. acquire the authoritative physical-account lease
-        5. check account-wide unresolved reservations
+        5. ask the injected authority whether a prior outcome is still
+           uncorrelated or uncertain — never inferred from the binary claim
         6. reserve and COMMIT the binary claim
         7. re-assert lease ownership and re-run the lane guards
         8. invoke the injected callback, retained against cancellation
@@ -2364,6 +2453,7 @@ async def coordinate_mock_order_mutation(
     scope = physical_account_scope_for_entry(entry)
     port = _required_persistence(persistence)
     evidence_port = require_dispatch_evidence_port(dispatch_evidence)
+    gate = require_account_uncertainty_gate(uncertainty_gate)
 
     persist_error, persist_cancellation = await _run_retained(
         lambda: port.persist(envelope)
@@ -2386,7 +2476,22 @@ async def coordinate_mock_order_mutation(
     claim: DurableClaim | None = None
     held: _HeldCoordination | None = None
     try:
-        if await claims.account_has_unresolved_claim(scope):
+        # Asked *after* the lease is held and *before* the claim is reserved:
+        # any earlier vantage point would be a check whose answer could change
+        # before it is used.
+        unresolved, gate_error, gate_cancellation = await _account_uncertainty(
+            gate, scope
+        )
+        if gate_error is not None:
+            raise CoordinationError(
+                CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+                lane_id=entry.lane_id,
+            ) from gate_error
+        if gate_cancellation is not None:
+            raise gate_cancellation
+        if unresolved:
+            # An unknown prior outcome blocks the whole account, including
+            # unrelated plans. A *known* open order does not reach here.
             raise CoordinationError(
                 CoordinationReasonCode.DURABLE_CLAIM_CONFLICT, lane_id=entry.lane_id
             )
@@ -2629,6 +2734,7 @@ __all__ = [
     "LANE_FENCING_MATRIX",
     "LEASE_TTL_SECONDS",
     "NOT_BROKER_ENFORCED_FENCING_STATEMENT",
+    "AccountUncertaintyGatePort",
     "AdvisoryLockRow",
     "BackendSessionTerminationUnproven",
     "BackendTerminationReceipt",
@@ -2659,6 +2765,7 @@ __all__ = [
     "held_coordinations",
     "ordered_advisory_keyset",
     "physical_account_scope_for_entry",
+    "require_account_uncertainty_gate",
     "require_dispatch_evidence_port",
     "row_proves_ownership",
     "split_advisory_key",

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -461,6 +461,11 @@ class _RetainedAuthority:
     connection: LockAuthorityConnection
     grant: AdvisoryLeaseGrant
     owner: object
+    # The exact ``UnreleasedAuthorityHold`` object recorded with this entry.
+    # Suppressing the safe fallback on "some object exists under this id" would
+    # accept a stale, equal-but-nonidentical, or impostor row and leave the real
+    # authority unrooted, so the correspondence is held by identity, not by id.
+    raw_hold: UnreleasedAuthorityHold
 
 
 # History is immutable evidence: every hold ever recorded, resolved or not.
@@ -651,7 +656,11 @@ def _authority_already_retained(
         entry.owner is owner
         and entry.grant is grant
         and entry.connection is connection
-        and _ACTIVE_AUTHORITY_HOLDS.get(hold_id) is not None
+        and entry.hold_id == hold_id
+        # The corresponding active row must be the *exact* record this entry was
+        # written with. Presence, equality, or a matching id string would all
+        # accept an impostor and suppress the fallback that roots the authority.
+        and _ACTIVE_AUTHORITY_HOLDS.get(hold_id) is entry.raw_hold
         for hold_id, entry in _RETAINED_AUTHORITIES.items()
     )
 
@@ -893,11 +902,18 @@ def _record_unreleased_authority(
     reason_code: CoordinationReasonCode,
     termination_proven: bool,
     durable_evidence_written: bool,
-    connection: LockAuthorityConnection | None = None,
+    connection: LockAuthorityConnection,
     hold_id: str | None = None,
     capability: object | None = None,
 ) -> UnreleasedAuthorityHold:
-    """Record a hold, never overwriting one that belongs to somebody else."""
+    """Record a hold, never overwriting one that belongs to somebody else.
+
+    ``connection`` is required. A hold without the real connection is metadata
+    claiming an authority nobody is holding: it would append history and create
+    an active row while writing no retained root, so a GC pass or a pool return
+    could drop the session the row says is still live. Every production caller
+    already has the connection, so there is nothing to shorten.
+    """
 
     if hold_id is None:
         hold_id = _allocate_hold_id()
@@ -934,7 +950,7 @@ def _record_unreleased_authority(
             #     not that handle's authority record, and an id is not a right.
             and held.lease is owner
             and held.grant is grant
-            and (connection is None or connection is held.lease._connection)
+            and connection is held.lease._connection
             and capability is not None
             and _COORDINATION_RELEASE_CAPABILITIES.get(hold_id) is capability
             # (4) the first authority transition for that id, ever.
@@ -957,10 +973,13 @@ def _record_unreleased_authority(
     )
     _AUTHORITY_HOLD_HISTORY.append(hold)
     _ACTIVE_AUTHORITY_HOLDS[hold.hold_id] = hold
-    if connection is not None:
-        _RETAINED_AUTHORITIES[hold.hold_id] = _RetainedAuthority(
-            hold_id=hold.hold_id, connection=connection, grant=grant, owner=owner
-        )
+    _RETAINED_AUTHORITIES[hold.hold_id] = _RetainedAuthority(
+        hold_id=hold.hold_id,
+        connection=connection,
+        grant=grant,
+        owner=owner,
+        raw_hold=hold,
+    )
     return hold
 
 

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -146,15 +146,15 @@ class BackendSessionTerminationUnproven(RuntimeError):
 
 
 # --------------------------------------------------------------------------
-# Not-broker-enforced fencing (statement 2 of 3 lives on the lease class)
+# This is NOT broker-enforced fencing (statement 2 of 3 lives on the lease class)
 # --------------------------------------------------------------------------
 
 FENCING_NOT_BROKER_ENFORCED: Final[str] = "not_broker_enforced"
 
 NOT_BROKER_ENFORCED_FENCING_STATEMENT: Final[str] = (
-    "The J3A physical-account lease is process coordination only. It is NOT "
-    "broker-enforced fencing: no lane broker rejects a request because another "
-    "process holds this lease."
+    "The J3A physical-account lease is process coordination only. It is "
+    "NOT broker-enforced fencing: no lane broker rejects a request because "
+    "another process holds this lease."
 )
 
 # One row per canonical J2A lane. There is intentionally no per-lane exception:

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -472,6 +472,11 @@ _RETAINED_AUTHORITIES: dict[str, _RetainedAuthority] = {}
 
 _HOLD_ID_ALLOCATION_ATTEMPTS: Final[int] = 8
 _QUARANTINE_SEQUENCE = 0
+# Every opaque id ever issued, resolved ones included. The active maps forget a
+# resolved hold but history does not, so re-issuing its id would let an old
+# immutable record project a *later* owner's reachability, and would make a
+# stale id name an unrelated coordination.
+_ISSUED_HOLD_IDS: set[str] = set()
 
 
 def _hold_view(hold: UnreleasedAuthorityHold) -> UnreleasedAuthorityHold:
@@ -483,6 +488,12 @@ def _hold_view(hold: UnreleasedAuthorityHold) -> UnreleasedAuthorityHold:
     process — and there is deliberately no recovery API to add one.
     """
 
+    # Cross-generation aliasing is prevented at the source, in
+    # :func:`_allocate_hold_id`, which never reissues an id. An identity check
+    # here was tried and removed: ``lease.unreleased_authority_hold`` already
+    # returns a *view*, so comparing object identity made this function answer
+    # differently for the same hold depending on whether it was re-viewed. One
+    # load-bearing guard beats two that disagree.
     retained = _RETAINED_AUTHORITIES.get(hold.hold_id)
     owner = retained.owner if retained is not None else None
     # The two reasons a release is refused are a permanent coordination seal
@@ -574,7 +585,8 @@ def _unregister_owned_coordination(owner: object) -> None:
 
 def _hold_id_in_use(hold_id: str) -> bool:
     return (
-        hold_id in _ACTIVE_AUTHORITY_HOLDS
+        hold_id in _ISSUED_HOLD_IDS
+        or hold_id in _ACTIVE_AUTHORITY_HOLDS
         or hold_id in _RETAINED_AUTHORITIES
         or hold_id in _HELD_COORDINATION
         or hold_id in _COORDINATION_RELEASE_CAPABILITIES
@@ -592,6 +604,7 @@ def _allocate_hold_id() -> str:
     for _ in range(_HOLD_ID_ALLOCATION_ATTEMPTS):
         candidate = f"hold:{secrets.token_hex(8)}"
         if not _hold_id_in_use(candidate):
+            _ISSUED_HOLD_IDS.add(candidate)
             return candidate
     # Exhaustion must never leave a newly unsafe authority unreachable, so fall
     # back to a quarantine id derived from a monotonic counter rather than
@@ -603,6 +616,7 @@ def _allocate_hold_id() -> str:
         _QUARANTINE_SEQUENCE += 1
         candidate = f"hold:quarantine:{_QUARANTINE_SEQUENCE:012d}"
         if not _hold_id_in_use(candidate):
+            _ISSUED_HOLD_IDS.add(candidate)
             return candidate
 
 
@@ -1329,13 +1343,15 @@ async def acquire_physical_account_lease(
         # it must not abandon a connection that may still hold a key. The
         # original failure is re-raised only after the rollback reached a safe
         # outcome — confirmed unlock, positive termination, or strong retention.
-        rollback: asyncio.Task[None] = asyncio.ensure_future(
+        rollback: asyncio.Task[BaseException | None] = asyncio.ensure_future(
             _rollback_partial_acquisition(
                 connection, acquired, grant, in_flight=tuple(in_flight)
             )
         )
         rollback_cancellation = await _await_retained_task(rollback)
-        if _task_error(rollback) is not None:
+        rollback_error = _task_error(rollback)
+        rollback_interruption = rollback.result() if rollback_error is None else None
+        if rollback_error is not None:
             # The rollback itself failed, so nothing proved this connection is
             # safe and nothing may have retained it. Retain it here rather than
             # letting it fall out of scope with a key possibly still held.
@@ -1351,6 +1367,11 @@ async def acquire_physical_account_lease(
             # A cancellation that arrived while the rollback was still running is
             # re-delivered now that a safe outcome exists — never before it.
             raise rollback_cancellation
+        if rollback_interruption is not None:
+            # Same rule for a cancellation that landed *inside* the rollback: the
+            # authority is already terminated or strongly retained, so the caller
+            # now gets the exception it actually raised.
+            raise rollback_interruption
         raise
 
     return PostgresAdvisoryKeysetLease(connection=connection, grant=grant)
@@ -1426,7 +1447,7 @@ async def _rollback_partial_acquisition(
     grant: AdvisoryLeaseGrant,
     *,
     in_flight: Sequence[int] = (),
-) -> None:
+) -> BaseException | None:
     """Unlock every already-acquired key in reverse order, proving each one.
 
     If any unlock cannot be proven, the session is terminated rather than
@@ -1442,7 +1463,7 @@ async def _rollback_partial_acquisition(
 
     if in_flight:
         if await _terminate_authority(connection, grant) is not None:
-            return
+            return None
         _record_unreleased_authority(
             grant,
             owner=connection,
@@ -1451,21 +1472,26 @@ async def _rollback_partial_acquisition(
             durable_evidence_written=True,
             connection=connection,
         )
-        return
+        return None
 
     proven = True
+    interruption: BaseException | None = None
     try:
         for key in reversed(tuple(acquired)):
             if not await _unlock_proven(connection, key):
                 proven = False
                 break
-    except BaseException:
+    except BaseException as exc:
         # Including a cancellation: an interrupted unlock proves nothing, so the
-        # remainder is unknown rather than absent.
+        # remainder is unknown rather than absent. The interruption is carried
+        # back so the caller can re-deliver it *after* the safe outcome below.
+        # Swallowing it reports the earlier acquisition failure to someone who
+        # actually asked to be cancelled.
+        interruption = exc
         proven = False
     if proven:
         await _close_quietly(connection)
-        return
+        return interruption
     if await _terminate_authority(connection, grant) is None:
         # Metadata alone would let a GC pass or a pool return drop the very
         # authority it claims is still held, so the real connection is retained.
@@ -1477,6 +1503,7 @@ async def _rollback_partial_acquisition(
             durable_evidence_written=True,
             connection=connection,
         )
+    return interruption
 
 
 # --------------------------------------------------------------------------
@@ -2065,6 +2092,11 @@ async def _await_retained_task(
         try:
             await asyncio.shield(task)
         except asyncio.CancelledError as exc:
+            if task.cancelled():
+                # The *inner* task ended cancelled and shield is relaying that.
+                # Nobody cancelled this coordinator, so recording an outer
+                # cancellation here would put a false fact in durable evidence.
+                break
             outer_cancellation = outer_cancellation or exc
             if task.done():
                 break
@@ -2299,7 +2331,15 @@ async def coordinate_mock_order_mutation(
         await lease.assert_owned(grant)
         _require_pinned_entry(envelope, registry, entry)
 
-    task: asyncio.Task[MutationCallbackResult] | None = None
+    async def _drive_callback(awaited: Awaitable[Any]) -> Any:
+        # The public contract accepts any ``Awaitable``. ``ensure_future`` would
+        # hand back a caller-supplied Future unchanged, and then every later
+        # ``.done()`` / ``.exception()`` / ``.result()`` would be caller code
+        # running after a possible send. Awaiting it inside a module-owned
+        # coroutine makes the retained task ours, so outcome access is ours too.
+        return await awaited
+
+    task: asyncio.Task[Any] | None = None
     invocation_error: BaseException | None = None
     try:
         started = mutation(CoordinationScope(_assert_scope_owned))
@@ -2308,18 +2348,26 @@ async def coordinate_mock_order_mutation(
                 "mock mutation callback did not return an awaitable; the send "
                 "may already have happened synchronously"
             )
-        task = asyncio.ensure_future(started)
+        task = asyncio.ensure_future(_drive_callback(started))
     except BaseException as exc:
         invocation_error = exc
 
-    if task is None:
-        outer_cancellation = None
-        result, callback_error = None, invocation_error
-    else:
-        outer_cancellation = await _await_retained_task(task)
-        result, callback_error = _callback_outcome(task)
-    # The coordinated section is over: a captured scope must stop working.
-    gate.active = False
+    try:
+        if task is None:
+            outer_cancellation = None
+            result, callback_error = None, invocation_error
+        else:
+            try:
+                outer_cancellation = await _await_retained_task(task)
+                result, callback_error = _callback_outcome(task)
+            except BaseException as exc:
+                # Reading the outcome happens after a possible send, so a failure
+                # there is uncertainty, not an escape.
+                outer_cancellation, result, callback_error = None, None, exc
+    finally:
+        # In a ``finally`` so no path — including an outcome-access failure —
+        # leaves a live scope behind for a captured reference to keep using.
+        gate.active = False
     if callback_error is None:
         try:
             result, callback_error = _validated_callback_result(result)

--- a/app/services/mock_integration/coordination.py
+++ b/app/services/mock_integration/coordination.py
@@ -48,7 +48,7 @@ import asyncio
 import hashlib
 import secrets
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from decimal import Decimal
 from enum import StrEnum
 from types import MappingProxyType
@@ -413,23 +413,27 @@ def supports_backend_session_termination(connection: object) -> bool:
 
 @dataclass(frozen=True, slots=True)
 class UnreleasedAuthorityHold:
-    """An advisory lease this process could **not** prove it released.
+    """A **capability-free** record of an authority that is not proven released.
 
-    Its existence is the audit trail: the physical-account writer authority is
-    still held (or may be), so no successor may safely mutate that account.  It
-    is reachable through :func:`unreleased_authority_holds` and through the
-    owning lease — never left to a garbage collector or a pooled ``close()``
-    side effect to resolve, and never expired by a clock.
+    Deliberately carries no live connection, no grant, no backend PID, no owner
+    token, and nothing callable.  Seeing that an account is stuck is a different
+    right from being able to unstick it, and only the second one is dangerous:
+    a PID plus an owner token is enough to terminate the very backend whose lock
+    is the safety property.  The real connection lives in the module-private
+    ownership map below, reachable only by the coordination-owned release path.
     """
 
     hold_id: str
-    keys: tuple[int, ...]
-    backend_pid: int
-    database_oid: int
-    connection_token: str
+    key_count: int
     reason_code: CoordinationReasonCode
     termination_proven: bool
     durable_evidence_written: bool
+    # Whether a retry is *actually reachable*, recomputed on every read — not a
+    # guess from the owner's type. A rollback hold has no owning lease, and a
+    # coordination-sealed lease is never unsealed after a failed release, so both
+    # are permanent until the process dies. Claiming otherwise would be the same
+    # kind of false report B30 forbade in the other direction.
+    recoverable_in_process: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -441,13 +445,15 @@ class _RetainedAuthority:
     keeps the real dedicated connection, together with the exact grant identity,
     reachable for as long as the hold stands.
 
-    It is a lifetime guard only: no TTL, no janitor, no retry, no takeover, no
-    scheduler, and no reason code of its own.
+    Module-private on purpose: this is the capability, and it is never returned
+    from a public function.  It is a lifetime guard only — no TTL, no janitor,
+    no retry, no takeover, no scheduler, no reason code of its own.
     """
 
     hold_id: str
     connection: LockAuthorityConnection
     grant: AdvisoryLeaseGrant
+    owner: object
 
 
 # History is immutable evidence: every hold ever recorded, resolved or not.
@@ -456,6 +462,29 @@ class _RetainedAuthority:
 _AUTHORITY_HOLD_HISTORY: list[UnreleasedAuthorityHold] = []
 _ACTIVE_AUTHORITY_HOLDS: dict[str, UnreleasedAuthorityHold] = {}
 _RETAINED_AUTHORITIES: dict[str, _RetainedAuthority] = {}
+
+_HOLD_ID_ALLOCATION_ATTEMPTS: Final[int] = 8
+
+
+def _hold_view(hold: UnreleasedAuthorityHold) -> UnreleasedAuthorityHold:
+    """Recompute the reachability flag against the world as it is now.
+
+    A retry is reachable only through an owning lease that is still releasable.
+    A rollback hold has no lease at all, and a coordination-sealed lease stays
+    sealed forever once its release failed, so neither can be retried in this
+    process — and there is deliberately no recovery API to add one.
+    """
+
+    retained = _RETAINED_AUTHORITIES.get(hold.hold_id)
+    owner = retained.owner if retained is not None else None
+    recoverable = (
+        isinstance(owner, PostgresAdvisoryKeysetLease)
+        and not owner.coordination_sealed
+        and not owner.released
+    )
+    if recoverable == hold.recoverable_in_process:
+        return hold
+    return replace(hold, recoverable_in_process=recoverable)
 
 
 def authority_hold_history() -> tuple[UnreleasedAuthorityHold, ...]:
@@ -467,28 +496,109 @@ def authority_hold_history() -> tuple[UnreleasedAuthorityHold, ...]:
 def unreleased_authority_holds() -> tuple[UnreleasedAuthorityHold, ...]:
     """The authorities that are unresolved **right now**, in recording order."""
 
-    return tuple(_ACTIVE_AUTHORITY_HOLDS.values())
+    return tuple(_hold_view(hold) for hold in _ACTIVE_AUTHORITY_HOLDS.values())
 
 
-def retained_authority_connections() -> Mapping[str, _RetainedAuthority]:
-    """The still-reachable connections behind every *active* unproven hold."""
+def _retained_authorities() -> Mapping[str, _RetainedAuthority]:
+    """Module-private: the live connections behind every active hold."""
 
     return MappingProxyType(dict(_RETAINED_AUTHORITIES))
 
 
-def _resolve_authority_hold(hold: UnreleasedAuthorityHold | None) -> None:
-    """Drop exactly this hold's active entries, both of them, in one step.
+def _authority_lockout(
+    connection: LockAuthorityConnection, *, owner: object | None = None
+) -> str | None:
+    """The hold id making this *authority* unreleasable, regardless of wrapper.
+
+    Non-releasability belongs to the authority, not to whichever
+    :class:`PostgresAdvisoryKeysetLease` object happens to wrap it. Otherwise a
+    fresh wrapper around the same connection and grant would carry a blank
+    ``_hold`` straight past the durable-evidence gate.
+    """
+
+    for hold_id, retained in _RETAINED_AUTHORITIES.items():
+        if retained.connection is not connection:
+            continue
+        hold = _ACTIVE_AUTHORITY_HOLDS.get(hold_id)
+        if hold is not None and not hold.durable_evidence_written:
+            # Sticky: nobody may release this, the owning lease included. This
+            # clause and the coordination seal are **not** substitutes — the seal
+            # stops the public path, and this stops every path, owner or not.
+            return hold_id
+        if retained.owner is not owner:
+            # Whatever the evidence flag says, a foreign wrapper never releases
+            # somebody else's retained authority.
+            return hold_id
+    for hold_id, held in _HELD_COORDINATION.items():
+        if held.lease.owns_connection(connection) and held.lease is not owner:
+            return hold_id
+    return None
+
+
+def _unregister_owned_coordination(owner: object) -> None:
+    """Drop the held-coordination entry owned by this lease, if any.
+
+    Reached from every proven-release path, including the ones that go on to
+    re-raise: an authority that is provably released must never keep being
+    reported as held just because the triggering call failed afterwards.
+    """
+
+    for hold_id, held in list(_HELD_COORDINATION.items()):
+        if held.lease is owner:
+            _COORDINATION_RELEASE_CAPABILITIES.pop(hold_id, None)
+            del _HELD_COORDINATION[hold_id]
+
+
+def _hold_id_in_use(hold_id: str) -> bool:
+    return (
+        hold_id in _ACTIVE_AUTHORITY_HOLDS
+        or hold_id in _RETAINED_AUTHORITIES
+        or hold_id in _HELD_COORDINATION
+        or hold_id in _COORDINATION_RELEASE_CAPABILITIES
+    )
+
+
+def _allocate_hold_id() -> str:
+    """Allocate an id unused across **every** active map, or fail closed.
+
+    One namespace, one owner. Overwriting a colliding id would let a later hold
+    silently adopt an earlier one's entry — and then delete it during its own
+    recovery, taking a foreign authority with it.
+    """
+
+    for _ in range(_HOLD_ID_ALLOCATION_ATTEMPTS):
+        candidate = f"hold:{secrets.token_hex(8)}"
+        if not _hold_id_in_use(candidate):
+            return candidate
+    raise CoordinationError(CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE)
+
+
+def _resolve_authority_hold(
+    hold: UnreleasedAuthorityHold | None,
+    *,
+    owner: object,
+    connection: LockAuthorityConnection,
+) -> None:
+    """Compare-and-delete exactly this owner's entries, both of them, in one step.
 
     Only ever called after a proven full unlock or a positive termination
-    receipt.  A foreign or stale hold id matches nothing and therefore clears
-    nothing, and an ambiguous or failed recovery never reaches here at all.
-    History is untouched.
+    receipt.  The stored owner identity must match, so a stale or foreign hold
+    id clears nothing, and one lease's recovery can never delete another's
+    entry.  History is untouched.
     """
 
     if hold is None:
         return
-    _ACTIVE_AUTHORITY_HOLDS.pop(hold.hold_id, None)
-    _RETAINED_AUTHORITIES.pop(hold.hold_id, None)
+    retained = _RETAINED_AUTHORITIES.get(hold.hold_id)
+    if retained is not None and (
+        retained.owner is not owner or retained.connection is not connection
+    ):
+        return
+    if _ACTIVE_AUTHORITY_HOLDS.get(hold.hold_id) is hold:
+        del _ACTIVE_AUTHORITY_HOLDS[hold.hold_id]
+    if retained is not None:
+        _RETAINED_AUTHORITIES.pop(hold.hold_id, None)
+    _unregister_owned_coordination(owner)
 
 
 def split_advisory_key(key: int) -> tuple[int, int]:
@@ -532,6 +642,24 @@ def row_proves_ownership(
         and row.objsubid == _BIGINT_ADVISORY_OBJSUBID
         and row.classid == classid
         and row.objid == objid
+    )
+
+
+def _rows_hold_any_key(
+    rows: Sequence[AdvisoryLockRow],
+    *,
+    keys: Sequence[int],
+    backend_pid: int,
+    database_oid: int,
+) -> bool:
+    """True if this backend already holds *any* of these keys."""
+
+    return any(
+        row_proves_ownership(
+            row, key=key, backend_pid=backend_pid, database_oid=database_oid
+        )
+        for key in keys
+        for row in rows
     )
 
 
@@ -656,7 +784,9 @@ async def _terminate_authority(
         receipt = await connection.terminate_backend_session(
             expected_pid=grant.backend_pid, owner_token=grant.connection_token
         )
-    except Exception:
+    except BaseException:
+        # A cancellation here is not "no lock was taken" — it is "the outcome is
+        # unknown", which is the same fail-closed answer as any other failure.
         return None
     if (
         not isinstance(receipt, BackendTerminationReceipt)
@@ -671,27 +801,45 @@ async def _terminate_authority(
 def _record_unreleased_authority(
     grant: AdvisoryLeaseGrant,
     *,
+    owner: object,
     reason_code: CoordinationReasonCode,
     termination_proven: bool,
     durable_evidence_written: bool,
     connection: LockAuthorityConnection | None = None,
     hold_id: str | None = None,
 ) -> UnreleasedAuthorityHold:
+    """Record a hold, never overwriting one that belongs to somebody else."""
+
+    if hold_id is None:
+        hold_id = _allocate_hold_id()
+    else:
+        retained = _RETAINED_AUTHORITIES.get(hold_id)
+        held = _HELD_COORDINATION.get(hold_id)
+        foreign = (
+            (retained is not None and retained.owner is not owner)
+            or (held is not None and held.lease is not owner)
+            or (retained is None and hold_id in _ACTIVE_AUTHORITY_HOLDS)
+        )
+        if foreign:
+            # A supplied id that belongs to another owner is refused outright;
+            # adopting it would let this hold delete that one during recovery.
+            raise CoordinationError(
+                CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE, hold_id=hold_id
+            )
     hold = UnreleasedAuthorityHold(
-        hold_id=hold_id or f"hold:{secrets.token_hex(8)}",
-        keys=grant.keys,
-        backend_pid=grant.backend_pid,
-        database_oid=grant.database_oid,
-        connection_token=grant.connection_token,
+        hold_id=hold_id,
+        key_count=len(grant.keys),
         reason_code=reason_code,
         termination_proven=termination_proven,
         durable_evidence_written=durable_evidence_written,
+        # Recorded conservatively; :func:`_hold_view` recomputes it on read.
+        recoverable_in_process=False,
     )
     _AUTHORITY_HOLD_HISTORY.append(hold)
     _ACTIVE_AUTHORITY_HOLDS[hold.hold_id] = hold
     if connection is not None:
         _RETAINED_AUTHORITIES[hold.hold_id] = _RetainedAuthority(
-            hold_id=hold.hold_id, connection=connection, grant=grant
+            hold_id=hold.hold_id, connection=connection, grant=grant, owner=owner
         )
     return hold
 
@@ -724,8 +872,10 @@ class PostgresAdvisoryKeysetLease:
 
     __slots__ = (
         "_connection",
+        "_coordination_hold_id",
         "_grant",
         "_hold",
+        "_release_capability",
         "_release_task",
         "_released",
         "_termination_receipt",
@@ -745,6 +895,20 @@ class PostgresAdvisoryKeysetLease:
         self._release_task: asyncio.Task[None] | None = None
         self._hold: UnreleasedAuthorityHold | None = None
         self._termination_receipt: BackendTerminationReceipt | None = None
+        # While sealed, only the coordination flow that sealed it may release.
+        self._release_capability: object | None = None
+        self._coordination_hold_id: str | None = None
+        lockout = _authority_lockout(connection)
+        if lockout is not None:
+            # A second wrapper around an authority that is already held would
+            # arrive with a blank _hold and sail past the durable-evidence gate.
+            raise CoordinationError(
+                CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+                hold_id=lockout,
+            )
+
+    def owns_connection(self, connection: LockAuthorityConnection) -> bool:
+        return self._connection is connection
 
     @property
     def grant(self) -> AdvisoryLeaseGrant:
@@ -764,7 +928,7 @@ class PostgresAdvisoryKeysetLease:
     def unreleased_authority_hold(self) -> UnreleasedAuthorityHold | None:
         """Set when this lease could not be proven released."""
 
-        return self._hold
+        return None if self._hold is None else _hold_view(self._hold)
 
     @property
     def termination_receipt(self) -> BackendTerminationReceipt | None:
@@ -810,12 +974,13 @@ class PostgresAdvisoryKeysetLease:
         if not attested:
             raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
 
-    def retain_authority(
+    def _retain_authority(
         self,
         *,
         reason_code: CoordinationReasonCode,
         durable_evidence_written: bool,
         hold_id: str | None = None,
+        capability: object | None = None,
     ) -> UnreleasedAuthorityHold:
         """Deliberately keep the writer authority and record why.
 
@@ -825,8 +990,25 @@ class PostgresAdvisoryKeysetLease:
         resolved by a timer.
         """
 
+        if self._release_capability is not None and (
+            capability is None or capability is not self._release_capability
+        ):
+            # Only the coordination flow that sealed this lease may say anything
+            # about its evidence state.
+            raise CoordinationError(
+                CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+                hold_id=self._coordination_hold_id,
+            )
+        existing = self._hold
+        if existing is not None and not existing.durable_evidence_written:
+            # Sticky and monotonic: a missing durable receipt cannot be talked
+            # away in-process, and there is no signed recovery API to grant one.
+            # Only process termination ends this, and the durable claim outlives
+            # that anyway.
+            return existing
         hold = _record_unreleased_authority(
             self._grant,
+            owner=self,
             reason_code=reason_code,
             termination_proven=False,
             durable_evidence_written=durable_evidence_written,
@@ -836,30 +1018,72 @@ class PostgresAdvisoryKeysetLease:
         self._hold = hold
         return hold
 
+    @property
+    def coordination_sealed(self) -> bool:
+        """True while a coordination flow owns this lease's release rights."""
+
+        return self._release_capability is not None
+
+    def _seal_for_coordination(self, *, hold_id: str, capability: object) -> None:
+        self._release_capability = capability
+        self._coordination_hold_id = hold_id
+
     async def release(self, expected_grant: AdvisoryLeaseGrant) -> None:
-        """Re-attest, then unlock each key in reverse order, proving every one.
+        """The generic, public release. Refused whenever coordination owns this.
 
         A normal release is *attested unlock, then close*.  If ownership cannot
         be re-attested, or PostgreSQL reports ``false`` for any unlock, the lock
         state is unknown — so this ends the backend session instead of quietly
         closing a pooled connection and calling that a release, and if even that
         cannot be proven it records an :class:`UnreleasedAuthorityHold`.
+
+        A lease that a coordination flow has sealed is off limits here for its
+        **entire** active lifetime — while the callback runs, while either
+        durable write is in flight, during a cancellation-retained wait, and
+        while an acknowledgement anomaly is being recorded.  Holding the exact
+        grant from public introspection does not change that: seeing a lease is
+        not owning it, and the window in which a release would be most damaging
+        is precisely the window in which nothing is yet known.
         """
 
         self._require_grant(expected_grant)
-        hold = self._hold
-        if hold is not None and not hold.durable_evidence_written:
-            # The post-send AND gate never closed, so nobody knows whether an
-            # order went out. Surrendering the advisory lock here would let an
-            # old or non-claim-aware writer mutate the account concurrently, and
-            # holding the exact grant does not make that safe. Public
-            # introspection may still *see* this lease; it may not release it.
-            # There is deliberately no recovery API in this epoch: process
-            # termination ends the ephemeral session, while the durable binary
-            # claim survives and keeps blocking a successor's repost.
+        if self._release_capability is not None:
             raise CoordinationError(
                 CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
-                hold_id=hold.hold_id,
+                hold_id=self._coordination_hold_id,
+            )
+        await self._release_guarded(expected_grant)
+
+    async def _release_with_capability(
+        self, expected_grant: AdvisoryLeaseGrant, capability: object
+    ) -> None:
+        """The coordination-owned release; reached only after the AND gate."""
+
+        self._require_grant(expected_grant)
+        if capability is None or capability is not self._release_capability:
+            raise CoordinationError(
+                CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+                hold_id=self._coordination_hold_id,
+            )
+        await self._release_guarded(expected_grant)
+        # Unsealed only once a proven outcome was reached.
+        self._release_capability = None
+
+    async def _release_guarded(self, expected_grant: AdvisoryLeaseGrant) -> None:
+        # The post-send AND gate never closing means nobody knows whether an
+        # order went out. Surrendering the advisory lock then would let an old or
+        # non-claim-aware writer mutate the account concurrently, and holding the
+        # exact grant does not make that safe — so the check lives on the
+        # *authority*, not on this wrapper. Public introspection may still see a
+        # stuck lease; no wrapper of it may release it. There is deliberately no
+        # recovery API in this epoch: process termination ends the ephemeral
+        # session, while the durable binary claim survives and keeps blocking a
+        # successor's repost.
+        lockout = _authority_lockout(self._connection, owner=self)
+        if lockout is not None:
+            raise CoordinationError(
+                CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+                hold_id=lockout,
             )
         if self._released:
             return
@@ -878,6 +1102,14 @@ class PostgresAdvisoryKeysetLease:
             raise cancellation
 
     async def _release_impl(self) -> None:
+        """Attest, reverse-unlock with proof, then prove the rows are gone.
+
+        Every failure mode here — including a ``CancelledError`` arriving inside
+        an attestation, an unlock, or a termination — means the authority's fate
+        is *unknown*, never that it was released. Partial unlock progress is kept
+        so the remaining authority is described honestly.
+        """
+
         try:
             attested = await _attest_full_ownership(
                 self._connection,
@@ -885,8 +1117,10 @@ class PostgresAdvisoryKeysetLease:
                 backend_pid=self._grant.backend_pid,
                 database_oid=self._grant.database_oid,
             )
-        except Exception as exc:
+        except BaseException as exc:
             await self._terminate_or_hold(CoordinationReasonCode.LEASE_LOST)
+            if isinstance(exc, CoordinationError):
+                raise
             raise CoordinationError(
                 CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
             ) from exc
@@ -900,11 +1134,16 @@ class PostgresAdvisoryKeysetLease:
                 if not await _unlock_proven(self._connection, key):
                     raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
                 confirmed.append(key)
+            # A session advisory lock is re-entrant, so one true unlock does not
+            # prove the row is gone. Ask the same backend.
+            remaining = await _read_owned_advisory_rows(
+                self._connection, self._grant.backend_pid
+            )
         except CoordinationError:
             self._unlocked_keys = tuple(confirmed)
             await self._terminate_or_hold(CoordinationReasonCode.LEASE_LOST)
             raise
-        except Exception as exc:
+        except BaseException as exc:
             self._unlocked_keys = tuple(confirmed)
             await self._terminate_or_hold(
                 CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
@@ -914,13 +1153,29 @@ class PostgresAdvisoryKeysetLease:
             ) from exc
 
         self._unlocked_keys = tuple(confirmed)
-        await self._connection.close()
-        # Proven full reverse unlock: any hold this lease left behind on an
-        # earlier attempt is now genuinely resolved.
+        if _rows_hold_any_key(
+            remaining,
+            keys=self._grant.keys,
+            backend_pid=self._grant.backend_pid,
+            database_oid=self._grant.database_oid,
+        ):
+            # A row survived the unlock: this backend held the key more than
+            # once, so the account is still locked.
+            await self._terminate_or_hold(CoordinationReasonCode.LEASE_LOST)
+            raise CoordinationError(CoordinationReasonCode.LEASE_LOST)
+
+        # Proven released at this instant. Resolving before the fallible close
+        # keeps introspection honest: a pool-return error must not leave a
+        # released authority reported as still held.
+        self._released = True
         self._resolve_own_hold()
+        _unregister_owned_coordination(self)
+        # The close failure is still surfaced — it just cannot un-prove the
+        # unlock that already happened.
+        await self._connection.close()
 
     def _resolve_own_hold(self) -> None:
-        _resolve_authority_hold(self._hold)
+        _resolve_authority_hold(self._hold, owner=self, connection=self._connection)
         self._hold = None
 
     async def _terminate_or_hold(self, reason_code: CoordinationReasonCode) -> None:
@@ -931,8 +1186,8 @@ class PostgresAdvisoryKeysetLease:
             # caller still sees the failure that forced it.
             self._termination_receipt = receipt
             self._released = True
-            # A positive receipt resolves any hold from an earlier attempt.
             self._resolve_own_hold()
+            _unregister_owned_coordination(self)
             return
         if self._hold is not None:
             # One lease is one authority: a repeat failure is the *same*
@@ -940,6 +1195,7 @@ class PostgresAdvisoryKeysetLease:
             return
         self._hold = _record_unreleased_authority(
             self._grant,
+            owner=self,
             reason_code=reason_code,
             termination_proven=False,
             durable_evidence_written=True,
@@ -987,6 +1243,27 @@ async def acquire_physical_account_lease(
             CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
         ) from exc
 
+    # PostgreSQL session advisory locks are re-entrant per backend: a pooled
+    # connection that already holds one of these keys would answer
+    # pg_try_advisory_lock with true, and one later unlock would leave the row
+    # standing. Refuse to start from a non-zero baseline rather than mistake a
+    # stacked lock for an exclusive one.
+    try:
+        preexisting = await _read_owned_advisory_rows(connection, backend_pid)
+    except Exception as exc:
+        await _close_quietly(connection)
+        raise CoordinationError(
+            CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+        ) from exc
+    if _rows_hold_any_key(
+        preexisting,
+        keys=ordered_keys,
+        backend_pid=backend_pid,
+        database_oid=database_oid,
+    ):
+        await _close_quietly(connection)
+        raise CoordinationError(CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE)
+
     grant = AdvisoryLeaseGrant(
         keys=ordered_keys,
         backend_pid=backend_pid,
@@ -1004,9 +1281,16 @@ async def acquire_physical_account_lease(
     try:
         await _acquire_attested_keyset(connection, grant, acquired, in_flight)
     except BaseException:
-        await _rollback_partial_acquisition(
-            connection, acquired, grant, in_flight=tuple(in_flight)
+        # The rollback runs as a retained task: a cancellation arriving *during*
+        # it must not abandon a connection that may still hold a key. The
+        # original failure is re-raised only after the rollback reached a safe
+        # outcome — confirmed unlock, positive termination, or strong retention.
+        rollback: asyncio.Task[None] = asyncio.ensure_future(
+            _rollback_partial_acquisition(
+                connection, acquired, grant, in_flight=tuple(in_flight)
+            )
         )
+        await _await_retained_task(rollback)
         raise
 
     return PostgresAdvisoryKeysetLease(connection=connection, grant=grant)
@@ -1101,6 +1385,7 @@ async def _rollback_partial_acquisition(
             return
         _record_unreleased_authority(
             grant,
+            owner=connection,
             reason_code=CoordinationReasonCode.LEASE_LOST,
             termination_proven=False,
             durable_evidence_written=True,
@@ -1114,16 +1399,19 @@ async def _rollback_partial_acquisition(
             if not await _unlock_proven(connection, key):
                 proven = False
                 break
-    except Exception:
+    except BaseException:
+        # Including a cancellation: an interrupted unlock proves nothing, so the
+        # remainder is unknown rather than absent.
         proven = False
     if proven:
-        await connection.close()
+        await _close_quietly(connection)
         return
     if await _terminate_authority(connection, grant) is None:
         # Metadata alone would let a GC pass or a pool return drop the very
         # authority it claims is still held, so the real connection is retained.
         _record_unreleased_authority(
             grant,
+            owner=connection,
             reason_code=CoordinationReasonCode.LEASE_LOST,
             termination_proven=False,
             durable_evidence_written=True,
@@ -1475,7 +1763,23 @@ def require_dispatch_evidence_port(
 
 
 @dataclass(frozen=True, slots=True)
-class HeldCoordination:
+class HeldCoordinationSnapshot:
+    """A capability-free view of one held coordination.
+
+    Enough to see *that* an account is stuck and why; nothing with which to
+    unstick it. There is no lease, no grant, no connection, no PID, no owner
+    token, and nothing callable — the release capability lives only in the
+    module-private ownership maps.
+    """
+
+    hold_id: str
+    claim_account_scope: str
+    durable_evidence_written: bool
+    released: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _HeldCoordination:
     """A strong handle on coordination authority that is currently in use.
 
     Created the instant the durable binary reservation is committed and *before*
@@ -1498,17 +1802,45 @@ class HeldCoordination:
 
 
 # Strong references, keyed by the opaque hold id and nothing else.
-_HELD_COORDINATION: dict[str, HeldCoordination] = {}
+_HELD_COORDINATION: dict[str, _HeldCoordination] = {}
+
+# The release rights for each held lease. Deliberately module-private with no
+# accessor: ``HeldCoordination`` publishes the lease and the grant so operators
+# and later lanes can *see* what is stuck, and neither of those is enough to
+# release it. Capability identity cannot be reconstructed from the public
+# handle, so a generic caller cannot forge one.
+_COORDINATION_RELEASE_CAPABILITIES: dict[str, object] = {}
 
 
-def held_coordinations() -> Mapping[str, HeldCoordination]:
-    """Every coordination authority this process is still holding."""
+def _snapshot_held(held: _HeldCoordination) -> HeldCoordinationSnapshot:
+    hold = held.lease.unreleased_authority_hold
+    return HeldCoordinationSnapshot(
+        hold_id=held.hold_id,
+        claim_account_scope=held.claim.claim_account_scope,
+        durable_evidence_written=(
+            hold.durable_evidence_written if hold is not None else False
+        ),
+        released=held.lease.released,
+    )
 
-    return MappingProxyType(dict(_HELD_COORDINATION))
+
+def held_coordinations() -> Mapping[str, HeldCoordinationSnapshot]:
+    """Every coordination authority this process is still holding, redacted."""
+
+    return MappingProxyType(
+        {hold_id: _snapshot_held(held) for hold_id, held in _HELD_COORDINATION.items()}
+    )
 
 
-def held_coordination(hold_id: str) -> HeldCoordination | None:
-    """Look one held authority up by its opaque id."""
+def held_coordination(hold_id: str) -> HeldCoordinationSnapshot | None:
+    """Look one held authority up by its opaque id, capability-free."""
+
+    held = _HELD_COORDINATION.get(hold_id)
+    return None if held is None else _snapshot_held(held)
+
+
+def _held_coordination(hold_id: str) -> _HeldCoordination | None:
+    """Module-private: the real handle, for the coordination-owned path only."""
 
     return _HELD_COORDINATION.get(hold_id)
 
@@ -1519,26 +1851,42 @@ def _register_held_coordination(
     grant: AdvisoryLeaseGrant,
     claim: DurableClaim,
     envelope: LineageEnvelope,
-) -> HeldCoordination:
-    held = HeldCoordination(
-        hold_id=f"hold:{secrets.token_hex(8)}",
+) -> _HeldCoordination:
+    held = _HeldCoordination(
+        hold_id=_allocate_hold_id(),
         lease=lease,
         grant=grant,
         claim=claim,
         envelope=envelope,
     )
+    capability = object()
+    _COORDINATION_RELEASE_CAPABILITIES[held.hold_id] = capability
+    # Sealed at registration — before the callback task exists — so there is no
+    # instant in which the handle is public and the lease is generically
+    # releasable.
+    lease._seal_for_coordination(hold_id=held.hold_id, capability=capability)
     _HELD_COORDINATION[held.hold_id] = held
     return held
 
 
-async def _release_and_unregister(held: HeldCoordination) -> None:
-    """Drop the handle only after an allowed release outcome is proven."""
+async def _release_and_unregister(held: _HeldCoordination) -> None:
+    """Drop the handle only after an allowed release outcome is proven.
 
-    await held.lease.release(held.grant)
-    _HELD_COORDINATION.pop(held.hold_id, None)
+    This is the single coordination-owned release path. It runs only once both
+    post-send durable writes have landed (or, on the early-failure path, before
+    the callback ever started), and it is the only caller that holds the
+    capability the lease was sealed with.
+    """
+
+    capability = _COORDINATION_RELEASE_CAPABILITIES.get(held.hold_id)
+    await held.lease._release_with_capability(held.grant, capability)
+    # Compare-and-delete: only this exact handle's entries, never a namesake's.
+    if _HELD_COORDINATION.get(held.hold_id) is held:
+        _COORDINATION_RELEASE_CAPABILITIES.pop(held.hold_id, None)
+        del _HELD_COORDINATION[held.hold_id]
 
 
-async def _release_and_unregister_quietly(held: HeldCoordination) -> None:
+async def _release_and_unregister_quietly(held: _HeldCoordination) -> None:
     """Release on an already-failing path; keep the handle if unproven."""
 
     try:
@@ -1556,7 +1904,9 @@ class CoordinatedMutationResult:
     claim: DurableClaim
     certainty: MutationCertainty
     evidence: DispatchEvidence
-    lease_grant: AdvisoryLeaseGrant
+    # Opaque derived keys only — never the grant, which pairs a backend PID with
+    # an owner token and is therefore a termination capability.
+    lease_keys: tuple[int, ...]
 
 
 async def _await_retained_task(
@@ -1709,7 +2059,7 @@ async def coordinate_mock_order_mutation(
     )
     grant = lease.grant
     claim: DurableClaim | None = None
-    held: HeldCoordination | None = None
+    held: _HeldCoordination | None = None
     try:
         if await claims.account_has_unresolved_claim(scope):
             raise CoordinationError(
@@ -1814,10 +2164,15 @@ async def coordinate_mock_order_mutation(
         # exact handle and grant; J3A schedules nothing.
         # One stuck authority, one opaque id: the coordination handle and the
         # authority hold share it so an operator follows a single thread.
-        lease.retain_authority(
+        lease._retain_authority(
             reason_code=CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
             durable_evidence_written=False,
             hold_id=held.hold_id if held is not None else None,
+            capability=(
+                _COORDINATION_RELEASE_CAPABILITIES.get(held.hold_id)
+                if held is not None
+                else None
+            ),
         )
         raise CoordinationError(
             CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
@@ -1849,7 +2204,7 @@ async def coordinate_mock_order_mutation(
         claim=claim,
         certainty=result.certainty,
         evidence=evidence,
-        lease_grant=grant,
+        lease_keys=grant.keys,
     )
 
 
@@ -1869,6 +2224,13 @@ async def _release_lease_quietly(
         pass
 
 
+# Public here means the right to *see*. `AdvisoryLeaseGrant` pairs a backend PID
+# with an owner token and is therefore a termination capability;
+# `PostgresAdvisoryKeysetLease` holds the connection and the release methods; and
+# `acquire_physical_account_lease` is the one sanctioned way to hand both to a
+# caller. None of the three is exported. A broker lane supplies its extra keys
+# through `coordinate_mock_order_mutation(additional_advisory_keys=...)` and never
+# touches a lease.
 __all__ = [
     "AUTOMATIC_CLAIM_RELEASE_AVAILABLE",
     "CLAIM_FOLLOWUP_OPERATIONS",
@@ -1877,7 +2239,6 @@ __all__ = [
     "LANE_FENCING_MATRIX",
     "LEASE_TTL_SECONDS",
     "NOT_BROKER_ENFORCED_FENCING_STATEMENT",
-    "AdvisoryLeaseGrant",
     "AdvisoryLockRow",
     "BackendSessionTerminationUnproven",
     "BackendTerminationReceipt",
@@ -1891,18 +2252,16 @@ __all__ = [
     "DispatchEvidencePort",
     "DurableClaim",
     "DurableSendClaimAdapter",
-    "HeldCoordination",
+    "HeldCoordinationSnapshot",
     "LockAuthorityConnection",
     "MockMutationCallback",
     "MutationCallbackResult",
     "MutationCertainty",
     "OrderSendIntentReservationPort",
     "PhysicalAccountScope",
-    "PostgresAdvisoryKeysetLease",
     "SqlAlchemyLockAuthority",
     "TerminalClaimEvidence",
     "UnreleasedAuthorityHold",
-    "acquire_physical_account_lease",
     "coordinate_mock_order_mutation",
     "describe_claim_followup",
     "held_coordination",
@@ -1914,6 +2273,5 @@ __all__ = [
     "split_advisory_key",
     "supports_backend_session_termination",
     "authority_hold_history",
-    "retained_authority_connections",
     "unreleased_authority_holds",
 ]

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -231,8 +231,10 @@ opaque hold id. It is a lifetime and safety guard: **not** a retry queue, not a
 durable state store, with no TTL, janitor, takeover, automatic retry, claim
 deletion, or scheduler. Entries are removed only when both post-send durable
 writes succeeded *and* release reached a proven outcome. Process death may end
-the ephemeral session, but the durable reservation survives and keeps blocking a
-successor.
+the ephemeral session, but the durable reservation survives and keeps preventing
+replay of that exact send lineage. Whether an unrelated plan may proceed is a
+separate question, answered by the injected `AccountUncertaintyGatePort` and never
+by the presence of that reservation.
 
 When the AND gate does **not** close, the lease is marked with an authority hold
 carrying `durable_evidence_written=False`, and from that moment the lease is

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -278,7 +278,10 @@ non-`None` supplied `hold_id` is therefore not a caller-selected id; it is a
 
 1. the id is in the issued set;
 2. an exact, still-live preallocated coordination handle exists for it;
-3. that handle is owned by this very lease, sealed with this very capability;
+3. **all four identities match that handle** — the lease recording it, the grant
+   it was acquired under, the connection that actually holds the keys, and the
+   private release capability it was sealed with. A capability is *required*, not
+   optional: an id is a thread an operator follows, never a right to act on;
 4. the id has no authority history, active record, or retained record — ever.
 
 A retired id, a foreign id, a completed-success coordination id, and a
@@ -289,6 +292,20 @@ a rejection.
 Reachability is projected onto a record only when that record *is* the exact
 object the active map holds under its id. Looking the id up as a string would
 let a retired generation's history row report a later owner's recoverability.
+
+### Release order: unlock, then remove, then close
+
+On a proven full reverse unlock the active hold and the coordination handle are
+compare-and-deleted **immediately**, and only then is the connection closed:
+
+```
+second lineage write  <  dispatch evidence  <  unlock  <  remove  <  close
+```
+
+The close is deliberately last because it is fallible. A close failure must never
+turn an already-proven unlock back into a false active hold — the proof of
+release is what the removal is conditioned on, not the disposal of the socket.
+For the same reason removal never runs *before* the unlock proof.
 
 ### Error precedence when several things fail at once
 

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -94,8 +94,10 @@ A row proves ownership only when *all* hold: `locktype='advisory'`,
 the **reconstructed signed high/low 32-bit halves**. `objid` is never compared to
 the signed key directly — for a negative key it never matches.
 
-`assert_owned(grant)` repeats PID + exact-row proof immediately before every
-mutation (there is no heartbeat, so an idle lease is never assumed).
+Ownership is re-proven — PID plus exact-row — immediately before every mutation;
+there is no heartbeat, so an idle lease is never assumed. The lane does not hold a
+grant to do that with: it calls `await scope.assert_owned()` on the
+`CoordinationScope` it is handed (see §6).
 
 Multi-key: partial-acquire rolls back every acquired key in reverse order;
 release unlocks in reverse order and counts only keys PostgreSQL confirmed.
@@ -169,12 +171,46 @@ to make that possible.
 5. check account-wide unresolved reservations
 6. reserve and COMMIT the binary claim
 7. re-assert lease ownership and re-run the lane guards
-8. register the strong `HeldCoordination` handle, then start the callback task
+8. register the strong held-coordination handle and seal the lease, then invoke
+   the callback with its `CoordinationScope` (no `await` between those two)
 9. persist the ACK/uncertainty envelope **and** the typed dispatch evidence —
    both retained against cancellation, forming a single AND gate
 10. release the lease and drop the handle **only if** step 9 closed
 
 The durable claim is never released here.
+
+### 5.1 The callback interface — what J3B/J3C must do
+
+```python
+type MockMutationCallback = Callable[
+    [CoordinationScope], Awaitable[MutationCallbackResult]
+]
+```
+
+The callback takes **one argument**. `CoordinationScope` exposes exactly one
+coroutine and nothing else:
+
+```python
+await scope.assert_owned()
+```
+
+It carries no lease, grant, connection, backend PID, owner token, advisory key,
+hold id, release, or termination — the right to see, never the right to act. Each
+call re-proves ownership of the exact lease **and** re-checks the pinned canonical
+registry entry, so a registry mutated mid-flight fails here too.
+
+**The obligation is per send, not per callback.** A lane must
+`await scope.assert_owned()` immediately before **every** POST in a same-cycle
+batch, and before **every** supported cancel or reduce — in particular after any
+intervening `await` (account truth, token refresh, rate limiting). The
+coordinator's single assertion before the callback is deliberately *not*
+sufficient: ownership can be lost in that interval, and a failure discovered at
+release is discovered after the orders are already out.
+
+The scope stops working when its coordinated section ends, so a captured scope
+raises rather than asserting against a finished lease. A lane must also not move
+the send into a detached task: a compliant callback awaits `assert_owned()` inside
+the callback task the coordinator retains.
 
 ### Cancellation
 

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -33,7 +33,11 @@ expensive available misreading of this module.
 Every canonical J2A lane, with no exception. A lane that later gains real
 broker-side fencing must add its own evidence rather than reinterpreting a row.
 
-| Lane | Fencing |
+Every row below is NOT broker-enforced fencing. The `not_broker_enforced`
+token is the machine-readable form of that same statement, mirroring
+`coordination.FENCING_NOT_BROKER_ENFORCED`.
+
+| Lane | Fencing (every row: NOT broker-enforced fencing) |
 |---|---|
 | `kr.kis.mock` | `not_broker_enforced` |
 | `kr.kiwoom.mock` | `not_broker_enforced` |

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -113,10 +113,24 @@ Release is exactly two things:
 is not a receipt. When neither can be proven, the lease is not marked released
 and an auditable `UnreleasedAuthorityHold` is recorded.
 
+A single `pg_advisory_unlock` returning true is **not** proof either. Session
+advisory locks stack per backend, so acquisition first proves this backend holds
+none of the target keys, and release re-reads the same backend afterwards to prove
+every row is gone. Only that pair survives re-entrancy.
+
 Release is cancellation-safe: it delegates to one retained inner task, captures
-outer cancellation, and re-raises only after a safe definite outcome. A failed or
-interrupted release stays recoverable **by the exact grant**; stale or foreign
-grants keep being rejected.
+outer cancellation, and re-raises only after a safe definite outcome. Every
+failure inside the critical section — a `CancelledError` included — means the
+outcome is *unknown*, never that the lock was released.
+
+Whether a failed release can be retried at all depends on who owns it. A lease a
+caller still holds and that is not coordination-sealed can retry with its exact
+grant; stale or foreign grants keep being rejected. A coordination-sealed lease is
+never unsealed after a failed release, and a partial-acquisition rollback has no
+owning lease, so **neither can be retried in this process**.
+`UnreleasedAuthorityHold.recoverable_in_process` is recomputed on every read to
+say exactly that, because a hold reported as recoverable when nothing can reach it
+is the same kind of false report as one reported as held after it was released.
 
 ---
 
@@ -183,14 +197,29 @@ hold share one opaque id, so an operator follows a single thread.
 ### Resolving a hold
 
 The opposite failure matters too: reporting a resolved hold as unresolved is as
-much a defect as releasing early. So a hold recorded because the *release itself*
+much a defect as releasing early. A hold recorded because the *release itself*
 failed (`durable_evidence_written=True`) is cleared — atomically, and only its own
-active entries — as soon as a later exact-grant retry proves a full reverse unlock
-or a positive backend-termination receipt. A foreign or stale grant clears
-nothing, an ambiguous or failed retry clears nothing, and one lease's hold never
-touches another's. `unreleased_authority_holds()` and
-`retained_authority_connections()` answer "what is unresolved right now";
-`authority_hold_history()` keeps the immutable record of everything ever held.
+entries — the instant a retry proves a full reverse unlock plus row absence, or a
+positive backend-termination receipt. Cleanup happens **before** the fallible
+`close()`, so a pool-return error cannot strand an authority that is provably
+released. A foreign or stale grant clears nothing, an ambiguous or failed retry
+clears nothing, and one lease's hold never touches another's: every delete
+compares the stored owner and connection, not just the id.
+
+`unreleased_authority_holds()` and `held_coordinations()` answer "what is
+unresolved right now"; `authority_hold_history()` keeps the immutable record.
+All three are **capability-free**: they carry no connection, no lease, no grant,
+no backend PID, no owner token, and nothing callable. Public here means the right
+to *see*; the right to *release* is module-private without exception, because a
+PID paired with an owner token is by itself enough to terminate the backend whose
+lock is the safety property.
+
+### Strength of this guarantee
+
+Like the repository's Kiwoom read-only lane, this is **accident prevention plus
+static detection — not structural impossibility**. One line reaching into a
+private attribute still reaches the capability. The boundary is drawn so that such
+a line has to be written deliberately, and so that a reviewer can see it.
 
 ---
 

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -97,7 +97,7 @@ the signed key directly — for a negative key it never matches.
 Ownership is re-proven — PID plus exact-row — immediately before every mutation;
 there is no heartbeat, so an idle lease is never assumed. The lane does not hold a
 grant to do that with: it calls `await scope.assert_owned()` on the
-`CoordinationScope` it is handed (see §6).
+`CoordinationScope` it is handed (see §5.1).
 
 Multi-key: partial-acquire rolls back every acquired key in reverse order;
 release unlocks in reverse order and counts only keys PostgreSQL confirmed.

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -280,8 +280,12 @@ non-`None` supplied `hold_id` is therefore not a caller-selected id; it is a
 2. an exact, still-live preallocated coordination handle exists for it;
 3. **all four identities match that handle** — the lease recording it, the grant
    it was acquired under, the connection that actually holds the keys, and the
-   private release capability it was sealed with. A capability is *required*, not
-   optional: an id is a thread an operator follows, never a right to act on;
+   private release capability it was sealed with. Both the connection and the
+   capability are *required*, never optional: an id is a thread an operator
+   follows, never a right to act on. A record without the real connection would
+   append history and create an active row while writing no retained root — an
+   authority nobody is holding, which a garbage collection or a pool return could
+   silently drop;
 4. the id has no authority history, active record, or retained record — ever.
 
 A retired id, a foreign id, a completed-success coordination id, and a
@@ -292,6 +296,15 @@ a rejection.
 Reachability is projected onto a record only when that record *is* the exact
 object the active map holds under its id. Looking the id up as a string would
 let a retired generation's history row report a later owner's recoverability.
+
+### Duplicate retention is decided by exact record identity
+
+The rollback fallback may skip recording only when the retained entry it finds is
+*this exact authority*: same owner, same grant, same connection, and an active row
+that **is the very record that entry was written with**. Presence under the id, an
+equal-but-different row, or a matching id string are all insufficient — accepting
+any of them would suppress the fallback and leave the real connection unrooted
+while the maps claim the account is covered.
 
 ### Release order: unlock, then remove, then close
 

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -123,14 +123,23 @@ outer cancellation, and re-raises only after a safe definite outcome. Every
 failure inside the critical section — a `CancelledError` included — means the
 outcome is *unknown*, never that the lock was released.
 
-Whether a failed release can be retried at all depends on who owns it. A lease a
-caller still holds and that is not coordination-sealed can retry with its exact
-grant; stale or foreign grants keep being rejected. A coordination-sealed lease is
-never unsealed after a failed release, and a partial-acquisition rollback has no
-owning lease, so **neither can be retried in this process**.
+Whether a failed release can be retried at all depends on who owns it, and
 `UnreleasedAuthorityHold.recoverable_in_process` is recomputed on every read to
-say exactly that, because a hold reported as recoverable when nothing can reach it
-is the same kind of false report as one reported as held after it was released.
+report exactly that — a hold called recoverable when nothing can reach it is the
+same kind of false report as one called held after it was released.
+
+| Owner state | Evidence | `recoverable_in_process` | Why |
+|---|---|---|---|
+| unsealed standalone lease | durable-true | `True` | the owner still holds its exact private lease/grant and may retry |
+| unsealed standalone lease | durable-false | `False` | release is refused for every caller, the owner included |
+| coordination-sealed lease | durable-true | `False` | a sealed lease is never unsealed after a failed release |
+| coordination-sealed lease | durable-false | `False` | both blockers apply |
+| partial-acquisition rollback | — | `False` | there is no owning lease at all |
+
+The flag is the negation of the two things that block a release: a permanent
+coordination seal, and missing durable evidence. There is no in-process recovery
+API in this epoch, and the presence of private machinery is not a supported retry
+path. Stale or foreign grants are always rejected.
 
 ---
 
@@ -187,9 +196,10 @@ successor.
 
 When the AND gate does **not** close, the lease is marked with an authority hold
 carrying `durable_evidence_written=False`, and from that moment the lease is
-unreleasable in this process — including through the exact grant reachable from
-`held_coordination(hold_id)`. Introspection may *see* a stuck lease; it may not
-release it. There is deliberately no recovery API: surrendering the advisory lock
+unreleasable in this process by any caller, the owning lease included.
+`held_coordination(hold_id)` returns a capability-free `HeldCoordinationSnapshot`
+— no lease, no grant, no connection, no PID, no owner token, nothing callable —
+so introspection can *see* a stuck lease and has no way to release it. There is deliberately no recovery API: surrendering the advisory lock
 while nobody knows whether an order went out would let an old or non-claim-aware
 writer mutate the account concurrently. The coordination handle and the authority
 hold share one opaque id, so an operator follows a single thread.

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -1,0 +1,240 @@
+# ROB-1262 J3A — coordination port (lease / fence)
+
+Broker-neutral coordination for one **physical** mock/paper/demo account:
+a PostgreSQL session advisory lease, a durable binary send reservation,
+lane-owned durable evidence ports, and an injected mutation callback.
+
+- Source: `app/services/mock_integration/coordination.py`
+- Tests: `tests/services/mock_integration/test_coordination.py`
+- Consumes (read/import only): J2A `mock_lane_registry`, J2B
+  `mock_integration/lineage` + `brokers/client_order_ids`, and the existing
+  `order_send_intent_service`.
+
+J3A imports **no broker transport**, opens no socket, signs nothing, and loads no
+credential value. It registers no scheduler, adds no model and no migration.
+
+---
+
+## 1. This is NOT broker-enforced fencing
+
+> **The J3A physical-account lease is process coordination only. It is NOT
+> broker-enforced fencing.**
+
+Holding the lease proves that no *other holder of this same lease* is mutating
+the account. It proves nothing about the broker. No broker below accepts a
+fencing token, so a stale deployment, an out-of-repo process, or a human at a
+broker console reaches the same account without ever contending for this lease.
+
+"The lease is held, therefore the broker will reject everyone else" is the most
+expensive available misreading of this module.
+
+### Lane matrix
+
+Every canonical J2A lane, with no exception. A lane that later gains real
+broker-side fencing must add its own evidence rather than reinterpreting a row.
+
+| Lane | Fencing |
+|---|---|
+| `kr.kis.mock` | `not_broker_enforced` |
+| `kr.kiwoom.mock` | `not_broker_enforced` |
+| `us.kis.mock` | `not_broker_enforced` |
+| `us.kiwoom.mock` | `not_broker_enforced` |
+| `us.alpaca.paper.default` | `not_broker_enforced` |
+| `us.alpaca.paper.lab` | `not_broker_enforced` |
+| `crypto.binance.spot_demo.canonical` | `not_broker_enforced` |
+| `crypto.binance.spot_demo.b0x_sidecar` | `not_broker_enforced` |
+| `crypto.alpaca.paper.default` | `not_broker_enforced` |
+| `crypto.alpaca.paper.clean` | `not_broker_enforced` |
+| `crypto.upbit.shadow` | `not_broker_enforced` |
+| `crypto.binance.futures_demo` | `not_broker_enforced` |
+
+The same table is machine-readable as `coordination.LANE_FENCING_MATRIX`.
+
+---
+
+## 2. Identity and scope
+
+The lock scope is derived from the canonical J2A `physical_account_id` of a
+validated, identity-known registry entry. A caller-supplied scope is never
+accepted, and the raw identifier is never logged, serialized, or stored.
+
+```python
+d = sha256(b"mock-physical-account-v1\0" + physical_account_id.encode("utf-8")).digest()
+claim_account_scope = "mockpa:v1:" + d.hex()
+advisory_key        = int.from_bytes(d[:8], byteorder="big", signed=True)
+```
+
+Two logical lanes on one physical account derive the same scope and key. Unknown
+or blank identity fails before any lease, persistence, reservation, or callback.
+
+J2A's `PolicyBinding`, exact lane guards, and reject literals are **consumed, not
+redefined**. `assert_lineage_registry_binding` then `assert_entry_execution_ready`
+both run before anything else.
+
+---
+
+## 3. The advisory lease
+
+Authority is a **dedicated** connection holding a session-level
+`pg_try_advisory_lock(bigint)`. There is **no TTL**, no heartbeat, no automatic
+takeover, and **no file-lock fallback** — the existing KIS PID file remains a
+later J3B *diagnostic* seam, never authority.
+
+Acquisition:
+
+1. verify the authority can prove backend-session termination;
+2. read and retain `pg_backend_pid()`;
+3. `pg_try_advisory_lock` each key in deterministic global numeric order
+   (de-duplicated first) — `false` ⇒ `lease_contended`;
+4. **explicit COMMIT**;
+5. in the new transaction, re-read the PID and prove every exact `pg_locks` row.
+
+A row proves ownership only when *all* hold: `locktype='advisory'`,
+`mode='ExclusiveLock'`, `granted`, database oid, retained PID, `objsubid=1`, and
+the **reconstructed signed high/low 32-bit halves**. `objid` is never compared to
+the signed key directly — for a negative key it never matches.
+
+`assert_owned(grant)` repeats PID + exact-row proof immediately before every
+mutation (there is no heartbeat, so an idle lease is never assumed).
+
+Multi-key: partial-acquire rolls back every acquired key in reverse order;
+release unlocks in reverse order and counts only keys PostgreSQL confirmed.
+
+### Release, and what does not count as one
+
+Release is exactly two things:
+
+- an **attested** owner/key-matched `pg_advisory_unlock` whose boolean is `true`
+  for every key, then close; or
+- a **positive termination receipt** bound to the exact backend PID and owner
+  token.
+
+`close()` and a pool return are **never** termination. An ambiguous driver error
+is not a receipt. When neither can be proven, the lease is not marked released
+and an auditable `UnreleasedAuthorityHold` is recorded.
+
+Release is cancellation-safe: it delegates to one retained inner task, captures
+outer cancellation, and re-raises only after a safe definite outcome. A failed or
+interrupted release stays recoverable **by the exact grant**; stale or foreign
+grants keep being rejected.
+
+---
+
+## 4. Durable claim
+
+`review.order_send_intents` is a **binary reservation only** — not a lifecycle
+store, not a hold store, not a broker-order-id store, not a retry queue. J3A
+adapts the existing `OrderSendIntentService` and never edits it into a state
+machine. The unrestricted `release` is not part of the consumed port.
+
+An existing reservation on the physical account is the account block. It is
+removed only by an evidence-gated `release_if_matches` after lane-native terminal
+evidence **plus** account/position reconciliation. Unknown, anomaly, rejection
+without proven absence, and partial fills with an unknown remainder all retain
+it. Nothing releases a claim automatically, and there is no clock in this module
+to make that possible.
+
+---
+
+## 5. Order of operations
+
+1. canonical J2A lane/identity/policy validation
+2. require **both** lane-supplied durable write ports
+3. persist the immutable envelope — a cancellation observed here aborts before
+   any lease, reservation, or send
+4. acquire the physical-account lease
+5. check account-wide unresolved reservations
+6. reserve and COMMIT the binary claim
+7. re-assert lease ownership and re-run the lane guards
+8. register the strong `HeldCoordination` handle, then start the callback task
+9. persist the ACK/uncertainty envelope **and** the typed dispatch evidence —
+   both retained against cancellation, forming a single AND gate
+10. release the lease and drop the handle **only if** step 9 closed
+
+The durable claim is never released here.
+
+### Cancellation
+
+`asyncio.shield` alone is not enough: it lets the caller raise while the socket
+write continues, after which a naive `finally` would surrender the lease on an
+order that may already be at the broker. The inner task is retained and awaited
+to a definite result — completion or durable uncertainty — before any cleanup.
+
+### Held coordination
+
+The handle is created the instant the reservation commits and before the callback
+task exists, and is held by a module-owned strong-reference map keyed only by an
+opaque hold id. It is a lifetime and safety guard: **not** a retry queue, not a
+durable state store, with no TTL, janitor, takeover, automatic retry, claim
+deletion, or scheduler. Entries are removed only when both post-send durable
+writes succeeded *and* release reached a proven outcome. Process death may end
+the ephemeral session, but the durable reservation survives and keeps blocking a
+successor.
+
+When the AND gate does **not** close, the lease is marked with an authority hold
+carrying `durable_evidence_written=False`, and from that moment the lease is
+unreleasable in this process — including through the exact grant reachable from
+`held_coordination(hold_id)`. Introspection may *see* a stuck lease; it may not
+release it. There is deliberately no recovery API: surrendering the advisory lock
+while nobody knows whether an order went out would let an old or non-claim-aware
+writer mutate the account concurrently. The coordination handle and the authority
+hold share one opaque id, so an operator follows a single thread.
+
+### Resolving a hold
+
+The opposite failure matters too: reporting a resolved hold as unresolved is as
+much a defect as releasing early. So a hold recorded because the *release itself*
+failed (`durable_evidence_written=True`) is cleared — atomically, and only its own
+active entries — as soon as a later exact-grant retry proves a full reverse unlock
+or a positive backend-termination receipt. A foreign or stale grant clears
+nothing, an ambiguous or failed retry clears nothing, and one lease's hold never
+touches another's. `unreleased_authority_holds()` and
+`retained_authority_connections()` answer "what is unresolved right now";
+`authority_hold_history()` keeps the immutable record of everything ever held.
+
+---
+
+## 6. Dispatch evidence
+
+`DispatchEvidence` is a typed immutable record carrying intent / plan / attempt /
+cycle correlation, so an unknown is legible at rest rather than inferred from a
+missing field. Kinds — an *evidence* vocabulary, never a reason code:
+
+| Kind | Meaning |
+|---|---|
+| `acknowledged` | definitive, with a broker order id attached via J2B |
+| `definitive_without_broker_id` | definitive, no id reported |
+| `lane_reported_uncertain` | the lane could not tell |
+| `callback_failed` | the callback raised — the write may still have landed |
+| `ack_attachment_failed` | J2B rejected the broker id — also uncertain |
+
+`outer_cancellation_requested` is orthogonal and never overwrites the kind:
+cancelling the caller says nothing about what the transport did.
+
+---
+
+## 7. Reason codes
+
+Exactly eight, J3A-owned. `lineage_persistence_unavailable` reuses J2B's literal;
+J2B's `LineageReasonCode` is never modified or overloaded.
+
+`lock_authority_unavailable` · `lease_contended` · `lease_lost` ·
+`lease_event_loop_mismatch` · `durable_claim_conflict` ·
+`lineage_persistence_unavailable` · `terminal_evidence_required` ·
+`claim_followup_not_authorized`
+
+---
+
+## 8. Ownership boundaries
+
+J3A provides a **broker-neutral** ordered keyset primitive. It does not choose or
+supply any KIS key, does not edit KIS singleton or mutation call sites, and does
+not own old-legacy-only compatibility — those belong to J3B, which supplies the
+exact KIS physical + legacy keyset and retains both for the whole DAG.
+
+J3A also does not claim host/profile coupling. It validates canonical J2A
+lane/identity/policy and coordinates an injected, fake-tested callback; verifying
+the real client host and profile at the send boundary is J3B/J3C's job.
+
+`describe_claim_followup` reports **capability only**. It never authorizes a
+cancel or reduce, never releases a claim, and cannot be constructed as if it did.

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -269,6 +269,51 @@ a line has to be written deliberately, and so that a reviewer can see it.
 
 ---
 
+### The opaque hold id is issued once, for the life of the process
+
+An id comes from the allocator exactly once and stays in the process-lifetime
+issued set forever — including the id of a coordination that **succeeded**. A
+non-`None` supplied `hold_id` is therefore not a caller-selected id; it is a
+*same-generation handoff*, and it is accepted only when all four hold:
+
+1. the id is in the issued set;
+2. an exact, still-live preallocated coordination handle exists for it;
+3. that handle is owned by this very lease, sealed with this very capability;
+4. the id has no authority history, active record, or retained record — ever.
+
+A retired id, a foreign id, a completed-success coordination id, and a
+same-owner historical id are all refused **before** any history row is appended
+or any map slot is written. A rejection that has to be undone afterwards is not
+a rejection.
+
+Reachability is projected onto a record only when that record *is* the exact
+object the active map holds under its id. Looking the id up as a string would
+let a retired generation's history row report a later owner's recoverability.
+
+### Error precedence when several things fail at once
+
+Outer cancellation and an outcome-access failure are independent facts, and
+neither erases the other. Whether the caller cancelled is established *before*
+the outcome is read and is never cleared by containing a failure of that read —
+durable evidence must not record `outer_cancellation_requested=False` for a send
+the caller demonstrably asked to stop.
+
+Once the callback has definitely ended, both durable writes and the safe
+release/retention outcome complete first. Only then is one exception surfaced,
+in this exact order:
+
+```
+lineage_persistence_unavailable  >  ack error  >  callback/outcome error  >  outer cancellation
+```
+
+So a captured `CancelledError` never covers an outcome-access exception; it is
+re-delivered only when nothing above it applies.
+
+The callback scope expires in a `finally` that wraps the task wait *and* the
+outcome read, so it is dead before validation, acknowledgement, the durable
+writes, retention/release, and exception delivery — on every branch, including
+the one where the callback cancelled itself.
+
 ## 6. Dispatch evidence
 
 `DispatchEvidence` is a typed immutable record carrying intent / plan / attempt /

--- a/docs/contracts/rob-1262-coordination-port.md
+++ b/docs/contracts/rob-1262-coordination-port.md
@@ -152,9 +152,10 @@ store, not a hold store, not a broker-order-id store, not a retry queue. J3A
 adapts the existing `OrderSendIntentService` and never edits it into a state
 machine. The unrestricted `release` is not part of the consumed port.
 
-An existing reservation on the physical account is the account block. It is
-removed only by an evidence-gated `release_if_matches` after lane-native terminal
-evidence **plus** account/position reconciliation. Unknown, anomaly, rejection
+A reservation records that **one exact send lineage** was attempted; it prevents
+replay of that logical send and is not an account-wide block. It is removed only
+by an evidence-gated `release_if_matches` after lane-native terminal evidence
+**plus** account/position reconciliation. Unknown, anomaly, rejection
 without proven absence, and partial fills with an unknown remainder all retain
 it. Nothing releases a claim automatically, and there is no clock in this module
 to make that possible.
@@ -168,7 +169,10 @@ to make that possible.
 3. persist the immutable envelope — a cancellation observed here aborts before
    any lease, reservation, or send
 4. acquire the physical-account lease
-5. check account-wide unresolved reservations
+5. ask the injected `AccountUncertaintyGatePort` whether a prior outcome on this
+   physical account is still uncorrelated or uncertain — asked here, after the
+   lease and before the reservation, so the answer cannot go stale between the
+   check and its use, and never inferred from the binary claim
 6. reserve and COMMIT the binary claim
 7. re-assert lease ownership and re-run the lane guards
 8. register the strong held-coordination handle and seal the lease, then invoke
@@ -296,6 +300,60 @@ a rejection.
 Reachability is projected onto a record only when that record *is* the exact
 object the active map holds under its id. Looking the id up as a string would
 let a retired generation's history row report a later owner's recoverability.
+
+### What the lease is, what the claim is, and what neither is
+
+The physical-account advisory lease serializes broker-mutation critical
+sections; it is not an account-lifecycle mutex.
+
+A durable send claim is keyed to the exact immutable send lineage. The
+exact-lineage claim continues to prevent replay of that logical send.
+
+An account-wide unresolved-claim gate blocks unrelated new sends only while
+a prior mutation outcome remains uncorrelated or uncertain, including the
+absence of a durably attributed native broker order ID and immutable ACK.
+
+A durably ACK-correlated open order continues through lane-native lifecycle
+tracking and does not, by itself, block unrelated execution plans, subject
+to the lane's max_open_orders, exposure caps, and policy vetoes.
+
+If an epoch intentionally requires one-order-at-a-time terminal canaries,
+that restriction must be declared as an activation policy, not inferred
+from the generic durable-claim invariant.
+
+The advisory lease and the durable claim have distinct lifetimes.
+
+After the mutation callback has reached either a definitive attributed
+result or a durably recorded uncertainty, and the required lineage and
+dispatch evidence has committed, the advisory lease may be explicitly
+released.
+
+The durable claim may remain after lease release until its evidence-gated
+release condition is satisfied.
+
+Backend termination proves only cessation of lease authority. It is never
+broker-outcome evidence and never, by itself, authorizes durable-claim
+release.
+
+### Who answers "is this account settled"
+
+`AccountUncertaintyGatePort` is a required, injected, read-only authority. The
+coordinator asks it **after** the lease is held and **before** the claim is
+reserved, so the answer cannot go stale between the check and its use.
+
+Only an exact `True` or `False` is an answer. A missing port, a raised
+exception, or any non-`bool` return fails closed as
+`lineage_persistence_unavailable`, with no reservation and no send; a missing
+port fails before the lease is even taken. No new reason code is introduced.
+
+J3A does not implement this port and never infers its answer from its own
+tables. Aggregating lane-native evidence into a physical-account verdict belongs
+to the lane that owns that evidence. Nothing here reads back from a broker,
+retries, queues, or holds state.
+
+A one-order-at-a-time canary is a lane **activation policy**, declared by the
+lane. The generic coordinator does not infer it from the durable-claim
+invariant.
 
 ### Duplicate retention is decided by exact record identity
 

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -73,6 +73,7 @@ from app.services.mock_integration.coordination import (
     PostgresAdvisoryKeysetLease,
     SqlAlchemyLockAuthority,
     _held_coordination,
+    _hold_view,
     _retained_authorities,
     acquire_physical_account_lease,
     authority_hold_history,
@@ -580,7 +581,11 @@ class RecordingPersistence:
             raise RuntimeError("simulated lane persistence backend failure")
         self.persisted.append(envelope)
         if self._events is not None:
-            self._events.append("persist")
+            # B56: the pre-send write and the mandatory post-send write must be
+            # separate events. Sharing one label lets `events.index("persist")`
+            # silently select the pre-send write, so an assertion about "the"
+            # lineage write proves nothing about the post-send one.
+            self._events.append("persist_pre" if self.calls == 1 else "persist_post")
 
 
 class RecordingDispatchEvidence:
@@ -2185,11 +2190,11 @@ async def test_claim_persist_precedes_reserve_precedes_callback_precedes_release
     await _run(envelope, stack)
 
     assert events == [
-        "persist",
+        "persist_pre",
         "reserve",
         "callback_start",
         "callback_end",
-        "persist",
+        "persist_post",
         "evidence_start",
         "evidence",
         "lease_unlock",
@@ -4877,24 +4882,94 @@ async def test_lock_close_cancellation_after_absence_keeps_the_receipt(which: st
 
 
 @pytest.mark.asyncio
-async def test_lock_rollback_cancelled_after_a_confirmed_unlock_prefix():
-    """V1/B47: the whole conjunction, in one test.
+async def test_lock_inner_cancellation_after_a_confirmed_unlock_prefix():
+    """B52: the load-bearing conjunction, in one test.
 
-    Two tests each proving one half let a regression through: keep the inner
-    handling but break re-delivery only *after* a confirmed prefix, and both stay
-    green. So this establishes a non-empty confirmed prefix, cancels the outer
-    acquisition while the next unlock is blocked, and then requires the
-    cancellation back — after the safe outcome, never before it.
+    Two half-tests do not cover this. One cancels on the *first* reverse unlock,
+    so it has no confirmed prefix; the other establishes a prefix but cancels the
+    **outer** acquisition task, which travels a different path. A defect that
+    re-delivers an inner cancellation only when it lands on the first unlock, and
+    swallows it once anything has been confirmed, passes both of them.
+
+    So: confirm one unlock, then make the *next unlock await itself* raise
+    ``CancelledError``.
     """
 
+    import gc
+    import weakref
+
     space = FakeLockSpace()
-    blocker = FakeLockConnection(space, pid=11001)
+    blocker = FakeLockConnection(space, pid=12003)
+    await acquire_physical_account_lease(
+        keys=[1203], connection_factory=ConnectionFactory(blocker)
+    )
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    # Reverse rollback order is 1202 then 1201: 1202 confirms, 1201 blocks and
+    # then raises the inner cancellation.
+    connection = FakeLockConnection(
+        space,
+        pid=12002,
+        unlock_gate_on_key=1201,
+        unlock_gate=gate,
+        unlock_gate_started=started,
+        unlock_raises_on_key=1201,
+        unlock_raises_error=asyncio.CancelledError(),
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    weak_connection = weakref.ref(connection)
+    retained_before = set(_retained_authorities())
+    held_before = set(held_coordinations())
+
+    task = asyncio.ensure_future(
+        acquire_physical_account_lease(
+            keys=[1201, 1202, 1203], connection_factory=ConnectionFactory(connection)
+        )
+    )
+    await started.wait()
+    # A non-empty confirmed prefix exists before the interruption arrives.
+    assert connection.unlock_calls == [1202, 1201]
+    # And the outer acquisition has not finished, so nothing was surrendered
+    # while the rollback was still in flight.
+    assert task.done() is False
+
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Exactly one strong hold, no close, no coordination handle, no claim work.
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    hold_id = new_holds.pop()
+    assert _retained_authorities()[hold_id].connection is connection
+    assert connection.closed is False
+    assert set(held_coordinations()) == held_before
+
+    # The authority outlives every caller-side reference to it.
+    del connection, task
+    gc.collect()
+    assert weak_connection() is not None
+    assert _retained_authorities()[hold_id].connection is weak_connection()
+
+    successor = FakeLockConnection(space, pid=12004)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[1201], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+
+@pytest.mark.asyncio
+async def test_lock_outer_cancellation_during_a_gated_rollback_unlock_is_retained():
+    """The sibling path: the cancellation comes from *outside*, not the unlock."""
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=11003)
     await acquire_physical_account_lease(
         keys=[1103], connection_factory=ConnectionFactory(blocker)
     )
     gate = asyncio.Event()
     started = asyncio.Event()
-    # Reverse rollback order is 1102 then 1101: 1102 confirms, 1101 blocks.
     connection = FakeLockConnection(
         space,
         pid=11002,
@@ -4912,17 +4987,15 @@ async def test_lock_rollback_cancelled_after_a_confirmed_unlock_prefix():
         )
     )
     await started.wait()
-    # A confirmed prefix already exists before the cancellation arrives.
     assert connection.unlock_calls == [1102, 1101]
 
     task.cancel()
     for _ in range(10):
         await asyncio.sleep(0)
-    # Nothing was surrendered while the rollback was still in flight.
     assert task.done() is False
     assert connection.closed is False
 
-    connection._unlock_returns = False  # the blocked unlock proves nothing
+    connection._unlock_returns = False
     gate.set()
     with pytest.raises(asyncio.CancelledError):
         await task
@@ -4932,13 +5005,6 @@ async def test_lock_rollback_cancelled_after_a_confirmed_unlock_prefix():
     assert len(new_holds) == 1
     assert _retained_authorities()[new_holds.pop()].connection is connection
 
-    successor = FakeLockConnection(space, pid=11003)
-    with pytest.raises(CoordinationError) as contended:
-        await acquire_physical_account_lease(
-            keys=[1101], connection_factory=ConnectionFactory(successor)
-        )
-    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
-
 
 @pytest.mark.asyncio
 async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
@@ -4947,6 +5013,7 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
     """U6/B40: the collision storm must also cover the confirmed-partial branch."""
 
     import gc
+    import weakref
 
     space = FakeLockSpace()
     _, victim_connection, victim_hold = await _durable_true_hold(
@@ -4981,17 +5048,49 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
     quarantined = new_holds.pop()
     assert quarantined.startswith("hold:quarantine:")
     assert _retained_authorities()[quarantined].connection is intruder
-    gc.collect()
-    assert _retained_authorities()[quarantined].connection is intruder
     assert intruder.closed is False
+    assert intruder.unlock_calls == [1113]
+
+    # B55: prove the *module* is what keeps this authority alive. Collecting
+    # while the caller still holds `intruder` proves nothing, so bind weak
+    # references to the exact original objects, drop every caller-side strong
+    # reference, and force a collection.
+    weak_connection = weakref.ref(intruder)
+    # ``AdvisoryLeaseGrant`` is a frozen slots dataclass and cannot be weakly
+    # referenced. Its id is still a sound identity witness here: the retained
+    # entry holds it strongly for the whole test, so it is never freed and its
+    # id can never be recycled onto a different object.
+    grant_id = id(_retained_authorities()[quarantined].grant)
+    del intruder
+    gc.collect()
+    assert weak_connection() is not None
+    retained = _retained_authorities()[quarantined]
+    # Exact identity, recovered only through the module-private seam.
+    assert retained.connection is weak_connection()
+    assert id(retained.grant) == grant_id
+    assert retained.connection.closed is False
+    assert retained.connection.unlock_calls == [1113]
+
+    # And the physical key is genuinely still held.
+    successor = FakeLockConnection(space, pid=11104)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[1112], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
     # The victim is untouched by the storm.
     assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
     assert _retained_authorities()[victim_hold.hold_id].owner is victim_owner
+    assert victim_connection.closed is False
 
 
 @pytest.mark.asyncio
 async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch):
     """U6/B40: if the rollback task itself fails, nothing may fall out of scope."""
+
+    import gc
+    import weakref
 
     space = FakeLockSpace()
     blocker = FakeLockConnection(space, pid=11201)
@@ -5015,10 +5114,38 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
 
     new_holds = set(_retained_authorities()) - retained_before
     assert len(new_holds) == 1
-    retained = _retained_authorities()[new_holds.pop()]
+    hold_id = new_holds.pop()
+    retained = _retained_authorities()[hold_id]
     assert retained.connection is connection
     assert retained.grant.backend_pid == 11202
     assert connection.closed is False
+
+    # B55: same obligation on this branch — exact identity must survive losing
+    # every caller reference, and the physical key must really still be held.
+    weak_connection = weakref.ref(connection)
+    grant_id = id(retained.grant)  # see the note on the collision branch
+    victim_before = dict(_retained_authorities())
+    del connection, retained
+    gc.collect()
+    assert weak_connection() is not None
+    recovered = _retained_authorities()[hold_id]
+    assert recovered.connection is weak_connection()
+    assert id(recovered.grant) == grant_id
+    assert recovered.connection.closed is False
+    assert recovered.connection.unlock_calls == []
+
+    successor = FakeLockConnection(space, pid=11203)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[1121], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+    # Every foreign entry is byte-for-byte what it was.
+    for other, entry in victim_before.items():
+        if other == hold_id:
+            continue
+        assert _retained_authorities()[other] is entry
 
 
 @pytest.mark.asyncio
@@ -5937,7 +6064,7 @@ async def test_claim_both_durable_writes_precede_any_cleanup(certainty):
     assert stack["persistence"].calls == 2
     assert stack["evidence"].calls == 1
     # Both durable writes land, in order, strictly before the lease is given up.
-    assert events.index("persist") < events.index("evidence")
+    assert events.index("persist_post") < events.index("evidence")
     assert events.index("evidence") < events.index("lease_unlock")
     assert events.index("lease_unlock") < events.index("lease_closed")
     assert {h.hold_id for h in unreleased_authority_holds()} == held_before
@@ -6002,3 +6129,638 @@ async def test_claim_dispatch_evidence_failure_halts_before_cleanup(certainty):
     assert stack["connection"].unlock_calls == []
     assert stack["connection"].closed is False
     assert stack["intents"].rows != {}
+
+
+# ===========================================================================
+# §B53 — a supplied hold id is a same-generation handoff, never a chosen id
+# ===========================================================================
+
+
+async def _resolved_failed_hold(space: FakeLockSpace, *, pid: int, key: int) -> str:
+    """Create a durable-true hold, then resolve it, and return its retired id."""
+
+    lease, connection, hold = await _durable_true_hold(space, pid=pid, key=key)
+    connection._unlock_returns = None
+    await lease.release(lease.grant)
+    assert hold.hold_id not in _retained_authorities()
+    assert held_coordination(hold.hold_id) is None
+    return hold.hold_id
+
+
+def _fresh_lease_for(space: FakeLockSpace, *, pid: int, key: int) -> Any:
+    return FakeLockConnection(
+        space, pid=pid, termination_raises=RuntimeError("cannot terminate")
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_supplied_retired_failed_hold_id_is_refused_before_recording():
+    """B53: a retired id supplied through the private seam is fail-closed.
+
+    `_ISSUED_HOLD_IDS` is not an allocator property, it is an *id* property. A
+    supplied id that skipped the allocator would otherwise walk straight around
+    it, and the retired generation's history row would start reporting the new
+    owner's reachability as its own.
+    """
+
+    space = FakeLockSpace()
+    retired = await _resolved_failed_hold(space, pid=8801, key=8801)
+    connection = _fresh_lease_for(space, pid=8802, key=8802)
+    lease = await acquire_physical_account_lease(
+        keys=[8802], connection_factory=ConnectionFactory(connection)
+    )
+    history_before = len(authority_hold_history())
+    active_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        lease._retain_authority(
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            durable_evidence_written=True,
+            hold_id=retired,
+        )
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    # The refusal happens *before* any record is written. A rejection that has
+    # to be undone afterwards is not a rejection.
+    assert len(authority_hold_history()) == history_before
+    assert set(_retained_authorities()) == active_before
+    assert retired not in _retained_authorities()
+
+
+@pytest.mark.asyncio
+async def test_lock_supplied_unissued_id_is_refused():
+    """B53: an id the allocator never issued is not a handoff at all."""
+
+    space = FakeLockSpace()
+    connection = _fresh_lease_for(space, pid=8811, key=8811)
+    lease = await acquire_physical_account_lease(
+        keys=[8811], connection_factory=ConnectionFactory(connection)
+    )
+    history_before = len(authority_hold_history())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        lease._retain_authority(
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            durable_evidence_written=True,
+            hold_id="hold:deadbeefdeadbeef",
+        )
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert len(authority_hold_history()) == history_before
+
+
+@pytest.mark.asyncio
+async def test_lock_completed_success_coordination_id_cannot_be_supplied_again():
+    """B53: a *successful* coordination retires its id just as firmly."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    seen: dict[str, str] = {}
+    before = set(held_coordinations())
+
+    async def capture(scope: Any) -> Any:
+        ids = set(held_coordinations()) - before
+        assert len(ids) == 1
+        seen["hold_id"] = ids.pop()
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000011"
+        )
+
+    stack["callback"] = capture
+    await _run(envelope, stack)
+    completed = seen["hold_id"]
+    # The successful coordination surrendered its handle...
+    assert held_coordination(completed) is None
+
+    space = FakeLockSpace()
+    connection = _fresh_lease_for(space, pid=8821, key=8821)
+    lease = await acquire_physical_account_lease(
+        keys=[8821], connection_factory=ConnectionFactory(connection)
+    )
+    history_before = len(authority_hold_history())
+    with pytest.raises(CoordinationError) as excinfo:
+        lease._retain_authority(
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            durable_evidence_written=True,
+            hold_id=completed,
+        )
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert len(authority_hold_history()) == history_before
+
+
+@pytest.mark.asyncio
+async def test_lock_completed_success_coordination_id_is_never_reallocated(
+    monkeypatch,
+):
+    """B53: issuing must be recorded at *allocation*, not only on failure.
+
+    A defect that adds ids to the process-lifetime set only when a failed hold is
+    recorded leaves every successful coordination id free to be drawn again.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    seen: dict[str, str] = {}
+    before = set(held_coordinations())
+
+    async def capture(scope: Any) -> Any:
+        seen["hold_id"] = (set(held_coordinations()) - before).pop()
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000012"
+        )
+
+    stack["callback"] = capture
+    await _run(envelope, stack)
+    completed = seen["hold_id"]
+
+    # Force the allocator to draw exactly that retired token again.
+    monkeypatch.setattr(
+        coordination.secrets, "token_hex", lambda _n: completed.removeprefix("hold:")
+    )
+    space = FakeLockSpace()
+    connection = _fresh_lease_for(space, pid=8831, key=8831)
+    lease = await acquire_physical_account_lease(
+        keys=[8831], connection_factory=ConnectionFactory(connection)
+    )
+    connection._unlock_returns = False
+    with pytest.raises(CoordinationError):
+        await lease.release(lease.grant)
+    fresh = lease.unreleased_authority_hold
+    assert fresh is not None
+    assert fresh.hold_id != completed
+
+
+@pytest.mark.asyncio
+async def test_lock_legitimate_active_preallocation_handoff_stays_green():
+    """B53: the supported case — one stuck account keeps one opaque id."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    authority_hold = _held_coordination(hold_id).lease.unreleased_authority_hold
+    assert authority_hold is not None
+    # The coordination handle and the authority record share the one id.
+    assert authority_hold.hold_id == hold_id
+    assert authority_hold.durable_evidence_written is False
+    # Exactly one history row was written for that id, ever.
+    assert len([h for h in authority_hold_history() if h.hold_id == hold_id]) == 1
+
+
+@pytest.mark.asyncio
+async def test_lock_retired_history_row_never_borrows_a_live_owners_truth():
+    """B53: projection is bound to the exact active record, not to the id string.
+
+    Deliberately white-box. The handoff gate above makes id aliasing unreachable
+    from outside, so this constructs the state the projection guard exists to
+    refuse rather than pretending a public path reaches it. It pins the
+    invariant: if a later change ever lets one id name two generations, the older
+    record must still not report the newer owner's reachability.
+    """
+
+    space = FakeLockSpace()
+    lease, connection, live_hold = await _durable_true_hold(space, pid=8841, key=8841)
+    raw_active = coordination._ACTIVE_AUTHORITY_HOLDS[live_hold.hold_id]
+    assert _hold_view(raw_active).recoverable_in_process is True
+
+    # A different record object carrying the same id — what aliasing would make.
+    stale = replace(raw_active, recoverable_in_process=True)
+    assert stale is not raw_active and stale.hold_id == raw_active.hold_id
+
+    assert _hold_view(stale).recoverable_in_process is False
+    # The genuine active record is unaffected by the question being asked.
+    assert _hold_view(raw_active).recoverable_in_process is True
+    assert _retained_authorities()[live_hold.hold_id].connection is connection
+    assert lease.unreleased_authority_hold == _hold_view(raw_active)
+
+
+# ===========================================================================
+# §B54 — outer cancellation and outcome-access failure are independent facts
+# ===========================================================================
+
+
+async def _run_with_outer_cancel_and_failing_outcome(
+    stack: dict[str, Any], monkeypatch: Any
+) -> tuple[BaseException | None, Any]:
+    """Cancel the coordinator, then make reading the callback outcome raise."""
+
+    _, envelope = _attempt_envelope()
+    gate, started = asyncio.Event(), asyncio.Event()
+    stack["callback"] = RecordingCallback(gate=gate, started=started)
+
+    def hostile_outcome(task: Any) -> Any:
+        raise RuntimeError("custom Task outcome access failed")
+
+    monkeypatch.setattr(coordination, "_callback_outcome", hostile_outcome)
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    task.cancel()  # a real outer cancellation
+    for _ in range(5):
+        await asyncio.sleep(0)
+    gate.set()
+    surfaced: BaseException | None = None
+    try:
+        await task
+    except BaseException as exc:
+        surfaced = exc
+    return surfaced, stack["callback"].scopes[0]
+
+
+@pytest.mark.asyncio
+async def test_claim_outcome_access_failure_keeps_the_captured_outer_cancellation(
+    monkeypatch,
+):
+    """B54: two independent facts, and neither may erase the other.
+
+    ``_await_retained_task`` establishes whether the caller cancelled us. If
+    reading the callback outcome then fails, containing that failure must replace
+    the *result* only — writing ``outer_cancellation_requested=False`` into
+    durable evidence for a send the caller demonstrably asked to stop is a lie
+    about the one thing an operator needs.
+    """
+
+    stack = _default_stack()
+    surfaced, scope = await _run_with_outer_cancel_and_failing_outcome(
+        stack, monkeypatch
+    )
+
+    # Precedence: outcome error outranks the outer cancellation, so the
+    # CancelledError does not cover it.
+    assert isinstance(surfaced, RuntimeError)
+    assert "outcome access failed" in str(surfaced)
+
+    # Both durable writes closed before anything was surrendered.
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert evidence.outer_cancellation_requested is True
+
+    # The captured scope is permanently dead.
+    with pytest.raises(CoordinationError) as expired:
+        await scope.assert_owned()
+    assert expired.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+
+@pytest.mark.asyncio
+async def test_claim_scope_is_dead_after_a_self_cancelling_callback():
+    """B54: the self-cancel branch expires the scope too, not only the happy path."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    captured: dict[str, Any] = {}
+    posts: list[str] = []
+
+    async def self_cancelling(scope: Any) -> Any:
+        captured["scope"] = scope
+        await scope.assert_owned()
+        posts.append("POST")
+        current = asyncio.current_task()
+        assert current is not None
+        current.cancel()
+        await asyncio.sleep(0)
+        raise AssertionError("unreachable")
+
+    stack["callback"] = self_cancelling
+    with pytest.raises(asyncio.CancelledError):
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    assert stack["evidence"].only.outer_cancellation_requested is False
+    with pytest.raises(CoordinationError) as expired:
+        await captured["scope"].assert_owned()
+    assert expired.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+
+@pytest.mark.parametrize("failing", ["lineage", "evidence"])
+@pytest.mark.asyncio
+async def test_claim_outcome_access_failure_durable_write_precedence(
+    failing, monkeypatch
+):
+    """B54: a durable-write failure outranks the outcome error, and holds fast."""
+
+    stack = _default_stack()
+    if failing == "lineage":
+        stack["persistence"] = RecordingPersistence(fail_from_call=1)
+    else:
+        stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+
+    surfaced, scope = await _run_with_outer_cancel_and_failing_outcome(
+        stack, monkeypatch
+    )
+
+    # Precedence: lineage_persistence_unavailable beats the outcome error, which
+    # in turn beats the outer cancellation.
+    assert isinstance(surfaced, CoordinationError)
+    assert surfaced.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+
+    # Both writes were attempted; one failing never skips the other.
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert surfaced.hold_id == hold_id
+    held = _held_coordination(hold_id)
+    authority_hold = held.lease.unreleased_authority_hold
+    assert authority_hold is not None
+    # Same opaque id on both records, durable-false, and nothing cleaned up.
+    assert authority_hold.hold_id == hold_id
+    assert authority_hold.durable_evidence_written is False
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert stack["intents"].rows != {}
+    assert stack["intents"].release_if_matches_calls == []
+
+    # The public handle still refuses to release it.
+    with pytest.raises(CoordinationError) as refused:
+        await held.lease.release(held.grant)
+    assert refused.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+
+    with pytest.raises(CoordinationError):
+        await scope.assert_owned()
+
+
+@pytest.mark.asyncio
+async def test_claim_self_cancelled_callback_scope_dies_even_when_the_lease_is_kept():
+    """B54: the gate must be what kills the scope, not the lease release.
+
+    On every path that releases the lease, a captured scope fails anyway because
+    the lease itself refuses — so asserting "dead scope" there proves nothing
+    about the gate. Here the durable write fails, so the authority is deliberately
+    retained and the lease is *not* released: if the gate stayed live for the
+    self-cancel branch, the captured scope would still work.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    captured: dict[str, Any] = {}
+    held_before = set(held_coordinations())
+
+    async def self_cancelling(scope: Any) -> Any:
+        captured["scope"] = scope
+        await scope.assert_owned()
+        current = asyncio.current_task()
+        assert current is not None
+        current.cancel()
+        await asyncio.sleep(0)
+        raise AssertionError("unreachable")
+
+    stack["callback"] = self_cancelling
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+
+    # The lease is retained, not released — so it would still attest ownership.
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    held = _held_coordination(stuck.pop())
+    assert held.lease.released is False
+    await held.lease.assert_owned(held.grant)
+
+    # The scope is nevertheless dead, and only the gate can have done that.
+    with pytest.raises(CoordinationError) as expired:
+        await captured["scope"].assert_owned()
+    assert expired.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+
+@pytest.mark.asyncio
+async def test_lock_rollback_that_retains_then_raises_makes_only_one_hold(monkeypatch):
+    """B55: the outer fallback must not double-count one stuck account.
+
+    The helper can retain the exact authority and *then* fail on its way out. If
+    the caller's fallback records unconditionally, one stuck account appears
+    twice, and every count that follows it — holds, successors, operator triage —
+    is wrong. The existing exploding helper raises before retaining, so it cannot
+    see this.
+    """
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=11301)
+    await acquire_physical_account_lease(
+        keys=[1132], connection_factory=ConnectionFactory(blocker)
+    )
+    connection = FakeLockConnection(
+        space, pid=11302, termination_raises=RuntimeError("cannot terminate")
+    )
+
+    async def retain_then_explode(
+        conn: Any, acquired: Any, grant: Any, *, in_flight: Any = ()
+    ) -> None:
+        coordination._record_unreleased_authority(
+            grant,
+            owner=conn,
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=conn,
+        )
+        raise RuntimeError("rollback failed after retaining")
+
+    monkeypatch.setattr(
+        coordination, "_rollback_partial_acquisition", retain_then_explode
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[1131, 1132], connection_factory=ConnectionFactory(connection)
+        )
+
+    new_holds = set(_retained_authorities()) - retained_before
+    # Exactly one — the helper's record, adopted rather than duplicated.
+    assert len(new_holds) == 1
+    retained = _retained_authorities()[new_holds.pop()]
+    assert retained.connection is connection
+    assert connection.closed is False
+    # And exactly one history row for this authority, not two.
+    rows = [
+        h
+        for h in authority_hold_history()
+        if h.hold_id
+        in set(_retained_authorities()) - retained_before | {retained.hold_id}
+    ]
+    assert len([h for h in rows if h.hold_id == retained.hold_id]) == 1
+
+
+# ===========================================================================
+# §B56 — the two exact post-send stimuli crossed with all three outcomes
+# ===========================================================================
+
+
+def _install_scheduling_failure_stimulus(
+    stack: dict[str, Any], monkeypatch: Any, posts: list[str]
+) -> type[BaseException]:
+    """Stimulus 1: a synchronous POST, then ``ensure_future`` itself refuses."""
+
+    real_ensure_future = asyncio.ensure_future
+    armed = {"value": False}
+    pending: dict[str, Any] = {}
+
+    def one_shot_failure(coro_or_future: Any, **kwargs: Any) -> Any:
+        if armed["value"]:
+            armed["value"] = False
+            if asyncio.iscoroutine(coro_or_future):
+                coro_or_future.close()
+            inner = pending.pop("inner", None)
+            if asyncio.iscoroutine(inner):
+                inner.close()
+            raise RuntimeError("event loop refused to schedule")
+        return real_ensure_future(coro_or_future, **kwargs)
+
+    monkeypatch.setattr(coordination.asyncio, "ensure_future", one_shot_failure)
+
+    async def sender(scope: Any) -> MutationCallbackResult:  # pragma: no cover
+        return MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN)
+
+    def arming_callback(scope: Any) -> Any:
+        posts.append("POST")
+        armed["value"] = True
+        pending["inner"] = sender(scope)
+        return pending["inner"]
+
+    stack["callback"] = arming_callback
+    return RuntimeError
+
+
+def _install_sync_cancellation_stimulus(
+    stack: dict[str, Any], monkeypatch: Any, posts: list[str]
+) -> type[BaseException]:
+    """Stimulus 2: a synchronous POST, then a synchronous ``CancelledError``."""
+
+    def sync_cancel(scope: Any) -> Any:
+        posts.append("POST")
+        raise asyncio.CancelledError()
+
+    stack["callback"] = sync_cancel
+    return asyncio.CancelledError
+
+
+_B56_STIMULI = {
+    "scheduling_failure": _install_scheduling_failure_stimulus,
+    "sync_cancellation": _install_sync_cancellation_stimulus,
+}
+
+
+@pytest.mark.parametrize("stimulus", sorted(_B56_STIMULI))
+@pytest.mark.asyncio
+async def test_claim_stimulus_success_orders_both_writes_before_any_cleanup(
+    stimulus, monkeypatch
+):
+    """B56: for each exact stimulus, prove the *post-send* write ordering.
+
+    Asserting on the first ``persist`` event proves nothing: that is the pre-send
+    write, and it is already ordered before everything. The mandatory post-send
+    write is a separate event, and it is the one that must precede cleanup.
+    """
+
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    stack = _default_stack(events)
+    posts: list[str] = []
+    expected = _B56_STIMULI[stimulus](stack, monkeypatch, posts)
+
+    with pytest.raises(expected):
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert stack["evidence"].only.certainty is MutationCertainty.UNCERTAIN
+
+    # The exact post-send order, anchored on the *second* lineage write.
+    order = [
+        events.index("persist_post"),
+        events.index("evidence"),
+        events.index("lease_unlock"),
+        events.index("lease_closed"),
+    ]
+    assert order == sorted(order)
+    assert events.index("persist_pre") < events.index("persist_post")
+    # The durable claim is never released by coordination.
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+
+
+@pytest.mark.parametrize("failing", ["lineage", "evidence"])
+@pytest.mark.parametrize("stimulus", sorted(_B56_STIMULI))
+@pytest.mark.asyncio
+async def test_claim_stimulus_durable_write_failure_locks_the_account(
+    stimulus, failing, monkeypatch
+):
+    """B56: each stimulus crossed with each individual durable-write failure.
+
+    A stimulus-specific early release, or a short-circuit that skips the
+    dispatch-evidence attempt once the second lineage write failed, is invisible
+    to a success-only stimulus test and to a stimulus-free failure test.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    if failing == "lineage":
+        stack["persistence"] = RecordingPersistence(fail_from_call=1)
+    else:
+        stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    posts: list[str] = []
+    _B56_STIMULI[stimulus](stack, monkeypatch, posts)
+    held_before = set(held_coordinations())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    # The durable-write failure outranks the stimulus error.
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    # Both writes were attempted; one failing never skips the other.
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    held = _held_coordination(hold_id)
+    authority_hold = held.lease.unreleased_authority_hold
+    assert authority_hold is not None
+    # One opaque id across both records, durable-false, and zero cleanup.
+    assert authority_hold.hold_id == hold_id
+    assert authority_hold.durable_evidence_written is False
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+    assert held_coordination(hold_id) is not None
+
+    # Neither the public handle nor the owning lease can release it.
+    with pytest.raises(CoordinationError) as public_refusal:
+        await held.lease.release(held.grant)
+    assert public_refusal.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -638,6 +638,50 @@ class RecordingDispatchEvidence:
         return self.records[0]
 
 
+class FakeUncertaintyGate:
+    """Stand-in for the lane's account-uncertainty authority.
+
+    It knows nothing about reservations. Correction 1 exists because "has this
+    exact send already gone out" and "is any prior outcome on this account still
+    unknown" are different questions; wiring this fake to the reservation rows
+    would rebuild the very defect under test.
+    """
+
+    def __init__(
+        self,
+        *,
+        unresolved: object = False,
+        error: BaseException | None = None,
+        cancel: bool = False,
+        gate: asyncio.Event | None = None,
+        started: asyncio.Event | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self.calls: list[str] = []
+        self._unresolved = unresolved
+        self._error = error
+        self._cancel = cancel
+        self._gate = gate
+        self._started = started
+        self._events = events
+
+    async def has_unresolved_account_uncertainty(
+        self, *, claim_account_scope: str
+    ) -> bool:
+        self.calls.append(claim_account_scope)
+        if self._events is not None:
+            self._events.append("uncertainty_query")
+        if self._started is not None:
+            self._started.set()
+        if self._gate is not None:
+            await self._gate.wait()
+        if self._cancel:
+            raise asyncio.CancelledError()
+        if self._error is not None:
+            raise self._error
+        return self._unresolved  # type: ignore[return-value]
+
+
 class FakeIntents:
     """Structural stand-in for ``OrderSendIntentService`` (binary claims only)."""
 
@@ -775,12 +819,14 @@ def _coordination_kwargs(
     intents: FakeIntents,
     factory: ConnectionFactory,
     callback: RecordingCallback,
+    uncertainty_gate: Any = None,
 ) -> dict[str, Any]:
     return {
         "envelope": envelope,
         "registry": lane_registry,
         "persistence": persistence,
         "dispatch_evidence": evidence,
+        "uncertainty_gate": uncertainty_gate,
         "claims": DurableSendClaimAdapter(intents),
         "connection_factory": factory,
         "mutation": callback,
@@ -798,6 +844,7 @@ def _default_stack(events: list[str] | None = None) -> dict[str, Any]:
         "evidence": RecordingDispatchEvidence(events=events),
         "intents": FakeIntents(events=events),
         "callback": RecordingCallback(events=events),
+        "uncertainty_gate": FakeUncertaintyGate(events=events),
     }
 
 
@@ -816,6 +863,7 @@ async def _run(
             intents=stack["intents"],
             factory=stack["factory"],
             callback=stack["callback"],
+            uncertainty_gate=stack.get("uncertainty_gate"),
         )
     )
 
@@ -2199,6 +2247,10 @@ async def test_claim_persist_precedes_reserve_precedes_callback_precedes_release
 
     assert events == [
         "persist_pre",
+        # Correction 1: the account-uncertainty authority is asked after the
+        # lease is held and before the claim is reserved, so the answer cannot
+        # go stale between the check and its use.
+        "uncertainty_query",
         "reserve",
         "callback_start",
         "callback_end",
@@ -2275,41 +2327,110 @@ async def test_claim_duplicate_binary_claim_maps_to_durable_claim_conflict():
 
 
 @pytest.mark.asyncio
-async def test_claim_account_wide_unresolved_reservation_blocks_a_different_order():
+async def test_claim_ack_correlated_open_claim_does_not_block_an_unrelated_plan():
+    """Correction 1 / AC1: a known open order is a position, not an unknown.
+
+    The lease serializes broker-mutation critical sections; it is not an
+    account-lifecycle mutex. A durable claim is keyed to one immutable send
+    lineage and prevents replay of *that* send. Neither of them says an account
+    is unsafe, so a durably ACK-correlated open order must not, by itself, stop
+    an unrelated execution plan.
+    """
+
     _, first_envelope = _attempt_envelope()
     _, second_envelope = _attempt_envelope(
-        attempt_overrides={"cycle_id": "cycle-j3a-2"}
-    )
-    assert (
-        first_envelope.order_attempt.idempotency_key
-        != second_envelope.order_attempt.idempotency_key
+        attempt_overrides={"cycle_id": "cycle-j3a-8"}
     )
     space = FakeLockSpace()
     intents = FakeIntents()
+
     first_stack = _default_stack()
     first_stack["space"] = space
     first_stack["connection"] = FakeLockConnection(space, pid=1)
     first_stack["factory"] = ConnectionFactory(first_stack["connection"])
     first_stack["intents"] = intents
-
-    await _run(first_envelope, first_stack)
+    first_stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000042"
+        )
+    )
+    first = await _run(first_envelope, first_stack)
+    # Durably attributed native id and an immutable ACK: the outcome is known.
+    assert first.evidence.kind is DispatchEvidenceKind.ACKNOWLEDGED
+    assert first.evidence.broker_order_id == "ODNO-0000042"
     assert len(intents.rows) == 1
 
     second_stack = _default_stack()
     second_stack["connection"] = FakeLockConnection(space, pid=2)
     second_stack["factory"] = ConnectionFactory(second_stack["connection"])
     second_stack["intents"] = intents
+    # The authority reports the account settled — the open claim is not evidence
+    # of uncertainty and is deliberately not consulted for this question.
+    second_stack["uncertainty_gate"] = FakeUncertaintyGate(unresolved=False)
 
+    second = await _run(second_envelope, second_stack)
+
+    assert second_stack["callback"].calls == 1
+    assert second.claim.idempotency_key != first.claim.idempotency_key
+    # A second exact claim exists, and the first is untouched.
+    assert len(intents.rows) == 2
+    assert first.claim.row_id in intents.rows
+    assert intents.release_if_matches_calls == []
+    # The authority was asked about this exact physical account.
+    assert second_stack["uncertainty_gate"].calls == [second.scope.claim_account_scope]
+
+
+@pytest.mark.asyncio
+async def test_claim_same_exact_lineage_is_still_blocked_by_the_binary_claim():
+    """Correction 1 / AC2: replay protection is unchanged and is the claim's job."""
+
+    _, envelope = _attempt_envelope()
+    space = FakeLockSpace()
+    intents = FakeIntents()
+
+    first_stack = _default_stack()
+    first_stack["space"] = space
+    first_stack["connection"] = FakeLockConnection(space, pid=1)
+    first_stack["factory"] = ConnectionFactory(first_stack["connection"])
+    first_stack["intents"] = intents
+    await _run(envelope, first_stack)
+    assert len(intents.rows) == 1
+
+    replay = _default_stack()
+    replay["connection"] = FakeLockConnection(space, pid=2)
+    replay["factory"] = ConnectionFactory(replay["connection"])
+    replay["intents"] = intents
+    replay["uncertainty_gate"] = FakeUncertaintyGate(unresolved=False)
+
+    # Same exact idempotency/lineage, and the account is settled: the block comes
+    # from the reservation's unique conflict, not from an account-wide gate.
     with pytest.raises(CoordinationError) as excinfo:
-        await _run(second_envelope, second_stack)
-
+        await _run(envelope, replay)
     assert excinfo.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
-    assert second_stack["callback"].calls == 0
+    assert replay["callback"].calls == 0
     assert len(intents.rows) == 1
 
 
 @pytest.mark.asyncio
-async def test_claim_survives_a_crash_and_blocks_the_next_lease_owner():
+async def test_claim_unresolved_account_uncertainty_blocks_even_a_different_plan():
+    """Correction 1 / AC3: an *unknown* prior outcome does block the account."""
+
+    _, envelope = _attempt_envelope(attempt_overrides={"cycle_id": "cycle-j3a-7"})
+    stack = _default_stack()
+    stack["uncertainty_gate"] = FakeUncertaintyGate(unresolved=True)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+    # Nothing was reserved and nothing was sent.
+    assert stack["intents"].reserve_calls == []
+    assert stack["intents"].rows == {}
+    assert stack["callback"].calls == 0
+
+
+@pytest.mark.asyncio
+async def test_claim_survives_a_crash_and_uncertainty_blocks_the_next_owner():
     _, envelope = _attempt_envelope()
     _, next_envelope = _attempt_envelope(attempt_overrides={"cycle_id": "cycle-j3a-9"})
     space = FakeLockSpace()
@@ -2334,13 +2455,35 @@ async def test_claim_survives_a_crash_and_blocks_the_next_lease_owner():
     successor["connection"] = FakeLockConnection(space, pid=2)
     successor["factory"] = ConnectionFactory(successor["connection"])
     successor["intents"] = intents
+    # A callback that died mid-send leaves the outcome uncorrelated, which is
+    # what the lane's authority reports. Correction 1: the successor is stopped
+    # by *that*, not by the surviving claim row — the row only proves this exact
+    # send was already attempted.
+    successor["uncertainty_gate"] = FakeUncertaintyGate(unresolved=True)
+    reserves_before = len(intents.reserve_calls)
 
     with pytest.raises(CoordinationError) as excinfo:
         await _run(next_envelope, successor)
 
     assert excinfo.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
     assert successor["callback"].calls == 0
+    # No new reservation was even attempted: the gate is asked before reserve.
+    assert len(intents.reserve_calls) == reserves_before
     assert len(intents.rows) == 1
+
+    # And once the lane can correlate that outcome, an unrelated plan proceeds
+    # even though the crashed send's claim is still on the account.
+    settled = _default_stack()
+    settled["connection"] = FakeLockConnection(space, pid=3)
+    settled["factory"] = ConnectionFactory(settled["connection"])
+    settled["intents"] = intents
+    settled["uncertainty_gate"] = FakeUncertaintyGate(unresolved=False)
+    _, third_envelope = _attempt_envelope(
+        attempt_overrides={"cycle_id": "cycle-j3a-10"}
+    )
+    await _run(third_envelope, settled)
+    assert settled["callback"].calls == 1
+    assert len(intents.rows) == 2
 
 
 @pytest.mark.asyncio
@@ -2394,7 +2537,7 @@ async def test_claim_terminal_evidence_plus_reconcile_permits_exact_release():
         "claimed_absence_without_reconcile",
     ],
 )
-async def test_claim_insufficient_evidence_retains_the_claim_and_the_account_block(
+async def test_claim_insufficient_evidence_retains_the_exact_claim(
     evidence: coordination.TerminalClaimEvidence,
 ):
     _, envelope = _attempt_envelope()
@@ -2411,7 +2554,10 @@ async def test_claim_insufficient_evidence_retains_the_claim_and_the_account_blo
     # The evidence-less delete never reached the database at all.
     assert stack["intents"].release_if_matches_calls == []
     assert len(stack["intents"].rows) == 1
-    assert await adapter.account_has_unresolved_claim(result.scope) is True
+    # Correction 1 / AC8: the retained row proves this exact send was made. It is
+    # deliberately NOT asserted to block unrelated plans — that question belongs
+    # to the account-uncertainty authority, and the adapter no longer answers it.
+    assert not hasattr(adapter, "account_has_unresolved_claim")
 
 
 @pytest.mark.asyncio
@@ -3244,6 +3390,7 @@ async def test_claim_evidence_ack_attachment_failure_is_durable_before_release()
                 intents=stack["intents"],
                 factory=stack["factory"],
                 callback=stack["callback"],
+                uncertainty_gate=stack.get("uncertainty_gate"),
             ),
             lineage_factory=_FailingAckFactory(),
         )
@@ -3282,6 +3429,7 @@ async def test_claim_evidence_ack_failure_with_broken_durability_keeps_the_hold(
                 intents=stack["intents"],
                 factory=stack["factory"],
                 callback=stack["callback"],
+                uncertainty_gate=stack.get("uncertainty_gate"),
             ),
             lineage_factory=_FailingAckFactory(),
         )
@@ -4517,6 +4665,7 @@ async def test_claim_registry_swapped_during_reserve_never_reaches_the_callback(
                     intents=stack["intents"],
                     factory=stack["factory"],
                     callback=stack["callback"],
+                    uncertainty_gate=stack.get("uncertainty_gate"),
                 ),
                 "registry": MutatingRegistry(),
             }
@@ -4885,6 +5034,7 @@ async def test_claim_cancelled_ack_attachment_still_reaches_both_writes():
                 intents=stack["intents"],
                 factory=stack["factory"],
                 callback=stack["callback"],
+                uncertainty_gate=stack.get("uncertainty_gate"),
             ),
             lineage_factory=_CancellingAckFactory(),
         )
@@ -5334,6 +5484,7 @@ async def test_claim_scope_local_pinned_entry_check_is_independently_load_bearin
                     intents=stack["intents"],
                     factory=stack["factory"],
                     callback=stack["callback"],
+                    uncertainty_gate=stack.get("uncertainty_gate"),
                 ),
                 "registry": LateSwitchingRegistry(),
             }
@@ -5679,6 +5830,7 @@ async def test_scope_authorized_future_consumer_may_import_and_use_the_port():
             intents=stack["intents"],
             factory=stack["factory"],
             callback=stack["callback"],
+            uncertainty_gate=stack.get("uncertainty_gate"),
         ),
         # A broker lane supplies its own extra keys; J3A never chooses them.
         additional_advisory_keys=(4242,),
@@ -5842,37 +5994,53 @@ async def test_lock_real_postgres_multi_key_rollback_leaves_nothing_held(db_sess
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_claim_real_order_send_intent_service_round_trip(db_session):
+async def test_claim_real_order_send_intent_service_exact_lineage_round_trip(
+    db_session,
+):
+    """AC9: against the real service, the claim is an exact-lineage record only.
+
+    Correction 1: this test deliberately proves nothing about account lifecycle
+    or uncertainty. `has_reservations()` is not consulted, because "some row
+    exists on this account" is not an answer to "is a prior outcome unknown" —
+    that question belongs to the injected `AccountUncertaintyGatePort`.
+    """
+
     _, envelope = _attempt_envelope(attempt_overrides={"cycle_id": "pg-claim"})
+    _, other = _attempt_envelope(attempt_overrides={"cycle_id": "pg-claim-other"})
     scope = physical_account_scope_for_entry(
         _fully_bound_entry(
             envelope, "kr.kis.mock", physical_account_id="rob-1262-pg-claim"
         )
     )
     adapter = DurableSendClaimAdapter(OrderSendIntentService(db_session))
-    idempotency_key = envelope.order_attempt.idempotency_key
+    key = envelope.order_attempt.idempotency_key
+    other_key = other.order_attempt.idempotency_key
+    assert key != other_key
 
-    assert await adapter.account_has_unresolved_claim(scope) is False
     claim = await adapter.reserve(
-        scope=scope, idempotency_key=idempotency_key, symbol="005930", side="buy"
+        scope=scope, idempotency_key=key, symbol="005930", side="buy"
     )
+    second: Any = None
     try:
-        assert await adapter.account_has_unresolved_claim(scope) is True
+        # The same exact lineage is refused by the unique constraint.
         with pytest.raises(CoordinationError) as excinfo:
             await adapter.reserve(
-                scope=scope,
-                idempotency_key=idempotency_key,
-                symbol="005930",
-                side="buy",
+                scope=scope, idempotency_key=key, symbol="005930", side="buy"
             )
         assert excinfo.value.reason_code is (
             CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
         )
+        # A *different* exact lineage on the same account is accepted: the row
+        # is not an account-wide block.
+        second = await adapter.reserve(
+            scope=scope, idempotency_key=other_key, symbol="005930", side="buy"
+        )
+        assert second.idempotency_key == other_key
+        # Evidence-less release still removes nothing.
         with pytest.raises(CoordinationError):
             await adapter.release_with_terminal_evidence(
                 claim, coordination.TerminalClaimEvidence()
             )
-        assert await adapter.account_has_unresolved_claim(scope) is True
     finally:
         deleted = await adapter.release_with_terminal_evidence(
             claim,
@@ -5882,8 +6050,21 @@ async def test_claim_real_order_send_intent_service_round_trip(db_session):
                 remainder_known=True,
             ),
         )
-    assert deleted == 1
-    assert await adapter.account_has_unresolved_claim(scope) is False
+        assert deleted == 1
+        if second is not None:
+            # Exact release removed only the matching row; the sibling survived
+            # until its own evidence arrived.
+            assert (
+                await adapter.release_with_terminal_evidence(
+                    second,
+                    coordination.TerminalClaimEvidence(
+                        lane_native_terminal_evidence=True,
+                        account_position_reconciled=True,
+                        remainder_known=True,
+                    ),
+                )
+                == 1
+            )
 
 
 # ===========================================================================
@@ -7461,3 +7642,200 @@ async def test_lock_rollback_that_retains_then_raises_makes_only_one_hold(monkey
     assert connection.closed is False
     # And exactly one history row for it, not two.
     assert len([h for h in authority_hold_history() if h.hold_id == hold_id]) == 1
+
+
+# ===========================================================================
+# §Correction 1 — the account-uncertainty authority is separate and fail-closed
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_claim_definitive_without_attributed_id_is_judged_by_the_authority():
+    """AC4: J3A never infers 'settled' from the presence of a binary row.
+
+    A definitive callback that produced no attributed native order id is exactly
+    the state a lane may still consider uncorrelated. J3A does not decide that
+    from its own tables — it asks, and it obeys the answer.
+    """
+
+    _, first = _attempt_envelope()
+    space = FakeLockSpace()
+    intents = FakeIntents()
+    stack = _default_stack()
+    stack["space"] = space
+    stack["connection"] = FakeLockConnection(space, pid=1)
+    stack["factory"] = ConnectionFactory(stack["connection"])
+    stack["intents"] = intents
+    stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(certainty=MutationCertainty.DEFINITIVE)
+    )
+    result = await _run(first, stack)
+    # Definitive, but with no attributed native id and therefore no ACK.
+    assert result.evidence.kind is DispatchEvidenceKind.DEFINITIVE_WITHOUT_BROKER_ID
+    assert result.evidence.broker_order_id is None
+    assert len(intents.rows) == 1
+
+    _, second = _attempt_envelope(attempt_overrides={"cycle_id": "cycle-j3a-11"})
+    successor = _default_stack()
+    successor["connection"] = FakeLockConnection(space, pid=2)
+    successor["factory"] = ConnectionFactory(successor["connection"])
+    successor["intents"] = intents
+    successor["uncertainty_gate"] = FakeUncertaintyGate(unresolved=True)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(second, successor)
+    assert excinfo.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+    assert successor["callback"].calls == 0
+
+
+@pytest.mark.parametrize(
+    "flavour",
+    [
+        "missing",
+        "raises",
+        "returns_truthy_string",
+        "returns_falsy_zero",
+        "returns_none",
+    ],
+)
+@pytest.mark.asyncio
+async def test_claim_uncertainty_authority_failures_are_fail_closed(flavour):
+    """AC5: missing, failing, or mistyped authority answers block the send.
+
+    ``"0"`` is truthy and ``0`` is falsy; neither is an answer to "is this
+    account settled". Deciding a broker-safety question on an accidental
+    truthiness is the failure mode this rejects, so only an exact ``bool`` is
+    accepted and everything else is unavailability.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    if flavour == "missing":
+        stack["uncertainty_gate"] = None
+    elif flavour == "raises":
+        stack["uncertainty_gate"] = FakeUncertaintyGate(
+            error=RuntimeError("lane evidence store unreachable")
+        )
+    elif flavour == "returns_truthy_string":
+        stack["uncertainty_gate"] = FakeUncertaintyGate(unresolved="false")
+    elif flavour == "returns_falsy_zero":
+        stack["uncertainty_gate"] = FakeUncertaintyGate(unresolved=0)
+    else:
+        stack["uncertainty_gate"] = FakeUncertaintyGate(unresolved=None)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    ), flavour
+    assert stack["intents"].reserve_calls == [], flavour
+    assert stack["intents"].rows == {}, flavour
+    assert stack["callback"].calls == 0, flavour
+    if flavour == "missing":
+        # Fail-closed before the lease is ever taken.
+        assert stack["factory"].calls == 0
+        assert stack["connection"].lock_calls == []
+
+
+@pytest.mark.asyncio
+async def test_claim_cancellation_during_the_uncertainty_query_is_redelivered():
+    """AC6: a pre-send cancellation stops cleanly and is re-delivered."""
+
+    _, envelope = _attempt_envelope()
+    gate, started = asyncio.Event(), asyncio.Event()
+    stack = _default_stack()
+    stack["uncertainty_gate"] = FakeUncertaintyGate(gate=gate, started=started)
+    holds_before = {h.hold_id for h in unreleased_authority_holds()}
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Nothing was reserved and nothing was sent, and the lease was surrendered.
+    assert stack["intents"].reserve_calls == []
+    assert stack["callback"].calls == 0
+    assert stack["connection"].closed is True
+    # The lease was proven released, so this cancellation left no new stuck
+    # authority behind.
+    assert {h.hold_id for h in unreleased_authority_holds()} == holds_before
+
+
+@pytest.mark.parametrize("outcome", ["attributed_ack", "durable_uncertainty"])
+@pytest.mark.asyncio
+async def test_claim_lease_releases_while_the_claim_remains(outcome):
+    """AC7: distinct lifetimes — the lease goes, the claim stays.
+
+    Both durable writes land, so the ephemeral advisory lease may be released.
+    The claim outlives it and is removed only by terminal evidence plus
+    reconcile, never by lease release, backend termination, GC or time.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    if outcome == "attributed_ack":
+        stack["callback"] = RecordingCallback(
+            result=MutationCallbackResult(
+                certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000077"
+            )
+        )
+    else:
+        stack["callback"] = RecordingCallback(
+            result=MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN)
+        )
+
+    result = await _run(envelope, stack)
+
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    # Lease surrendered...
+    assert stack["connection"].closed is True
+    assert stack["space"].held == {}
+    # ...claim retained, and never released by anything but exact evidence.
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+    assert stack["intents"].unrestricted_release_calls == 0
+    assert result.claim.row_id in stack["intents"].rows
+
+
+def test_scope_no_account_wide_claim_prose_survives():
+    """AC10: the retired 'claim == account block' framing must not come back.
+
+    Word-presence checks are false green here — the correction is about what the
+    sentences *say*. These are exact propositions, plus the verbatim block the
+    contract is required to carry.
+    """
+
+    source = pathlib.Path(coordination.__file__).read_text()
+    contract = (REPO_ROOT / "docs/contracts/rob-1262-coordination-port.md").read_text()
+
+    for text, label in ((source, "source"), (contract, "contract")):
+        flat = " ".join(text.split()).lower()
+        for retired in (
+            "the durable claim is the entire account block",
+            "mere existence is the account-wide block",
+            "any unresolved reservation blocks every new order",
+            "any reservation blocks the account",
+        ):
+            assert retired not in flat, f"{label}: stale phrase {retired!r}"
+
+    # The coordinator must not reach the generic reservation predicates.
+    assert "has_reservations" not in source
+    assert "account_has_unresolved_claim" not in source
+
+    # The verbatim correction is carried in the contract, not paraphrased.
+    for sentence in (
+        "it is not an account-lifecycle mutex",
+        "a durable send claim is keyed to the exact immutable send lineage",
+        "a durably ack-correlated open order continues through lane-native "
+        "lifecycle tracking and does not, by itself, block unrelated execution plans",
+        "that restriction must be declared as an activation policy",
+        "the advisory lease and the durable claim have distinct lifetimes",
+        "backend termination proves only cessation of lease authority",
+    ):
+        assert sentence in " ".join(contract.split()).lower(), sentence

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -5081,9 +5081,12 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
     _capture_rollback_identities(monkeypatch, captured)
     retained_before = set(_retained_authorities())
     active_before = set(_active_holds())
-    # Snapshot the foreign world BEFORE the failure, excluding anything new.
+    # X3: snapshot the foreign world BEFORE the failure, by object identity and
+    # order — history included. A count cannot see a foreign row replaced by an
+    # equal-but-different object.
     foreign_before = dict(_retained_authorities())
     foreign_active_before = dict(_active_holds())
+    foreign_history_before = list(coordination._AUTHORITY_HOLD_HISTORY)
 
     with pytest.raises(CoordinationError):
         await acquire_physical_account_lease(
@@ -5126,11 +5129,19 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
         )
     assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
 
-    # Every foreign entry is identical, by object, to the pre-failure snapshot.
+    # Every foreign entry is identical, by object, to the pre-failure snapshot —
+    # retained, active, and the full history prefix in order.
     for other, entry in foreign_before.items():
         assert _retained_authorities()[other] is entry
     for other, row in foreign_active_before.items():
         assert _active_holds()[other] is row
+    history_now = list(coordination._AUTHORITY_HOLD_HISTORY)
+    assert [id(h) for h in history_now[: len(foreign_history_before)]] == [
+        id(h) for h in foreign_history_before
+    ]
+    # Exactly one row was appended, and it is this branch's authority.
+    assert len(history_now) == len(foreign_history_before) + 1
+    assert history_now[-1] is _retained_authorities()[quarantined].raw_hold
     assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
     assert _retained_authorities()[victim_hold.hold_id].owner is victim_owner
     assert victim_connection.closed is False
@@ -5158,7 +5169,7 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
     victim_owner = _retained_authorities()[victim_hold.hold_id].owner
     foreign_before = dict(_retained_authorities())
     foreign_active_before = dict(_active_holds())
-    foreign_history_before = len(authority_hold_history())
+    foreign_history_before = list(coordination._AUTHORITY_HOLD_HISTORY)
 
     blocker = FakeLockConnection(space, pid=11201)
     await acquire_physical_account_lease(
@@ -5194,6 +5205,16 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
     assert _retained_authorities()[hold_id].connection is connection
     assert connection.closed is False
 
+    # X3: measured here, before the successor runs — the exploding helper is
+    # still installed, so a later contended acquisition legitimately records its
+    # own hold and would otherwise be miscounted as foreign corruption.
+    history_after_failure = list(coordination._AUTHORITY_HOLD_HISTORY)
+    assert [id(h) for h in history_after_failure[: len(foreign_history_before)]] == [
+        id(h) for h in foreign_history_before
+    ]
+    assert len(history_after_failure) == len(foreign_history_before) + 1
+    assert history_after_failure[-1] is _retained_authorities()[hold_id].raw_hold
+
     weak_connection = captured["connection"]
     weak_grant = captured["grant"]
     assert weak_connection() is connection
@@ -5224,10 +5245,17 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
     assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
     assert _retained_authorities()[victim_hold.hold_id].owner is victim_owner
     assert victim_connection.closed is False
-    # Exactly one history row exists for this authority — the fallback recorded
-    # it once, not twice.
-    assert len([h for h in authority_hold_history() if h.hold_id == hold_id]) == 1
-    assert len(authority_hold_history()) >= foreign_history_before + 1
+    for other, row in foreign_active_before.items():
+        assert _active_holds()[other] is row
+    # The foreign prefix is still object-identical and in order after everything.
+    history_now = list(coordination._AUTHORITY_HOLD_HISTORY)
+    assert [id(h) for h in history_now[: len(foreign_history_before)]] == [
+        id(h) for h in foreign_history_before
+    ]
+    # This branch's authority was recorded exactly once, and the retained entry
+    # still points at that exact raw row.
+    assert len([h for h in history_now if h.hold_id == hold_id]) == 1
+    assert recovered.raw_hold is history_after_failure[-1]
 
 
 @pytest.mark.asyncio
@@ -6924,6 +6952,33 @@ async def _live_preallocated_handle(space: FakeLockSpace, *, pid: int, key: int)
     return lease, connection, held, capability
 
 
+def _exact_state() -> dict[str, Any]:
+    """Every map and the history list, captured by object identity and order.
+
+    r32 X1/X3: counts cannot detect replacement of a row by an equal-but-
+    different object, so nothing here is a length.
+    """
+
+    return {
+        "history": list(coordination._AUTHORITY_HOLD_HISTORY),
+        "active": dict(_active_holds()),
+        "retained": dict(_retained_authorities()),
+        "held": dict(coordination._HELD_COORDINATION),
+        "capabilities": dict(coordination._COORDINATION_RELEASE_CAPABILITIES),
+    }
+
+
+def _assert_exact_state(before: dict[str, Any], label: str) -> None:
+    after = _exact_state()
+    assert [id(h) for h in after["history"]] == [id(h) for h in before["history"]], (
+        f"{label}: history rows changed by object or order"
+    )
+    for key in ("active", "retained", "held", "capabilities"):
+        assert set(after[key]) == set(before[key]), f"{label}: {key} keys changed"
+        for k in before[key]:
+            assert after[key][k] is before[key][k], f"{label}: {key}[{k}] not identical"
+
+
 def _record_state() -> tuple[int, dict[str, Any], dict[str, Any]]:
     return (
         len(authority_hold_history()),
@@ -6934,11 +6989,13 @@ def _record_state() -> tuple[int, dict[str, Any], dict[str, Any]]:
 
 @pytest.mark.asyncio
 async def test_lock_supplied_id_requires_every_exact_identity():
-    """W2: an id is not a right. Lease, grant, connection and capability all bind.
+    """X1: an id is not a right — lease, grant, connection and capability all bind.
 
-    Each rejection below is a *first* transition on a genuinely live, genuinely
-    issued coordination id — the one shape that would otherwise be accepted — so
-    each one isolates exactly one identity condition.
+    Each cell below is a *first* transition on a genuinely live, genuinely issued
+    coordination id, so each isolates exactly one identity condition. Every
+    rejection is asserted against an exact object-level snapshot of history,
+    active, retained, held and capability state, because a count cannot see a row
+    being replaced by an equal-but-different object.
     """
 
     space = FakeLockSpace()
@@ -6952,14 +7009,27 @@ async def test_lock_supplied_id_requires_every_exact_identity():
     foreign_capability = object()
 
     cases = {
-        "wrong_grant": {
-            "grant": other_lease.grant,
-            "connection": connection,
+        # r32 X1: a missing connection is a rejection, not shorthand. It would
+        # otherwise append history and create an active row while writing no
+        # retained root — an authority nobody is holding.
+        "missing_connection": {
+            "grant": held.grant,
+            "connection": None,
             "capability": capability,
         },
         "wrong_connection": {
             "grant": held.grant,
             "connection": other_conn,
+            "capability": capability,
+        },
+        "wrong_grant": {
+            "grant": other_lease.grant,
+            "connection": connection,
+            "capability": capability,
+        },
+        "equal_copy_grant": {
+            "grant": replace(held.grant),
+            "connection": connection,
             "capability": capability,
         },
         "missing_capability": {
@@ -6974,7 +7044,7 @@ async def test_lock_supplied_id_requires_every_exact_identity():
         },
     }
     for name, kwargs in cases.items():
-        history_before, retained_before, active_before = _record_state()
+        before = _exact_state()
         with pytest.raises(CoordinationError) as excinfo:
             coordination._record_unreleased_authority(
                 kwargs["grant"],
@@ -6989,13 +7059,10 @@ async def test_lock_supplied_id_requires_every_exact_identity():
         assert excinfo.value.reason_code is (
             CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
         ), name
-        # Refused before any record was written, on every one of them.
-        assert len(authority_hold_history()) == history_before, name
-        assert dict(_retained_authorities()) == retained_before, name
-        assert dict(_active_holds()) == active_before, name
+        _assert_exact_state(before, name)
 
-    # And the legitimate exact handoff is still accepted, once.
-    history_before, _, _ = _record_state()
+    # The legitimate exact handoff is still accepted, once.
+    before = _exact_state()
     hold = coordination._record_unreleased_authority(
         held.grant,
         owner=lease,
@@ -7007,11 +7074,11 @@ async def test_lock_supplied_id_requires_every_exact_identity():
         capability=capability,
     )
     assert hold.hold_id == held.hold_id
-    assert len(authority_hold_history()) == history_before + 1
+    assert len(coordination._AUTHORITY_HOLD_HISTORY) == len(before["history"]) + 1
     assert _retained_authorities()[held.hold_id].connection is connection
 
     # A second transition on the same id is refused: it is no longer the first.
-    history_before, retained_before, active_before = _record_state()
+    before = _exact_state()
     with pytest.raises(CoordinationError):
         coordination._record_unreleased_authority(
             held.grant,
@@ -7023,9 +7090,64 @@ async def test_lock_supplied_id_requires_every_exact_identity():
             hold_id=held.hold_id,
             capability=capability,
         )
-    assert len(authority_hold_history()) == history_before
-    assert dict(_retained_authorities()) == retained_before
-    assert dict(_active_holds()) == active_before
+    _assert_exact_state(before, "second_transition")
+
+
+@pytest.mark.asyncio
+async def test_lock_same_owner_retired_id_cannot_be_reused_for_a_second_handoff():
+    """X1 cell 6: resolving the first record does not re-open the id.
+
+    The live preallocated handle is deliberately kept, so the only thing that
+    changed is that this id already carried an authority record once. That alone
+    must close it forever — otherwise the same owner could recycle its own id and
+    the retired generation's history row would start describing a new authority.
+    """
+
+    space = FakeLockSpace()
+    lease, connection, held, capability = await _live_preallocated_handle(
+        space, pid=7311, key=7311
+    )
+    first = coordination._record_unreleased_authority(
+        held.grant,
+        owner=lease,
+        reason_code=CoordinationReasonCode.LEASE_LOST,
+        termination_proven=False,
+        durable_evidence_written=True,
+        connection=connection,
+        hold_id=held.hold_id,
+        capability=capability,
+    )
+    # Retire only the *authority* record. `_resolve_authority_hold` also
+    # unregisters the coordination handle, which would turn this into a
+    # missing-handle rejection instead of the historical-reuse rejection under
+    # test. So the two authority maps are cleared directly and the live
+    # preallocated handle is deliberately left in place — exactly the state r32
+    # describes, and the only thing that has changed about this id is that it
+    # once carried an authority record.
+    del coordination._ACTIVE_AUTHORITY_HOLDS[first.hold_id]
+    del coordination._RETAINED_AUTHORITIES[first.hold_id]
+    assert held.hold_id not in _active_holds()
+    assert held.hold_id not in _retained_authorities()
+    assert coordination._HELD_COORDINATION[held.hold_id] is held
+    assert held.hold_id in coordination._COORDINATION_RELEASE_CAPABILITIES
+    assert any(h.hold_id == held.hold_id for h in coordination._AUTHORITY_HOLD_HISTORY)
+
+    before = _exact_state()
+    with pytest.raises(CoordinationError) as excinfo:
+        coordination._record_unreleased_authority(
+            held.grant,
+            owner=lease,
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=connection,
+            hold_id=held.hold_id,
+            capability=capability,
+        )
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    _assert_exact_state(before, "same_owner_retired_reuse")
 
 
 @pytest.mark.asyncio
@@ -7123,9 +7245,32 @@ async def test_lock_duplicate_guard_discriminates_connection_grant_and_record():
         is False
     )
 
+    # X2: an *impostor* active row — equal by value, not the exact object the
+    # entry was written with, and not any history object. Presence, equality, or
+    # a matching id string would all accept it and suppress the fallback that
+    # roots the real authority.
+    genuine = _active_holds()[hold.hold_id]
+    impostor = replace(genuine)
+    assert impostor == genuine and impostor is not genuine
+    assert not any(h is impostor for h in coordination._AUTHORITY_HOLD_HISTORY)
+    coordination._ACTIVE_AUTHORITY_HOLDS[hold.hold_id] = impostor
+    assert (
+        coordination._authority_already_retained(
+            owner=connection, grant=lease.grant, connection=connection
+        )
+        is False
+    )
+    # Restoring the exact record makes it true again, so the difference is the
+    # identity of the row and nothing else.
+    coordination._ACTIVE_AUTHORITY_HOLDS[hold.hold_id] = genuine
+    assert (
+        coordination._authority_already_retained(
+            owner=connection, grant=lease.grant, connection=connection
+        )
+        is True
+    )
+
     # A retained row whose active record is gone is not a recorded authority.
-    # Deliberately white-box: the writers always create both, so this pins the
-    # clause against a future change that could leave one behind.
     del coordination._ACTIVE_AUTHORITY_HOLDS[hold.hold_id]
     assert (
         coordination._authority_already_retained(

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -352,6 +352,9 @@ class FakeLockConnection:
         close_raises: BaseException | None = None,
         fail_sql_error: BaseException | None = None,
         unlock_false_on_key: int | None = None,
+        unlock_gate_on_key: int | None = None,
+        unlock_gate: asyncio.Event | None = None,
+        unlock_gate_started: asyncio.Event | None = None,
         unlock_raises_on_key: int | None = None,
         unlock_raises_error: BaseException | None = None,
         raise_after_lock_on_key: int | None = None,
@@ -371,6 +374,9 @@ class FakeLockConnection:
         self._close_raises = close_raises
         self._fail_sql_error = fail_sql_error
         self._unlock_false_on_key = unlock_false_on_key
+        self._unlock_gate_on_key = unlock_gate_on_key
+        self._unlock_gate = unlock_gate
+        self._unlock_gate_started = unlock_gate_started
         self._unlock_raises_on_key = unlock_raises_on_key
         self._unlock_raises_error = unlock_raises_error
         self._raise_after_lock_on_key = raise_after_lock_on_key
@@ -435,6 +441,11 @@ class FakeLockConnection:
         if "pg_advisory_unlock" in sql:
             key = int(params["key"])
             self.unlock_calls.append(key)
+            if key == self._unlock_gate_on_key:
+                if self._unlock_gate_started is not None:
+                    self._unlock_gate_started.set()
+                if self._unlock_gate is not None:
+                    await self._unlock_gate.wait()
             if key == self._unlock_raises_on_key:
                 raise self._unlock_raises_error or RuntimeError("unlock interrupted")
             if self._events is not None:
@@ -3717,9 +3728,13 @@ def test_scope_contract_documents_the_every_send_callback_interface():
     assert "cancel or reduce" in flat
     assert "captured scope" in flat
 
-    # And the capability-free shape.
-    for absent in ("lease", "grant", "connection", "owner token"):
-        assert absent in flat, absent
+    # The capability-free shape, as exact propositions. Searching for the words
+    # "lease"/"grant" is a false green: rewriting "carries no lease" into
+    # "carries a lease" keeps every one of those words present.
+    assert "carries no lease, grant, connection, backend PID, owner token" in flat
+    assert "the right to see, never the right to act" in flat
+    for forbidden in ("carries a lease", "exposes the grant", "returns the connection"):
+        assert forbidden not in flat, forbidden
     # The stale grant-bearing instruction is gone.
     assert "`assert_owned(grant)` repeats" not in doc
 
@@ -4578,11 +4593,11 @@ async def test_lock_cancellation_during_confirmed_rollback_unlock_is_retained():
     )
     retained_before = set(_retained_authorities())
 
-    with pytest.raises(CoordinationError) as excinfo:
+    # The interruption is re-delivered — not the earlier contention error.
+    with pytest.raises(asyncio.CancelledError):
         await acquire_physical_account_lease(
             keys=[971, 972, 973], connection_factory=ConnectionFactory(connection)
         )
-    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
 
     new_holds = set(_retained_authorities()) - retained_before
     assert len(new_holds) == 1
@@ -4821,6 +4836,8 @@ async def test_claim_cancelled_ack_attachment_still_reaches_both_writes():
     assert evidence.kind is DispatchEvidenceKind.ACK_ATTACHMENT_FAILED
     assert evidence.certainty is MutationCertainty.UNCERTAIN
     assert evidence.broker_order_id is None
+    # Nobody cancelled the coordinator; the ACK helper cancelled itself.
+    assert evidence.outer_cancellation_requested is False
     assert stack["persistence"].calls == 2
     # Cleanup happened only after the gate closed, and the claim is retained.
     assert stack["connection"].closed is True
@@ -4861,32 +4878,55 @@ async def test_lock_close_cancellation_after_absence_keeps_the_receipt(which: st
 
 @pytest.mark.asyncio
 async def test_lock_rollback_cancelled_after_a_confirmed_unlock_prefix():
-    """U5/B39: cancel *after* rollback has already confirmed one unlock."""
+    """V1/B47: the whole conjunction, in one test.
+
+    Two tests each proving one half let a regression through: keep the inner
+    handling but break re-delivery only *after* a confirmed prefix, and both stay
+    green. So this establishes a non-empty confirmed prefix, cancels the outer
+    acquisition while the next unlock is blocked, and then requires the
+    cancellation back — after the safe outcome, never before it.
+    """
 
     space = FakeLockSpace()
     blocker = FakeLockConnection(space, pid=11001)
     await acquire_physical_account_lease(
         keys=[1103], connection_factory=ConnectionFactory(blocker)
     )
-    # Reverse rollback order is 1102, then 1101 — so injecting on 1101 leaves a
-    # confirmed prefix of exactly [1102].
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    # Reverse rollback order is 1102 then 1101: 1102 confirms, 1101 blocks.
     connection = FakeLockConnection(
         space,
         pid=11002,
-        unlock_raises_on_key=1101,
-        unlock_raises_error=asyncio.CancelledError(),
+        unlock_gate_on_key=1101,
+        unlock_gate=gate,
+        unlock_gate_started=started,
+        unlock_returns=None,
         termination_raises=RuntimeError("cannot terminate"),
     )
     retained_before = set(_retained_authorities())
 
-    with pytest.raises(CoordinationError) as excinfo:
-        await acquire_physical_account_lease(
+    task = asyncio.ensure_future(
+        acquire_physical_account_lease(
             keys=[1101, 1102, 1103], connection_factory=ConnectionFactory(connection)
         )
-    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
-
-    # A confirmed unlock happened first, then the cancellation.
+    )
+    await started.wait()
+    # A confirmed prefix already exists before the cancellation arrives.
     assert connection.unlock_calls == [1102, 1101]
+
+    task.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    # Nothing was surrendered while the rollback was still in flight.
+    assert task.done() is False
+    assert connection.closed is False
+
+    connection._unlock_returns = False  # the blocked unlock proves nothing
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
     assert connection.closed is False
     new_holds = set(_retained_authorities()) - retained_before
     assert len(new_holds) == 1
@@ -5044,12 +5084,16 @@ async def test_claim_callback_scheduling_failure_takes_the_evidence_path(monkeyp
     posts: list[str] = []
     real_ensure_future = asyncio.ensure_future
     armed = {"value": False}
+    pending: dict[str, Any] = {}
 
     def one_shot_failure(coro_or_future: Any, **kwargs: Any) -> Any:
         if armed["value"]:
             armed["value"] = False
             if asyncio.iscoroutine(coro_or_future):
                 coro_or_future.close()
+            inner = pending.pop("inner", None)
+            if asyncio.iscoroutine(inner):
+                inner.close()
             raise RuntimeError("event loop refused to schedule")
         return real_ensure_future(coro_or_future, **kwargs)
 
@@ -5061,7 +5105,8 @@ async def test_claim_callback_scheduling_failure_takes_the_evidence_path(monkeyp
     def arming_callback(scope: Any) -> Any:
         posts.append("POST")  # a synchronous send already happened
         armed["value"] = True  # the scheduling of the rest now fails
-        return sender(scope)
+        pending["inner"] = sender(scope)
+        return pending["inner"]
 
     stack["callback"] = arming_callback
     with pytest.raises(RuntimeError, match="refused to schedule"):
@@ -5567,3 +5612,393 @@ async def test_claim_real_order_send_intent_service_round_trip(db_session):
         )
     assert deleted == 1
     assert await adapter.account_has_unresolved_claim(scope) is False
+
+
+# ===========================================================================
+# §V2–V5 — cross-generation ids, awaitable normalization, retention, AND gate
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_lock_hold_id_is_never_reused_after_its_generation_is_resolved(
+    monkeypatch,
+):
+    """V2/B48: a retired opaque id must not be handed to a later owner.
+
+    Collision refusal that only consults the *live* maps is not enough. Once a
+    hold resolves it leaves those maps, so the next allocation with the same
+    random token would reissue the retired id — and every stale reference to
+    the old generation would silently resolve to a different account's owner.
+    """
+
+    space = FakeLockSpace()
+    first_conn = FakeLockConnection(
+        space, pid=9611, termination_raises=RuntimeError("cannot terminate")
+    )
+    first_lease = await acquire_physical_account_lease(
+        keys=[9611], connection_factory=ConnectionFactory(first_conn)
+    )
+    first_conn._unlock_returns = False
+    with pytest.raises(CoordinationError):
+        await first_lease.release(first_lease.grant)
+    first = first_lease.unreleased_authority_hold
+    assert first is not None
+
+    # Resolve that generation: it leaves every live map.
+    first_conn._unlock_returns = None
+    await first_lease.release(first_lease.grant)
+    assert first.hold_id not in _retained_authorities()
+    assert held_coordination(first.hold_id) is None
+
+    # Now force the allocator to draw exactly the retired token again.
+    monkeypatch.setattr(
+        coordination.secrets,
+        "token_hex",
+        lambda _n: first.hold_id.removeprefix("hold:"),
+    )
+    second_conn = FakeLockConnection(
+        space, pid=9612, termination_raises=RuntimeError("cannot terminate")
+    )
+    second_lease = await acquire_physical_account_lease(
+        keys=[9612], connection_factory=ConnectionFactory(second_conn)
+    )
+    second_conn._unlock_returns = False
+    with pytest.raises(CoordinationError):
+        await second_lease.release(second_lease.grant)
+    second = second_lease.unreleased_authority_hold
+    assert second is not None
+
+    # The new owner got a different id...
+    assert second.hold_id != first.hold_id
+    # ...the retired generation's rows never became recoverable...
+    retired = [h for h in authority_hold_history() if h.hold_id == first.hold_id]
+    assert retired
+    assert all(row.recoverable_in_process is False for row in retired)
+    # ...and a stale lookup of the retired id resolves to nobody, least of all
+    # to the new owner.
+    assert held_coordination(first.hold_id) is None
+    assert first.hold_id not in _retained_authorities()
+    assert _retained_authorities()[second.hold_id].connection is second_conn
+
+
+@pytest.mark.asyncio
+async def test_claim_hostile_completed_future_from_the_callback_is_contained():
+    """V3/B49: the caller's awaitable is never the thing whose outcome we read.
+
+    ``asyncio.ensure_future`` returns a *Future argument unchanged*, so reading
+    the outcome off it means calling the caller's own ``result()``/
+    ``exception()``. A callback that returns a hostile completed Future would
+    then raise from outside the guarded region — after a POST already went out,
+    leaving the send with no durable evidence at all. Normalizing through a
+    module-owned task is what makes that unreachable, so this asserts the
+    containment directly: those accessors are never invoked.
+    """
+
+    class HostileFuture(asyncio.Future):
+        accesses = 0
+
+        def result(self) -> Any:
+            type(self).accesses += 1
+            raise RuntimeError("hostile result access")
+
+        def exception(self, *args: Any, **kwargs: Any) -> Any:
+            type(self).accesses += 1
+            raise RuntimeError("hostile exception access")
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    posts: list[str] = []
+
+    def hostile_callback(scope: Any) -> Any:
+        posts.append("POST")  # the broker already has it
+        hostile = HostileFuture()
+        hostile.set_result(
+            MutationCallbackResult(
+                certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000009"
+            )
+        )
+        return hostile
+
+    stack["callback"] = hostile_callback
+    held_before = {h.hold_id for h in unreleased_authority_holds()}
+    result = await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    assert HostileFuture.accesses == 0
+    assert result.certainty is MutationCertainty.DEFINITIVE
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.outer_cancellation_requested is False
+    assert stack["connection"].closed is True
+    assert {h.hold_id for h in unreleased_authority_holds()} == held_before
+
+
+@pytest.mark.asyncio
+async def test_claim_callback_that_cancels_itself_is_not_an_outer_cancellation():
+    """V3/B49: an inner self-cancel is the callback's failure, not the caller's.
+
+    Labelling it as an outer cancellation would tell the operator that somebody
+    asked for this send to stop, when in fact the lane's own coroutine died
+    mid-flight with the order already at the broker.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    posts: list[str] = []
+
+    async def self_cancelling(scope: Any) -> Any:
+        await scope.assert_owned()
+        posts.append("POST")
+        current = asyncio.current_task()
+        assert current is not None
+        current.cancel()
+        await asyncio.sleep(0)
+        raise AssertionError("unreachable")
+
+    stack["callback"] = self_cancelling
+    held_before = {h.hold_id for h in unreleased_authority_holds()}
+    with pytest.raises(asyncio.CancelledError):
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert evidence.outer_cancellation_requested is False
+    assert {h.hold_id for h in unreleased_authority_holds()} == held_before
+
+
+@pytest.mark.asyncio
+async def test_claim_hostile_outcome_with_broken_durability_retains_the_authority():
+    """V3/B49 × B1: no durable evidence means the account stays blocked."""
+
+    class HostileFuture(asyncio.Future):
+        def result(self) -> Any:
+            raise RuntimeError("hostile result access")
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+
+    def hostile_callback(scope: Any) -> Any:
+        hostile = HostileFuture()
+        hostile.set_result(
+            MutationCallbackResult(certainty=MutationCertainty.DEFINITIVE)
+        )
+        return hostile
+
+    stack["callback"] = hostile_callback
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    authority_hold = _held_coordination(hold_id).lease.unreleased_authority_hold
+    assert authority_hold is not None
+    assert authority_hold.durable_evidence_written is False
+    assert stack["connection"].closed is False
+
+
+@pytest.mark.asyncio
+async def test_claim_self_cancelling_callback_with_broken_durability_is_retained():
+    """V3/B49 × B1: same for the inner-cancellation branch."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+
+    async def self_cancelling(scope: Any) -> Any:
+        current = asyncio.current_task()
+        assert current is not None
+        current.cancel()
+        await asyncio.sleep(0)
+        raise AssertionError("unreachable")
+
+    stack["callback"] = self_cancelling
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    authority_hold = _held_coordination(hold_id).lease.unreleased_authority_hold
+    assert authority_hold is not None
+    assert authority_hold.durable_evidence_written is False
+    assert stack["connection"].closed is False
+
+
+@pytest.mark.asyncio
+async def test_lock_retained_rollback_authority_survives_losing_every_caller_ref():
+    """V4/U6 (rollback branch): retention must be rooted, not incidental.
+
+    If the only thing keeping the connection alive were the caller's local
+    variable, the backend session would be collected and PostgreSQL would drop
+    the advisory lock — silently unblocking an account we were unable to prove
+    safe.
+    """
+
+    import gc
+
+    space = FakeLockSpace()
+    retained_before = set(_retained_authorities())
+    connection = FakeLockConnection(
+        space,
+        pid=9701,
+        raise_after_lock_on_key=9702,
+        unlock_returns=False,
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    with pytest.raises(RuntimeError):
+        await acquire_physical_account_lease(
+            keys=[9701, 9702], connection_factory=ConnectionFactory(connection)
+        )
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    hold_id = new_holds.pop()
+
+    del connection
+    gc.collect()
+
+    # Recoverable only through the private retained seam.
+    retained = _retained_authorities()[hold_id]
+    assert isinstance(retained.connection, FakeLockConnection)
+    assert retained.connection.closed is False
+
+    successor = FakeLockConnection(space, pid=9703)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[9701], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+
+@pytest.mark.asyncio
+async def test_lock_retained_release_failure_authority_survives_losing_every_ref():
+    """V4/U6 (release-failure branch): same obligation, other retention path."""
+
+    import gc
+
+    space = FakeLockSpace()
+    victim_lease, victim_conn, victim_hold = await _durable_true_hold(
+        space, pid=9801, key=9801
+    )
+    victim_retained = _retained_authorities()[victim_hold.hold_id]
+
+    lease, connection, hold = await _durable_true_hold(space, pid=9802, key=9802)
+    del lease, connection, hold
+    stuck = [
+        hold_id
+        for hold_id, entry in _retained_authorities().items()
+        if hold_id != victim_hold.hold_id and entry.grant.keys == (9802,)
+    ]
+    assert len(stuck) == 1
+    hold_id = stuck[0]
+    gc.collect()
+
+    retained = _retained_authorities()[hold_id]
+    assert isinstance(retained.connection, FakeLockConnection)
+    assert retained.connection.closed is False
+
+    successor = FakeLockConnection(space, pid=9803)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[9802], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+    # The foreign hold is untouched by any of it.
+    assert _retained_authorities()[victim_hold.hold_id] is victim_retained
+    assert victim_conn.closed is False
+    assert victim_lease.unreleased_authority_hold == victim_hold
+
+
+@pytest.mark.parametrize(
+    "certainty", [MutationCertainty.DEFINITIVE, MutationCertainty.UNCERTAIN]
+)
+@pytest.mark.asyncio
+async def test_claim_both_durable_writes_precede_any_cleanup(certainty):
+    """V5/U8: the AND gate holds for every send outcome, not just the happy one."""
+
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    stack = _default_stack(events)
+    stack["callback"] = RecordingCallback(
+        events=events, result=MutationCallbackResult(certainty=certainty)
+    )
+    held_before = {h.hold_id for h in unreleased_authority_holds()}
+    await _run(envelope, stack)
+
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    # Both durable writes land, in order, strictly before the lease is given up.
+    assert events.index("persist") < events.index("evidence")
+    assert events.index("evidence") < events.index("lease_unlock")
+    assert events.index("lease_unlock") < events.index("lease_closed")
+    assert {h.hold_id for h in unreleased_authority_holds()} == held_before
+    # The binary claim is the durable record of the send; nothing releases it.
+    assert stack["intents"].rows != {}
+    assert stack["intents"].release_if_matches_calls == []
+
+
+@pytest.mark.parametrize(
+    "certainty", [MutationCertainty.DEFINITIVE, MutationCertainty.UNCERTAIN]
+)
+@pytest.mark.asyncio
+async def test_claim_second_lineage_persist_failure_halts_before_cleanup(certainty):
+    """V5/U8: half the AND gate is not the AND gate."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["persistence"] = RecordingPersistence(fail_from_call=1)
+    stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(certainty=certainty)
+    )
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    authority_hold = _held_coordination(hold_id).lease.unreleased_authority_hold
+    assert authority_hold is not None
+    assert authority_hold.durable_evidence_written is False
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert stack["intents"].rows != {}
+
+
+@pytest.mark.parametrize(
+    "certainty", [MutationCertainty.DEFINITIVE, MutationCertainty.UNCERTAIN]
+)
+@pytest.mark.asyncio
+async def test_claim_dispatch_evidence_failure_halts_before_cleanup(certainty):
+    """V5/U8: the other half, independently."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(certainty=certainty)
+    )
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    authority_hold = _held_coordination(hold_id).lease.unreleased_authority_hold
+    assert authority_hold is not None
+    assert authority_hold.durable_evidence_written is False
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert stack["intents"].rows != {}

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -3695,6 +3695,35 @@ def test_scope_no_stale_public_capability_prose_survives():
         assert owner_state in doc, owner_state
 
 
+def test_scope_contract_documents_the_every_send_callback_interface():
+    """B45: J3B/J3C integrate from the contract, not from the source.
+
+    A contract that still describes ``assert_owned(grant)`` tells a downstream
+    lane to reach for a capability that is deliberately not public, and says
+    nothing about the per-send timing that is the whole point of the view.
+    """
+
+    doc = CONTRACT_DOC.read_text(encoding="utf-8")
+    flat = " ".join(doc.split())
+
+    # The exact interface, by name.
+    assert "CoordinationScope" in doc
+    assert "await scope.assert_owned()" in doc
+    assert "MockMutationCallback" in doc
+    assert "one argument" in flat or "one-argument" in flat
+
+    # The timing obligation, not just the existence of the call.
+    assert "immediately before **every** POST" in flat
+    assert "cancel or reduce" in flat
+    assert "captured scope" in flat
+
+    # And the capability-free shape.
+    for absent in ("lease", "grant", "connection", "owner token"):
+        assert absent in flat, absent
+    # The stale grant-bearing instruction is gone.
+    assert "`assert_owned(grant)` repeats" not in doc
+
+
 def test_scope_capability_bearing_symbols_are_not_public():
     """r17: a lane supplies extra keys through the coordinator, never a lease."""
 
@@ -4357,8 +4386,11 @@ def test_scope_view_exposes_exactly_one_operation_and_no_capability():
 
     public_names = {name for name in dir(CoordinationScope) if not name.startswith("_")}
     assert public_names == {"assert_owned"}
-    # The one private slot holds a closure, not the lease: no attribute walk
-    # from the view reaches a connection, a grant, or a release.
+    # The one private slot holds a closure, not the lease. On the supported and
+    # direct surface there is nothing to reach; under Python reflection
+    # ``_assert.__closure__`` can of course be traversed, exactly as any exported
+    # function's ``__globals__`` can. The signed grade is accident prevention plus
+    # static detection, not structural impossibility.
     private_names = {
         name
         for name in dir(CoordinationScope)
@@ -4697,6 +4729,400 @@ async def test_lock_c1_truth_table_all_five_rows():
 
 def _active_hold(hold_id: str) -> Any:
     return next(h for h in unreleased_authority_holds() if h.hold_id == hold_id)
+
+
+# ===========================================================================
+# §r21 — U1-U9
+# ===========================================================================
+
+
+class _RaisingBrokerId(str):
+    """A hostile ``str`` subclass: validation must not dispatch into it."""
+
+    def strip(self, *args: Any, **kwargs: Any) -> str:
+        raise RuntimeError("strip exploded")
+
+
+@pytest.mark.asyncio
+async def test_claim_hostile_broker_id_validation_still_reaches_both_writes():
+    """U1/B43: validation runs after a possible send, so it cannot escape.
+
+    An exact ``MutationCallbackResult`` can carry a ``str`` subclass whose
+    ``strip()`` raises. That happens after the callback may have POSTed and
+    before either durable write — the one window the AND gate exists to cover.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    posts: list[str] = []
+
+    async def hostile(scope: Any) -> MutationCallbackResult:
+        posts.append("POST")
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE,
+            broker_order_id=_RaisingBrokerId("ODNO"),
+        )
+
+    stack["callback"] = hostile
+    with pytest.raises(TypeError):
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert evidence.broker_order_id is None
+    assert len(stack["intents"].rows) == 1
+
+
+class _CancellingAckFactory(MockLineageFactory):
+    """A J2B factory whose acknowledgement step is cancelled."""
+
+    def acknowledge_order_attempt(
+        self, envelope: LineageEnvelope, broker_order_id: str
+    ) -> LineageEnvelope:
+        raise asyncio.CancelledError()
+
+
+@pytest.mark.asyncio
+async def test_claim_cancelled_ack_attachment_still_reaches_both_writes():
+    """U2/B44: a cancellation inside the ACK helper is uncertainty, not an exit."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    posts: list[str] = []
+
+    async def sender(scope: Any) -> MutationCallbackResult:
+        posts.append("POST")
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO"
+        )
+
+    stack["callback"] = sender
+    with pytest.raises(asyncio.CancelledError):
+        await coordinate_mock_order_mutation(
+            **_coordination_kwargs(
+                envelope,
+                lane_registry=_bound_registry(envelope),
+                persistence=stack["persistence"],
+                evidence=stack["evidence"],
+                intents=stack["intents"],
+                factory=stack["factory"],
+                callback=stack["callback"],
+            ),
+            lineage_factory=_CancellingAckFactory(),
+        )
+
+    assert posts == ["POST"]
+    assert stack["evidence"].calls == 1
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.ACK_ATTACHMENT_FAILED
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert evidence.broker_order_id is None
+    assert stack["persistence"].calls == 2
+    # Cleanup happened only after the gate closed, and the claim is retained.
+    assert stack["connection"].closed is True
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("which", ["observer", "owner"])
+async def test_lock_close_cancellation_after_absence_keeps_the_receipt(which: str):
+    """U4/B37: once absence is proven, cleanup cannot un-prove it."""
+
+    owner = _dedicated_connection_double([])
+    observer = _dedicated_connection_double(
+        [_FakeResult([{"terminated": True}]), _FakeResult([{"alive": 0}])]
+    )
+    if which == "observer":
+        observer.close = AsyncMock(side_effect=asyncio.CancelledError())
+    else:
+        owner.close = AsyncMock(side_effect=asyncio.CancelledError())
+
+    async def observer_factory() -> Any:
+        return observer
+
+    authority = SqlAlchemyLockAuthority(owner, observer_factory=observer_factory)
+    holds_before = len(unreleased_authority_holds())
+
+    receipt = await authority.terminate_backend_session(
+        expected_pid=4242, owner_token="lockconn:abc"
+    )
+
+    # The proof stands, bound to the exact PID and owner token.
+    assert receipt == BackendTerminationReceipt(
+        backend_pid=4242, owner_token="lockconn:abc", terminated=True
+    )
+    # And no false active authority was manufactured by the failed cleanup.
+    assert len(unreleased_authority_holds()) == holds_before
+
+
+@pytest.mark.asyncio
+async def test_lock_rollback_cancelled_after_a_confirmed_unlock_prefix():
+    """U5/B39: cancel *after* rollback has already confirmed one unlock."""
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=11001)
+    await acquire_physical_account_lease(
+        keys=[1103], connection_factory=ConnectionFactory(blocker)
+    )
+    # Reverse rollback order is 1102, then 1101 — so injecting on 1101 leaves a
+    # confirmed prefix of exactly [1102].
+    connection = FakeLockConnection(
+        space,
+        pid=11002,
+        unlock_raises_on_key=1101,
+        unlock_raises_error=asyncio.CancelledError(),
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[1101, 1102, 1103], connection_factory=ConnectionFactory(connection)
+        )
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+    # A confirmed unlock happened first, then the cancellation.
+    assert connection.unlock_calls == [1102, 1101]
+    assert connection.closed is False
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    assert _retained_authorities()[new_holds.pop()].connection is connection
+
+    successor = FakeLockConnection(space, pid=11003)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[1101], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+
+@pytest.mark.asyncio
+async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
+    monkeypatch,
+):
+    """U6/B40: the collision storm must also cover the confirmed-partial branch."""
+
+    import gc
+
+    space = FakeLockSpace()
+    _, victim_connection, victim_hold = await _durable_true_hold(
+        space, pid=11101, key=1111
+    )
+    victim_owner = _retained_authorities()[victim_hold.hold_id].owner
+
+    blocker = FakeLockConnection(space, pid=11102)
+    await acquire_physical_account_lease(
+        keys=[1114], connection_factory=ConnectionFactory(blocker)
+    )
+    colliding = victim_hold.hold_id.removeprefix("hold:")
+    monkeypatch.setattr(coordination.secrets, "token_hex", lambda _n: colliding)
+
+    # 1112/1113 acquire, 1114 contends -> confirmed-partial rollback, and the
+    # unprovable unlock forces retention while every random id collides.
+    intruder = FakeLockConnection(
+        space,
+        pid=11103,
+        unlock_returns=False,
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[1112, 1113, 1114], connection_factory=ConnectionFactory(intruder)
+        )
+
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    quarantined = new_holds.pop()
+    assert quarantined.startswith("hold:quarantine:")
+    assert _retained_authorities()[quarantined].connection is intruder
+    gc.collect()
+    assert _retained_authorities()[quarantined].connection is intruder
+    assert intruder.closed is False
+    # The victim is untouched by the storm.
+    assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
+    assert _retained_authorities()[victim_hold.hold_id].owner is victim_owner
+
+
+@pytest.mark.asyncio
+async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch):
+    """U6/B40: if the rollback task itself fails, nothing may fall out of scope."""
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=11201)
+    await acquire_physical_account_lease(
+        keys=[1122], connection_factory=ConnectionFactory(blocker)
+    )
+    connection = FakeLockConnection(space, pid=11202)
+
+    async def exploding_rollback(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("rollback itself failed")
+
+    monkeypatch.setattr(
+        coordination, "_rollback_partial_acquisition", exploding_rollback
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[1121, 1122], connection_factory=ConnectionFactory(connection)
+        )
+
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    retained = _retained_authorities()[new_holds.pop()]
+    assert retained.connection is connection
+    assert retained.grant.backend_pid == 11202
+    assert connection.closed is False
+
+
+@pytest.mark.asyncio
+async def test_claim_scope_local_pinned_entry_check_is_independently_load_bearing():
+    """U7/B41: exercise the check *inside* the scope, not the one before it.
+
+    The earlier regression swaps the registry during reserve, so it fails at the
+    post-reserve check and would stay green if the scope-local recheck were
+    deleted. This one keeps A until the callback is running.
+    """
+
+    _, envelope = _attempt_envelope()
+    bound = _bound_registry(envelope)
+    swapped = _bound_registry(envelope, physical_account_id="OTHER-PHYSICAL-ACCOUNT")
+    state = {"switched": False}
+
+    class LateSwitchingRegistry:
+        def __iter__(self) -> Any:
+            return iter(swapped if state["switched"] else bound)
+
+    stack = _default_stack()
+    posts: list[str] = []
+
+    async def lane(scope: Any) -> MutationCallbackResult:
+        state["switched"] = True  # the registry changes mid-callback
+        await scope.assert_owned()  # must catch it, before the POST
+        posts.append("POST")  # unreachable
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO"
+        )
+
+    stack["callback"] = lane
+    with pytest.raises(registry.LaneGuardError) as excinfo:
+        await coordinate_mock_order_mutation(
+            **{
+                **_coordination_kwargs(
+                    envelope,
+                    lane_registry=bound,
+                    persistence=stack["persistence"],
+                    evidence=stack["evidence"],
+                    intents=stack["intents"],
+                    factory=stack["factory"],
+                    callback=stack["callback"],
+                ),
+                "registry": LateSwitchingRegistry(),
+            }
+        )
+
+    assert excinfo.value.code == "canonical_lane_identity_mismatch"
+    assert posts == []
+    # The unknown is durable and the claim for account A is retained.
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_callback_scheduling_failure_takes_the_evidence_path(monkeypatch):
+    """U8/B42: even ``ensure_future`` itself failing is post-send uncertainty."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    posts: list[str] = []
+    real_ensure_future = asyncio.ensure_future
+    armed = {"value": False}
+
+    def one_shot_failure(coro_or_future: Any, **kwargs: Any) -> Any:
+        if armed["value"]:
+            armed["value"] = False
+            if asyncio.iscoroutine(coro_or_future):
+                coro_or_future.close()
+            raise RuntimeError("event loop refused to schedule")
+        return real_ensure_future(coro_or_future, **kwargs)
+
+    monkeypatch.setattr(coordination.asyncio, "ensure_future", one_shot_failure)
+
+    async def sender(scope: Any) -> MutationCallbackResult:  # pragma: no cover
+        return MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN)
+
+    def arming_callback(scope: Any) -> Any:
+        posts.append("POST")  # a synchronous send already happened
+        armed["value"] = True  # the scheduling of the rest now fails
+        return sender(scope)
+
+    stack["callback"] = arming_callback
+    with pytest.raises(RuntimeError, match="refused to schedule"):
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert stack["persistence"].calls == 2
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_synchronous_cancellation_takes_the_evidence_path():
+    """U8/B42: a synchronous ``CancelledError`` is uncertainty, not a clean abort."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    posts: list[str] = []
+
+    def sync_cancel(scope: Any) -> Any:
+        posts.append("POST")
+        raise asyncio.CancelledError()
+
+    stack["callback"] = sync_cancel
+    with pytest.raises(asyncio.CancelledError):
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert stack["evidence"].only.certainty is MutationCertainty.UNCERTAIN
+    assert stack["persistence"].calls == 2
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_lock_hold_history_and_active_view_never_disagree():
+    """U9/B46: one hold id must not report True and False at the same instant."""
+
+    space = FakeLockSpace()
+    lease, connection, hold = await _durable_true_hold(space, pid=11301, key=1131)
+
+    def flags(hold_id: str) -> tuple[Any, Any]:
+        active = [h for h in unreleased_authority_holds() if h.hold_id == hold_id]
+        history = [h for h in authority_hold_history() if h.hold_id == hold_id]
+        assert active and history
+        return active[-1].recoverable_in_process, history[-1].recoverable_in_process
+
+    # While active and genuinely retryable, both views say the same thing.
+    active_flag, history_flag = flags(hold.hold_id)
+    assert active_flag is True
+    assert history_flag == active_flag
+
+    # After a proven release the hold leaves the active view; history keeps the
+    # record and reports it as not retryable, which is now true.
+    await lease.release(lease.grant)
+    assert hold.hold_id not in {h.hold_id for h in unreleased_authority_holds()}
+    resolved = [h for h in authority_hold_history() if h.hold_id == hold.hold_id]
+    assert resolved and resolved[-1].recoverable_in_process is False
+    assert connection.closed is True
 
 
 # ===========================================================================

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -2590,7 +2590,8 @@ async def test_claim_truthy_non_boolean_evidence_cannot_delete_the_claim(
 ):
     """B36: ``"false"`` is truthy, and so is ``"0"``.
 
-    The durable claim is the entire account block. A mistyped field must not be
+    The durable claim is durable proof that this exact lineage was sent. A
+    mistyped field must not be
     able to authorize deleting it, and the adapter must not simply trust an
     overridable authorization property.
     """
@@ -3215,7 +3216,7 @@ async def test_claim_durable_false_hold_cannot_be_released_via_the_public_handle
     assert held.lease.released is False
     assert hold_id in held_coordinations()
     assert hold_id in {h.hold_id for h in unreleased_authority_holds()}
-    # The durable claim — the account block — is untouched throughout.
+    # The durable claim — this exact lineage's record — is untouched throughout.
     assert len(stack["intents"].rows) == 1
     assert stack["intents"].release_if_matches_calls == []
 
@@ -4371,8 +4372,8 @@ async def test_claim_model_premise_claim_commits_before_the_callback():
     """The whole process-death argument rests on this ordering.
 
     If the durable claim were written after the send, a crash mid-callback would
-    leave nothing blocking a successor's blind repost, and "process death is an
-    acceptable terminus" would stop being true.
+    leave nothing preventing a blind repost of that exact send lineage, and
+    "process death is an acceptable terminus" would stop being true.
     """
 
     _, envelope = _attempt_envelope()
@@ -4425,7 +4426,7 @@ async def test_claim_scope_assertion_blocks_a_send_after_delayed_ownership_loss(
 
     assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
     assert sends == []
-    # The unknown is still durable, and the claim still blocks the account.
+    # The unknown is still durable, and the claim still records this exact send.
     assert stack["evidence"].calls == 1
     assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
     assert len(stack["intents"].rows) == 1
@@ -7803,32 +7804,120 @@ async def test_claim_lease_releases_while_the_claim_remains(outcome):
     assert result.claim.row_id in stack["intents"].rows
 
 
-def test_scope_no_account_wide_claim_prose_survives():
-    """AC10: the retired 'claim == account block' framing must not come back.
+@pytest.mark.asyncio
+async def test_claim_proven_backend_termination_does_not_release_the_claim():
+    """Correction 1: termination ends lease authority, never the claim.
 
-    Word-presence checks are false green here — the correction is about what the
-    sentences *say*. These are exact propositions, plus the verbatim block the
-    contract is required to carry.
+    "Backend termination proves only cessation of lease authority. It is never
+    broker-outcome evidence and never, by itself, authorizes durable-claim
+    release." Here the reverse unlock cannot be proven, so release falls back to a
+    positive termination receipt — and the claim must survive that untouched.
     """
 
-    source = pathlib.Path(coordination.__file__).read_text()
-    contract = (REPO_ROOT / "docs/contracts/rob-1262-coordination-port.md").read_text()
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000099"
+        )
+    )
+    # Unlock cannot be proven, so the release path must terminate the backend.
+    stack["connection"]._unlock_returns = False
 
-    for text, label in ((source, "source"), (contract, "contract")):
+    # The unprovable unlock surfaces as a lost lease *after* the backend has been
+    # terminated. Both durable writes already landed before that point.
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    # The durable claim is entirely untouched by the termination.
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+    assert stack["intents"].unrestricted_release_calls == 0
+
+
+def test_scope_no_account_wide_claim_prose_survives():
+    """AC10 / r84 U-c: the retired framing must not return anywhere.
+
+    Two earlier versions of this guard were too narrow. It scanned only the source
+    and the contract, so the same claim survived in the *tests*; and it matched
+    four fixed literals, so any rephrasing walked straight past it.
+
+    What is forbidden is a sentence whose **subject is the claim or the
+    reservation** asserting that it blocks the account. The opposite subject is
+    correct and must survive: "uncertainty keeps the account blocked" is exactly
+    the post-correction contract, because the authority — not the claim — is what
+    blocks an account.
+    """
+
+    import itertools
+    import re
+
+    own_text = pathlib.Path(__file__).read_text()
+    # This guard names the forbidden phrases in order to hunt them, so scanning
+    # its own body would always match itself. It is the last function in the
+    # file, so everything above it is exactly the suite under audit.
+    marker = "def test_scope_no_account_wide_claim_prose_survives"
+    scanned = {
+        "source": pathlib.Path(coordination.__file__).read_text(),
+        "contract": (
+            REPO_ROOT / "docs/contracts/rob-1262-coordination-port.md"
+        ).read_text(),
+        "tests": own_text[: own_text.index(marker)],
+    }
+    subjects = ("claim", "reservation", "binary row", "durable row")
+    predicates = (
+        "account block",
+        "account-wide block",
+        "blocks the account",
+        "block the account",
+        "keeps the account blocked",
+        "keep the account blocked",
+        "blocks a successor",
+        "blocking a successor",
+        "blocks unrelated",
+        "blocks every new order",
+    )
+    # Sentences that *deny* the retired claim, and sentences whose real subject is
+    # the authority rather than the claim, are the corrected form — not matches.
+    # "unresolved-claim **gate** blocks unrelated new sends **only while** a prior
+    # outcome is uncertain" is the mandated verbatim text and must survive intact.
+    negations = (
+        "does not",
+        "never",
+        "not an account",
+        "cannot",
+        "no longer",
+        "rather than",
+        "only while",
+    )
+    for label, text in scanned.items():
         flat = " ".join(text.split()).lower()
-        for retired in (
-            "the durable claim is the entire account block",
-            "mere existence is the account-wide block",
-            "any unresolved reservation blocks every new order",
-            "any reservation blocks the account",
-        ):
-            assert retired not in flat, f"{label}: stale phrase {retired!r}"
+        for subject, predicate in itertools.product(subjects, predicates):
+            for m in re.finditer(re.escape(subject), flat):
+                window = flat[m.end() : m.end() + 90]
+                if "gate" in flat[m.end() : m.end() + 12]:
+                    continue  # the subject is the authority, not the claim
+                if predicate in window and not any(n in window for n in negations):
+                    raise AssertionError(
+                        f"{label}: '{subject}' still asserts '{predicate}': "
+                        f"...{flat[m.start() : m.end() + 90]}..."
+                    )
+
+    # The correct, opposite-subject sentence must still be present.
+    assert (
+        "uncertainty keeps the account blocked"
+        in " ".join(scanned["tests"].split()).lower()
+    )
 
     # The coordinator must not reach the generic reservation predicates.
-    assert "has_reservations" not in source
-    assert "account_has_unresolved_claim" not in source
+    assert "has_reservations" not in scanned["source"]
+    assert "account_has_unresolved_claim" not in scanned["source"]
 
     # The verbatim correction is carried in the contract, not paraphrased.
+    contract_flat = " ".join(scanned["contract"].split()).lower()
     for sentence in (
         "it is not an account-lifecycle mutex",
         "a durable send claim is keyed to the exact immutable send lineage",
@@ -7838,4 +7927,4 @@ def test_scope_no_account_wide_claim_prose_survives():
         "the advisory lease and the durable claim have distinct lifetimes",
         "backend termination proves only cessation of lease authority",
     ):
-        assert sentence in " ".join(contract.split()).lower(), sentence
+        assert sentence in contract_flat, sentence

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -7839,8 +7839,8 @@ async def test_claim_proven_backend_termination_does_not_release_the_claim():
 
 
 def test_scope_no_account_wide_claim_prose_survives():
-    """AC10 / r85: the retired framing must not return, and this guard must
-    actually be able to see it.
+    """AC10: the retired framing must not return in prose a contributor would
+    plausibly write.
 
     Forbidden is a sentence whose **subject is the claim or the reservation**
     asserting that it blocks the account. The opposite subject is correct and
@@ -7848,24 +7848,31 @@ def test_scope_no_account_wide_claim_prose_survives():
     post-correction contract, because the authority blocks an account, not the
     claim.
 
-    Three earlier versions were each too weak, and each weakness is closed here
-    with a mutant that proves it:
+    Guarantee grade, stated in the same form as the public surface's:
+    **detection of the enumerated shapes on the direct/supported prose surface,
+    not an oracle for sentences crafted to evade it.** A static prose matcher
+    can always be defeated by a sufficiently adversarial sentence, and chasing
+    that is not a reachable goal. What this guard owes is that ordinary prose
+    carrying the retired meaning is caught, and that the docstring never claims
+    more than the code does.
 
-    * it scanned only the *prefix* of this file up to this function, so anything
-      added below became silently unscanned. It now scans the whole file and
-      subtracts exactly this function's own source span, located with
-      ``inspect.getsource`` rather than by a comment claiming this is the last
-      function. A rule that cannot be enforced is not a rule;
-    * it exempted a match if any negation token appeared anywhere in a fixed
-      90-character window, so ``the claim blocks the account; it does not
-      authorize a broker mutation`` passed. Negation is now scoped to the clause
-      between that subject and that predicate;
-    * it exempted any occurrence of the substring ``gate`` just after the
-      subject, so ``claim gateway`` and ``claim, gated as settled`` passed. Only
-      the exact approved sentence from the verbatim correction is exempt;
-    * it used a fixed character window that crossed sentence boundaries in both
-      directions, attributing one sentence's predicate to another sentence's
-      subject. Matching is now per sentence.
+    The enumerated rules, so a reader can see the boundary rather than infer it:
+
+    * **subjects** — ``claim``, ``reservation``, ``binary row``, ``durable row``;
+    * **predicates** — the "blocks/keeps blocked the account / a successor /
+      unrelated / every new order" family listed below;
+    * **negation** — a negation token exempts a match only when it sits in the
+      sub-clause *immediately preceding* the predicate, after splitting the
+      span on conjunction boundaries (``, but``/``, and``/``, yet``/...).
+      A negation that denies some *other* verb does not exempt the predicate;
+    * **approved exemption** — a sentence is exempt only if, once normalized,
+      it is **equal in full** to an approved sentence. Splicing the approved
+      wording onto a forbidden tail is not an approved sentence;
+    * **scan span** — source, contract, and this whole test file minus exactly
+      this function's own source, located via ``inspect.getsource``;
+    * **sentence** — matching never crosses a sentence boundary, in either
+      direction, so one sentence's predicate is never attributed to another
+      sentence's subject.
 
     Scope, stated deliberately: the mutant **definitions** JSON is not scanned.
     `C1_stale_account_block_prose_restored` must contain the forbidden meaning as
@@ -7903,24 +7910,36 @@ def test_scope_no_account_wide_claim_prose_survives():
         "blocks every new order",
     )
     negations = ("does not", "never", "not ", "cannot", "no longer", "rather than")
-    # The one approved sentence whose subject is the authority, from the verbatim
-    # correction. Matched exactly — "gateway" and "gated" are not this.
-    approved = "unresolved-claim gate blocks unrelated new sends only while"
+    # Approved sentences from the verbatim correction, normalized and compared in
+    # FULL. Substring matching was the defect: it exempted any longer sentence
+    # that merely contained this wording, so an approved opening spliced onto a
+    # forbidden tail passed untouched.
+    approved_sentences = (
+        "an account-wide unresolved-claim gate blocks unrelated new sends only "
+        "while a prior mutation outcome remains uncorrelated or uncertain, "
+        "including the absence of a durably attributed native broker order id "
+        "and immutable ack",
+    )
+    # A negation only denies the verb of its own sub-clause.
+    conjunction = re.compile(r",\s*(?:but|and|yet|though|however|whereas|while)\s")
 
     for label, text in scanned.items():
         flat = " ".join(text.split()).lower()
         # Per sentence, so no predicate is ever attributed across a boundary.
         for sentence in re.split(r"[.;:!?]|\s-\s", flat):
-            if approved in sentence:
+            if sentence.strip() in approved_sentences:
                 continue
             for subject, predicate in itertools.product(subjects, predicates):
                 for sm in re.finditer(re.escape(subject), sentence):
                     pm = sentence.find(predicate, sm.end())
                     if pm == -1:
                         continue
-                    clause = sentence[sm.end() : pm]
-                    if any(n in clause for n in negations):
-                        continue  # this clause denies the assertion
+                    # Only the sub-clause immediately before the predicate can
+                    # deny it. "does not expire, but blocks the account" denies
+                    # `expire`, not `blocks the account`.
+                    governing = conjunction.split(sentence[sm.end() : pm])[-1]
+                    if any(n in governing for n in negations):
+                        continue
                     raise AssertionError(
                         f"{label}: '{subject}' asserts '{predicate}': "
                         f"...{sentence[max(0, sm.start() - 20) : pm + 40].strip()}..."
@@ -7932,12 +7951,17 @@ def test_scope_no_account_wide_claim_prose_survives():
         in " ".join(scanned["tests"].split()).lower()
     ), "the correct opposite-subject sentence was lost"
 
+    # Every approved sentence must still exist verbatim; otherwise the exemption
+    # above is silently dead and the guard's shape no longer matches the bytes.
+    contract_flat = " ".join(scanned["contract"].split()).lower()
+    for approved in approved_sentences:
+        assert approved in contract_flat, f"approved sentence missing: {approved}"
+
     # The coordinator must not reach the generic reservation predicates.
     assert "has_reservations" not in scanned["source"]
     assert "account_has_unresolved_claim" not in scanned["source"]
 
     # The verbatim correction is carried in the contract, not paraphrased.
-    contract_flat = " ".join(scanned["contract"].split()).lower()
     for sentence in (
         "it is not an account-lifecycle mutex",
         "a durable send claim is keyed to the exact immutable send lineage",

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -61,6 +61,7 @@ from app.services.mock_integration.coordination import (
     ClaimFollowupRequest,
     CoordinationError,
     CoordinationReasonCode,
+    CoordinationScope,
     DispatchEvidence,
     DispatchEvidenceKind,
     DispatchEvidencePort,
@@ -350,6 +351,7 @@ class FakeLockConnection:
         can_prove_termination: bool = True,
         close_raises: BaseException | None = None,
         fail_sql_error: BaseException | None = None,
+        unlock_false_on_key: int | None = None,
         unlock_raises_on_key: int | None = None,
         unlock_raises_error: BaseException | None = None,
         raise_after_lock_on_key: int | None = None,
@@ -368,6 +370,7 @@ class FakeLockConnection:
         self._can_prove_termination = can_prove_termination
         self._close_raises = close_raises
         self._fail_sql_error = fail_sql_error
+        self._unlock_false_on_key = unlock_false_on_key
         self._unlock_raises_on_key = unlock_raises_on_key
         self._unlock_raises_error = unlock_raises_error
         self._raise_after_lock_on_key = raise_after_lock_on_key
@@ -436,6 +439,9 @@ class FakeLockConnection:
                 raise self._unlock_raises_error or RuntimeError("unlock interrupted")
             if self._events is not None:
                 self._events.append("lease_unlock")
+            if key == self._unlock_false_on_key:
+                # PostgreSQL says "you did not hold that one" mid-sequence.
+                return _FakeResult([{"released": False}])
             if self._unlock_returns is None:
                 released = self._space.unlock(key, self.session_pid)
             else:
@@ -704,8 +710,11 @@ class RecordingCallback:
         events: list[str] | None = None,
         gate: asyncio.Event | None = None,
         started: asyncio.Event | None = None,
+        assert_before_send: bool = False,
     ) -> None:
         self.calls = 0
+        self.scopes: list[Any] = []
+        self.assert_before_send = assert_before_send
         self._result = result or MutationCallbackResult(
             certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000001"
         )
@@ -714,8 +723,12 @@ class RecordingCallback:
         self._gate = gate
         self._started = started
 
-    async def __call__(self) -> MutationCallbackResult:
+    async def __call__(self, scope: Any) -> MutationCallbackResult:
         self.calls += 1
+        self.scopes.append(scope)
+        if self.assert_before_send:
+            # What a real lane does immediately before each POST.
+            await scope.assert_owned()
         if self._events is not None:
             self._events.append("callback_start")
         if self._started is not None:
@@ -2377,6 +2390,84 @@ async def test_claim_insufficient_evidence_retains_the_claim_and_the_account_blo
     assert await adapter.account_has_unresolved_claim(result.scope) is True
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        coordination.TerminalClaimEvidence(
+            lane_native_terminal_evidence="false",
+            account_position_reconciled="no",
+            remainder_known="0",
+        ),
+        coordination.TerminalClaimEvidence(
+            lane_native_terminal_evidence=1,
+            account_position_reconciled=1,
+            remainder_known=1,
+        ),
+        coordination.TerminalClaimEvidence(
+            lane_native_terminal_evidence=object(),
+            account_position_reconciled=object(),
+            remainder_known=object(),
+        ),
+        coordination.TerminalClaimEvidence(
+            authoritative_absence_proven="yes", account_position_reconciled="yes"
+        ),
+    ],
+    ids=["strings", "ints", "objects", "truthy_absence"],
+)
+async def test_claim_truthy_non_boolean_evidence_cannot_delete_the_claim(
+    evidence: Any,
+):
+    """B36: ``"false"`` is truthy, and so is ``"0"``.
+
+    The durable claim is the entire account block. A mistyped field must not be
+    able to authorize deleting it, and the adapter must not simply trust an
+    overridable authorization property.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    result = await _run(envelope, stack)
+    adapter = DurableSendClaimAdapter(stack["intents"])
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await adapter.release_with_terminal_evidence(result.claim, evidence)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.TERMINAL_EVIDENCE_REQUIRED
+    )
+    assert stack["intents"].release_if_matches_calls == []
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_subclass_cannot_override_its_way_to_a_release():
+    """B36: the adapter recomputes the predicate rather than trusting it."""
+
+    class ForgedEvidence(coordination.TerminalClaimEvidence):
+        @property
+        def authorizes_release(self) -> bool:
+            return True
+
+        @property
+        def exact_booleans(self) -> bool:
+            return True
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    result = await _run(envelope, stack)
+    adapter = DurableSendClaimAdapter(stack["intents"])
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await adapter.release_with_terminal_evidence(result.claim, ForgedEvidence())
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.TERMINAL_EVIDENCE_REQUIRED
+    )
+    assert stack["intents"].release_if_matches_calls == []
+    assert len(stack["intents"].rows) == 1
+
+
 def test_claim_no_ttl_no_clock_and_no_automatic_release_exists():
     """The TTL / local-clock-expiry / automatic-cleanup mutants are structural.
 
@@ -3327,8 +3418,11 @@ async def test_cancel_bare_shield_finally_release_mutant_is_red():
     )
     callback = RecordingCallback(events=events, gate=gate, started=started)
 
+    async def _noop_assert() -> None:
+        return None
+
     async def bare_shield_mutant() -> None:
-        inner = asyncio.ensure_future(callback())
+        inner = asyncio.ensure_future(callback(CoordinationScope(_noop_assert)))
         try:
             await asyncio.shield(inner)
         finally:
@@ -3391,7 +3485,7 @@ async def test_claim_proven_termination_on_an_error_path_clears_the_held_handle(
     connection = stack["connection"]
     held_before = set(held_coordinations())
 
-    async def flip_then_report() -> MutationCallbackResult:
+    async def flip_then_report(scope: Any) -> MutationCallbackResult:
         # By release time the unlocks will be unprovable, forcing termination.
         connection._unlock_returns = False
         return MutationCallbackResult(
@@ -3558,6 +3652,47 @@ async def test_claim_durable_false_state_cannot_be_promoted_by_a_caller():
     )
     assert stack["connection"].unlock_calls == []
     assert stack["connection"].closed is False
+
+
+def test_scope_no_stale_public_capability_prose_survives():
+    """B34: prose drifts silently, and nothing else in this suite catches it.
+
+    Every phrase here described a public surface that three rounds of narrowing
+    removed. Leaving them behind is how a reader concludes a capability is
+    reachable when it is not — or, worse, that it is safe because a document
+    said so.
+    """
+
+    def flat(text: str) -> str:
+        # Prose wraps and gets recapitalised; a phrase split across a line break
+        # or starting a sentence is still the phrase.
+        return " ".join(text.split()).lower()
+
+    source = flat(COORDINATION_SOURCE.read_text(encoding="utf-8"))
+    doc = flat(CONTRACT_DOC.read_text(encoding="utf-8"))
+
+    for text, label in ((source, "coordination.py"), (doc, "contract")):
+        for stale in (
+            "exact grant obtained from public introspection",
+            "exact grant reachable from",
+            "publishes the lease and the grant",
+            "recoverable by the exact grant",
+            ":meth:`retain_authority`",
+            "grant is obtainable through public introspection",
+        ):
+            assert stale not in text, f"{label}: stale phrase {stale!r}"
+
+    # A public `retain_authority` no longer exists; only the private one may be
+    # named, and only in the source.
+    assert "retain_authority" not in doc
+    assert "def retain_authority" not in source
+    assert "_retain_authority" in source
+
+    # The contract must state the honest recovery split.
+    assert "no in-process recovery api in this epoch" in doc
+    assert "recoverable_in_process" in doc
+    for owner_state in ("unsealed standalone lease", "coordination-sealed lease"):
+        assert owner_state in doc, owner_state
 
 
 def test_scope_capability_bearing_symbols_are_not_public():
@@ -4000,7 +4135,568 @@ async def test_claim_model_premise_claim_commits_before_the_callback():
     # The only deletion path runs through the evidence gate.
     source = COORDINATION_SOURCE.read_text(encoding="utf-8")
     assert source.count("release_if_matches(") == 2  # the port and its one call
-    assert "if not evidence.authorizes_release:" in source
+    # The single deletion path is gated on exact-boolean terminal evidence.
+    assert "_terminal_evidence_authorizes(evidence)" in source
+    assert "CoordinationReasonCode.TERMINAL_EVIDENCE_REQUIRED" in source
+
+
+# ===========================================================================
+# §r20 — B33-B42 and the C1 truth table
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_claim_scope_assertion_blocks_a_send_after_delayed_ownership_loss():
+    """B33: the coordinator's single pre-callback check is not enough.
+
+    A lane can await account truth or a token refresh after entry, and ownership
+    can vanish in that interval. Detecting it at release — after the order is out
+    — is not the property the signed briefs ask for.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    connection = stack["connection"]
+    sends: list[str] = []
+
+    async def delayed_lane(scope: Any) -> MutationCallbackResult:
+        await asyncio.sleep(0)
+        connection.simulate_session_loss()
+        await scope.assert_owned()  # must raise
+        sends.append("POST")  # unreachable
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO"
+        )
+
+    stack["callback"] = delayed_lane
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    assert sends == []
+    # The unknown is still durable, and the claim still blocks the account.
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_scope_assertion_is_required_before_every_send_in_a_batch():
+    """B33: a same-cycle batch must re-assert per POST, not once."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    connection = stack["connection"]
+    sends: list[str] = []
+
+    async def two_post_lane(scope: Any) -> MutationCallbackResult:
+        await scope.assert_owned()
+        sends.append("POST#1")
+        # Ownership disappears between the two POSTs of the same batch.
+        connection.simulate_session_loss()
+        await scope.assert_owned()  # the second assert must catch it
+        sends.append("POST#2")  # unreachable
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO"
+        )
+
+    stack["callback"] = two_post_lane
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+
+    assert sends == ["POST#1"]
+    # A lane that skipped the second assertion would have sent twice; that is
+    # the whole point of putting the operation in the lane's hands.
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_result",
+    [
+        "not-a-result",
+        {"certainty": "definitive"},
+        MutationCallbackResult(certainty="uncertain", broker_order_id="ODNO"),
+        MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id=123
+        ),
+    ],
+    ids=["raw_string", "dict", "raw_string_certainty", "non_string_broker_id"],
+)
+async def test_claim_invalid_callback_result_becomes_typed_uncertainty(
+    bad_result: Any,
+):
+    """B35: an annotation is not a runtime guarantee.
+
+    A raw-string certainty slips past every ``is MutationCertainty.X`` branch and
+    lands in the durable record misclassified as an acknowledgement; a dict
+    raises on attribute access *after* a possible send. Both must become typed
+    uncertainty that is durable before anything is cleaned up.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+
+    async def returns_bad(scope: Any) -> Any:
+        return bad_result
+
+    stack["callback"] = returns_bad
+    with pytest.raises(TypeError):
+        await _run(envelope, stack)
+
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert isinstance(evidence.certainty, MutationCertainty)
+    assert evidence.broker_order_id is None
+    # Never an acknowledgement, and never an escape before the durable writes.
+    assert stack["persistence"].calls == 2
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_synchronous_send_then_raise_is_not_never_started():
+    """B42: a callable can POST in a synchronous prelude and *then* raise.
+
+    Calling that "the callback never started" writes no evidence and hands the
+    writer authority back, even though an order may already be at the broker.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    posts: list[str] = []
+
+    def sync_post_then_raise(scope: Any) -> Any:
+        posts.append("POST")  # a synchronous broker SDK call
+        raise RuntimeError("sdk exploded after sending")
+
+    stack["callback"] = sync_post_then_raise
+    with pytest.raises(RuntimeError, match="sdk exploded"):
+        await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    # The unknown became durable before anything was cleaned up.
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert stack["evidence"].only.certainty is MutationCertainty.UNCERTAIN
+    assert stack["persistence"].calls == 2
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_non_awaitable_callback_return_takes_the_evidence_path():
+    """B42: a non-awaitable return is also post-invocation, not pre-callback."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+
+    def non_awaitable(scope: Any) -> Any:
+        return "not a coroutine"
+
+    stack["callback"] = non_awaitable
+    with pytest.raises(TypeError, match="awaitable"):
+        await _run(envelope, stack)
+
+    assert stack["evidence"].calls == 1
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_invocation_failure_with_broken_durability_keeps_the_hold():
+    """B42: if either durable write fails, the durable-false hold must remain."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    posts: list[str] = []
+
+    def sync_post_then_raise(scope: Any) -> Any:
+        posts.append("POST")
+        raise RuntimeError("sdk exploded after sending")
+
+    stack["callback"] = sync_post_then_raise
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert posts == ["POST"]
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert len(set(held_coordinations()) - held_before) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_scope_is_dead_once_its_coordinated_section_ends():
+    """B33: a captured scope cannot assert against a finished lease."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    captured: list[Any] = []
+
+    async def capture(scope: Any) -> MutationCallbackResult:
+        captured.append(scope)
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO"
+        )
+
+    stack["callback"] = capture
+    await _run(envelope, stack)
+
+    assert len(captured) == 1
+    with pytest.raises(CoordinationError) as excinfo:
+        await captured[0].assert_owned()
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+
+def test_scope_view_exposes_exactly_one_operation_and_no_capability():
+    """B33: the view is the read right, never the write right."""
+
+    public_names = {name for name in dir(CoordinationScope) if not name.startswith("_")}
+    assert public_names == {"assert_owned"}
+    # The one private slot holds a closure, not the lease: no attribute walk
+    # from the view reaches a connection, a grant, or a release.
+    private_names = {
+        name
+        for name in dir(CoordinationScope)
+        if name.startswith("_") and not name.startswith("__")
+    }
+    assert private_names == {"_assert"}
+    assert CoordinationScope.__slots__ == ("_assert",)
+    for forbidden in (
+        "lease",
+        "grant",
+        "connection",
+        "release",
+        "terminate",
+        "backend_pid",
+        "owner_token",
+        "keys",
+        "hold_id",
+        "unlock",
+    ):
+        assert not hasattr(CoordinationScope, forbidden), forbidden
+
+
+@pytest.mark.asyncio
+async def test_claim_registry_swapped_during_reserve_never_reaches_the_callback():
+    """B41: authority is derived once; every later check must match that entry."""
+
+    _, envelope = _attempt_envelope()
+    bound = _bound_registry(envelope)
+    # A registry object that quietly becomes a *different* physical account the
+    # second time it is read — exactly what an awaited reserve permits.
+    swapped = _bound_registry(envelope, physical_account_id="OTHER-PHYSICAL-ACCOUNT")
+
+    class MutatingRegistry:
+        def __init__(self) -> None:
+            self.reads = 0
+
+        def __iter__(self) -> Any:
+            self.reads += 1
+            return iter(bound if self.reads <= 1 else swapped)
+
+    stack = _default_stack()
+    with pytest.raises(registry.LaneGuardError) as excinfo:
+        await coordinate_mock_order_mutation(
+            **{
+                **_coordination_kwargs(
+                    envelope,
+                    lane_registry=bound,
+                    persistence=stack["persistence"],
+                    evidence=stack["evidence"],
+                    intents=stack["intents"],
+                    factory=stack["factory"],
+                    callback=stack["callback"],
+                ),
+                "registry": MutatingRegistry(),
+            }
+        )
+
+    assert excinfo.value.code == "canonical_lane_identity_mismatch"
+    assert stack["callback"].calls == 0
+    # The claim for account A is retained; account B was never touched.
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("position", ["first", "middle", "final"])
+async def test_lock_cancellation_at_each_reverse_unlock_position(position: str):
+    """B38: cover first/middle/final, and assert the confirmed prefix."""
+
+    space = FakeLockSpace()
+    keys = [11, 22, 33]  # reverse order is 33, 22, 11
+    target = {"first": 33, "middle": 22, "final": 11}[position]
+    connection = FakeLockConnection(
+        space,
+        pid=9601,
+        termination_raises=RuntimeError("cannot terminate"),
+        unlock_raises_on_key=target,
+        unlock_raises_error=asyncio.CancelledError(),
+    )
+    lease = await acquire_physical_account_lease(
+        keys=keys, connection_factory=ConnectionFactory(connection)
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError):
+        await lease.release(lease.grant)
+
+    expected_prefix = {"first": (), "middle": (33,), "final": (33, 22)}[position]
+    assert lease.unlocked_keys == expected_prefix
+    assert lease.released is False
+    assert connection.closed is False
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    assert _retained_authorities()[new_holds.pop()].connection is connection
+
+
+@pytest.mark.asyncio
+async def test_lock_false_unlock_after_a_confirmed_prefix_keeps_the_progress():
+    """B38: a mid-sequence false unlock must still record what *was* confirmed.
+
+    Losing the prefix would describe the remaining authority as larger than it
+    is, which is the same dishonesty as claiming a release that did not happen.
+    """
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space,
+        pid=9651,
+        unlock_false_on_key=22,  # reverse order is 33, 22, 11
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    lease = await acquire_physical_account_lease(
+        keys=[11, 22, 33], connection_factory=ConnectionFactory(connection)
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    assert connection.unlock_calls == [33, 22]
+    assert lease.unlocked_keys == (33,)  # the confirmed prefix, preserved
+    assert lease.released is False
+    assert connection.closed is False
+    assert len(set(_retained_authorities()) - retained_before) == 1
+
+
+@pytest.mark.asyncio
+async def test_lock_rollback_survives_a_second_cancel_during_gated_termination():
+    """B39: a cancel arriving *inside* rollback termination must not abandon it."""
+
+    space = FakeLockSpace()
+    gate = asyncio.Event()
+    started = asyncio.Event()
+
+    class GatedTerminationConnection(FakeLockConnection):
+        async def terminate_backend_session(
+            self, *, expected_pid: int, owner_token: str
+        ):
+            started.set()
+            await gate.wait()
+            raise RuntimeError("termination still unproven")
+
+    connection = GatedTerminationConnection(
+        space, pid=9701, raise_after_lock_on_key=962
+    )
+    retained_before = set(_retained_authorities())
+
+    task = asyncio.ensure_future(
+        acquire_physical_account_lease(
+            keys=[961, 962], connection_factory=ConnectionFactory(connection)
+        )
+    )
+    await started.wait()
+    for _ in range(5):
+        task.cancel()  # the second (and third) cancel
+        await asyncio.sleep(0)
+
+    assert task.done() is False  # rollback still running, not abandoned
+    assert connection.closed is False
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    assert _retained_authorities()[new_holds.pop()].connection is connection
+    assert connection.closed is False
+
+
+@pytest.mark.asyncio
+async def test_lock_cancellation_during_confirmed_rollback_unlock_is_retained():
+    """B39: interrupting a confirmed partial rollback leaves it tracked."""
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=9801)
+    await acquire_physical_account_lease(
+        keys=[973], connection_factory=ConnectionFactory(blocker)
+    )
+    connection = FakeLockConnection(
+        space,
+        pid=9802,
+        unlock_raises_on_key=972,
+        unlock_raises_error=asyncio.CancelledError(),
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[971, 972, 973], connection_factory=ConnectionFactory(connection)
+        )
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    assert _retained_authorities()[new_holds.pop()].connection is connection
+    assert connection.closed is False
+
+
+@pytest.mark.asyncio
+async def test_lock_hold_id_exhaustion_still_retains_the_new_authority(monkeypatch):
+    """B40: a collision storm must not make the newly unsafe authority vanish."""
+
+    import gc
+
+    space = FakeLockSpace()
+    _, victim_connection, victim_hold = await _durable_true_hold(
+        space, pid=9901, key=981
+    )
+    victim_owner = _retained_authorities()[victim_hold.hold_id].owner
+
+    colliding = victim_hold.hold_id.removeprefix("hold:")
+    monkeypatch.setattr(coordination.secrets, "token_hex", lambda _n: colliding)
+
+    intruder = FakeLockConnection(
+        space,
+        pid=9902,
+        raise_after_lock_on_key=983,
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(_retained_authorities())
+    with pytest.raises(RuntimeError):
+        await acquire_physical_account_lease(
+            keys=[982, 983], connection_factory=ConnectionFactory(intruder)
+        )
+
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    quarantined = new_holds.pop()
+    assert quarantined.startswith("hold:quarantine:")
+    retained = _retained_authorities()[quarantined]
+    assert retained.connection is intruder
+    assert retained.grant.backend_pid == 9902
+    gc.collect()
+    assert _retained_authorities()[quarantined].connection is intruder
+    assert intruder.closed is False
+
+    # The victim is untouched, and a successor still contends on the held key.
+    assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
+    assert _retained_authorities()[victim_hold.hold_id].owner is victim_owner
+    successor = FakeLockConnection(space, pid=9903)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[983], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+
+@pytest.mark.asyncio
+async def test_lock_c1_truth_table_all_five_rows():
+    """C1: the flag must equal the negation of the two release blockers.
+
+    Each row asserts the flag **and** demonstrates the behaviour it claims —
+    asserting the flag alone would be a tautology.
+    """
+
+    space = FakeLockSpace()
+
+    # T1 unsealed x durable-TRUE -> True, and the retry really works.
+    lease, connection, hold = await _durable_true_hold(space, pid=10001, key=1011)
+    assert _active_hold(hold.hold_id).recoverable_in_process is True
+    await lease.release(lease.grant)
+    assert lease.released is True
+
+    # T2 unsealed x durable-FALSE -> False, and release is refused.
+    conn2 = FakeLockConnection(space, pid=10002)
+    lease2 = await acquire_physical_account_lease(
+        keys=[1012], connection_factory=ConnectionFactory(conn2)
+    )
+    hold2 = lease2._retain_authority(
+        reason_code=CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+        durable_evidence_written=False,
+    )
+    assert _active_hold(hold2.hold_id).recoverable_in_process is False
+    with pytest.raises(CoordinationError) as blocked:
+        await lease2.release(lease2.grant)
+    assert blocked.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert conn2.unlock_calls == []
+    assert conn2.closed is False
+
+    # T3 sealed x durable-TRUE -> False, public release refused, and ONE id.
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    sealed_conn = stack["connection"]
+    sealed_conn._termination_raises = RuntimeError("cannot terminate")
+
+    async def flip(scope: Any) -> MutationCallbackResult:
+        sealed_conn._unlock_returns = False
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO"
+        )
+
+    stack["callback"] = flip
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+    handle_id = (set(held_coordinations()) - held_before).pop()
+    sealed = _held_coordination(handle_id)
+    assert sealed is not None
+    sealed_hold = sealed.lease.unreleased_authority_hold
+    assert sealed_hold is not None
+    assert sealed_hold.durable_evidence_written is True
+    assert sealed_hold.recoverable_in_process is False
+    # One stuck authority, one opaque id an operator can follow.
+    assert sealed_hold.hold_id == handle_id
+    with pytest.raises(CoordinationError):
+        await sealed.lease.release(sealed.grant)
+
+    # T4 sealed x durable-FALSE -> False (covered in depth elsewhere).
+    _, env4 = _attempt_envelope()
+    stack4 = _default_stack()
+    stack4["evidence"] = RecordingDispatchEvidence(fail=True)
+    before4 = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(env4, stack4)
+    id4 = (set(held_coordinations()) - before4).pop()
+    assert _active_hold(id4).recoverable_in_process is False
+
+    # T5 rollback with no owning lease -> False.
+    rollback_conn = FakeLockConnection(
+        space,
+        pid=10005,
+        raise_after_lock_on_key=1052,
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(_retained_authorities())
+    with pytest.raises(RuntimeError):
+        await acquire_physical_account_lease(
+            keys=[1051, 1052], connection_factory=ConnectionFactory(rollback_conn)
+        )
+    rollback_id = (set(_retained_authorities()) - retained_before).pop()
+    assert _active_hold(rollback_id).recoverable_in_process is False
+
+
+def _active_hold(hold_id: str) -> Any:
+    return next(h for h in unreleased_authority_holds() if h.hold_id == hold_id)
 
 
 # ===========================================================================

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -5995,6 +5995,151 @@ async def test_lock_real_postgres_multi_key_rollback_leaves_nothing_held(db_sess
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_lock_real_postgres_pg05_session_loss_keeps_the_durable_row(db_session):
+    """PG05: closing the owner backend frees the session lock and nothing else.
+
+    The advisory lease is ephemeral state in one PostgreSQL backend; the durable
+    send record lives in a committed table. Killing the backend must therefore
+    end the lease and leave the record untouched, so a successor can take the
+    lease but still cannot re-send that exact lineage. Proven against a real
+    backend because the whole point is what PostgreSQL does when a session dies,
+    which a fake cannot demonstrate.
+    """
+
+    from sqlalchemy import text as sql_text
+
+    from app.core import db
+
+    _, envelope = _attempt_envelope(attempt_overrides={"cycle_id": "pg05"})
+    scope = physical_account_scope_for_entry(
+        _fully_bound_entry(envelope, "kr.kis.mock", physical_account_id="rob-1262-pg05")
+    )
+    adapter = DurableSendClaimAdapter(OrderSendIntentService(db_session))
+    key = envelope.order_attempt.idempotency_key
+
+    lease = await acquire_physical_account_lease(
+        keys=[scope.advisory_key], connection_factory=_open_run_owned_authority
+    )
+    grant = lease.grant
+    reserved = await adapter.reserve(
+        scope=scope, idempotency_key=key, symbol="005930", side="buy"
+    )
+    try:
+        receipt = await lease._connection.terminate_backend_session(
+            expected_pid=grant.backend_pid, owner_token=grant.connection_token
+        )
+        assert receipt.terminated is True
+
+        # The backend, and therefore the session lock, is gone.
+        observer = await db.engine.connect()
+        try:
+            alive = await observer.execute(
+                sql_text("SELECT count(*) FROM pg_stat_activity WHERE pid = :pid"),
+                {"pid": grant.backend_pid},
+            )
+            assert int(alive.scalar_one()) == 0
+        finally:
+            await observer.close()
+
+        # A successor takes the lease, which proves the lock really was freed.
+        successor = await acquire_physical_account_lease(
+            keys=[scope.advisory_key], connection_factory=_open_run_owned_authority
+        )
+        callbacks: list[str] = []
+        try:
+            # ...and still cannot re-send this exact lineage, because the
+            # committed row outlived the session that created it.
+            with pytest.raises(CoordinationError) as excinfo:
+                await adapter.reserve(
+                    scope=scope, idempotency_key=key, symbol="005930", side="buy"
+                )
+                callbacks.append("sent")
+            assert excinfo.value.reason_code is (
+                CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+            )
+            assert callbacks == []
+        finally:
+            await successor.release(successor.grant)
+    finally:
+        # The backend is gone but the connection object is still checked out;
+        # hand it back explicitly rather than leaving it to the collector.
+        await coordination._close_quietly(lease._connection)
+        assert (
+            await adapter.release_with_terminal_evidence(
+                reserved,
+                coordination.TerminalClaimEvidence(
+                    lane_native_terminal_evidence=True,
+                    account_position_reconciled=True,
+                    remainder_known=True,
+                ),
+            )
+            == 1
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lock_real_postgres_pg06_stale_grant_cannot_touch_the_new_lock(
+    db_session,
+):
+    """PG06: a grant from a dead session has no authority over the next owner.
+
+    After the first backend dies and a second owner acquires the same key, the
+    old grant must neither pass `assert_owned` nor unlock anything. If it could
+    unlock, one process could free another process's lease by replaying a token
+    it no longer backs — the exact failure the PID/connection identity in the
+    grant exists to prevent.
+    """
+
+    key = -778899001122
+    first = await acquire_physical_account_lease(
+        keys=[key], connection_factory=_open_run_owned_authority
+    )
+    stale_grant = first.grant
+    receipt = await first._connection.terminate_backend_session(
+        expected_pid=stale_grant.backend_pid,
+        owner_token=stale_grant.connection_token,
+    )
+    assert receipt.terminated is True
+
+    second = await acquire_physical_account_lease(
+        keys=[key], connection_factory=_open_run_owned_authority
+    )
+    try:
+        assert second.grant.backend_pid != stale_grant.backend_pid
+
+        # The stale grant cannot assert ownership of anything.
+        with pytest.raises(CoordinationError) as excinfo:
+            await first.assert_owned(stale_grant)
+        assert excinfo.value.reason_code in (
+            CoordinationReasonCode.LEASE_LOST,
+            CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE,
+        )
+
+        # Nor can it be replayed against the new owner's lease.
+        with pytest.raises(CoordinationError):
+            await second.release(stale_grant)
+
+        # The new owner still holds the key: a third contender is refused.
+        with pytest.raises(CoordinationError) as contended:
+            await acquire_physical_account_lease(
+                keys=[key], connection_factory=_open_run_owned_authority
+            )
+        assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+        assert second.released is False
+    finally:
+        await second.release(second.grant)
+        await coordination._close_quietly(first._connection)
+
+    # Only after the real owner released is the key free again.
+    third = await acquire_physical_account_lease(
+        keys=[key], connection_factory=_open_run_owned_authority
+    )
+    await third.release(third.grant)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_claim_real_order_send_intent_service_exact_lineage_round_trip(
     db_session,
 ):

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -7839,34 +7839,56 @@ async def test_claim_proven_backend_termination_does_not_release_the_claim():
 
 
 def test_scope_no_account_wide_claim_prose_survives():
-    """AC10 / r84 U-c: the retired framing must not return anywhere.
+    """AC10 / r85: the retired framing must not return, and this guard must
+    actually be able to see it.
 
-    Two earlier versions of this guard were too narrow. It scanned only the source
-    and the contract, so the same claim survived in the *tests*; and it matched
-    four fixed literals, so any rephrasing walked straight past it.
+    Forbidden is a sentence whose **subject is the claim or the reservation**
+    asserting that it blocks the account. The opposite subject is correct and
+    must survive — "uncertainty keeps the account blocked" is the
+    post-correction contract, because the authority blocks an account, not the
+    claim.
 
-    What is forbidden is a sentence whose **subject is the claim or the
-    reservation** asserting that it blocks the account. The opposite subject is
-    correct and must survive: "uncertainty keeps the account blocked" is exactly
-    the post-correction contract, because the authority — not the claim — is what
-    blocks an account.
+    Three earlier versions were each too weak, and each weakness is closed here
+    with a mutant that proves it:
+
+    * it scanned only the *prefix* of this file up to this function, so anything
+      added below became silently unscanned. It now scans the whole file and
+      subtracts exactly this function's own source span, located with
+      ``inspect.getsource`` rather than by a comment claiming this is the last
+      function. A rule that cannot be enforced is not a rule;
+    * it exempted a match if any negation token appeared anywhere in a fixed
+      90-character window, so ``the claim blocks the account; it does not
+      authorize a broker mutation`` passed. Negation is now scoped to the clause
+      between that subject and that predicate;
+    * it exempted any occurrence of the substring ``gate`` just after the
+      subject, so ``claim gateway`` and ``claim, gated as settled`` passed. Only
+      the exact approved sentence from the verbatim correction is exempt;
+    * it used a fixed character window that crossed sentence boundaries in both
+      directions, attributing one sentence's predicate to another sentence's
+      subject. Matching is now per sentence.
+
+    Scope, stated deliberately: the mutant **definitions** JSON is not scanned.
+    `C1_stale_account_block_prose_restored` must contain the forbidden meaning as
+    its payload — that is the point of it — so scanning it would make the guard
+    fight its own test data.
     """
 
+    import inspect
     import itertools
     import re
 
-    own_text = pathlib.Path(__file__).read_text()
-    # This guard names the forbidden phrases in order to hunt them, so scanning
-    # its own body would always match itself. It is the last function in the
-    # file, so everything above it is exactly the suite under audit.
-    marker = "def test_scope_no_account_wide_claim_prose_survives"
+    own_source = inspect.getsource(test_scope_no_account_wide_claim_prose_survives)
+    tests_text = pathlib.Path(__file__).read_text()
+    assert own_source in tests_text, "cannot locate this guard's own source span"
     scanned = {
         "source": pathlib.Path(coordination.__file__).read_text(),
         "contract": (
             REPO_ROOT / "docs/contracts/rob-1262-coordination-port.md"
         ).read_text(),
-        "tests": own_text[: own_text.index(marker)],
+        # Whole file minus exactly this function — not a prefix.
+        "tests": tests_text.replace(own_source, "\n"),
     }
+
     subjects = ("claim", "reservation", "binary row", "durable row")
     predicates = (
         "account block",
@@ -7880,37 +7902,35 @@ def test_scope_no_account_wide_claim_prose_survives():
         "blocks unrelated",
         "blocks every new order",
     )
-    # Sentences that *deny* the retired claim, and sentences whose real subject is
-    # the authority rather than the claim, are the corrected form — not matches.
-    # "unresolved-claim **gate** blocks unrelated new sends **only while** a prior
-    # outcome is uncertain" is the mandated verbatim text and must survive intact.
-    negations = (
-        "does not",
-        "never",
-        "not an account",
-        "cannot",
-        "no longer",
-        "rather than",
-        "only while",
-    )
+    negations = ("does not", "never", "not ", "cannot", "no longer", "rather than")
+    # The one approved sentence whose subject is the authority, from the verbatim
+    # correction. Matched exactly — "gateway" and "gated" are not this.
+    approved = "unresolved-claim gate blocks unrelated new sends only while"
+
     for label, text in scanned.items():
         flat = " ".join(text.split()).lower()
-        for subject, predicate in itertools.product(subjects, predicates):
-            for m in re.finditer(re.escape(subject), flat):
-                window = flat[m.end() : m.end() + 90]
-                if "gate" in flat[m.end() : m.end() + 12]:
-                    continue  # the subject is the authority, not the claim
-                if predicate in window and not any(n in window for n in negations):
+        # Per sentence, so no predicate is ever attributed across a boundary.
+        for sentence in re.split(r"[.;:!?]|\s-\s", flat):
+            if approved in sentence:
+                continue
+            for subject, predicate in itertools.product(subjects, predicates):
+                for sm in re.finditer(re.escape(subject), sentence):
+                    pm = sentence.find(predicate, sm.end())
+                    if pm == -1:
+                        continue
+                    clause = sentence[sm.end() : pm]
+                    if any(n in clause for n in negations):
+                        continue  # this clause denies the assertion
                     raise AssertionError(
-                        f"{label}: '{subject}' still asserts '{predicate}': "
-                        f"...{flat[m.start() : m.end() + 90]}..."
+                        f"{label}: '{subject}' asserts '{predicate}': "
+                        f"...{sentence[max(0, sm.start() - 20) : pm + 40].strip()}..."
                     )
 
     # The correct, opposite-subject sentence must still be present.
     assert (
         "uncertainty keeps the account blocked"
         in " ".join(scanned["tests"].split()).lower()
-    )
+    ), "the correct opposite-subject sentence was lost"
 
     # The coordinator must not reach the generic reservation predicates.
     assert "has_reservations" not in scanned["source"]

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -1,0 +1,3568 @@
+"""ROB-1262 J3A coordination-port tests.
+
+Test-name prefixes map to the six sections of the bound preflight artifact
+``answer-codexmock-j3a-preflight-20260816.md`` (§Exact tests and mutants):
+
+``identity_``      Identity, registry, and policy binding
+``nullable_cid_``  Nullable broker-native client ID
+``lock_``          Advisory lock ownership and pooling
+``claim_``         Reservation, persistence, restart, and release
+``cancel_``        Cancellation and injected callback
+``scope_``         Scope and static safety
+
+No test imports or instantiates a real broker client, opens a socket, or reads a
+credential value; ``scope_test_file_imports_no_broker_or_network_surface``
+enforces that statically over this very file.
+
+Two things this file deliberately does **not** do:
+
+* it does not forbid future authorized consumers from importing this module —
+  the write fence is proved from the job's own ``base..HEAD`` diff, and
+  ``scope_authorized_future_consumer_may_import_and_use_the_port`` pins that an
+  approved J3B/J3C integration stays green;
+* it does not accept "the broker order id is absent" or "the same envelope was
+  written twice" as evidence of durable uncertainty — the ``claim_evidence_``
+  tests read the typed :class:`DispatchEvidence` record itself.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import pathlib
+import shutil
+import subprocess
+from dataclasses import replace
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from app.schemas.execution_contracts import LaneStatus, SchedulerOwner
+from app.services import mock_lane_registry as registry
+from app.services.brokers.client_order_ids import BrokerClientIdTarget
+from app.services.mock_integration import coordination
+from app.services.mock_integration.coordination import (
+    AUTOMATIC_CLAIM_RELEASE_AVAILABLE,
+    COORDINATION_REASON_CODES,
+    FENCING_NOT_BROKER_ENFORCED,
+    LANE_FENCING_MATRIX,
+    LEASE_TTL_SECONDS,
+    NOT_BROKER_ENFORCED_FENCING_STATEMENT,
+    AdvisoryLeaseGrant,
+    AdvisoryLockRow,
+    BackendSessionTerminationUnproven,
+    BackendTerminationReceipt,
+    ClaimFollowupRequest,
+    CoordinationError,
+    CoordinationReasonCode,
+    DispatchEvidence,
+    DispatchEvidenceKind,
+    DispatchEvidencePort,
+    DurableSendClaimAdapter,
+    HeldCoordination,
+    MutationCallbackResult,
+    MutationCertainty,
+    OrderSendIntentReservationPort,
+    PostgresAdvisoryKeysetLease,
+    SqlAlchemyLockAuthority,
+    acquire_physical_account_lease,
+    authority_hold_history,
+    coordinate_mock_order_mutation,
+    describe_claim_followup,
+    held_coordination,
+    held_coordinations,
+    ordered_advisory_keyset,
+    physical_account_scope_for_entry,
+    require_dispatch_evidence_port,
+    retained_authority_connections,
+    row_proves_ownership,
+    split_advisory_key,
+    supports_backend_session_termination,
+    unreleased_authority_holds,
+)
+from app.services.mock_integration.lineage import (
+    CallerOwnedIdRejected,
+    DecisionIntentDraft,
+    ExecutionPlanDraft,
+    LineageEnvelope,
+    LineageReasonCode,
+    MockLineageFactory,
+    OrderAttemptDraft,
+)
+from app.services.order_send_intent_service import (
+    DuplicateOrderIntent,
+    OrderSendIntentService,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+COORDINATION_SOURCE = (
+    REPO_ROOT / "app" / "services" / "mock_integration" / "coordination.py"
+)
+CONTRACT_DOC = REPO_ROOT / "docs" / "contracts" / "rob-1262-coordination-port.md"
+TEST_SOURCE = pathlib.Path(__file__).resolve()
+
+# The exact J3A write fence (brief B-8) and the base this job branched from.
+J3A_WRITE_FENCE: frozenset[str] = frozenset(
+    {
+        "app/services/mock_integration/coordination.py",
+        "tests/services/mock_integration/test_coordination.py",
+        "docs/contracts/rob-1262-coordination-port.md",
+    }
+)
+J3A_FENCE_BASE_SHA = "e057941425d2ea7d35a36ebf6074a6c70eba3013"
+# Operator/test scratch artifacts are explicitly allowed to change and are
+# equally explicitly never committed (brief §불변).
+FENCE_EXEMPT_PREFIXES: tuple[str, ...] = (".smoke-out/",)
+
+RAW_PHYSICAL_ACCOUNT_ID = "RAW-PHYSICAL-ACCOUNT-4242-DO-NOT-LEAK"
+
+
+# ---------------------------------------------------------------------------
+# Canonical J2B lineage + J2A registry fixtures
+# ---------------------------------------------------------------------------
+
+
+def _intent_draft(**overrides: object) -> DecisionIntentDraft:
+    values: dict[str, object] = {
+        "policy_version": "trading-policy-v9",
+        "policy_version_hash": "f" * 16,
+        "decision_timestamp": datetime(2026, 8, 16, 0, 30, tzinfo=UTC),
+        "market_data_cutoff": datetime(2026, 8, 16, 0, 29, tzinfo=UTC),
+        "symbol": "005930",
+        "side": "buy",
+        "target_notional": Decimal("100000"),
+        "target_notional_currency": "KRW",
+        "limit_policy": {"order_type": "limit"},
+        "expiry_policy": {"kind": "day"},
+        "rationale": "J3A 조정 포트 픽스처",
+    }
+    values.update(overrides)
+    return DecisionIntentDraft(**values)
+
+
+def _plan_draft(**overrides: object) -> ExecutionPlanDraft:
+    values: dict[str, object] = {
+        "lane_id": "kr.kis.mock",
+        "broker": "kis",
+        "account_profile": "mock",
+        "account_mode": "mock",
+        "normalized_symbol": "005930",
+        "quantity": Decimal("1"),
+        "limit_price": Decimal("70000"),
+        "quote_currency": "KRW",
+        "tick_rounding": {"mode": "down"},
+        "session": "regular",
+        "time_in_force": "day",
+        "min_order_validation": {"min_notional": "1"},
+        "risk_caps": {"max_notional": "100000"},
+    }
+    values.update(overrides)
+    return ExecutionPlanDraft(**values)
+
+
+def _attempt_draft(**overrides: object) -> OrderAttemptDraft:
+    values: dict[str, object] = {
+        "cycle_id": "cycle-j3a-1",
+        "attempt_seq": 1,
+        # KIS/Kiwoom have no confirmed broker client-order-ID boundary, so J2B
+        # requires the both-None pair rather than a synthesized native ID.
+        "lane_prefix": None,
+        "broker_client_id_target": None,
+    }
+    values.update(overrides)
+    return OrderAttemptDraft(**values)
+
+
+def _attempt_envelope(
+    *,
+    intent_overrides: dict[str, object] | None = None,
+    plan_overrides: dict[str, object] | None = None,
+    attempt_overrides: dict[str, object] | None = None,
+) -> tuple[MockLineageFactory, LineageEnvelope]:
+    factory = MockLineageFactory()
+    intent = factory.create_decision_intent(_intent_draft(**(intent_overrides or {})))
+    plan_envelope = factory.create_plan_envelope(
+        intent, _plan_draft(**(plan_overrides or {}))
+    )
+    return factory, factory.create_attempt_envelope(
+        plan_envelope, _attempt_draft(**(attempt_overrides or {}))
+    )
+
+
+def _by_id() -> dict[str, registry.LaneRegistryEntry]:
+    return {entry.lane_id: entry for entry in registry.CANONICAL_LANE_REGISTRY}
+
+
+def _fully_bound_entry(
+    envelope: LineageEnvelope,
+    lane_id: str,
+    **overrides: object,
+) -> registry.LaneRegistryEntry:
+    """Test-only fully bound row; canonical rows are intentionally blocked."""
+
+    values: dict[str, object] = {
+        "lane_status": LaneStatus.AUTO_ENABLED,
+        "activation_status": registry.ActivationStatus.ENABLED,
+        "activation_reason": "test-only fully bound fixture",
+        "policy_binding": registry.PolicyBinding(
+            envelope.decision_intent.policy_version,
+            envelope.decision_intent.policy_version_hash,
+        ),
+        "execution_mode": "test-only-bounded",
+        "scheduler_owner": SchedulerOwner.MANUAL,
+        "timing_owner": "test-only-timing",
+        "writer": True,
+        "auto_order_enabled": True,
+        "max_order_notional": Decimal("100000"),
+        "max_orders_per_session": 1,
+        "max_open_orders": 1,
+        "allowed_order_types": ("limit",),
+        "allowed_time_in_force": ("day",),
+        "reconcile_required": True,
+        "physical_account_id": RAW_PHYSICAL_ACCOUNT_ID,
+        "identity_status": "KNOWN",
+        "fingerprint_evidence_ref": "test-only-fingerprint",
+        "canary_binding": "test-only-bounded-canary",
+        "missing_bindings": (),
+    }
+    values.update(overrides)
+    return replace(_by_id()[lane_id], **values)
+
+
+def _bound_registry(
+    envelope: LineageEnvelope, lane_id: str = "kr.kis.mock", **overrides: object
+) -> tuple[registry.LaneRegistryEntry, ...]:
+    replacement = _fully_bound_entry(envelope, lane_id, **overrides)
+    return tuple(
+        replacement if entry.lane_id == replacement.lane_id else entry
+        for entry in registry.CANONICAL_LANE_REGISTRY
+    )
+
+
+# ---------------------------------------------------------------------------
+# Injected fakes — no broker transport, no socket, no credential value
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = list(rows)
+
+    def mappings(self) -> _FakeResult:
+        return self
+
+    def one(self) -> dict[str, Any]:
+        if len(self._rows) != 1:
+            raise AssertionError(f"expected exactly one row, got {len(self._rows)}")
+        return self._rows[0]
+
+    def all(self) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+    def scalar_one(self) -> Any:
+        return next(iter(self.one().values()))
+
+
+class FakeLockSpace:
+    """A minimal stand-in for one PostgreSQL cluster's advisory-lock table."""
+
+    def __init__(self) -> None:
+        self.held: dict[int, int] = {}
+
+    def try_lock(self, key: int, pid: int) -> bool:
+        owner = self.held.get(key)
+        if owner is None or owner == pid:
+            self.held[key] = pid
+            return True
+        return False
+
+    def unlock(self, key: int, pid: int) -> bool:
+        if self.held.get(key) == pid:
+            del self.held[key]
+            return True
+        return False
+
+    def terminate(self, pid: int) -> None:
+        """Backend-session termination releases every advisory lock it held."""
+
+        for key in [key for key, owner in self.held.items() if owner == pid]:
+            del self.held[key]
+
+    def rows(self, pid: int, database_oid: int) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for key, owner in self.held.items():
+            if owner != pid:
+                continue
+            classid, objid = split_advisory_key(key)
+            rows.append(
+                {
+                    "locktype": "advisory",
+                    "mode": "ExclusiveLock",
+                    "granted": True,
+                    "database_oid": database_oid,
+                    "pid": owner,
+                    "objsubid": 1,
+                    "classid": classid,
+                    "objid": objid,
+                }
+            )
+        return rows
+
+
+class FakeLockConnection:
+    """An injected stand-in for one dedicated PostgreSQL session.
+
+    ``close`` models a *pool return*: the backend and its locks survive.  Only
+    ``terminate_backend_session`` ends the session for real, which is exactly
+    the distinction the lease contract depends on.
+    """
+
+    def __init__(
+        self,
+        space: FakeLockSpace,
+        *,
+        pid: int = 4242,
+        database_oid: int = 99001,
+        pid_after_commit: int | None = None,
+        fail_sql: str | None = None,
+        row_filter: Any = None,
+        unlock_returns: Any = None,
+        termination_receipt: Any = "default",
+        termination_raises: BaseException | None = None,
+        can_prove_termination: bool = True,
+        raise_after_lock_on_key: int | None = None,
+        raise_after_lock_error: BaseException | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        self._space = space
+        self._pid = pid
+        self._database_oid = database_oid
+        self._pid_after_commit = pid_after_commit
+        self._fail_sql = fail_sql
+        self._row_filter = row_filter
+        self._unlock_returns = unlock_returns
+        self._termination_receipt = termination_receipt
+        self._termination_raises = termination_raises
+        self._can_prove_termination = can_prove_termination
+        self._raise_after_lock_on_key = raise_after_lock_on_key
+        self._raise_after_lock_error = raise_after_lock_error
+        self._events = events
+        self.termination_calls: list[tuple[int, str]] = []
+        self.statements: list[str] = []
+        self.lock_calls: list[int] = []
+        self.unlock_calls: list[int] = []
+        self.committed = False
+        self.closed = False
+        self.terminated = False
+
+    @property
+    def session_pid(self) -> int:
+        if self.committed and self._pid_after_commit is not None:
+            return self._pid_after_commit
+        return self._pid
+
+    def simulate_reconnect(self, *, new_pid: int) -> None:
+        """Drop the old backend (releasing its locks) and land on a new one."""
+
+        self._space.terminate(self._pid)
+        self._pid = new_pid
+        self._pid_after_commit = None
+
+    def simulate_session_loss(self) -> None:
+        self._space.terminate(self.session_pid)
+
+    async def execute(self, statement: Any, parameters: Any = None, /) -> _FakeResult:
+        sql = str(statement)
+        self.statements.append(sql)
+        if self._fail_sql is not None and self._fail_sql in sql:
+            raise RuntimeError("simulated PostgreSQL authority failure")
+        params = dict(parameters or {})
+        if "pg_terminate_backend" in sql:
+            self.terminated = True
+            self._space.terminate(self.session_pid)
+            return _FakeResult([{"terminated": True}])
+        if "pg_backend_pid" in sql:
+            return _FakeResult(
+                [
+                    {
+                        "backend_pid": self.session_pid,
+                        "database_oid": self._database_oid,
+                    }
+                ]
+            )
+        if "pg_try_advisory_lock" in sql:
+            key = int(params["key"])
+            self.lock_calls.append(key)
+            granted = self._space.try_lock(key, self.session_pid)
+            if key == self._raise_after_lock_on_key:
+                # PostgreSQL granted the key; the client-side await then fails
+                # before the caller ever sees the value.
+                raise self._raise_after_lock_error or RuntimeError(
+                    "connection lost after the lock was granted"
+                )
+            return _FakeResult([{"acquired": granted}])
+        if "pg_advisory_unlock" in sql:
+            key = int(params["key"])
+            self.unlock_calls.append(key)
+            if self._events is not None:
+                self._events.append("lease_unlock")
+            if self._unlock_returns is None:
+                released = self._space.unlock(key, self.session_pid)
+            else:
+                # PostgreSQL saying "you did not hold that key" must not also
+                # quietly drop it from the lock space.
+                released = self._unlock_returns
+                if released:
+                    self._space.unlock(key, self.session_pid)
+            return _FakeResult([{"released": released}])
+        if "pg_locks" in sql:
+            rows = self._space.rows(int(params["pid"]), self._database_oid)
+            if self._row_filter is not None:
+                rows = self._row_filter(rows)
+            return _FakeResult(rows)
+        raise AssertionError(f"unexpected statement: {sql}")
+
+    def can_prove_backend_session_termination(self) -> bool:
+        return self._can_prove_termination
+
+    async def commit(self) -> None:
+        self.committed = True
+
+    async def close(self) -> None:
+        """A pool return: the backend survives, and so would its locks."""
+
+        self.closed = True
+        if self._events is not None:
+            self._events.append("lease_closed")
+
+    async def terminate_backend_session(
+        self, *, expected_pid: int, owner_token: str
+    ) -> BackendTerminationReceipt:
+        """A receipt, an unproven-termination error, or a deliberately bad receipt.
+
+        ``close()`` is intentionally *not* called here: a pool return is never
+        part of proving a backend died.
+        """
+
+        self.termination_calls.append((expected_pid, owner_token))
+        if self._termination_raises is not None:
+            raise self._termination_raises
+        if expected_pid != self._pid:
+            # A real ``pg_terminate_backend(pid)`` targets the PID it is given.
+            # Asking it to kill backend 0 — or any other session — must never
+            # look like this backend died.
+            raise BackendSessionTerminationUnproven(
+                f"expected_pid {expected_pid} is not this backend ({self._pid})"
+            )
+        receipt = self._termination_receipt
+        if receipt == "default":
+            receipt = BackendTerminationReceipt(
+                backend_pid=expected_pid, owner_token=owner_token, terminated=True
+            )
+        if isinstance(receipt, BackendTerminationReceipt) and receipt.terminated:
+            self.terminated = True
+            self._space.terminate(self._pid)
+        return receipt  # type: ignore[return-value]
+
+
+class PooledOnlyConnection:
+    """An authority that can only be *returned to a pool*, never terminated."""
+
+    def __init__(self, space: FakeLockSpace) -> None:
+        self._space = space
+        self.closed = False
+        self.statements: list[str] = []
+
+    async def execute(self, statement: Any, parameters: Any = None, /) -> _FakeResult:
+        self.statements.append(str(statement))
+        raise AssertionError("an unusable authority must never be queried")
+
+    async def commit(self) -> None:  # pragma: no cover - never reached
+        raise AssertionError("an unusable authority must never commit")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class ConnectionFactory:
+    def __init__(self, *connections: Any, fail: bool = False) -> None:
+        self._connections = list(connections)
+        self._fail = fail
+        self.calls = 0
+
+    async def __call__(self) -> Any:
+        self.calls += 1
+        if self._fail:
+            raise RuntimeError("cannot open a dedicated lock-authority session")
+        return self._connections.pop(0)
+
+
+class RecordingPersistence:
+    """A lane-owned lineage persistence port stand-in."""
+
+    def __init__(
+        self,
+        *,
+        events: list[str] | None = None,
+        fail_from_call: int | None = None,
+        cancel_from_call: int | None = None,
+        gate: asyncio.Event | None = None,
+        started: asyncio.Event | None = None,
+    ) -> None:
+        self.persisted: list[LineageEnvelope] = []
+        self.calls = 0
+        self._events = events
+        self._fail_from_call = fail_from_call
+        self._cancel_from_call = cancel_from_call
+        self._gate = gate
+        self._started = started
+
+    async def persist(self, envelope: LineageEnvelope, /) -> None:
+        self.calls += 1
+        if self._started is not None:
+            self._started.set()
+        if self._gate is not None and self.calls == 1:
+            await self._gate.wait()
+        if self._cancel_from_call is not None and self.calls > self._cancel_from_call:
+            raise asyncio.CancelledError()
+        if self._fail_from_call is not None and self.calls > self._fail_from_call:
+            raise RuntimeError("simulated lane persistence backend failure")
+        self.persisted.append(envelope)
+        if self._events is not None:
+            self._events.append("persist")
+
+
+class RecordingDispatchEvidence:
+    """A lane-owned dispatch-evidence port stand-in (the B1 durable unknown)."""
+
+    def __init__(
+        self,
+        *,
+        events: list[str] | None = None,
+        fail: bool = False,
+        cancel: bool = False,
+        gate: asyncio.Event | None = None,
+        started: asyncio.Event | None = None,
+    ) -> None:
+        self.records: list[DispatchEvidence] = []
+        self.calls = 0
+        self._events = events
+        self._fail = fail
+        self._cancel = cancel
+        self._gate = gate
+        self._started = started
+
+    async def persist_dispatch_evidence(self, evidence: DispatchEvidence, /) -> None:
+        self.calls += 1
+        if self._events is not None:
+            self._events.append("evidence_start")
+        if self._started is not None:
+            self._started.set()
+        if self._gate is not None:
+            await self._gate.wait()
+        if self._cancel:
+            raise asyncio.CancelledError()
+        if self._fail:
+            raise RuntimeError("simulated dispatch-evidence backend failure")
+        self.records.append(evidence)
+        if self._events is not None:
+            self._events.append("evidence")
+
+    @property
+    def only(self) -> DispatchEvidence:
+        assert len(self.records) == 1, self.records
+        return self.records[0]
+
+
+class FakeIntents:
+    """Structural stand-in for ``OrderSendIntentService`` (binary claims only)."""
+
+    def __init__(
+        self,
+        *,
+        events: list[str] | None = None,
+        always_duplicate: bool = False,
+    ) -> None:
+        self.rows: dict[int, tuple[str, str, str | None]] = {}
+        self.reserve_calls: list[dict[str, Any]] = []
+        self.release_if_matches_calls: list[dict[str, Any]] = []
+        self.has_reservations_calls = 0
+        self.unrestricted_release_calls = 0
+        self._next_id = 1
+        self._events = events
+        self._always_duplicate = always_duplicate
+
+    async def has_reservations(self, *, account_scope: str) -> bool:
+        self.has_reservations_calls += 1
+        return any(scope == account_scope for scope, _, _ in self.rows.values())
+
+    async def reserve(
+        self,
+        *,
+        account_scope: str,
+        idempotency_key: str,
+        symbol: str | None = None,
+        side: str | None = None,
+        conflicting_key_sides: tuple[tuple[str, str], ...] = (),
+    ) -> int:
+        self.reserve_calls.append(
+            {
+                "account_scope": account_scope,
+                "idempotency_key": idempotency_key,
+                "symbol": symbol,
+                "side": side,
+            }
+        )
+        already = any(
+            (scope, key) == (account_scope, idempotency_key)
+            for scope, key, _ in self.rows.values()
+        )
+        if self._always_duplicate or already:
+            raise DuplicateOrderIntent(f"already reserved: {account_scope}")
+        row_id = self._next_id
+        self._next_id += 1
+        self.rows[row_id] = (account_scope, idempotency_key, side)
+        if self._events is not None:
+            self._events.append("reserve")
+        return row_id
+
+    async def list_reservations(self, *, account_scope: str) -> list[tuple[int, str]]:
+        return [
+            (row_id, key)
+            for row_id, (scope, key, _) in self.rows.items()
+            if scope == account_scope
+        ]
+
+    async def release_if_matches(
+        self,
+        *,
+        account_scope: str,
+        row_id: int,
+        idempotency_key: str,
+        side: str | None,
+    ) -> int:
+        self.release_if_matches_calls.append(
+            {
+                "account_scope": account_scope,
+                "row_id": row_id,
+                "idempotency_key": idempotency_key,
+                "side": side,
+            }
+        )
+        if self.rows.get(row_id) != (account_scope, idempotency_key, side):
+            return 0
+        del self.rows[row_id]
+        return 1
+
+    async def release(self, *, account_scope: str, idempotency_key: str) -> int:
+        self.unrestricted_release_calls += 1
+        raise AssertionError("J3A must never call the unrestricted release()")
+
+
+class RecordingCallback:
+    """The injected mutation callback; a fake, never a broker client."""
+
+    def __init__(
+        self,
+        *,
+        result: MutationCallbackResult | None = None,
+        error: BaseException | None = None,
+        events: list[str] | None = None,
+        gate: asyncio.Event | None = None,
+        started: asyncio.Event | None = None,
+    ) -> None:
+        self.calls = 0
+        self._result = result or MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000001"
+        )
+        self._error = error
+        self._events = events
+        self._gate = gate
+        self._started = started
+
+    async def __call__(self) -> MutationCallbackResult:
+        self.calls += 1
+        if self._events is not None:
+            self._events.append("callback_start")
+        if self._started is not None:
+            self._started.set()
+        if self._gate is not None:
+            await self._gate.wait()
+        if self._events is not None:
+            self._events.append("callback_end")
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+def _coordination_kwargs(
+    envelope: LineageEnvelope,
+    *,
+    lane_registry: tuple[registry.LaneRegistryEntry, ...],
+    persistence: RecordingPersistence | None,
+    evidence: RecordingDispatchEvidence | None,
+    intents: FakeIntents,
+    factory: ConnectionFactory,
+    callback: RecordingCallback,
+) -> dict[str, Any]:
+    return {
+        "envelope": envelope,
+        "registry": lane_registry,
+        "persistence": persistence,
+        "dispatch_evidence": evidence,
+        "claims": DurableSendClaimAdapter(intents),
+        "connection_factory": factory,
+        "mutation": callback,
+    }
+
+
+def _default_stack(events: list[str] | None = None) -> dict[str, Any]:
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, events=events)
+    return {
+        "space": space,
+        "connection": connection,
+        "factory": ConnectionFactory(connection),
+        "persistence": RecordingPersistence(events=events),
+        "evidence": RecordingDispatchEvidence(events=events),
+        "intents": FakeIntents(events=events),
+        "callback": RecordingCallback(events=events),
+    }
+
+
+async def _run(
+    envelope: LineageEnvelope,
+    stack: dict[str, Any],
+    *,
+    lane_registry: tuple[registry.LaneRegistryEntry, ...] | None = None,
+) -> Any:
+    return await coordinate_mock_order_mutation(
+        **_coordination_kwargs(
+            envelope,
+            lane_registry=lane_registry or _bound_registry(envelope),
+            persistence=stack["persistence"],
+            evidence=stack["evidence"],
+            intents=stack["intents"],
+            factory=stack["factory"],
+            callback=stack["callback"],
+        )
+    )
+
+
+def _assert_no_downstream_work(stack: dict[str, Any]) -> None:
+    """Lease, persistence, reservation, and callback counts are all zero."""
+
+    assert stack["factory"].calls == 0
+    assert stack["persistence"].calls == 0
+    assert stack["evidence"].calls == 0
+    assert stack["intents"].reserve_calls == []
+    assert stack["callback"].calls == 0
+    assert stack["connection"].lock_calls == []
+
+
+# ===========================================================================
+# §Identity, registry, and policy binding
+# ===========================================================================
+
+
+def test_identity_same_physical_account_across_two_lanes_derives_identical_scope():
+    _, envelope = _attempt_envelope()
+    kis_entry = _fully_bound_entry(envelope, "kr.kis.mock")
+    kiwoom_entry = _fully_bound_entry(envelope, "kr.kiwoom.mock")
+    assert kis_entry.physical_account_id == kiwoom_entry.physical_account_id
+
+    kis_scope = physical_account_scope_for_entry(kis_entry)
+    kiwoom_scope = physical_account_scope_for_entry(kiwoom_entry)
+
+    assert kis_scope == kiwoom_scope
+    assert kis_scope.claim_account_scope == kiwoom_scope.claim_account_scope
+    assert kis_scope.advisory_key == kiwoom_scope.advisory_key
+
+
+def test_identity_different_physical_accounts_derive_different_scopes():
+    _, envelope = _attempt_envelope()
+    first = physical_account_scope_for_entry(
+        _fully_bound_entry(envelope, "kr.kis.mock", physical_account_id="account-a")
+    )
+    second = physical_account_scope_for_entry(
+        _fully_bound_entry(envelope, "kr.kis.mock", physical_account_id="account-b")
+    )
+    assert first.claim_account_scope != second.claim_account_scope
+    assert first.advisory_key != second.advisory_key
+
+
+def test_identity_scope_derivation_uses_the_pinned_domain_separated_bytes():
+    import hashlib
+
+    _, envelope = _attempt_envelope()
+    entry = _fully_bound_entry(envelope, "kr.kis.mock")
+    digest = hashlib.sha256(
+        b"mock-physical-account-v1\0" + RAW_PHYSICAL_ACCOUNT_ID.encode("utf-8")
+    ).digest()
+
+    scope = physical_account_scope_for_entry(entry)
+
+    assert scope.claim_account_scope == "mockpa:v1:" + digest.hex()
+    assert scope.advisory_key == int.from_bytes(
+        digest[:8], byteorder="big", signed=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_identity_raw_physical_account_id_never_leaves_the_derivation():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    entry = _fully_bound_entry(envelope, "kr.kis.mock")
+    scope = physical_account_scope_for_entry(entry)
+
+    result = await _run(envelope, stack)
+
+    serialized_artifacts = [
+        repr(scope),
+        scope.claim_account_scope,
+        repr(entry),
+        repr(result.claim),
+        repr(result.lease_grant),
+        result.claim.claim_account_scope,
+        result.evidence.claim_account_scope,
+        json.dumps(stack["intents"].reserve_calls),
+        stack["persistence"].persisted[-1].model_dump_json(),
+        str(
+            CoordinationError(CoordinationReasonCode.LEASE_LOST, lane_id="kr.kis.mock")
+        ),
+    ]
+    for artifact in serialized_artifacts:
+        assert RAW_PHYSICAL_ACCOUNT_ID not in artifact
+
+
+@pytest.mark.asyncio
+async def test_identity_unknown_physical_identity_fails_before_any_downstream_work():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+
+    with pytest.raises(registry.LaneGuardError) as excinfo:
+        # Canonical rows ship exactly like this: null id, UNKNOWN, writer/auto false.
+        await _run(envelope, stack, lane_registry=registry.CANONICAL_LANE_REGISTRY)
+
+    assert excinfo.value.code == "lane_binding_incomplete"
+    _assert_no_downstream_work(stack)
+
+
+def test_identity_null_physical_identity_rejected_by_the_scope_derivation():
+    _, envelope = _attempt_envelope()
+    unknown = _fully_bound_entry(
+        envelope,
+        "kr.kis.mock",
+        physical_account_id=None,
+        identity_status="UNKNOWN",
+        fingerprint_evidence_ref=None,
+        writer=False,
+        auto_order_enabled=False,
+    )
+    with pytest.raises(registry.LaneGuardError) as excinfo:
+        physical_account_scope_for_entry(unknown)
+    assert excinfo.value.code == "physical_account_identity_unknown"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("plan_overrides", "intent_overrides", "entry_overrides", "expected"),
+    [
+        ({"broker": "kiwoom"}, {}, {}, "lane_broker_mismatch"),
+        ({"account_profile": "paper"}, {}, {}, "lane_account_profile_mismatch"),
+        ({"account_mode": "paper"}, {}, {}, "lane_account_mode_mismatch"),
+        ({}, {"policy_version": "other-policy"}, {}, "lane_policy_binding_mismatch"),
+        ({}, {"policy_version_hash": "a" * 16}, {}, "lane_policy_binding_mismatch"),
+        (
+            {},
+            {},
+            {
+                "policy_binding": None,
+                "missing_bindings": (registry.MissingBinding.POLICY,),
+                "activation_status": registry.ActivationStatus.BLOCKED,
+                "lane_status": LaneStatus.NOT_READY,
+                "writer": False,
+                "auto_order_enabled": False,
+            },
+            "lane_binding_incomplete",
+        ),
+    ],
+    ids=[
+        "broker_mismatch",
+        "account_profile_mismatch",
+        "account_mode_mismatch",
+        "policy_version_mismatch",
+        "policy_hash_mismatch",
+        "missing_policy_binding",
+    ],
+)
+async def test_identity_registry_mismatch_fails_with_zero_downstream_calls(
+    plan_overrides: dict[str, object],
+    intent_overrides: dict[str, object],
+    entry_overrides: dict[str, object],
+    expected: str,
+):
+    # The registry is bound against a matching envelope; only the *plan under
+    # test* diverges, so the failure is the mismatch and nothing else.
+    _, bound_envelope = _attempt_envelope()
+    _, envelope = _attempt_envelope(
+        intent_overrides=intent_overrides, plan_overrides=plan_overrides
+    )
+    stack = _default_stack()
+
+    with pytest.raises(registry.LaneGuardError) as excinfo:
+        await _run(
+            envelope,
+            stack,
+            lane_registry=_bound_registry(bound_envelope, **entry_overrides),
+        )
+
+    assert excinfo.value.code == expected
+    _assert_no_downstream_work(stack)
+
+
+@pytest.mark.asyncio
+async def test_identity_canonical_fully_bound_envelope_passes_without_a_broker():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+
+    result = await _run(envelope, stack)
+
+    assert result.certainty is MutationCertainty.DEFINITIVE
+    assert stack["callback"].calls == 1
+    assert stack["connection"].closed is True
+    assert stack["connection"].terminated is False
+    # The only I/O surfaces reached are the injected fakes.
+    assert stack["factory"].calls == 1
+
+
+def test_identity_j2a_policy_binding_is_consumed_not_redefined():
+    assert coordination.__dict__.get("PolicyBinding") is None
+    source = ast.parse(COORDINATION_SOURCE.read_text(encoding="utf-8"))
+    defined = {
+        node.name
+        for node in ast.walk(source)
+        if isinstance(node, ast.ClassDef | ast.FunctionDef)
+    }
+    assert "PolicyBinding" not in defined
+    binding = registry.PolicyBinding("v", "h")
+    assert (binding.policy_version, binding.policy_version_hash) == ("v", "h")
+    with pytest.raises(ValueError, match="lane_binding_incomplete"):
+        registry.PolicyBinding("  ", "h")
+
+
+def test_identity_reason_code_vocabulary_is_the_exact_eight_values():
+    assert [code.value for code in CoordinationReasonCode] == [
+        "lock_authority_unavailable",
+        "lease_contended",
+        "lease_lost",
+        "lease_event_loop_mismatch",
+        "durable_claim_conflict",
+        "lineage_persistence_unavailable",
+        "terminal_evidence_required",
+        "claim_followup_not_authorized",
+    ]
+    assert len(COORDINATION_REASON_CODES) == 8
+    # The one shared literal is reused from J2B, never redefined.
+    assert (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE.value
+        == LineageReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE.value
+    )
+    # J2B's own enum is untouched.
+    assert sorted(code.value for code in LineageReasonCode) == [
+        "broker_client_id_constraint_violation",
+        "broker_client_id_target_mismatch",
+        "broker_order_id_conflict",
+        "currency_conversion_not_authorized",
+        "lane_quote_currency_mismatch",
+        "lineage_persistence_unavailable",
+    ]
+    # The evidence vocabulary is separate and never overlaps the reason codes.
+    assert COORDINATION_REASON_CODES.isdisjoint(
+        {kind.value for kind in DispatchEvidenceKind}
+    )
+
+
+# ===========================================================================
+# §Nullable broker-native client ID
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("lane_id", "broker"), [("kr.kis.mock", "kis"), ("kr.kiwoom.mock", "kiwoom")]
+)
+def test_nullable_cid_internal_ids_stay_non_null_while_broker_cid_is_null(
+    lane_id: str, broker: str
+):
+    _, envelope = _attempt_envelope(
+        plan_overrides={"lane_id": lane_id, "broker": broker}
+    )
+    attempt = envelope.order_attempt
+    assert attempt is not None
+    assert attempt.order_attempt_id.startswith("mock-attempt-v1:")
+    assert attempt.idempotency_key.startswith("mock-idempotency-v1:")
+    assert attempt.broker_client_order_id is None
+    assert attempt.broker_order_id is None
+    assert envelope.lane_prefix is None
+    assert envelope.broker_client_id_target is None
+
+
+def test_nullable_cid_persistence_roundtrip_preserves_json_null():
+    _, envelope = _attempt_envelope()
+    payload = json.loads(envelope.model_dump_json())
+    assert payload["order_attempt"]["broker_client_order_id"] is None
+    assert payload["lane_prefix"] is None
+    assert payload["broker_client_id_target"] is None
+    restored = LineageEnvelope.model_validate_json(envelope.model_dump_json())
+    assert restored.order_attempt.broker_client_order_id is None
+
+
+@pytest.mark.asyncio
+async def test_nullable_cid_durable_claim_uses_internal_idempotency_key():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+
+    result = await _run(envelope, stack)
+
+    assert result.claim.idempotency_key == envelope.order_attempt.idempotency_key
+    assert result.claim.idempotency_key.startswith("mock-idempotency-v1:")
+    assert stack["intents"].reserve_calls[0]["idempotency_key"] == (
+        envelope.order_attempt.idempotency_key
+    )
+    assert envelope.order_attempt.broker_client_order_id is None
+
+
+@pytest.mark.asyncio
+async def test_nullable_cid_lane_ack_lands_only_on_broker_order_id():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id=" ODNO-42 "
+        )
+    )
+
+    result = await _run(envelope, stack)
+
+    acknowledged = result.envelope.order_attempt
+    assert acknowledged.broker_order_id == "ODNO-42"
+    assert acknowledged.broker_client_order_id is None
+    assert acknowledged.idempotency_key == envelope.order_attempt.idempotency_key
+    assert stack["persistence"].persisted[-1] is result.envelope
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.ACKNOWLEDGED
+
+
+def test_nullable_cid_mutant_copying_internal_key_into_broker_cid_is_red():
+    _, envelope = _attempt_envelope()
+    attempt = envelope.order_attempt
+    mutant_attempt = attempt.model_copy(
+        update={"broker_client_order_id": attempt.idempotency_key}
+    )
+    with pytest.raises(ValidationError) as excinfo:
+        LineageEnvelope(
+            decision_intent=envelope.decision_intent,
+            execution_plan=envelope.execution_plan,
+            order_attempt=mutant_attempt,
+            attempt_seq=envelope.attempt_seq,
+            lane_prefix=envelope.lane_prefix,
+            broker_client_id_target=envelope.broker_client_id_target,
+        )
+    # J2B's CallerOwnedIdRejected, surfaced through pydantic's validator wrapper.
+    assert "broker_client_order_id must be absent" in str(excinfo.value)
+    assert isinstance(CallerOwnedIdRejected("x"), ValueError)
+
+
+def test_nullable_cid_mutant_adding_kis_or_kiwoom_enum_target_is_red():
+    assert {target.value for target in BrokerClientIdTarget} == {
+        "toss",
+        "binance_spot_demo",
+        "alpaca_paper",
+    }
+    for absent in ("kis", "kiwoom"):
+        with pytest.raises(ValueError, match=absent):
+            BrokerClientIdTarget(absent)
+
+
+# ===========================================================================
+# §Advisory lock ownership and pooling
+# ===========================================================================
+
+
+def _row(**overrides: Any) -> AdvisoryLockRow:
+    classid, objid = split_advisory_key(-7)
+    values: dict[str, Any] = {
+        "locktype": "advisory",
+        "mode": "ExclusiveLock",
+        "granted": True,
+        "database_oid": 99001,
+        "pid": 4242,
+        "objsubid": 1,
+        "classid": classid,
+        "objid": objid,
+    }
+    values.update(overrides)
+    return AdvisoryLockRow(**values)
+
+
+def test_lock_negative_signed_key_reconstructs_the_unsigned_halves():
+    key = -7
+    classid, objid = split_advisory_key(key)
+    assert classid == 0xFFFFFFFF
+    assert objid == 0xFFFFFFF9
+    assert (classid << 32 | objid) == key & ((1 << 64) - 1)
+    assert row_proves_ownership(_row(), key=key, backend_pid=4242, database_oid=99001)
+
+
+def test_lock_direct_signed_key_to_objid_comparison_mutant_fails():
+    """The mutant: ``row.objid == key``. For a negative key it is never true."""
+
+    key = -7
+    row = _row()
+    assert row.objid != key
+    assert row_proves_ownership(row, key=key, backend_pid=4242, database_oid=99001)
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"database_oid": 12345},
+        {"pid": 9999},
+        {"classid": 1},
+        {"objid": 1},
+        {"objsubid": 2},
+        {"granted": False},
+        {"mode": "ShareLock"},
+        {"locktype": "transactionid"},
+    ],
+    ids=[
+        "wrong_database_oid",
+        "wrong_retained_pid",
+        "wrong_classid",
+        "wrong_objid",
+        "wrong_objsubid",
+        "not_granted",
+        "non_exclusive_mode",
+        "wrong_locktype",
+    ],
+)
+def test_lock_any_single_predicate_mismatch_fails_ownership(override: dict[str, Any]):
+    assert not row_proves_ownership(
+        _row(**override), key=-7, backend_pid=4242, database_oid=99001
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_reconnect_after_acquisition_cannot_pass_assert_owned():
+    """G1: the single quietest failure path in this design."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    await lease.assert_owned(lease.grant)
+
+    connection.simulate_reconnect(new_pid=5555)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.assert_owned(lease.grant)
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+
+@pytest.mark.asyncio
+async def test_lock_false_green_naive_acquire_only_check_survives_a_reconnect():
+    """Documented false green.
+
+    "``pg_try_advisory_lock`` returned true, therefore we still own it" stays
+    green across a reconnect. Only the PID + exact-row attestation catches it.
+    """
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    connection.simulate_reconnect(new_pid=5555)
+
+    naive_check_is_green = bool(connection.lock_calls)
+    assert naive_check_is_green is True
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.assert_owned(lease.grant)
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+
+@pytest.mark.asyncio
+async def test_lock_commit_boundary_with_a_changed_backend_pid_fails():
+    """G2: exactly what a transaction pooler does to a session-level lock."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242, pid_after_commit=7777)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert connection.committed is True
+
+
+@pytest.mark.asyncio
+async def test_lock_unattested_session_semantics_fail_closed():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242, row_filter=lambda rows: [])
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert connection.closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("open_fails", [True, False], ids=["open_fails", "query_fails"])
+async def test_lock_authority_failure_runs_no_callback_and_no_file_fallback(
+    open_fails: bool,
+):
+    _, envelope = _attempt_envelope()
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, fail_sql="pg_backend_pid")
+    stack = _default_stack()
+    stack["connection"] = connection
+    stack["factory"] = ConnectionFactory(connection, fail=open_fails)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert stack["callback"].calls == 0
+    assert stack["intents"].reserve_calls == []
+    assert stack["evidence"].calls == 0
+    # G5: no file lock exists anywhere in this authority.
+    assert "fcntl" not in COORDINATION_SOURCE.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_lock_authority_without_backend_termination_is_rejected_at_acquire():
+    """A pool return is not a termination, so a pool-only authority is unusable."""
+
+    space = FakeLockSpace()
+    pooled_only = PooledOnlyConnection(space)
+    assert supports_backend_session_termination(pooled_only) is False
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7], connection_factory=ConnectionFactory(pooled_only)
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    # Rejected before a single statement, so no lock could have been taken.
+    assert pooled_only.statements == []
+    assert pooled_only.closed is True
+    assert space.held == {}
+
+
+@pytest.mark.asyncio
+async def test_lock_coordination_with_a_pool_only_authority_runs_no_callback():
+    _, envelope = _attempt_envelope()
+    space = FakeLockSpace()
+    stack = _default_stack()
+    stack["factory"] = ConnectionFactory(PooledOnlyConnection(space))
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert stack["callback"].calls == 0
+    assert stack["intents"].reserve_calls == []
+
+
+async def _lease_forced_down_the_termination_path(
+    connection: FakeLockConnection,
+) -> Any:
+    """Acquire a lease, then make its unlock unprovable so release must terminate."""
+
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    connection._unlock_returns = False
+    return lease
+
+
+@pytest.mark.asyncio
+async def test_lock_termination_receipt_must_bind_the_exact_pid_and_owner_token():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242)
+    lease = await _lease_forced_down_the_termination_path(connection)
+    holds_before = len(unreleased_authority_holds())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    # Termination was actually invoked, bound to this exact acquisition.
+    assert connection.termination_calls == [(4242, lease.grant.connection_token)]
+    receipt = lease.termination_receipt
+    assert receipt is not None
+    assert receipt.backend_pid == lease.grant.backend_pid
+    assert receipt.owner_token == lease.grant.connection_token
+    assert receipt.terminated is True
+    # A proven termination is an allowed outcome, and the false unlock is not
+    # counted as a release.
+    assert lease.released is True
+    assert lease.unlocked_keys == ()
+    assert lease.unreleased_authority_hold is None
+    assert len(unreleased_authority_holds()) == holds_before
+    assert space.held == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("receipt", "raises"),
+    [
+        (
+            BackendTerminationReceipt(
+                backend_pid=9999, owner_token="", terminated=True
+            ),
+            None,
+        ),
+        (
+            BackendTerminationReceipt(
+                backend_pid=4242, owner_token="forged", terminated=True
+            ),
+            None,
+        ),
+        (
+            BackendTerminationReceipt(
+                backend_pid=4242, owner_token="", terminated=False
+            ),
+            None,
+        ),
+        (None, None),
+        (None, PermissionError("must be a superuser to terminate")),
+        (None, RuntimeError("query failed")),
+        (None, BackendSessionTerminationUnproven("ambiguous driver error")),
+    ],
+    ids=[
+        "wrong_pid",
+        "wrong_owner_token",
+        "terminated_false",
+        "null_receipt",
+        "permission_failure",
+        "query_failure",
+        "ambiguous_driver_error",
+    ],
+)
+async def test_lock_unproven_termination_is_never_counted_as_a_release(
+    receipt: Any, raises: BaseException | None
+):
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space,
+        pid=4242,
+        termination_receipt=receipt,
+        termination_raises=raises,
+    )
+    lease = await _lease_forced_down_the_termination_path(connection)
+    if isinstance(receipt, BackendTerminationReceipt) and receipt.owner_token == "":
+        # Bind the "right token, wrong everything else" cases to the real token.
+        connection._termination_receipt = replace(
+            receipt, owner_token=lease.grant.connection_token
+        )
+    holds_before = len(unreleased_authority_holds())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    assert lease.released is False
+    assert lease.unlocked_keys == ()
+    assert lease.termination_receipt is None
+    hold = lease.unreleased_authority_hold
+    assert hold is not None
+    assert hold.termination_proven is False
+    assert hold.connection_token == lease.grant.connection_token
+    assert len(unreleased_authority_holds()) == holds_before + 1
+    assert unreleased_authority_holds()[-1] is hold
+
+
+@pytest.mark.asyncio
+async def test_lock_close_alone_is_never_accepted_as_backend_termination():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space,
+        pid=4242,
+        termination_raises=BackendSessionTerminationUnproven("only close() worked"),
+    )
+    lease = await _lease_forced_down_the_termination_path(connection)
+
+    with pytest.raises(CoordinationError):
+        await lease.release(lease.grant)
+
+    # The connection object can still be closed; that proves nothing.
+    await connection.close()
+    assert connection.closed is True
+    assert connection.terminated is False
+    assert lease.released is False
+    assert lease.unreleased_authority_hold is not None
+
+
+@pytest.mark.asyncio
+async def test_lock_exact_grant_recovers_after_a_failed_release():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space, pid=4242, termination_raises=RuntimeError("cannot terminate")
+    )
+    lease = await _lease_forced_down_the_termination_path(connection)
+    active_before = set(retained_authority_connections())
+    history_before = len(authority_hold_history())
+
+    with pytest.raises(CoordinationError):
+        await lease.release(lease.grant)
+    assert lease.released is False
+
+    # Exactly one active strong hold appears.
+    new_active = set(retained_authority_connections()) - active_before
+    assert len(new_active) == 1
+    hold_id = new_active.pop()
+    assert retained_authority_connections()[hold_id].connection is connection
+    assert lease.unreleased_authority_hold is not None
+    assert lease.unreleased_authority_hold.hold_id == hold_id
+
+    # A stale or foreign grant keeps failing during recovery, and clears nothing.
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(replace(lease.grant, connection_token="lockconn:forged"))
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    assert hold_id in retained_authority_connections()
+
+    # A second retry that still cannot prove anything keeps the hold.
+    with pytest.raises(CoordinationError):
+        await lease.release(lease.grant)
+    assert hold_id in retained_authority_connections()
+
+    # The exact grant finally proves a full reverse unlock.
+    connection._unlock_returns = None
+    await lease.release(lease.grant)
+    assert lease.released is True
+    assert lease.unlocked_keys == (-7,)
+    assert connection.closed is True
+
+    # B20: the resolved hold is gone from BOTH active views, and the retained
+    # connection is no longer reachable through them.
+    assert hold_id not in retained_authority_connections()
+    assert hold_id not in {hold.hold_id for hold in unreleased_authority_holds()}
+    assert lease.unreleased_authority_hold is None
+    assert all(
+        retained.connection is not connection
+        for retained in retained_authority_connections().values()
+    )
+    # History is immutable evidence and still records what happened.
+    assert len(authority_hold_history()) > history_before
+    assert hold_id in {hold.hold_id for hold in authority_hold_history()}
+
+
+@pytest.mark.asyncio
+async def test_lock_resolving_one_hold_leaves_a_concurrent_hold_untouched():
+    space = FakeLockSpace()
+    stuck = FakeLockConnection(
+        space, pid=5150, termination_raises=RuntimeError("cannot terminate")
+    )
+    stuck_lease = await acquire_physical_account_lease(
+        keys=[101], connection_factory=ConnectionFactory(stuck)
+    )
+    stuck._unlock_returns = False
+    with pytest.raises(CoordinationError):
+        await stuck_lease.release(stuck_lease.grant)
+    stuck_hold = stuck_lease.unreleased_authority_hold
+    assert stuck_hold is not None
+
+    recovering = FakeLockConnection(
+        space, pid=5151, termination_raises=RuntimeError("cannot terminate")
+    )
+    recovering_lease = await acquire_physical_account_lease(
+        keys=[202], connection_factory=ConnectionFactory(recovering)
+    )
+    recovering._unlock_returns = False
+    with pytest.raises(CoordinationError):
+        await recovering_lease.release(recovering_lease.grant)
+    recovering_hold = recovering_lease.unreleased_authority_hold
+    assert recovering_hold is not None
+    assert recovering_hold.hold_id != stuck_hold.hold_id
+
+    # Resolve exactly one of them.
+    recovering._unlock_returns = None
+    await recovering_lease.release(recovering_lease.grant)
+
+    active = retained_authority_connections()
+    assert recovering_hold.hold_id not in active
+    assert stuck_hold.hold_id in active
+    assert active[stuck_hold.hold_id].connection is stuck
+    assert stuck_lease.released is False
+
+
+def test_lock_sqlalchemy_authority_rejects_anything_but_a_dedicated_connection():
+    class _NotAConnection:
+        async def execute(self, statement: Any, parameters: Any = None, /) -> None:
+            return None
+
+    for rejected in (_NotAConnection(), object(), None):
+        with pytest.raises(CoordinationError) as excinfo:
+            SqlAlchemyLockAuthority(rejected)  # type: ignore[arg-type]
+        assert excinfo.value.reason_code is (
+            CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+        )
+
+
+# --- B17 · B14 · B15 · B18 --------------------------------------------------
+
+
+def _dedicated_connection_double(results: list[Any]) -> Any:
+    """A ``MagicMock`` that really is an ``AsyncConnection`` for isinstance."""
+
+    connection = MagicMock(spec=AsyncConnection)
+    connection.execute = AsyncMock(side_effect=list(results))
+    connection.close = AsyncMock()
+    connection.commit = AsyncMock()
+    assert isinstance(connection, AsyncConnection)
+    return connection
+
+
+@pytest.mark.asyncio
+async def test_lock_authority_that_cannot_prove_termination_is_rejected_before_sql():
+    """B17: a callable named ``terminate_backend_session`` is not a capability."""
+
+    space = FakeLockSpace()
+    unprovable = FakeLockConnection(space, can_prove_termination=False)
+    assert callable(unprovable.terminate_backend_session)
+    assert supports_backend_session_termination(unprovable) is False
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7], connection_factory=ConnectionFactory(unprovable)
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    # Not one statement was issued and not one key was requested.
+    assert unprovable.statements == []
+    assert unprovable.lock_calls == []
+    assert space.held == {}
+
+
+def test_lock_sqlalchemy_authority_without_an_observer_cannot_prove_termination():
+    """B17 regression: ``observer_factory=None`` must not pass the gate."""
+
+    connection = _dedicated_connection_double([])
+    authority = SqlAlchemyLockAuthority(connection)
+    assert authority.can_prove_backend_session_termination() is False
+    assert supports_backend_session_termination(authority) is False
+    with_observer = SqlAlchemyLockAuthority(
+        _dedicated_connection_double([]), observer_factory=AsyncMock()
+    )
+    assert supports_backend_session_termination(with_observer) is True
+
+
+@pytest.mark.asyncio
+async def test_lock_sqlalchemy_authority_with_no_observer_acquires_nothing():
+    connection = _dedicated_connection_double([])
+    authority = SqlAlchemyLockAuthority(connection)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7], connection_factory=ConnectionFactory(authority)
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert connection.execute.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "observer_results",
+    [
+        [_FakeResult([{"terminated": False}]), _FakeResult([{"alive": 1}])],
+        [_FakeResult([{"terminated": True}]), _FakeResult([{"alive": 1}])],
+        RuntimeError("permission denied for function pg_terminate_backend"),
+    ],
+    ids=[
+        "terminate_false_and_still_alive",
+        "backend_still_alive",
+        "permission_failure",
+    ],
+)
+async def test_lock_adapter_never_closes_the_owner_when_termination_is_unproven(
+    observer_results: Any,
+):
+    """B14: the owner connection still holds the lock — it must not be returned."""
+
+    owner = _dedicated_connection_double([])
+    if isinstance(observer_results, BaseException):
+        observer = MagicMock(spec=AsyncConnection)
+        observer.execute = AsyncMock(side_effect=observer_results)
+        observer.close = AsyncMock()
+    else:
+        observer = _dedicated_connection_double(observer_results)
+
+    async def observer_factory() -> Any:
+        return observer
+
+    authority = SqlAlchemyLockAuthority(owner, observer_factory=observer_factory)
+
+    with pytest.raises(Exception) as excinfo:
+        await authority.terminate_backend_session(
+            expected_pid=4242, owner_token="lockconn:abc"
+        )
+    assert not isinstance(excinfo.value, BackendTerminationReceipt)
+
+    # The observer is disposable; the owner is not.
+    assert observer.close.await_count == 1
+    assert owner.close.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_lock_adapter_closes_the_owner_only_after_a_proven_termination():
+    owner = _dedicated_connection_double([])
+    observer = _dedicated_connection_double(
+        [_FakeResult([{"terminated": True}]), _FakeResult([{"alive": 0}])]
+    )
+
+    async def observer_factory() -> Any:
+        return observer
+
+    authority = SqlAlchemyLockAuthority(owner, observer_factory=observer_factory)
+    receipt = await authority.terminate_backend_session(
+        expected_pid=4242, owner_token="lockconn:abc"
+    )
+
+    assert receipt == BackendTerminationReceipt(
+        backend_pid=4242, owner_token="lockconn:abc", terminated=True
+    )
+    assert owner.close.await_count == 1
+    assert observer.close.await_count == 1
+    # The PID actually sent to PostgreSQL is the one we were asked to terminate.
+    sent = observer.execute.await_args_list[0].args
+    assert sent[1] == {"pid": 4242}
+
+
+@pytest.mark.asyncio
+async def test_lock_partial_rollback_terminates_with_the_real_backend_pid_and_token():
+    """B18: a rollback must not ask PostgreSQL to terminate backend 0."""
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=2002)
+    await acquire_physical_account_lease(
+        keys=[11], connection_factory=ConnectionFactory(blocker)
+    )
+    # This session's unlocks are unprovable, so rollback must fall back to
+    # terminating *this* backend.
+    connection = FakeLockConnection(space, pid=3003, unlock_returns=False)
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[-7, 5, 11], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert len(connection.termination_calls) == 1
+    sent_pid, sent_token = connection.termination_calls[0]
+    assert sent_pid == 3003
+    assert sent_pid != 0
+    assert sent_token.startswith("lockconn:")
+    assert connection.terminated is True
+
+
+@pytest.mark.asyncio
+async def test_lock_unprovable_rollback_retains_the_real_connection_strongly():
+    """B15: metadata alone would let GC or a pool return drop the authority."""
+
+    import gc
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=2002)
+    await acquire_physical_account_lease(
+        keys=[11], connection_factory=ConnectionFactory(blocker)
+    )
+    connection = FakeLockConnection(
+        space,
+        pid=3003,
+        unlock_returns=False,
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(retained_authority_connections())
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[-7, 5, 11], connection_factory=ConnectionFactory(connection)
+        )
+
+    new_holds = set(retained_authority_connections()) - retained_before
+    assert len(new_holds) == 1
+    hold_id = new_holds.pop()
+    retained = retained_authority_connections()[hold_id]
+
+    # The real connection object is reachable, with the real identity.
+    assert retained.connection is connection
+    assert retained.grant.backend_pid == 3003
+    assert retained.grant.database_oid == connection._database_oid
+    assert retained.grant.keys == (-7, 5, 11)
+    assert retained.grant.event_loop is asyncio.get_running_loop()
+
+    # It survives a collection, and was never closed or pool-returned.
+    gc.collect()
+    assert retained_authority_connections()[hold_id].connection is connection
+    assert connection.closed is False
+    assert connection.terminated is False
+
+    # The keys the fake still reports as held stay contended for a successor.
+    assert set(space.held) >= {-7, 5}
+    successor = FakeLockConnection(space, pid=4004)
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7], connection_factory=ConnectionFactory(successor)
+        )
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+    # A stale/foreign hold id recovers nothing.
+    assert retained_authority_connections().get("hold:forged") is None
+
+
+@pytest.mark.asyncio
+async def test_lock_two_contenders_for_one_physical_key_yield_exactly_one_owner():
+    space = FakeLockSpace()
+    first_connection = FakeLockConnection(space, pid=1001)
+    second_connection = FakeLockConnection(space, pid=1002)
+
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(first_connection)
+    )
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7], connection_factory=ConnectionFactory(second_connection)
+        )
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+    assert second_connection.closed is True
+    await lease.assert_owned(lease.grant)
+    await lease.release(lease.grant)
+
+
+@pytest.mark.asyncio
+async def test_lock_two_distinct_physical_keys_do_not_contend():
+    space = FakeLockSpace()
+    first = await acquire_physical_account_lease(
+        keys=[-7],
+        connection_factory=ConnectionFactory(FakeLockConnection(space, pid=1)),
+    )
+    second = await acquire_physical_account_lease(
+        keys=[11],
+        connection_factory=ConnectionFactory(FakeLockConnection(space, pid=2)),
+    )
+    await first.assert_owned(first.grant)
+    await second.assert_owned(second.grant)
+    await first.release(first.grant)
+    await second.release(second.grant)
+
+
+def test_lock_keyset_is_deduplicated_and_globally_sorted():
+    assert ordered_advisory_keyset([5, -7, 5, 11, -7]) == (-7, 5, 11)
+
+
+@pytest.mark.asyncio
+async def test_lock_duplicate_key_is_acquired_once_and_unlocked_once():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space)
+    lease = await acquire_physical_account_lease(
+        keys=[-7, -7, -7], connection_factory=ConnectionFactory(connection)
+    )
+    assert lease.grant.keys == (-7,)
+    assert connection.lock_calls == [-7]
+
+    await lease.release(lease.grant)
+    assert connection.unlock_calls == [-7]
+    assert lease.unlocked_keys == (-7,)
+
+
+@pytest.mark.asyncio
+async def test_lock_partial_multi_key_acquisition_rolls_back_every_acquired_key():
+    space = FakeLockSpace()
+    blocker_connection = FakeLockConnection(space, pid=2002)
+    await acquire_physical_account_lease(
+        keys=[11], connection_factory=ConnectionFactory(blocker_connection)
+    )
+    connection = FakeLockConnection(space, pid=3003)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7, 5, 11], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+    assert connection.lock_calls == [-7, 5, 11]
+    # Reverse order, exactly the keys that were actually acquired.
+    assert connection.unlock_calls == [5, -7]
+    assert connection.closed is True
+    assert space.held == {11: 2002}
+
+
+@pytest.mark.asyncio
+async def test_lock_unprovable_rollback_terminates_the_backend_session():
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=2002)
+    await acquire_physical_account_lease(
+        keys=[11], connection_factory=ConnectionFactory(blocker)
+    )
+    # This session's unlocks always report false: the lock state is unknown.
+    connection = FakeLockConnection(space, pid=3003, unlock_returns=False)
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[-7, 5, 11], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert connection.terminated is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("connection lost after the lock was granted"),
+        asyncio.CancelledError(),
+    ],
+    ids=["exception_after_grant", "cancellation_after_grant"],
+)
+async def test_lock_in_flight_acquisition_never_takes_the_confirmed_rollback_path(
+    error: BaseException,
+):
+    """B19: the key may already be held server-side even though we never saw it."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space,
+        pid=3003,
+        raise_after_lock_on_key=5,
+        raise_after_lock_error=error,
+        # Termination cannot be proven, so the authority must be retained.
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(retained_authority_connections())
+
+    with pytest.raises(BaseException) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7, 5], connection_factory=ConnectionFactory(connection)
+        )
+    assert isinstance(excinfo.value, type(error))
+
+    # PostgreSQL really did grant the ambiguous key.
+    assert connection.lock_calls == [-7, 5]
+    assert space.held.get(5) == 3003
+    # The confirmed-only unlock path was NOT taken, and the owner was not
+    # closed or pool-returned.
+    assert connection.unlock_calls == []
+    assert connection.closed is False
+    assert connection.terminated is False
+    # Exact-PID termination was attempted and could not be proven.
+    assert connection.termination_calls == [(3003, connection.termination_calls[0][1])]
+    assert connection.termination_calls[0][0] == 3003
+
+    # The real connection is retained strongly under an opaque hold.
+    new_holds = set(retained_authority_connections()) - retained_before
+    assert len(new_holds) == 1
+    retained = retained_authority_connections()[new_holds.pop()]
+    assert retained.connection is connection
+    assert retained.grant.backend_pid == 3003
+    assert retained.grant.keys == (-7, 5)
+
+    # A successor still contends on the ambiguous key.
+    successor = FakeLockConnection(space, pid=4004)
+    with pytest.raises(CoordinationError) as contended:
+        await acquire_physical_account_lease(
+            keys=[5], connection_factory=ConnectionFactory(successor)
+        )
+    assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+
+@pytest.mark.asyncio
+async def test_lock_in_flight_uncertainty_is_resolved_by_a_proven_termination():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=3003, raise_after_lock_on_key=5)
+    retained_before = set(retained_authority_connections())
+
+    with pytest.raises(RuntimeError):
+        await acquire_physical_account_lease(
+            keys=[-7, 5], connection_factory=ConnectionFactory(connection)
+        )
+
+    # A positive exact-PID receipt resolves the ambiguity without a hold.
+    assert connection.termination_calls[0][0] == 3003
+    assert connection.terminated is True
+    assert connection.unlock_calls == []
+    assert space.held == {}
+    assert set(retained_authority_connections()) == retained_before
+
+
+@pytest.mark.asyncio
+async def test_lock_explicit_false_stays_a_known_not_acquired_path():
+    """Over-fail-closed is also a defect: a definite ``False`` is not ambiguity."""
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=2002)
+    await acquire_physical_account_lease(
+        keys=[11], connection_factory=ConnectionFactory(blocker)
+    )
+    connection = FakeLockConnection(space, pid=3003)
+    retained_before = set(retained_authority_connections())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[-7, 5, 11], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+    # The ordinary confirmed rollback ran: reverse unlock, then a plain close,
+    # with no termination and no hold invented.
+    assert connection.unlock_calls == [5, -7]
+    assert connection.closed is True
+    assert connection.terminated is False
+    assert connection.termination_calls == []
+    assert set(retained_authority_connections()) == retained_before
+
+
+@pytest.mark.asyncio
+async def test_lock_multi_key_release_is_reverse_order_with_exact_unlock_count():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space)
+    lease = await acquire_physical_account_lease(
+        keys=[11, -7, 5], connection_factory=ConnectionFactory(connection)
+    )
+    assert lease.grant.keys == (-7, 5, 11)
+
+    await lease.release(lease.grant)
+
+    assert connection.unlock_calls == [11, 5, -7]
+    assert lease.unlocked_keys == (11, 5, -7)
+    assert connection.closed is True
+    assert connection.terminated is False
+
+    # A second release must not unlock anything a second time.
+    await lease.release(lease.grant)
+    assert connection.unlock_calls == [11, 5, -7]
+    assert lease.unlocked_keys == (11, 5, -7)
+
+
+@pytest.mark.asyncio
+async def test_lock_release_reattests_ownership_before_unlocking():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    connection.simulate_reconnect(new_pid=5555)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    # No unlock was even attempted.
+    assert connection.unlock_calls == []
+    assert lease.unlocked_keys == ()
+    # Termination was requested against the *retained* PID — never the new one —
+    # and this reconnected session cannot prove it, so the authority is held
+    # rather than reported as released.
+    assert connection.termination_calls == [(4242, lease.grant.connection_token)]
+    assert connection.terminated is False
+    assert lease.released is False
+    hold = lease.unreleased_authority_hold
+    assert hold is not None
+    assert hold.termination_proven is False
+    assert hold.backend_pid == 4242
+    assert retained_authority_connections()[hold.hold_id].connection is connection
+
+
+@pytest.mark.asyncio
+async def test_lock_false_unlock_return_is_never_recorded_as_a_release():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242)
+    lease = await acquire_physical_account_lease(
+        keys=[-7, 5], connection_factory=ConnectionFactory(connection)
+    )
+    # PostgreSQL now reports "you did not hold that key".
+    connection._unlock_returns = False
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    assert connection.unlock_calls == [5]
+    # The unproven key is NOT counted as released.
+    assert lease.unlocked_keys == ()
+    assert connection.terminated is True
+
+
+@pytest.mark.asyncio
+async def test_lock_stale_grant_or_token_cannot_drive_assert_or_release():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    stale_token = replace(lease.grant, connection_token="lockconn:forged")
+    copied_grant = replace(lease.grant)
+
+    for foreign in (stale_token, copied_grant):
+        with pytest.raises(CoordinationError) as excinfo:
+            await lease.assert_owned(foreign)
+        assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+        with pytest.raises(CoordinationError) as excinfo:
+            await lease.release(foreign)
+        assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+    assert connection.unlock_calls == []
+    assert lease.released is False
+    await lease.release(lease.grant)
+
+
+@pytest.mark.asyncio
+async def test_lock_event_loop_mismatch_fails_before_any_db_or_callback_work():
+    """G6: a lease is bound to the loop that acquired it."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    statements_before = len(connection.statements)
+
+    foreign_loop = asyncio.new_event_loop()
+    try:
+        foreign_grant = replace(lease.grant, event_loop=foreign_loop)
+        cross_loop_lease = PostgresAdvisoryKeysetLease(
+            connection=connection, grant=foreign_grant
+        )
+        with pytest.raises(CoordinationError) as excinfo:
+            await cross_loop_lease.assert_owned(foreign_grant)
+        assert excinfo.value.reason_code is (
+            CoordinationReasonCode.LEASE_EVENT_LOOP_MISMATCH
+        )
+        with pytest.raises(CoordinationError) as excinfo:
+            await cross_loop_lease.release(foreign_grant)
+        assert excinfo.value.reason_code is (
+            CoordinationReasonCode.LEASE_EVENT_LOOP_MISMATCH
+        )
+    finally:
+        foreign_loop.close()
+
+    assert len(connection.statements) == statements_before
+    assert connection.unlock_calls == []
+    await lease.release(lease.grant)
+
+
+@pytest.mark.asyncio
+async def test_lock_grant_is_immutable_and_carries_the_full_acquisition_identity():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=4242, database_oid=99001)
+    lease = await acquire_physical_account_lease(
+        keys=[5, -7], connection_factory=ConnectionFactory(connection)
+    )
+
+    grant = lease.grant
+    assert grant.keys == (-7, 5)
+    assert grant.backend_pid == 4242
+    assert grant.database_oid == 99001
+    assert grant.connection_token.startswith("lockconn:")
+    assert grant.event_loop is asyncio.get_running_loop()
+    assert isinstance(grant, AdvisoryLeaseGrant)
+    with pytest.raises(AttributeError):
+        grant.backend_pid = 1  # type: ignore[misc]
+    await lease.release(grant)
+
+
+@pytest.mark.asyncio
+async def test_lock_idle_lease_is_rechecked_at_use_time_not_by_a_heartbeat():
+    """G4: no heartbeat exists, so ownership is proven immediately before use."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    connection.simulate_session_loss()
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.assert_owned(lease.grant)
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+
+# ===========================================================================
+# §Reservation, persistence, restart, and release
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_claim_persist_precedes_reserve_precedes_callback_precedes_release():
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    stack = _default_stack(events)
+
+    await _run(envelope, stack)
+
+    assert events == [
+        "persist",
+        "reserve",
+        "callback_start",
+        "callback_end",
+        "persist",
+        "evidence_start",
+        "evidence",
+        "lease_unlock",
+        "lease_closed",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", ["persistence", "evidence"])
+async def test_claim_absent_durable_port_blocks_lease_reserve_and_callback(
+    missing: str,
+):
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack[missing] = None
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await coordinate_mock_order_mutation(
+            **_coordination_kwargs(
+                envelope,
+                lane_registry=_bound_registry(envelope),
+                persistence=stack["persistence"],
+                evidence=stack["evidence"],
+                intents=stack["intents"],
+                factory=stack["factory"],
+                callback=stack["callback"],
+            )
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert str(excinfo.value).startswith("lineage_persistence_unavailable")
+    assert stack["intents"].reserve_calls == []
+    assert stack["callback"].calls == 0
+    assert stack["factory"].calls == 0
+
+
+@pytest.mark.asyncio
+async def test_claim_failing_persistence_port_blocks_reserve_and_callback():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["persistence"] = RecordingPersistence(fail_from_call=0)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert stack["intents"].reserve_calls == []
+    assert stack["callback"].calls == 0
+    assert stack["factory"].calls == 0
+
+
+@pytest.mark.asyncio
+async def test_claim_duplicate_binary_claim_maps_to_durable_claim_conflict():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    # has_reservations stays False; the conflict surfaces at INSERT time.
+    stack["intents"] = FakeIntents(always_duplicate=True)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+    assert stack["callback"].calls == 0
+    assert stack["evidence"].calls == 0
+    assert stack["connection"].closed is True
+
+
+@pytest.mark.asyncio
+async def test_claim_account_wide_unresolved_reservation_blocks_a_different_order():
+    _, first_envelope = _attempt_envelope()
+    _, second_envelope = _attempt_envelope(
+        attempt_overrides={"cycle_id": "cycle-j3a-2"}
+    )
+    assert (
+        first_envelope.order_attempt.idempotency_key
+        != second_envelope.order_attempt.idempotency_key
+    )
+    space = FakeLockSpace()
+    intents = FakeIntents()
+    first_stack = _default_stack()
+    first_stack["space"] = space
+    first_stack["connection"] = FakeLockConnection(space, pid=1)
+    first_stack["factory"] = ConnectionFactory(first_stack["connection"])
+    first_stack["intents"] = intents
+
+    await _run(first_envelope, first_stack)
+    assert len(intents.rows) == 1
+
+    second_stack = _default_stack()
+    second_stack["connection"] = FakeLockConnection(space, pid=2)
+    second_stack["factory"] = ConnectionFactory(second_stack["connection"])
+    second_stack["intents"] = intents
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(second_envelope, second_stack)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+    assert second_stack["callback"].calls == 0
+    assert len(intents.rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_survives_a_crash_and_blocks_the_next_lease_owner():
+    _, envelope = _attempt_envelope()
+    _, next_envelope = _attempt_envelope(attempt_overrides={"cycle_id": "cycle-j3a-9"})
+    space = FakeLockSpace()
+    intents = FakeIntents()
+    stack = _default_stack()
+    stack["connection"] = FakeLockConnection(space, pid=1)
+    stack["factory"] = ConnectionFactory(stack["connection"])
+    stack["intents"] = intents
+    stack["callback"] = RecordingCallback(
+        error=RuntimeError("process crashed mid-send")
+    )
+
+    with pytest.raises(RuntimeError, match="process crashed mid-send"):
+        await _run(envelope, stack)
+
+    # The ephemeral lease is gone; the durable reservation is not.
+    assert stack["connection"].closed is True
+    assert space.held == {}
+    assert len(intents.rows) == 1
+
+    successor = _default_stack()
+    successor["connection"] = FakeLockConnection(space, pid=2)
+    successor["factory"] = ConnectionFactory(successor["connection"])
+    successor["intents"] = intents
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(next_envelope, successor)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+    assert successor["callback"].calls == 0
+    assert len(intents.rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_terminal_evidence_plus_reconcile_permits_exact_release():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    result = await _run(envelope, stack)
+    adapter = DurableSendClaimAdapter(stack["intents"])
+
+    deleted = await adapter.release_with_terminal_evidence(
+        result.claim,
+        coordination.TerminalClaimEvidence(
+            lane_native_terminal_evidence=True,
+            account_position_reconciled=True,
+            remainder_known=True,
+        ),
+    )
+
+    assert deleted == 1
+    assert stack["intents"].release_if_matches_calls == [
+        {
+            "account_scope": result.claim.claim_account_scope,
+            "row_id": result.claim.row_id,
+            "idempotency_key": result.claim.idempotency_key,
+            "side": "buy",
+        }
+    ]
+    assert stack["intents"].rows == {}
+    assert stack["intents"].unrestricted_release_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        coordination.TerminalClaimEvidence(),
+        coordination.TerminalClaimEvidence(lane_native_terminal_evidence=True),
+        coordination.TerminalClaimEvidence(
+            lane_native_terminal_evidence=True, account_position_reconciled=True
+        ),
+        coordination.TerminalClaimEvidence(
+            account_position_reconciled=True, remainder_known=True
+        ),
+        coordination.TerminalClaimEvidence(authoritative_absence_proven=True),
+    ],
+    ids=[
+        "no_evidence",
+        "terminal_without_reconcile",
+        "partial_with_unknown_remainder",
+        "unknown_or_anomaly_without_terminal",
+        "claimed_absence_without_reconcile",
+    ],
+)
+async def test_claim_insufficient_evidence_retains_the_claim_and_the_account_block(
+    evidence: coordination.TerminalClaimEvidence,
+):
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    result = await _run(envelope, stack)
+    adapter = DurableSendClaimAdapter(stack["intents"])
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await adapter.release_with_terminal_evidence(result.claim, evidence)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.TERMINAL_EVIDENCE_REQUIRED
+    )
+    # The evidence-less delete never reached the database at all.
+    assert stack["intents"].release_if_matches_calls == []
+    assert len(stack["intents"].rows) == 1
+    assert await adapter.account_has_unresolved_claim(result.scope) is True
+
+
+def test_claim_no_ttl_no_clock_and_no_automatic_release_exists():
+    """The TTL / local-clock-expiry / automatic-cleanup mutants are structural.
+
+    Adding any of them requires a clock, and this module has none.
+    """
+
+    assert AUTOMATIC_CLAIM_RELEASE_AVAILABLE is False
+    assert LEASE_TTL_SECONDS is None
+
+    tree = ast.parse(COORDINATION_SOURCE.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert imported.isdisjoint({"time", "datetime", "sched", "croniter"})
+
+    forbidden_asyncio_attrs = {"sleep", "wait_for", "timeout", "TimeoutError"}
+    used_asyncio_attrs = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "asyncio"
+    }
+    assert used_asyncio_attrs.isdisjoint(forbidden_asyncio_attrs)
+
+
+def test_claim_reservation_port_excludes_the_unrestricted_release():
+    """``OrderSendIntentService.release`` exists but is not part of the port."""
+
+    assert hasattr(OrderSendIntentService, "release")
+    assert not hasattr(OrderSendIntentReservationPort, "release")
+    assert isinstance(FakeIntents(), OrderSendIntentReservationPort)
+
+    tree = ast.parse(COORDINATION_SOURCE.read_text(encoding="utf-8"))
+    port_release_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and node.attr == "release"
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "_intents"
+    ]
+    assert port_release_calls == []
+
+
+def test_claim_followup_capability_never_authorizes_a_broker_mutation():
+    complete = ClaimFollowupRequest(
+        operation="cancel",
+        lane_capability_supports_operation=True,
+        attributed_native_order_id="ODNO-42",
+        known_remainder=Decimal("1"),
+        fresh_guards_passed=True,
+        lease_ownership_verified=True,
+    )
+    capability = describe_claim_followup(complete)
+    assert capability.capability_present is True
+    assert capability.reason_code is None
+    # Even a complete capability authorizes nothing here.
+    assert capability.authorizes_broker_mutation is False
+    assert capability.releases_durable_claim is False
+    with pytest.raises(TypeError):
+        coordination.ClaimFollowupCapability(
+            operation="cancel",
+            capability_present=True,
+            reason_code=None,
+            authorizes_broker_mutation=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"operation": "increase"},
+        {"operation": "new_order"},
+        {"lane_capability_supports_operation": False},
+        {"attributed_native_order_id": None},
+        {"attributed_native_order_id": "  "},
+        {"known_remainder": None},
+        {"fresh_guards_passed": False},
+        {"lease_ownership_verified": False},
+    ],
+)
+def test_claim_followup_missing_element_is_not_authorized(override: dict[str, Any]):
+    request = ClaimFollowupRequest(
+        **{
+            "operation": "reduce",
+            "lane_capability_supports_operation": True,
+            "attributed_native_order_id": "ODNO-42",
+            "known_remainder": Decimal("1"),
+            "fresh_guards_passed": True,
+            "lease_ownership_verified": True,
+            **override,
+        }
+    )
+    capability = describe_claim_followup(request)
+    assert capability.capability_present is False
+    assert capability.reason_code is (
+        CoordinationReasonCode.CLAIM_FOLLOWUP_NOT_AUTHORIZED
+    )
+
+
+# ===========================================================================
+# §Durable dispatch evidence — the typed unknown fact (B1/B5)
+# ===========================================================================
+
+
+def _assert_correlated(evidence: DispatchEvidence, envelope: LineageEnvelope) -> None:
+    """Evidence must be self-describing at rest, not only in this process."""
+
+    assert evidence.decision_intent_id == envelope.decision_intent.decision_intent_id
+    assert evidence.execution_plan_id == envelope.execution_plan.execution_plan_id
+    assert evidence.order_attempt_id == envelope.order_attempt.order_attempt_id
+    assert evidence.cycle_id == envelope.order_attempt.cycle_id
+    assert evidence.attempt_seq == envelope.attempt_seq
+    assert evidence.idempotency_key == envelope.order_attempt.idempotency_key
+    assert evidence.claim_account_scope.startswith("mockpa:v1:")
+    assert evidence.claim_row_id > 0
+
+
+def test_claim_evidence_port_is_required_and_fail_closed():
+    with pytest.raises(CoordinationError) as excinfo:
+        require_dispatch_evidence_port(None)
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    with pytest.raises(CoordinationError):
+        require_dispatch_evidence_port(object())  # type: ignore[arg-type]
+    port = RecordingDispatchEvidence()
+    assert isinstance(port, DispatchEvidencePort)
+    assert require_dispatch_evidence_port(port) is port
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_records_a_typed_acknowledgement():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+
+    result = await _run(envelope, stack)
+
+    evidence = stack["evidence"].only
+    assert evidence is result.evidence
+    assert evidence.kind is DispatchEvidenceKind.ACKNOWLEDGED
+    assert evidence.certainty is MutationCertainty.DEFINITIVE
+    assert evidence.broker_order_id == "ODNO-0000001"
+    assert evidence.callback_failed is False
+    assert evidence.outer_cancellation_requested is False
+    _assert_correlated(evidence, envelope)
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_records_a_typed_lane_reported_uncertainty():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN)
+    )
+
+    result = await _run(envelope, stack)
+
+    evidence = stack["evidence"].only
+    # The unknown is a typed fact, not an inference from a missing field.
+    assert evidence.kind is DispatchEvidenceKind.LANE_REPORTED_UNCERTAIN
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert evidence.broker_order_id is None
+    assert evidence.callback_failed is False
+    _assert_correlated(evidence, envelope)
+    assert result.certainty is MutationCertainty.UNCERTAIN
+    # Uncertainty keeps the account blocked.
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_records_a_typed_callback_failure():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["callback"] = RecordingCallback(error=RuntimeError("transport exploded"))
+
+    with pytest.raises(RuntimeError, match="transport exploded"):
+        await _run(envelope, stack)
+
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.CALLBACK_FAILED
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert evidence.callback_failed is True
+    assert evidence.broker_order_id is None
+    _assert_correlated(evidence, envelope)
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_records_a_typed_outer_cancellation():
+    _, envelope = _attempt_envelope()
+    started = asyncio.Event()
+    gate = asyncio.Event()
+    stack = _default_stack()
+    stack["callback"] = RecordingCallback(
+        gate=gate,
+        started=started,
+        result=MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN),
+    )
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    task.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    evidence = stack["evidence"].only
+    assert evidence.outer_cancellation_requested is True
+    assert evidence.kind is DispatchEvidenceKind.LANE_REPORTED_UNCERTAIN
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    _assert_correlated(evidence, envelope)
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_a_second_identical_envelope_write_is_not_evidence():
+    """Adversarial: the pre-B1 shape would have passed on these two facts alone.
+
+    Writing the same envelope twice and finding ``broker_order_id is None``
+    proves nothing — neither carries the uncertainty. The typed record must.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["callback"] = RecordingCallback(
+        result=MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN)
+    )
+
+    await _run(envelope, stack)
+
+    persisted = stack["persistence"].persisted
+    # The old false-green signals are still present...
+    assert len(persisted) == 2
+    assert persisted[0] == persisted[1]
+    assert persisted[-1].order_attempt.broker_order_id is None
+    # ...and they are demonstrably not evidence of anything.
+    envelope_payload = json.loads(persisted[-1].model_dump_json())
+    assert "uncertain" not in json.dumps(envelope_payload).lower()
+    # Only the typed record carries the fact.
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.LANE_REPORTED_UNCERTAIN
+
+
+def _post_send_write_failure_stacks() -> dict[str, dict[str, Any]]:
+    """The four independent ways the post-send AND gate can fail to close."""
+
+    return {
+        "lineage_write_failure": {
+            "persistence": RecordingPersistence(fail_from_call=1)
+        },
+        "lineage_write_cancellation": {
+            "persistence": RecordingPersistence(cancel_from_call=1)
+        },
+        "evidence_write_failure": {"evidence": RecordingDispatchEvidence(fail=True)},
+        "evidence_write_cancellation": {
+            "evidence": RecordingDispatchEvidence(cancel=True)
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", sorted(_post_send_write_failure_stacks()))
+async def test_claim_evidence_post_send_write_failure_holds_all_authority(
+    scenario: str,
+):
+    """Neither post-send durable write landing means nothing may be given up."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack.update(_post_send_write_failure_stacks()[scenario])
+    held_before = set(held_coordinations())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+
+    # 1. the lease was never surrendered, by any route
+    connection = stack["connection"]
+    assert connection.unlock_calls == []
+    assert connection.closed is False
+    assert connection.terminated is False
+
+    # 2. the durable claim stays unresolved
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+
+    # 3. the strong handle is still reachable after the raise — a GC pass or a
+    #    pool return cannot have collected it
+    new_holds = set(held_coordinations()) - held_before
+    assert len(new_holds) == 1
+    hold_id = new_holds.pop()
+    assert excinfo.value.hold_id == hold_id
+    held = held_coordination(hold_id)
+    assert isinstance(held, HeldCoordination)
+    assert held.grant is held.lease.grant
+    assert held.claim.claim_account_scope.startswith("mockpa:v1:")
+    import gc
+
+    gc.collect()
+    assert held_coordination(hold_id) is held
+
+    # 4. the authority hold is auditable and never says it was released
+    authority_hold = held.lease.unreleased_authority_hold
+    assert authority_hold is not None
+    assert authority_hold.durable_evidence_written is False
+    assert held.lease.released is False
+
+    # 5. a successor cannot mutate this physical account
+    _, successor_envelope = _attempt_envelope(
+        attempt_overrides={"cycle_id": "successor"}
+    )
+    successor = _default_stack()
+    successor["intents"] = stack["intents"]
+    successor["connection"] = FakeLockConnection(stack["space"], pid=9)
+    successor["factory"] = ConnectionFactory(successor["connection"])
+    with pytest.raises(CoordinationError) as successor_error:
+        await _run(successor_envelope, successor)
+    assert successor_error.value.reason_code in {
+        CoordinationReasonCode.LEASE_CONTENDED,
+        CoordinationReasonCode.DURABLE_CLAIM_CONFLICT,
+    }
+    assert successor["callback"].calls == 0
+
+    # The hold is intentionally left in place: dropping it here would be the
+    # very takeover this contract forbids.
+
+
+@pytest.mark.asyncio
+async def test_claim_durable_false_hold_cannot_be_released_via_the_public_handle():
+    """B21: public introspection may see a stuck lease; it may not release it."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+
+    with pytest.raises(CoordinationError) as coordinate_error:
+        await _run(envelope, stack)
+
+    hold_id = (set(held_coordinations()) - held_before).pop()
+    # One stuck authority carries one opaque id across both surfaces.
+    assert coordinate_error.value.hold_id == hold_id
+    held = held_coordination(hold_id)
+    assert isinstance(held, HeldCoordination)
+    authority_hold = held.lease.unreleased_authority_hold
+    assert authority_hold is not None
+    assert authority_hold.hold_id == hold_id
+    assert authority_hold.durable_evidence_written is False
+
+    connection = stack["connection"]
+    for attempt in range(3):
+        # Repeated attempts through the *public* handle and grant.
+        with pytest.raises(CoordinationError) as excinfo:
+            await held.lease.release(held.grant)
+        assert excinfo.value.reason_code is (
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+        ), attempt
+        assert excinfo.value.hold_id == hold_id
+        # A stale/foreign grant is refused for its own reason and also changes
+        # nothing.
+        with pytest.raises(CoordinationError) as foreign:
+            await held.lease.release(
+                replace(held.grant, connection_token="lockconn:forged")
+            )
+        assert foreign.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+    assert connection.unlock_calls == []
+    assert connection.closed is False
+    assert connection.terminated is False
+    assert held.lease.released is False
+    assert hold_id in held_coordinations()
+    assert hold_id in {h.hold_id for h in unreleased_authority_holds()}
+    # The durable claim — the account block — is untouched throughout.
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+
+
+@pytest.mark.asyncio
+async def test_claim_durable_false_hold_does_not_disturb_a_durable_true_hold():
+    """The two hold kinds are independent: handling one never moves the other."""
+
+    # A durable-TRUE hold: the release itself failed, so B20 recovery applies.
+    space = FakeLockSpace()
+    recoverable_conn = FakeLockConnection(
+        space, pid=6001, termination_raises=RuntimeError("cannot terminate")
+    )
+    recoverable = await acquire_physical_account_lease(
+        keys=[909], connection_factory=ConnectionFactory(recoverable_conn)
+    )
+    recoverable_conn._unlock_returns = False
+    with pytest.raises(CoordinationError):
+        await recoverable.release(recoverable.grant)
+    true_hold = recoverable.unreleased_authority_hold
+    assert true_hold is not None
+    assert true_hold.durable_evidence_written is True
+
+    # A durable-FALSE hold from a failed post-send evidence write.
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+    false_hold_id = (set(held_coordinations()) - held_before).pop()
+
+    # Recovering the durable-true one succeeds and clears only itself.
+    recoverable_conn._unlock_returns = None
+    await recoverable.release(recoverable.grant)
+    assert recoverable.released is True
+    assert true_hold.hold_id not in retained_authority_connections()
+
+    # The durable-false hold is completely unaffected and still unreleasable.
+    assert false_hold_id in held_coordinations()
+    stuck = held_coordination(false_hold_id)
+    assert stuck is not None
+    with pytest.raises(CoordinationError) as excinfo:
+        await stuck.lease.release(stuck.grant)
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_lease_release_count_is_zero_until_evidence_lands():
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    started = asyncio.Event()
+    gate = asyncio.Event()
+    stack = _default_stack(events)
+    stack["evidence"] = RecordingDispatchEvidence(
+        events=events, gate=gate, started=started
+    )
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # Evidence is mid-write: the lease has not been surrendered.
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert task.done() is False
+
+    gate.set()
+    await task
+
+    assert events.index("evidence") < events.index("lease_unlock")
+    assert events.index("evidence") < events.index("lease_closed")
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_cancellation_during_evidence_write_holds_the_lease():
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    started = asyncio.Event()
+    gate = asyncio.Event()
+    stack = _default_stack(events)
+    stack["evidence"] = RecordingDispatchEvidence(
+        events=events, gate=gate, started=started
+    )
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    task.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # Cancelling the caller must not abandon an in-flight evidence write.
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert stack["evidence"].records == []
+
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(stack["evidence"].records) == 1
+    assert events.index("evidence") < events.index("lease_unlock")
+    assert len(stack["intents"].rows) == 1
+
+
+# ===========================================================================
+# §Pre-I/O cancellation, ACK attachment anomaly, and held-handle lifetime
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_initial_persistence_never_reaches_lease_or_broker():
+    """A caller cancelled before the send must not acquire, reserve, or send."""
+
+    _, envelope = _attempt_envelope()
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    stack = _default_stack()
+    stack["persistence"] = RecordingPersistence(gate=gate, started=started)
+    held_before = set(held_coordinations())
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    task.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert task.done() is False
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The mandatory persist completed...
+    assert stack["persistence"].calls == 1
+    assert stack["persistence"].persisted == [envelope]
+    # ...and absolutely nothing after it ran.
+    assert stack["factory"].calls == 0
+    assert stack["connection"].lock_calls == []
+    assert stack["intents"].reserve_calls == []
+    assert stack["callback"].calls == 0
+    assert stack["evidence"].calls == 0
+    assert set(held_coordinations()) == held_before
+
+
+class _FailingAckFactory(MockLineageFactory):
+    """A J2B factory whose acknowledgement step rejects the broker's id."""
+
+    def acknowledge_order_attempt(
+        self, envelope: LineageEnvelope, broker_order_id: str
+    ) -> LineageEnvelope:
+        raise ValueError("broker_order_id must be strip-normalized")
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_ack_attachment_failure_is_durable_before_release():
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    stack = _default_stack(events)
+
+    with pytest.raises(ValueError, match="strip-normalized"):
+        await coordinate_mock_order_mutation(
+            **_coordination_kwargs(
+                envelope,
+                lane_registry=_bound_registry(envelope),
+                persistence=stack["persistence"],
+                evidence=stack["evidence"],
+                intents=stack["intents"],
+                factory=stack["factory"],
+                callback=stack["callback"],
+            ),
+            lineage_factory=_FailingAckFactory(),
+        )
+
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.ACK_ATTACHMENT_FAILED
+    assert evidence.certainty is MutationCertainty.UNCERTAIN
+    assert evidence.ack_attachment_failed is True
+    # No unusable broker id is smuggled through as an acknowledgement.
+    assert evidence.broker_order_id is None
+    assert evidence.envelope is envelope
+    assert evidence.envelope.order_attempt.broker_order_id is None
+    _assert_correlated(evidence, envelope)
+    # Durable first, cleanup second — and the original J2B error still surfaces.
+    assert events.index("evidence") < events.index("lease_unlock")
+    assert events.index("evidence") < events.index("lease_closed")
+    assert stack["connection"].closed is True
+    # The claim is not released by an unusable acknowledgement.
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_evidence_ack_failure_with_broken_durability_keeps_the_hold():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await coordinate_mock_order_mutation(
+            **_coordination_kwargs(
+                envelope,
+                lane_registry=_bound_registry(envelope),
+                persistence=stack["persistence"],
+                evidence=stack["evidence"],
+                intents=stack["intents"],
+                factory=stack["factory"],
+                callback=stack["callback"],
+            ),
+            lineage_factory=_FailingAckFactory(),
+        )
+
+    # The persistence failure wins and chains the cause; the hold survives.
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert len(set(held_coordinations()) - held_before) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_held_handle_is_dropped_only_after_a_proven_release():
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    held_before = set(held_coordinations())
+
+    result = await _run(envelope, stack)
+
+    assert set(held_coordinations()) == held_before
+    assert stack["connection"].unlock_calls == [result.lease_grant.keys[0]]
+    assert stack["connection"].closed is True
+
+
+@pytest.mark.asyncio
+async def test_lock_cancellation_mid_release_still_reaches_a_safe_outcome():
+    """Cancelling the releaser must not abandon a half-finished unlock."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space)
+    lease = await acquire_physical_account_lease(
+        keys=[11, -7], connection_factory=ConnectionFactory(connection)
+    )
+
+    async def release_and_wait() -> None:
+        await lease.release(lease.grant)
+
+    task = asyncio.ensure_future(release_and_wait())
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The retained release ran to a definite, safe result anyway.
+    assert lease.released is True
+    assert lease.unlocked_keys == (11, -7)
+    assert connection.closed is True
+    assert space.held == {}
+
+
+def test_scope_no_ttl_retry_queue_scheduler_or_schema_was_introduced():
+    """The absences are structural, not a matter of vocabulary.
+
+    A TTL or an expiry needs a clock, a retry queue or scheduler needs a
+    scheduling import, and a schema change needs DDL. None of the three has any
+    machinery here — the words themselves appear only in prohibitions.
+    """
+
+    tree = ast.parse(COORDINATION_SOURCE.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert imported.isdisjoint(
+        {
+            "alembic",
+            "apscheduler",
+            "celery",
+            "croniter",
+            "datetime",
+            "prefect",
+            "sched",
+            "taskiq",
+            "time",
+        }
+    )
+
+    assert LEASE_TTL_SECONDS is None
+    assert AUTOMATIC_CLAIM_RELEASE_AVAILABLE is False
+
+    upper_source = COORDINATION_SOURCE.read_text(encoding="utf-8").upper()
+    for ddl in ("CREATE TABLE", "ALTER TABLE", "DROP TABLE", "INSERT INTO"):
+        assert ddl not in upper_source, ddl
+
+    # The evidence vocabulary never leaks into the signed reason-code set.
+    assert len(COORDINATION_REASON_CODES) == 8
+    assert COORDINATION_REASON_CODES.isdisjoint(
+        {kind.value for kind in DispatchEvidenceKind}
+    )
+
+
+# ===========================================================================
+# §Cancellation and injected callback
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_write_holds_lease_and_claim_until_inner_completes():
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    stack = _default_stack(events)
+    stack["callback"] = RecordingCallback(
+        events=events,
+        gate=gate,
+        started=started,
+        result=MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-INFLIGHT"
+        ),
+    )
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+
+    task.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # The socket write may still be in flight: nothing has been given up.
+    assert task.done() is False
+    assert "callback_end" not in events
+    assert stack["connection"].closed is False
+    assert stack["connection"].unlock_calls == []
+    assert len(stack["intents"].rows) == 1
+
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events.index("callback_end") < events.index("evidence")
+    assert events.index("evidence") < events.index("lease_closed")
+    evidence = stack["evidence"].only
+    assert evidence.kind is DispatchEvidenceKind.ACKNOWLEDGED
+    assert evidence.broker_order_id == "ODNO-INFLIGHT"
+    assert evidence.outer_cancellation_requested is True
+    # The durable claim is never released by cancellation.
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_bare_shield_finally_release_mutant_is_red():
+    """The mutant releases in ``finally`` while the inner task still writes."""
+
+    events: list[str] = []
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, events=events)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    callback = RecordingCallback(events=events, gate=gate, started=started)
+
+    async def bare_shield_mutant() -> None:
+        inner = asyncio.ensure_future(callback())
+        try:
+            await asyncio.shield(inner)
+        finally:
+            await lease.release(lease.grant)
+
+    mutant_task = asyncio.ensure_future(bare_shield_mutant())
+    await started.wait()
+    mutant_task.cancel()
+    for _ in range(200):
+        if "lease_closed" in events:
+            break
+        await asyncio.sleep(0)
+
+    # The invariant asserted by the cancellation test above is already violated:
+    # the lease is gone while the inner task is still running.
+    assert "lease_closed" in events
+    assert "callback_end" not in events
+
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await mutant_task
+    assert events.index("lease_closed") < events.index("callback_end")
+
+
+# ===========================================================================
+# §Scope and static safety
+# ===========================================================================
+
+_FORBIDDEN_IMPORT_ROOTS: frozenset[str] = frozenset(
+    {
+        "aiohttp",
+        "boto3",
+        "certifi",
+        "hmac",
+        "httpcore",
+        "httpx",
+        "os",
+        "requests",
+        "socket",
+        "ssl",
+        "urllib",
+        "urllib3",
+        "websocket",
+        "websockets",
+    }
+)
+
+_FORBIDDEN_IMPORT_PREFIXES: tuple[str, ...] = (
+    "app.core.config",
+    "app.core.db",
+    "app.models",
+    "app.services.brokers",
+    "app.services.kis_mock_runner",
+    "app.tasks",
+    "app.flows",
+    "taskiq",
+    "prefect",
+    "celery",
+    "apscheduler",
+    "dotenv",
+)
+
+
+def _imported_modules(path: pathlib.Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_scope_module_imports_no_broker_transport_signing_or_credential_loader():
+    for module in _imported_modules(COORDINATION_SOURCE):
+        assert module.split(".")[0] not in _FORBIDDEN_IMPORT_ROOTS, module
+        for prefix in _FORBIDDEN_IMPORT_PREFIXES:
+            assert not module.startswith(prefix), module
+
+
+def test_scope_test_file_imports_no_broker_or_network_surface():
+    modules = _imported_modules(TEST_SOURCE)
+    network_roots = _FORBIDDEN_IMPORT_ROOTS - {"os"}
+    for module in modules:
+        assert module.split(".")[0] not in network_roots, module
+    # The only broker-namespaced import allowed is J2B's pure client-order-ID
+    # constraint module: constants and a regex, no transport of any kind.
+    broker_imports = {m for m in modules if m.startswith("app.services.brokers")}
+    assert broker_imports <= {"app.services.brokers.client_order_ids"}
+
+
+def test_scope_module_issues_only_read_and_lock_sql_never_a_ledger_write():
+    source_text = COORDINATION_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse(source_text)
+    # Only the module's pinned ``*_SQL`` constants count as SQL; a docstring
+    # that happens to begin with the word "Insert" is prose, not a statement.
+    sql_literals: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AnnAssign | ast.Assign):
+            continue
+        targets = [node.target] if isinstance(node, ast.AnnAssign) else node.targets
+        names = [t.id for t in targets if isinstance(t, ast.Name)]
+        if not any(name.endswith("_SQL") for name in names):
+            continue
+        value = node.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            sql_literals.append(value.value.strip())
+        elif isinstance(value, ast.JoinedStr | ast.BinOp):  # pragma: no cover
+            raise AssertionError("SQL constants must stay plain literals")
+    assert sql_literals, "expected the pinned lock statements to be present"
+    for statement in sql_literals:
+        assert statement.upper().startswith("SELECT"), statement
+    upper_source = source_text.upper()
+    for forbidden in ("INSERT INTO", "DELETE FROM", "UPDATE REVIEW.", "CREATE TABLE"):
+        assert forbidden not in upper_source
+
+
+# --- write fence: what this job wrote, not who may import it ----------------
+
+
+def paths_within_write_fence(paths: object) -> bool:
+    """The J3A write fence, as a pure predicate over changed paths."""
+
+    considered = {
+        path
+        for path in paths  # type: ignore[union-attr]
+        if not str(path).startswith(FENCE_EXEMPT_PREFIXES)
+    }
+    return considered <= set(J3A_WRITE_FENCE)
+
+
+def parse_porcelain_z(payload: str) -> set[str]:
+    """Parse ``git status --porcelain=v1 -z`` output into plain repository paths.
+
+    Each record is ``XY <path>`` terminated by NUL, and a rename/copy record is
+    followed by its origin path as a separate NUL-terminated field.  The two
+    status characters plus one space are stripped **by position** — never by
+    guessing from the command line that produced the output, which is how a
+    legitimate ``?? app/...`` entry turns into a false red.  NUL delimiting also
+    keeps spaces, quotes, and non-ASCII path bytes intact.
+    """
+
+    paths: set[str] = set()
+    fields = [field for field in payload.split("\0") if field]
+    index = 0
+    while index < len(fields):
+        record = fields[index]
+        index += 1
+        if len(record) < 4:
+            continue
+        status, path = record[:2], record[3:]
+        paths.add(path)
+        if status[0] in {"R", "C"} and index < len(fields):
+            paths.add(fields[index])
+            index += 1
+    return paths
+
+
+def _git(*args: str) -> str | None:
+    git = shutil.which("git")
+    if git is None:
+        return None
+    proc = subprocess.run(
+        [git, "-C", str(REPO_ROOT), *args], capture_output=True, text=True, check=False
+    )
+    return None if proc.returncode != 0 else proc.stdout
+
+
+def _changed_paths_since_base() -> set[str] | None:
+    diff = _git("diff", "--name-only", "-z", f"{J3A_FENCE_BASE_SHA}..HEAD")
+    status = _git("status", "--porcelain=v1", "-z", "--untracked-files=all")
+    if diff is None or status is None:
+        return None
+    changed = {field for field in diff.split("\0") if field}
+    changed |= parse_porcelain_z(status)
+    return changed
+
+
+def test_scope_porcelain_parser_normalizes_owned_untracked_paths():
+    payload = "".join(
+        f"{entry}\0"
+        for entry in (
+            "?? app/services/mock_integration/coordination.py",
+            "?? tests/services/mock_integration/test_coordination.py",
+            " M docs/contracts/rob-1262-coordination-port.md",
+        )
+    )
+    parsed = parse_porcelain_z(payload)
+    assert parsed == set(J3A_WRITE_FENCE)
+    assert paths_within_write_fence(parsed) is True
+
+
+def test_scope_porcelain_parser_keeps_out_of_fence_and_renamed_paths_visible():
+    payload = "".join(
+        f"{entry}\0"
+        for entry in (
+            "?? app/services/mock_lane_registry.py",
+            "R  app/services/new_name.py",
+            "app/services/old_name.py",
+        )
+    )
+    parsed = parse_porcelain_z(payload)
+    assert parsed == {
+        "app/services/mock_lane_registry.py",
+        "app/services/new_name.py",
+        "app/services/old_name.py",
+    }
+    assert paths_within_write_fence(parsed) is False
+    # A path with a space survives NUL parsing intact.
+    assert parse_porcelain_z("?? docs/a file.md\0") == {"docs/a file.md"}
+
+
+def test_scope_write_fence_predicate_reds_on_an_out_of_fence_path():
+    assert paths_within_write_fence(set(J3A_WRITE_FENCE)) is True
+    assert paths_within_write_fence({".smoke-out/rob179-feed-research-evidence.json"})
+    for out_of_fence in (
+        "app/services/order_send_intent_service.py",
+        "app/services/mock_lane_registry.py",
+        "app/services/mock_integration/lineage.py",
+        "app/services/brokers/client_order_ids.py",
+        "app/services/kis_mock_runner/singleton.py",
+        "scripts/b0x/kr/run.py",
+        "alembic/versions/deadbeef_add_coordination.py",
+        "app/models/review.py",
+    ):
+        assert paths_within_write_fence({out_of_fence}) is False, out_of_fence
+
+
+def test_scope_actual_job_diff_stays_inside_the_write_fence():
+    changed = _changed_paths_since_base()
+    if changed is None:
+        pytest.skip("git is unavailable; the write fence is verified in the report")
+    assert paths_within_write_fence(changed), sorted(
+        path for path in changed if not paths_within_write_fence({path})
+    )
+
+
+@pytest.mark.asyncio
+async def test_scope_authorized_future_consumer_may_import_and_use_the_port():
+    """A later J3B/J3C integration is an approved consumer, not a fence breach.
+
+    The fence governs what *this job wrote*; it must never make an authorized
+    downstream import go red, because those lanes cannot edit this file.
+    """
+
+    from app.services.mock_integration.coordination import (  # noqa: PLC0415
+        coordinate_mock_order_mutation as consumer_entrypoint,
+    )
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    result = await consumer_entrypoint(
+        **_coordination_kwargs(
+            envelope,
+            lane_registry=_bound_registry(envelope),
+            persistence=stack["persistence"],
+            evidence=stack["evidence"],
+            intents=stack["intents"],
+            factory=stack["factory"],
+            callback=stack["callback"],
+        ),
+        # A broker lane supplies its own extra keys; J3A never chooses them.
+        additional_advisory_keys=(4242,),
+    )
+    assert result.lease_grant.keys == tuple(sorted({result.scope.advisory_key, 4242}))
+    assert stack["evidence"].only.kind is DispatchEvidenceKind.ACKNOWLEDGED
+
+
+def test_scope_lease_is_documented_as_not_broker_enforced_fencing_in_three_places():
+    source = COORDINATION_SOURCE.read_text(encoding="utf-8")
+
+    # 1. module documentation
+    module_doc = ast.get_docstring(ast.parse(source)) or ""
+    assert "NOT BROKER-ENFORCED FENCING" in module_doc
+
+    # 2. source comment/docstring on the lease itself
+    lease_doc = PostgresAdvisoryKeysetLease.__doc__ or ""
+    assert "NOT BROKER-ENFORCED FENCING" in lease_doc
+    assert (
+        "not broker-enforced fencing" in NOT_BROKER_ENFORCED_FENCING_STATEMENT.lower()
+    )
+
+    # 3. lane matrix — every canonical lane, no exceptions
+    assert set(LANE_FENCING_MATRIX) == set(registry.CANONICAL_LANE_IDS)
+    assert set(LANE_FENCING_MATRIX.values()) == {FENCING_NOT_BROKER_ENFORCED}
+    assert CONTRACT_DOC.exists()
+    doc_text = CONTRACT_DOC.read_text(encoding="utf-8")
+    assert "NOT broker-enforced fencing" in doc_text
+    for lane_id in registry.CANONICAL_LANE_IDS:
+        assert lane_id in doc_text
+    with pytest.raises(TypeError):
+        LANE_FENCING_MATRIX["kr.kis.mock"] = "broker_enforced"  # type: ignore[index]
+
+
+# ===========================================================================
+# Real PostgreSQL attestation — run-owned test database only
+# ===========================================================================
+
+
+async def _open_observer_connection() -> Any:
+    from app.core import db
+
+    return await db.engine.connect()
+
+
+async def _open_run_owned_authority() -> SqlAlchemyLockAuthority:
+    from app.core import db
+
+    return SqlAlchemyLockAuthority(
+        await db.engine.connect(), observer_factory=_open_observer_connection
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lock_real_postgres_termination_receipt_proves_the_backend_is_gone(
+    db_session,
+):
+    """A real, independently observed termination receipt bound to the exact PID."""
+
+    from sqlalchemy import text as sql_text
+
+    from app.core import db
+
+    lease = await acquire_physical_account_lease(
+        keys=[-424242424242], connection_factory=_open_run_owned_authority
+    )
+    grant = lease.grant
+    receipt = await lease._connection.terminate_backend_session(
+        expected_pid=grant.backend_pid, owner_token=grant.connection_token
+    )
+    assert receipt.terminated is True
+    assert receipt.backend_pid == grant.backend_pid
+    assert receipt.owner_token == grant.connection_token
+
+    # Independently confirm the backend really is gone, and with it the lock.
+    observer = await db.engine.connect()
+    try:
+        alive = await observer.execute(
+            sql_text("SELECT count(*) FROM pg_stat_activity WHERE pid = :pid"),
+            {"pid": grant.backend_pid},
+        )
+        assert int(alive.scalar_one()) == 0
+    finally:
+        await observer.close()
+
+    successor = await acquire_physical_account_lease(
+        keys=[-424242424242], connection_factory=_open_run_owned_authority
+    )
+    await successor.release(successor.grant)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lock_real_postgres_attests_a_negative_key_and_releases_exactly_once(
+    db_session,
+):
+    _, envelope = _attempt_envelope()
+    scope = physical_account_scope_for_entry(
+        _fully_bound_entry(envelope, "kr.kis.mock")
+    )
+    lease = await acquire_physical_account_lease(
+        keys=[scope.advisory_key], connection_factory=_open_run_owned_authority
+    )
+    assert lease.grant.keys == (scope.advisory_key,)
+    assert lease.grant.backend_pid > 0
+    assert lease.grant.database_oid > 0
+    await lease.assert_owned(lease.grant)
+    await lease.release(lease.grant)
+    assert lease.unlocked_keys == (scope.advisory_key,)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lock_real_postgres_second_session_is_contended(db_session):
+    _, envelope = _attempt_envelope(attempt_overrides={"cycle_id": "pg-contend"})
+    scope = physical_account_scope_for_entry(
+        _fully_bound_entry(
+            envelope, "kr.kis.mock", physical_account_id="rob-1262-pg-contention"
+        )
+    )
+    holder = await acquire_physical_account_lease(
+        keys=[scope.advisory_key], connection_factory=_open_run_owned_authority
+    )
+    try:
+        with pytest.raises(CoordinationError) as excinfo:
+            await acquire_physical_account_lease(
+                keys=[scope.advisory_key],
+                connection_factory=_open_run_owned_authority,
+            )
+        assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+    finally:
+        await holder.release(holder.grant)
+
+    successor = await acquire_physical_account_lease(
+        keys=[scope.advisory_key], connection_factory=_open_run_owned_authority
+    )
+    await successor.release(successor.grant)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lock_real_postgres_multi_key_rollback_leaves_nothing_held(db_session):
+    keys = [-987654321012345, 12345678901234]
+    blocker = await acquire_physical_account_lease(
+        keys=[keys[1]], connection_factory=_open_run_owned_authority
+    )
+    try:
+        with pytest.raises(CoordinationError) as excinfo:
+            await acquire_physical_account_lease(
+                keys=keys, connection_factory=_open_run_owned_authority
+            )
+        assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+        rolled_back = await acquire_physical_account_lease(
+            keys=[keys[0]], connection_factory=_open_run_owned_authority
+        )
+        await rolled_back.release(rolled_back.grant)
+    finally:
+        await blocker.release(blocker.grant)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_claim_real_order_send_intent_service_round_trip(db_session):
+    _, envelope = _attempt_envelope(attempt_overrides={"cycle_id": "pg-claim"})
+    scope = physical_account_scope_for_entry(
+        _fully_bound_entry(
+            envelope, "kr.kis.mock", physical_account_id="rob-1262-pg-claim"
+        )
+    )
+    adapter = DurableSendClaimAdapter(OrderSendIntentService(db_session))
+    idempotency_key = envelope.order_attempt.idempotency_key
+
+    assert await adapter.account_has_unresolved_claim(scope) is False
+    claim = await adapter.reserve(
+        scope=scope, idempotency_key=idempotency_key, symbol="005930", side="buy"
+    )
+    try:
+        assert await adapter.account_has_unresolved_claim(scope) is True
+        with pytest.raises(CoordinationError) as excinfo:
+            await adapter.reserve(
+                scope=scope,
+                idempotency_key=idempotency_key,
+                symbol="005930",
+                side="buy",
+            )
+        assert excinfo.value.reason_code is (
+            CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+        )
+        with pytest.raises(CoordinationError):
+            await adapter.release_with_terminal_evidence(
+                claim, coordination.TerminalClaimEvidence()
+            )
+        assert await adapter.account_has_unresolved_claim(scope) is True
+    finally:
+        deleted = await adapter.release_with_terminal_evidence(
+            claim,
+            coordination.TerminalClaimEvidence(
+                lane_native_terminal_evidence=True,
+                account_position_reconciled=True,
+                remainder_known=True,
+            ),
+        )
+    assert deleted == 1
+    assert await adapter.account_has_unresolved_claim(scope) is False

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -33,6 +33,7 @@ import json
 import pathlib
 import shutil
 import subprocess
+import weakref
 from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -353,6 +354,7 @@ class FakeLockConnection:
         close_raises: BaseException | None = None,
         fail_sql_error: BaseException | None = None,
         unlock_false_on_key: int | None = None,
+        release_observer: Any = None,
         unlock_gate_on_key: int | None = None,
         unlock_gate: asyncio.Event | None = None,
         unlock_gate_started: asyncio.Event | None = None,
@@ -375,6 +377,7 @@ class FakeLockConnection:
         self._close_raises = close_raises
         self._fail_sql_error = fail_sql_error
         self._unlock_false_on_key = unlock_false_on_key
+        self._release_observer = release_observer
         self._unlock_gate_on_key = unlock_gate_on_key
         self._unlock_gate = unlock_gate
         self._unlock_gate_started = unlock_gate_started
@@ -449,6 +452,8 @@ class FakeLockConnection:
                     await self._unlock_gate.wait()
             if key == self._unlock_raises_on_key:
                 raise self._unlock_raises_error or RuntimeError("unlock interrupted")
+            if self._release_observer is not None:
+                self._release_observer("lease_unlock")
             if self._events is not None:
                 self._events.append("lease_unlock")
             if key == self._unlock_false_on_key:
@@ -482,6 +487,8 @@ class FakeLockConnection:
         if self._close_raises is not None:
             raise self._close_raises
         self.closed = True
+        if self._release_observer is not None:
+            self._release_observer("lease_closed")
         if self._events is not None:
             self._events.append("lease_closed")
 
@@ -3468,6 +3475,33 @@ async def test_cancel_bare_shield_finally_release_mutant_is_red():
 # ===========================================================================
 
 
+def _active_holds() -> dict[str, Any]:
+    """Module-private active-hold map, read-only, for exact-record assertions."""
+
+    return coordination._ACTIVE_AUTHORITY_HOLDS
+
+
+def _capture_rollback_identities(monkeypatch: Any, captured: dict[str, Any]) -> None:
+    """Weakref the exact connection and grant *entering* the rollback.
+
+    r29 W1/W4: a witness taken afterwards from ``_retained_authorities`` only
+    re-reads the object the module already holds, so it cannot show that the
+    module is the *only* root. These references are bound before any retention
+    happens and own nothing.
+    """
+
+    real = coordination._rollback_partial_acquisition
+
+    async def spy(
+        connection: Any, acquired: Any, grant: Any, *, in_flight: Any = ()
+    ) -> Any:
+        captured["connection"] = weakref.ref(connection)
+        captured["grant"] = weakref.ref(grant)
+        return await real(connection, acquired, grant, in_flight=in_flight)
+
+    monkeypatch.setattr(coordination, "_rollback_partial_acquisition", spy)
+
+
 async def _durable_true_hold(space: FakeLockSpace, *, pid: int, key: int) -> Any:
     """A lease whose *release* failed, so B20 recovery semantics apply."""
 
@@ -4882,7 +4916,7 @@ async def test_lock_close_cancellation_after_absence_keeps_the_receipt(which: st
 
 
 @pytest.mark.asyncio
-async def test_lock_inner_cancellation_after_a_confirmed_unlock_prefix():
+async def test_lock_inner_cancellation_after_a_confirmed_unlock_prefix(monkeypatch):
     """B52: the load-bearing conjunction, in one test.
 
     Two half-tests do not cover this. One cancels on the *first* reverse unlock,
@@ -4896,7 +4930,9 @@ async def test_lock_inner_cancellation_after_a_confirmed_unlock_prefix():
     """
 
     import gc
-    import weakref
+
+    captured: dict[str, Any] = {}
+    _capture_rollback_identities(monkeypatch, captured)
 
     space = FakeLockSpace()
     blocker = FakeLockConnection(space, pid=12003)
@@ -4917,7 +4953,6 @@ async def test_lock_inner_cancellation_after_a_confirmed_unlock_prefix():
         unlock_raises_error=asyncio.CancelledError(),
         termination_raises=RuntimeError("cannot terminate"),
     )
-    weak_connection = weakref.ref(connection)
     retained_before = set(_retained_authorities())
     held_before = set(held_coordinations())
 
@@ -4945,11 +4980,18 @@ async def test_lock_inner_cancellation_after_a_confirmed_unlock_prefix():
     assert connection.closed is False
     assert set(held_coordinations()) == held_before
 
-    # The authority outlives every caller-side reference to it.
+    # The authority outlives every caller-side reference to it — and the retained
+    # entry holds the exact ORIGINAL connection *and* the exact original grant,
+    # both witnessed before any retention could have happened.
+    weak_connection = captured["connection"]
+    weak_grant = captured["grant"]
     del connection, task
     gc.collect()
     assert weak_connection() is not None
-    assert _retained_authorities()[hold_id].connection is weak_connection()
+    assert weak_grant() is not None
+    retained = _retained_authorities()[hold_id]
+    assert retained.connection is weak_connection()
+    assert retained.grant is weak_grant()
 
     successor = FakeLockConnection(space, pid=12004)
     with pytest.raises(CoordinationError) as contended:
@@ -5010,10 +5052,9 @@ async def test_lock_outer_cancellation_during_a_gated_rollback_unlock_is_retaine
 async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
     monkeypatch,
 ):
-    """U6/B40: the collision storm must also cover the confirmed-partial branch."""
+    """U6/B40 + r29 W4: the collision branch proves its own unique root."""
 
     import gc
-    import weakref
 
     space = FakeLockSpace()
     _, victim_connection, victim_hold = await _durable_true_hold(
@@ -5036,7 +5077,13 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
         unlock_returns=False,
         termination_raises=RuntimeError("cannot terminate"),
     )
+    captured: dict[str, Any] = {}
+    _capture_rollback_identities(monkeypatch, captured)
     retained_before = set(_retained_authorities())
+    active_before = set(_active_holds())
+    # Snapshot the foreign world BEFORE the failure, excluding anything new.
+    foreign_before = dict(_retained_authorities())
+    foreign_active_before = dict(_active_holds())
 
     with pytest.raises(CoordinationError):
         await acquire_physical_account_lease(
@@ -5051,25 +5098,25 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
     assert intruder.closed is False
     assert intruder.unlock_calls == [1113]
 
-    # B55: prove the *module* is what keeps this authority alive. Collecting
-    # while the caller still holds `intruder` proves nothing, so bind weak
-    # references to the exact original objects, drop every caller-side strong
-    # reference, and force a collection.
-    weak_connection = weakref.ref(intruder)
-    # ``AdvisoryLeaseGrant`` is a frozen slots dataclass and cannot be weakly
-    # referenced. Its id is still a sound identity witness here: the retained
-    # entry holds it strongly for the whole test, so it is never freed and its
-    # id can never be recycled onto a different object.
-    grant_id = id(_retained_authorities()[quarantined].grant)
+    # W4: prove the module-private map is the ONLY root. Both witnesses were
+    # bound before retention, and the foreign snapshot deliberately excludes the
+    # entry under test — including it would keep the object alive and turn this
+    # into a false green.
+    weak_connection = captured["connection"]
+    weak_grant = captured["grant"]
+    assert weak_connection() is intruder
     del intruder
     gc.collect()
     assert weak_connection() is not None
+    assert weak_grant() is not None
     retained = _retained_authorities()[quarantined]
-    # Exact identity, recovered only through the module-private seam.
     assert retained.connection is weak_connection()
-    assert id(retained.grant) == grant_id
+    assert retained.grant is weak_grant()
     assert retained.connection.closed is False
     assert retained.connection.unlock_calls == [1113]
+    # Exactly one new active hold, and its active record exists.
+    assert len(set(_active_holds()) - active_before) == 1
+    assert quarantined in _active_holds()
 
     # And the physical key is genuinely still held.
     successor = FakeLockConnection(space, pid=11104)
@@ -5079,7 +5126,11 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
         )
     assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
 
-    # The victim is untouched by the storm.
+    # Every foreign entry is identical, by object, to the pre-failure snapshot.
+    for other, entry in foreign_before.items():
+        assert _retained_authorities()[other] is entry
+    for other, row in foreign_active_before.items():
+        assert _active_holds()[other] is row
     assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
     assert _retained_authorities()[victim_hold.hold_id].owner is victim_owner
     assert victim_connection.closed is False
@@ -5087,25 +5138,48 @@ async def test_lock_collision_exhaustion_during_confirmed_partial_rollback(
 
 @pytest.mark.asyncio
 async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch):
-    """U6/B40: if the rollback task itself fails, nothing may fall out of scope."""
+    """U6/B40 + r29 W4: the task-error branch proves its own unique root.
+
+    The previous shape had a false root: it snapshotted *all* retained entries —
+    including the one under test — into a local, and that local `_RetainedAuthority`
+    itself strongly owns the connection and grant. Deleting the caller's variables
+    therefore proved nothing. Here the foreign snapshot is taken before the
+    failure, a real foreign victim exists, and the entry under test is never
+    placed in a local that outlives the collection.
+    """
 
     import gc
-    import weakref
 
     space = FakeLockSpace()
+    # A real foreign victim, constructed BEFORE the failure under test.
+    _, victim_connection, victim_hold = await _durable_true_hold(
+        space, pid=11210, key=1120
+    )
+    victim_owner = _retained_authorities()[victim_hold.hold_id].owner
+    foreign_before = dict(_retained_authorities())
+    foreign_active_before = dict(_active_holds())
+    foreign_history_before = len(authority_hold_history())
+
     blocker = FakeLockConnection(space, pid=11201)
     await acquire_physical_account_lease(
         keys=[1122], connection_factory=ConnectionFactory(blocker)
     )
     connection = FakeLockConnection(space, pid=11202)
+    captured: dict[str, Any] = {}
 
-    async def exploding_rollback(*args: Any, **kwargs: Any) -> None:
+    async def exploding_rollback(
+        conn: Any, acquired: Any, grant: Any, *, in_flight: Any = ()
+    ) -> None:
+        # Witness the exact originals before anything can retain them.
+        captured["connection"] = weakref.ref(conn)
+        captured["grant"] = weakref.ref(grant)
         raise RuntimeError("rollback itself failed")
 
     monkeypatch.setattr(
         coordination, "_rollback_partial_acquisition", exploding_rollback
     )
     retained_before = set(_retained_authorities())
+    active_before = set(_active_holds())
 
     with pytest.raises(CoordinationError):
         await acquire_physical_account_lease(
@@ -5115,22 +5189,23 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
     new_holds = set(_retained_authorities()) - retained_before
     assert len(new_holds) == 1
     hold_id = new_holds.pop()
-    retained = _retained_authorities()[hold_id]
-    assert retained.connection is connection
-    assert retained.grant.backend_pid == 11202
+    # Exactly one new active record, matching that hold.
+    assert set(_active_holds()) - active_before == {hold_id}
+    assert _retained_authorities()[hold_id].connection is connection
     assert connection.closed is False
 
-    # B55: same obligation on this branch — exact identity must survive losing
-    # every caller reference, and the physical key must really still be held.
-    weak_connection = weakref.ref(connection)
-    grant_id = id(retained.grant)  # see the note on the collision branch
-    victim_before = dict(_retained_authorities())
-    del connection, retained
+    weak_connection = captured["connection"]
+    weak_grant = captured["grant"]
+    assert weak_connection() is connection
+    # Drop every caller-side strong reference. Nothing that owns the connection
+    # or grant may survive this point except the module-private map.
+    del connection
     gc.collect()
     assert weak_connection() is not None
+    assert weak_grant() is not None
     recovered = _retained_authorities()[hold_id]
     assert recovered.connection is weak_connection()
-    assert id(recovered.grant) == grant_id
+    assert recovered.grant is weak_grant()
     assert recovered.connection.closed is False
     assert recovered.connection.unlock_calls == []
 
@@ -5141,11 +5216,18 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
         )
     assert contended.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
 
-    # Every foreign entry is byte-for-byte what it was.
-    for other, entry in victim_before.items():
-        if other == hold_id:
-            continue
+    # The foreign world is identical, by object, to the pre-failure snapshot.
+    for other, entry in foreign_before.items():
         assert _retained_authorities()[other] is entry
+    for other, row in foreign_active_before.items():
+        assert _active_holds()[other] is row
+    assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
+    assert _retained_authorities()[victim_hold.hold_id].owner is victim_owner
+    assert victim_connection.closed is False
+    # Exactly one history row exists for this authority — the fallback recorded
+    # it once, not twice.
+    assert len([h for h in authority_hold_history() if h.hold_id == hold_id]) == 1
+    assert len(authority_hold_history()) >= foreign_history_before + 1
 
 
 @pytest.mark.asyncio
@@ -6501,25 +6583,34 @@ async def test_claim_outcome_access_failure_durable_write_precedence(
 
 
 @pytest.mark.asyncio
-async def test_claim_self_cancelled_callback_scope_dies_even_when_the_lease_is_kept():
-    """B54: the gate must be what kills the scope, not the lease release.
+@pytest.mark.parametrize("failing", ["lineage", "evidence"])
+@pytest.mark.asyncio
+async def test_claim_self_cancelled_callback_retained_across_both_write_failures(
+    failing,
+):
+    """W3/B54: the self-cancel case crossed with *each* durable-write failure.
 
-    On every path that releases the lease, a captured scope fails anyway because
-    the lease itself refuses — so asserting "dead scope" there proves nothing
-    about the gate. Here the durable write fails, so the authority is deliberately
-    retained and the lease is *not* released: if the gate stayed live for the
-    self-cancel branch, the captured scope would still work.
+    Hard-coding one failure kind leaves the other half of this exact case
+    unproven. And on every path that releases the lease, a captured scope fails
+    anyway because the lease itself refuses — so asserting a dead scope only
+    proves something about the gate here, where the authority is deliberately
+    retained and the lease is *not* released.
     """
 
     _, envelope = _attempt_envelope()
     stack = _default_stack()
-    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    if failing == "lineage":
+        stack["persistence"] = RecordingPersistence(fail_from_call=1)
+    else:
+        stack["evidence"] = RecordingDispatchEvidence(fail=True)
     captured: dict[str, Any] = {}
+    posts: list[str] = []
     held_before = set(held_coordinations())
 
     async def self_cancelling(scope: Any) -> Any:
         captured["scope"] = scope
         await scope.assert_owned()
+        posts.append("POST")
         current = asyncio.current_task()
         assert current is not None
         current.cancel()
@@ -6529,80 +6620,55 @@ async def test_claim_self_cancelled_callback_scope_dies_even_when_the_lease_is_k
     stack["callback"] = self_cancelling
     with pytest.raises(CoordinationError) as excinfo:
         await _run(envelope, stack)
+
+    assert posts == ["POST"]
+    # Precedence: the durable failure outranks the callback self-cancellation.
     assert excinfo.value.reason_code is (
         CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
     )
+    # Both post-send writes were attempted; one failing never skips the other.
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
 
-    # The lease is retained, not released — so it would still attest ownership.
     stuck = set(held_coordinations()) - held_before
     assert len(stuck) == 1
-    held = _held_coordination(stuck.pop())
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    held = _held_coordination(hold_id)
+    authority_hold = held.lease.unreleased_authority_hold
+    assert authority_hold is not None
+    # One opaque id on both records, durable-false, claim kept, zero cleanup.
+    assert authority_hold.hold_id == hold_id
+    assert authority_hold.durable_evidence_written is False
+    assert len(stack["intents"].rows) == 1
+    assert stack["intents"].release_if_matches_calls == []
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+
+    # The lease is retained, so it would still attest — the scope is dead only
+    # because the gate closed it.
     assert held.lease.released is False
     await held.lease.assert_owned(held.grant)
-
-    # The scope is nevertheless dead, and only the gate can have done that.
     with pytest.raises(CoordinationError) as expired:
         await captured["scope"].assert_owned()
     assert expired.value.reason_code is CoordinationReasonCode.LEASE_LOST
 
-
-@pytest.mark.asyncio
-async def test_lock_rollback_that_retains_then_raises_makes_only_one_hold(monkeypatch):
-    """B55: the outer fallback must not double-count one stuck account.
-
-    The helper can retain the exact authority and *then* fail on its way out. If
-    the caller's fallback records unconditionally, one stuck account appears
-    twice, and every count that follows it — holds, successors, operator triage —
-    is wrong. The existing exploding helper raises before retaining, so it cannot
-    see this.
-    """
-
-    space = FakeLockSpace()
-    blocker = FakeLockConnection(space, pid=11301)
-    await acquire_physical_account_lease(
-        keys=[1132], connection_factory=ConnectionFactory(blocker)
-    )
-    connection = FakeLockConnection(
-        space, pid=11302, termination_raises=RuntimeError("cannot terminate")
-    )
-
-    async def retain_then_explode(
-        conn: Any, acquired: Any, grant: Any, *, in_flight: Any = ()
-    ) -> None:
-        coordination._record_unreleased_authority(
-            grant,
-            owner=conn,
-            reason_code=CoordinationReasonCode.LEASE_LOST,
-            termination_proven=False,
-            durable_evidence_written=True,
-            connection=conn,
-        )
-        raise RuntimeError("rollback failed after retaining")
-
-    monkeypatch.setattr(
-        coordination, "_rollback_partial_acquisition", retain_then_explode
-    )
-    retained_before = set(_retained_authorities())
-
-    with pytest.raises(CoordinationError):
-        await acquire_physical_account_lease(
-            keys=[1131, 1132], connection_factory=ConnectionFactory(connection)
-        )
-
-    new_holds = set(_retained_authorities()) - retained_before
-    # Exactly one — the helper's record, adopted rather than duplicated.
-    assert len(new_holds) == 1
-    retained = _retained_authorities()[new_holds.pop()]
-    assert retained.connection is connection
-    assert connection.closed is False
-    # And exactly one history row for this authority, not two.
-    rows = [
-        h
-        for h in authority_hold_history()
-        if h.hold_id
-        in set(_retained_authorities()) - retained_before | {retained.hold_id}
-    ]
-    assert len([h for h in rows if h.hold_id == retained.hold_id]) == 1
+    # Both the public handle and the exact private capability refuse release.
+    for attempt in ("public", "private"):
+        with pytest.raises(CoordinationError) as refused:
+            if attempt == "public":
+                await held.lease.release(held.grant)
+            else:
+                await held.lease._release_with_capability(
+                    held.grant,
+                    coordination._COORDINATION_RELEASE_CAPABILITIES[hold_id],
+                )
+        assert refused.value.reason_code is (
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+        ), attempt
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+    assert held_coordination(hold_id) is not None
 
 
 # ===========================================================================
@@ -6680,6 +6746,31 @@ async def test_claim_stimulus_success_orders_both_writes_before_any_cleanup(
     events: list[str] = []
     stack = _default_stack(events)
     posts: list[str] = []
+    captured: dict[str, Any] = {}
+    registered_at: dict[str, bool] = {}
+    held_before = set(held_coordinations())
+
+    # W5: "remove" only fires if the handle genuinely left the map, and the
+    # observer records whether it was still registered at each physical release
+    # boundary. Without that, a defect that deletes the entry *before* releasing
+    # still produces the same event sequence.
+    def observe(step: str) -> None:
+        hold_id = captured.get("hold_id")
+        if hold_id is not None:
+            registered_at[step] = (
+                hold_id in coordination._HELD_COORDINATION,
+                hold_id in coordination._COORDINATION_RELEASE_CAPABILITIES,
+            )
+
+    stack["connection"]._release_observer = observe
+    real_release = coordination._release_and_unregister
+
+    async def removing(held: Any) -> None:
+        captured["hold_id"] = held.hold_id
+        await real_release(held)
+        assert held.hold_id not in coordination._HELD_COORDINATION
+
+    monkeypatch.setattr(coordination, "_release_and_unregister", removing)
     expected = _B56_STIMULI[stimulus](stack, monkeypatch, posts)
 
     with pytest.raises(expected):
@@ -6691,7 +6782,8 @@ async def test_claim_stimulus_success_orders_both_writes_before_any_cleanup(
     assert stack["evidence"].only.kind is DispatchEvidenceKind.CALLBACK_FAILED
     assert stack["evidence"].only.certainty is MutationCertainty.UNCERTAIN
 
-    # The exact post-send order, anchored on the *second* lineage write.
+    # The exact post-send order, anchored on the *second* lineage write, and
+    # carried all the way through removal.
     order = [
         events.index("persist_post"),
         events.index("evidence"),
@@ -6700,6 +6792,27 @@ async def test_claim_stimulus_success_orders_both_writes_before_any_cleanup(
     ]
     assert order == sorted(order)
     assert events.index("persist_pre") < events.index("persist_post")
+
+    # r30: the order is persist_post < evidence < unlock < remove < close.
+    # Removal happens on a PROVEN reverse unlock and *before* the fallible
+    # close — a close failure must never turn an already-proven unlock back into
+    # a false active hold (B23). Both maps are observed at both boundaries:
+    #   at unlock  -> the exact handle and its capability are still present, so
+    #                 removal cannot precede the proof;
+    #   at close   -> both are already gone, so removal is neither skipped,
+    #                 deferred behind a fallible step, nor half-done.
+    assert registered_at == {
+        "lease_unlock": (True, True),
+        "lease_closed": (False, False),
+    }
+
+    # The handle and its private release capability are both gone.
+    hold_id = captured["hold_id"]
+    assert held_coordination(hold_id) is None
+    assert hold_id not in coordination._HELD_COORDINATION
+    assert hold_id not in coordination._COORDINATION_RELEASE_CAPABILITIES
+    assert set(held_coordinations()) == held_before
+
     # The durable claim is never released by coordination.
     assert len(stack["intents"].rows) == 1
     assert stack["intents"].release_if_matches_calls == []
@@ -6756,11 +6869,415 @@ async def test_claim_stimulus_durable_write_failure_locks_the_account(
     assert stack["intents"].release_if_matches_calls == []
     assert held_coordination(hold_id) is not None
 
-    # Neither the public handle nor the owning lease can release it.
-    with pytest.raises(CoordinationError) as public_refusal:
-        await held.lease.release(held.grant)
-    assert public_refusal.value.reason_code is (
-        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    # W5: refusal must hold for the *exact private capability* as well, not only
+    # for the generic public handle — that private path is the one an owning
+    # coordination would actually use.
+    before_refusals = (
+        dict(_retained_authorities()),
+        dict(_active_holds()),
+        dict(stack["intents"].rows),
     )
+    capability = coordination._COORDINATION_RELEASE_CAPABILITIES[hold_id]
+    for attempt in ("public", "private"):
+        with pytest.raises(CoordinationError) as refusal:
+            if attempt == "public":
+                await held.lease.release(held.grant)
+            else:
+                await held.lease._release_with_capability(held.grant, capability)
+        assert refusal.value.reason_code is (
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+        ), attempt
+    # Nothing moved across either refusal.
+    assert dict(_retained_authorities()) == before_refusals[0]
+    assert dict(_active_holds()) == before_refusals[1]
+    assert dict(stack["intents"].rows) == before_refusals[2]
     assert stack["connection"].unlock_calls == []
     assert stack["connection"].closed is False
+    assert held_coordination(hold_id) is not None
+
+
+# ===========================================================================
+# §W2 — the supplied-ID handoff binds lease, grant, connection, and capability
+# ===========================================================================
+
+
+async def _live_preallocated_handle(space: FakeLockSpace, *, pid: int, key: int) -> Any:
+    """A registered coordination handle whose id has no authority record yet."""
+
+    connection = FakeLockConnection(
+        space, pid=pid, termination_raises=RuntimeError("cannot terminate")
+    )
+    lease = await acquire_physical_account_lease(
+        keys=[key], connection_factory=ConnectionFactory(connection)
+    )
+    _, envelope = _attempt_envelope()
+    claim = coordination.DurableClaim(
+        row_id=1,
+        claim_account_scope="mockpa:v1:w2",
+        idempotency_key="w2-key",
+        side="buy",
+    )
+    held = coordination._register_held_coordination(
+        lease=lease, grant=lease.grant, claim=claim, envelope=envelope
+    )
+    capability = coordination._COORDINATION_RELEASE_CAPABILITIES[held.hold_id]
+    return lease, connection, held, capability
+
+
+def _record_state() -> tuple[int, dict[str, Any], dict[str, Any]]:
+    return (
+        len(authority_hold_history()),
+        dict(_retained_authorities()),
+        dict(_active_holds()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_supplied_id_requires_every_exact_identity():
+    """W2: an id is not a right. Lease, grant, connection and capability all bind.
+
+    Each rejection below is a *first* transition on a genuinely live, genuinely
+    issued coordination id — the one shape that would otherwise be accepted — so
+    each one isolates exactly one identity condition.
+    """
+
+    space = FakeLockSpace()
+    lease, connection, held, capability = await _live_preallocated_handle(
+        space, pid=7301, key=7301
+    )
+    other_conn = FakeLockConnection(space, pid=7302)
+    other_lease = await acquire_physical_account_lease(
+        keys=[7302], connection_factory=ConnectionFactory(other_conn)
+    )
+    foreign_capability = object()
+
+    cases = {
+        "wrong_grant": {
+            "grant": other_lease.grant,
+            "connection": connection,
+            "capability": capability,
+        },
+        "wrong_connection": {
+            "grant": held.grant,
+            "connection": other_conn,
+            "capability": capability,
+        },
+        "missing_capability": {
+            "grant": held.grant,
+            "connection": connection,
+            "capability": None,
+        },
+        "foreign_capability": {
+            "grant": held.grant,
+            "connection": connection,
+            "capability": foreign_capability,
+        },
+    }
+    for name, kwargs in cases.items():
+        history_before, retained_before, active_before = _record_state()
+        with pytest.raises(CoordinationError) as excinfo:
+            coordination._record_unreleased_authority(
+                kwargs["grant"],
+                owner=lease,
+                reason_code=CoordinationReasonCode.LEASE_LOST,
+                termination_proven=False,
+                durable_evidence_written=True,
+                connection=kwargs["connection"],
+                hold_id=held.hold_id,
+                capability=kwargs["capability"],
+            )
+        assert excinfo.value.reason_code is (
+            CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+        ), name
+        # Refused before any record was written, on every one of them.
+        assert len(authority_hold_history()) == history_before, name
+        assert dict(_retained_authorities()) == retained_before, name
+        assert dict(_active_holds()) == active_before, name
+
+    # And the legitimate exact handoff is still accepted, once.
+    history_before, _, _ = _record_state()
+    hold = coordination._record_unreleased_authority(
+        held.grant,
+        owner=lease,
+        reason_code=CoordinationReasonCode.LEASE_LOST,
+        termination_proven=False,
+        durable_evidence_written=True,
+        connection=connection,
+        hold_id=held.hold_id,
+        capability=capability,
+    )
+    assert hold.hold_id == held.hold_id
+    assert len(authority_hold_history()) == history_before + 1
+    assert _retained_authorities()[held.hold_id].connection is connection
+
+    # A second transition on the same id is refused: it is no longer the first.
+    history_before, retained_before, active_before = _record_state()
+    with pytest.raises(CoordinationError):
+        coordination._record_unreleased_authority(
+            held.grant,
+            owner=lease,
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=connection,
+            hold_id=held.hold_id,
+            capability=capability,
+        )
+    assert len(authority_hold_history()) == history_before
+    assert dict(_retained_authorities()) == retained_before
+    assert dict(_active_holds()) == active_before
+
+
+@pytest.mark.asyncio
+async def test_lock_sealed_release_failure_supplies_its_real_capability():
+    """W2: the sealed path must satisfy the record gate, not bypass it.
+
+    `_terminate_or_hold` shares the coordination id so one stuck account keeps
+    one thread. If it did not also supply the capability it was sealed with, the
+    record gate would have to accept `capability=None` — and then any caller
+    holding only the id could take the handoff.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    # If the sealed path stopped supplying its capability, the record gate would
+    # refuse the handoff and this would surface as lock_authority_unavailable
+    # instead — so the reason code is the load-bearing assertion here.
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    stuck = set(held_coordinations()) - held_before
+    assert len(stuck) == 1
+    hold_id = stuck.pop()
+    assert excinfo.value.hold_id == hold_id
+    held = _held_coordination(hold_id)
+    authority_hold = held.lease.unreleased_authority_hold
+    assert authority_hold is not None
+    # The id was shared, which is only possible if the capability matched.
+    assert authority_hold.hold_id == hold_id
+    assert authority_hold.durable_evidence_written is False
+    assert _retained_authorities()[hold_id].connection is stack["connection"]
+
+
+@pytest.mark.asyncio
+async def test_lock_duplicate_guard_discriminates_connection_grant_and_record():
+    """W4: owner+grant is not an authority. The connection and the active record count.
+
+    `_authority_already_retained` decides whether the outer fallback may skip
+    recording. If it says "already retained" for a row describing a *different
+    physical session*, the real connection is left unrooted while the maps claim
+    the account is covered — the exact failure the fallback exists to prevent.
+    """
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=7401)
+    lease = await acquire_physical_account_lease(
+        keys=[7401], connection_factory=ConnectionFactory(connection)
+    )
+    other = FakeLockConnection(space, pid=7402)
+
+    # A row with the right owner and grant but the WRONG connection.
+    coordination._record_unreleased_authority(
+        lease.grant,
+        owner=connection,
+        reason_code=CoordinationReasonCode.LEASE_LOST,
+        termination_proven=False,
+        durable_evidence_written=True,
+        connection=other,
+    )
+    assert (
+        coordination._authority_already_retained(
+            owner=connection, grant=lease.grant, connection=connection
+        )
+        is False
+    )
+    # ...and it does answer True for the row that really is this authority.
+    hold = coordination._record_unreleased_authority(
+        lease.grant,
+        owner=connection,
+        reason_code=CoordinationReasonCode.LEASE_LOST,
+        termination_proven=False,
+        durable_evidence_written=True,
+        connection=connection,
+    )
+    assert (
+        coordination._authority_already_retained(
+            owner=connection, grant=lease.grant, connection=connection
+        )
+        is True
+    )
+
+    # An equal-but-not-identical grant is a different acquisition.
+    equal_copy = replace(lease.grant)
+    assert equal_copy == lease.grant and equal_copy is not lease.grant
+    assert (
+        coordination._authority_already_retained(
+            owner=connection, grant=equal_copy, connection=connection
+        )
+        is False
+    )
+
+    # A retained row whose active record is gone is not a recorded authority.
+    # Deliberately white-box: the writers always create both, so this pins the
+    # clause against a future change that could leave one behind.
+    del coordination._ACTIVE_AUTHORITY_HOLDS[hold.hold_id]
+    assert (
+        coordination._authority_already_retained(
+            owner=connection, grant=lease.grant, connection=connection
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_rollback_retaining_a_wrong_connection_does_not_suppress_fallback(
+    monkeypatch,
+):
+    """W4: a helper that retains the wrong session must not disarm the fallback."""
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=11401)
+    await acquire_physical_account_lease(
+        keys=[1142], connection_factory=ConnectionFactory(blocker)
+    )
+    connection = FakeLockConnection(
+        space, pid=11402, termination_raises=RuntimeError("cannot terminate")
+    )
+    impostor = FakeLockConnection(space, pid=11403)
+
+    async def retain_wrong_then_explode(
+        conn: Any, acquired: Any, grant: Any, *, in_flight: Any = ()
+    ) -> None:
+        coordination._record_unreleased_authority(
+            grant,
+            owner=conn,
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=impostor,  # a DIFFERENT physical session
+        )
+        raise RuntimeError("rollback failed after retaining the wrong session")
+
+    monkeypatch.setattr(
+        coordination, "_rollback_partial_acquisition", retain_wrong_then_explode
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[1141, 1142], connection_factory=ConnectionFactory(connection)
+        )
+
+    new_holds = set(_retained_authorities()) - retained_before
+    # Two records: the impostor row the helper wrote, and the fallback's own row
+    # for the connection that actually holds the key.
+    assert len(new_holds) == 2
+    rooted = [
+        _retained_authorities()[h]
+        for h in new_holds
+        if _retained_authorities()[h].connection is connection
+    ]
+    assert len(rooted) == 1
+    assert connection.closed is False
+
+
+@pytest.mark.asyncio
+async def test_claim_sealed_release_failure_records_under_the_coordination_id():
+    """W2: `_terminate_or_hold` must satisfy the record gate, not bypass it.
+
+    This is the *release-failure* path, not the durable-write-failure path: the
+    two post-send writes land, the coordination-owned release then cannot prove
+    a full reverse unlock, and the lease records its hold under the coordination
+    id so one stuck account keeps one thread. That handoff is only permitted if
+    the exact sealed capability is supplied with it.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["connection"]._unlock_returns = False
+    stack["connection"]._termination_raises = RuntimeError("cannot terminate")
+    seen: dict[str, str] = {}
+    before = set(held_coordinations())
+
+    async def capture(scope: Any) -> Any:
+        seen["hold_id"] = (set(held_coordinations()) - before).pop()
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-0000021"
+        )
+
+    stack["callback"] = capture
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    coordination_id = seen["hold_id"]
+    # Both durable writes landed; the failure is the release itself.
+    assert stack["persistence"].calls == 2
+    assert stack["evidence"].calls == 1
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+
+    # The authority hold shares the coordination id — only possible if the
+    # exact sealed capability was handed to the record gate.
+    rows = [h for h in authority_hold_history() if h.hold_id == coordination_id]
+    assert len(rows) == 1
+    assert coordination_id in _retained_authorities()
+    assert _retained_authorities()[coordination_id].connection is stack["connection"]
+    assert stack["connection"].closed is False
+
+
+@pytest.mark.asyncio
+async def test_lock_rollback_that_retains_then_raises_makes_only_one_hold(monkeypatch):
+    """B55/W4: the outer fallback must not double-count one stuck account.
+
+    The helper can retain the exact authority and *then* fail on its way out. If
+    the caller's fallback records unconditionally, one stuck account appears
+    twice, and every count that follows it — holds, successors, operator triage —
+    is wrong.
+    """
+
+    space = FakeLockSpace()
+    blocker = FakeLockConnection(space, pid=11301)
+    await acquire_physical_account_lease(
+        keys=[1132], connection_factory=ConnectionFactory(blocker)
+    )
+    connection = FakeLockConnection(
+        space, pid=11302, termination_raises=RuntimeError("cannot terminate")
+    )
+
+    async def retain_then_explode(
+        conn: Any, acquired: Any, grant: Any, *, in_flight: Any = ()
+    ) -> None:
+        coordination._record_unreleased_authority(
+            grant,
+            owner=conn,
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            termination_proven=False,
+            durable_evidence_written=True,
+            connection=conn,
+        )
+        raise RuntimeError("rollback failed after retaining")
+
+    monkeypatch.setattr(
+        coordination, "_rollback_partial_acquisition", retain_then_explode
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError):
+        await acquire_physical_account_lease(
+            keys=[1131, 1132], connection_factory=ConnectionFactory(connection)
+        )
+
+    new_holds = set(_retained_authorities()) - retained_before
+    # Exactly one — the helper's record, adopted rather than duplicated.
+    assert len(new_holds) == 1
+    hold_id = new_holds.pop()
+    retained = _retained_authorities()[hold_id]
+    assert retained.connection is connection
+    assert connection.closed is False
+    # And exactly one history row for it, not two.
+    assert len([h for h in authority_hold_history() if h.hold_id == hold_id]) == 1

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -7856,6 +7856,15 @@ def test_scope_no_account_wide_claim_prose_survives():
     carrying the retired meaning is caught, and that the docstring never claims
     more than the code does.
 
+    The line between in-scope and out-of-scope is **whether the sentence was
+    crafted to evade**, not whether this docstring happens to enumerate its
+    shape. A gap reachable by prose a contributor would plausibly write is a
+    defect in this guard even when the rules below do not name that shape;
+    deciding otherwise would let any guard become correct merely by describing
+    itself narrowly. Zero-width characters, Unicode homoglyphs, nested
+    parenthetical splicing and similar constructions are crafted, and are out
+    of scope.
+
     The enumerated rules, so a reader can see the boundary rather than infer it:
 
     * **subjects** — ``claim``, ``reservation``, ``binary row``, ``durable row``;
@@ -7863,7 +7872,11 @@ def test_scope_no_account_wide_claim_prose_survives():
       unrelated / every new order" family listed below;
     * **negation** — a negation token exempts a match only when it sits in the
       sub-clause *immediately preceding* the predicate, after splitting the
-      span on conjunction boundaries (``, but``/``, and``/``, yet``/...).
+      span on conjunction boundaries (``but``/``and``/``yet``/``though``/
+      ``however``/``whereas``/``while``, **with or without a preceding
+      comma** — English normally drops the comma when the subject is not
+      repeated, so "does not expire but blocks the account" is the more
+      ordinary of the two forms, not the rarer one).
       A negation that denies some *other* verb does not exempt the predicate;
     * **approved exemption** — a sentence is exempt only if, once normalized,
       it is **equal in full** to an approved sentence. Splicing the approved
@@ -7921,7 +7934,7 @@ def test_scope_no_account_wide_claim_prose_survives():
         "and immutable ack",
     )
     # A negation only denies the verb of its own sub-clause.
-    conjunction = re.compile(r",\s*(?:but|and|yet|though|however|whereas|while)\s")
+    conjunction = re.compile(r",?\s*(?:but|and|yet|though|however|whereas|while)\s")
 
     for label, text in scanned.items():
         flat = " ".join(text.split()).lower()

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -33,6 +33,7 @@ import json
 import pathlib
 import shutil
 import subprocess
+import traceback
 import weakref
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -3475,6 +3476,25 @@ async def test_cancel_bare_shield_finally_release_mutant_is_red():
 # ===========================================================================
 
 
+def _drop_exception_roots(error: BaseException) -> None:
+    """Clear frames along an exception chain before a GC lifetime assertion.
+
+    r35 U1: a raised exception keeps its traceback, and those frames keep their
+    locals — including the connection a rollback helper was handed. That is a
+    *non-module* strong root, so a `weakref() is not None` assertion downstream
+    would pass for the wrong reason and could not detect the module dropping its
+    own root. Clearing the chain first makes the assertion mean what it says.
+    """
+
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if current.__traceback__ is not None:
+            traceback.clear_frames(current.__traceback__)
+        current = current.__cause__ or current.__context__
+
+
 def _active_holds() -> dict[str, Any]:
     """Module-private active-hold map, read-only, for exact-record assertions."""
 
@@ -5184,6 +5204,11 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
         # Witness the exact originals before anything can retain them.
         captured["connection"] = weakref.ref(conn)
         captured["grant"] = weakref.ref(grant)
+        # r35 U1: this frame is retained by the rollback task's exception
+        # traceback, so its locals would keep the connection alive and the GC
+        # assertion below would be satisfied by *this test* rather than by the
+        # module. Drop them before raising, or the proof proves nothing.
+        del conn, acquired, grant, in_flight
         raise RuntimeError("rollback itself failed")
 
     monkeypatch.setattr(
@@ -5192,10 +5217,20 @@ async def test_lock_rollback_task_error_still_retains_the_authority(monkeypatch)
     retained_before = set(_retained_authorities())
     active_before = set(_active_holds())
 
-    with pytest.raises(CoordinationError):
-        await acquire_physical_account_lease(
-            keys=[1121, 1122], connection_factory=ConnectionFactory(connection)
-        )
+    # Run the acquisition inside a helper so that frame — and every temporary it
+    # holds, including the connection factory — is destroyed on return. Left in
+    # the test's own frame, those temporaries are a *non-module* strong root and
+    # the GC assertion below would pass for the wrong reason.
+    async def attempt(factory: Any) -> None:
+        with pytest.raises(CoordinationError) as excinfo:
+            await acquire_physical_account_lease(
+                keys=[1121, 1122], connection_factory=factory
+            )
+        # The exploding helper's traceback frames hold the connection in their
+        # locals; clear them so they cannot root it either.
+        _drop_exception_roots(excinfo.value)
+
+    await attempt(ConnectionFactory(connection))
 
     new_holds = set(_retained_authorities()) - retained_before
     assert len(new_holds) == 1

--- a/tests/services/mock_integration/test_coordination.py
+++ b/tests/services/mock_integration/test_coordination.py
@@ -65,12 +65,14 @@ from app.services.mock_integration.coordination import (
     DispatchEvidenceKind,
     DispatchEvidencePort,
     DurableSendClaimAdapter,
-    HeldCoordination,
+    HeldCoordinationSnapshot,
     MutationCallbackResult,
     MutationCertainty,
     OrderSendIntentReservationPort,
     PostgresAdvisoryKeysetLease,
     SqlAlchemyLockAuthority,
+    _held_coordination,
+    _retained_authorities,
     acquire_physical_account_lease,
     authority_hold_history,
     coordinate_mock_order_mutation,
@@ -80,7 +82,6 @@ from app.services.mock_integration.coordination import (
     ordered_advisory_keyset,
     physical_account_scope_for_entry,
     require_dispatch_evidence_port,
-    retained_authority_connections,
     row_proves_ownership,
     split_advisory_key,
     supports_backend_session_termination,
@@ -274,25 +275,36 @@ class FakeLockSpace:
 
     def __init__(self) -> None:
         self.held: dict[int, int] = {}
+        # PostgreSQL session advisory locks stack per backend. ``pg_locks`` shows
+        # one row however deep the stack is, which is exactly why a single true
+        # unlock is not proof that the row is gone.
+        self.depth: dict[tuple[int, int], int] = {}
 
     def try_lock(self, key: int, pid: int) -> bool:
         owner = self.held.get(key)
         if owner is None or owner == pid:
             self.held[key] = pid
+            self.depth[(key, pid)] = self.depth.get((key, pid), 0) + 1
             return True
         return False
 
     def unlock(self, key: int, pid: int) -> bool:
-        if self.held.get(key) == pid:
+        if self.held.get(key) != pid:
+            return False
+        remaining = self.depth.get((key, pid), 1) - 1
+        if remaining <= 0:
+            self.depth.pop((key, pid), None)
             del self.held[key]
-            return True
-        return False
+        else:
+            self.depth[(key, pid)] = remaining
+        return True
 
     def terminate(self, pid: int) -> None:
         """Backend-session termination releases every advisory lock it held."""
 
         for key in [key for key, owner in self.held.items() if owner == pid]:
             del self.held[key]
+            self.depth.pop((key, pid), None)
 
     def rows(self, pid: int, database_oid: int) -> list[dict[str, Any]]:
         rows: list[dict[str, Any]] = []
@@ -336,6 +348,10 @@ class FakeLockConnection:
         termination_receipt: Any = "default",
         termination_raises: BaseException | None = None,
         can_prove_termination: bool = True,
+        close_raises: BaseException | None = None,
+        fail_sql_error: BaseException | None = None,
+        unlock_raises_on_key: int | None = None,
+        unlock_raises_error: BaseException | None = None,
         raise_after_lock_on_key: int | None = None,
         raise_after_lock_error: BaseException | None = None,
         events: list[str] | None = None,
@@ -350,6 +366,10 @@ class FakeLockConnection:
         self._termination_receipt = termination_receipt
         self._termination_raises = termination_raises
         self._can_prove_termination = can_prove_termination
+        self._close_raises = close_raises
+        self._fail_sql_error = fail_sql_error
+        self._unlock_raises_on_key = unlock_raises_on_key
+        self._unlock_raises_error = unlock_raises_error
         self._raise_after_lock_on_key = raise_after_lock_on_key
         self._raise_after_lock_error = raise_after_lock_error
         self._events = events
@@ -381,7 +401,9 @@ class FakeLockConnection:
         sql = str(statement)
         self.statements.append(sql)
         if self._fail_sql is not None and self._fail_sql in sql:
-            raise RuntimeError("simulated PostgreSQL authority failure")
+            raise self._fail_sql_error or RuntimeError(
+                "simulated PostgreSQL authority failure"
+            )
         params = dict(parameters or {})
         if "pg_terminate_backend" in sql:
             self.terminated = True
@@ -410,6 +432,8 @@ class FakeLockConnection:
         if "pg_advisory_unlock" in sql:
             key = int(params["key"])
             self.unlock_calls.append(key)
+            if key == self._unlock_raises_on_key:
+                raise self._unlock_raises_error or RuntimeError("unlock interrupted")
             if self._events is not None:
                 self._events.append("lease_unlock")
             if self._unlock_returns is None:
@@ -437,6 +461,8 @@ class FakeLockConnection:
     async def close(self) -> None:
         """A pool return: the backend survives, and so would its locks."""
 
+        if self._close_raises is not None:
+            raise self._close_raises
         self.closed = True
         if self._events is not None:
             self._events.append("lease_closed")
@@ -514,8 +540,10 @@ class RecordingPersistence:
         cancel_from_call: int | None = None,
         gate: asyncio.Event | None = None,
         started: asyncio.Event | None = None,
+        gate_on_call: int = 1,
     ) -> None:
         self.persisted: list[LineageEnvelope] = []
+        self._gate_on_call = gate_on_call
         self.calls = 0
         self._events = events
         self._fail_from_call = fail_from_call
@@ -525,9 +553,9 @@ class RecordingPersistence:
 
     async def persist(self, envelope: LineageEnvelope, /) -> None:
         self.calls += 1
-        if self._started is not None:
+        if self._started is not None and self.calls == self._gate_on_call:
             self._started.set()
-        if self._gate is not None and self.calls == 1:
+        if self._gate is not None and self.calls == self._gate_on_call:
             await self._gate.wait()
         if self._cancel_from_call is not None and self.calls > self._cancel_from_call:
             raise asyncio.CancelledError()
@@ -828,7 +856,7 @@ async def test_identity_raw_physical_account_id_never_leaves_the_derivation():
         scope.claim_account_scope,
         repr(entry),
         repr(result.claim),
-        repr(result.lease_grant),
+        repr(result.lease_keys),
         result.claim.claim_account_scope,
         result.evidence.claim_account_scope,
         json.dumps(stack["intents"].reserve_calls),
@@ -1400,9 +1428,14 @@ async def test_lock_unproven_termination_is_never_counted_as_a_release(
     hold = lease.unreleased_authority_hold
     assert hold is not None
     assert hold.termination_proven is False
-    assert hold.connection_token == lease.grant.connection_token
+    assert hold.key_count == len(lease.grant.keys)
+    assert hold.recoverable_in_process is True
+    # B26: the capability-free record carries no PID and no owner token.
+    assert not hasattr(hold, "backend_pid")
+    assert not hasattr(hold, "connection_token")
     assert len(unreleased_authority_holds()) == holds_before + 1
-    assert unreleased_authority_holds()[-1] is hold
+    # The active view recomputes reachability, so compare by value not identity.
+    assert unreleased_authority_holds()[-1] == hold
 
 
 @pytest.mark.asyncio
@@ -1433,7 +1466,7 @@ async def test_lock_exact_grant_recovers_after_a_failed_release():
         space, pid=4242, termination_raises=RuntimeError("cannot terminate")
     )
     lease = await _lease_forced_down_the_termination_path(connection)
-    active_before = set(retained_authority_connections())
+    active_before = set(_retained_authorities())
     history_before = len(authority_hold_history())
 
     with pytest.raises(CoordinationError):
@@ -1441,10 +1474,10 @@ async def test_lock_exact_grant_recovers_after_a_failed_release():
     assert lease.released is False
 
     # Exactly one active strong hold appears.
-    new_active = set(retained_authority_connections()) - active_before
+    new_active = set(_retained_authorities()) - active_before
     assert len(new_active) == 1
     hold_id = new_active.pop()
-    assert retained_authority_connections()[hold_id].connection is connection
+    assert _retained_authorities()[hold_id].connection is connection
     assert lease.unreleased_authority_hold is not None
     assert lease.unreleased_authority_hold.hold_id == hold_id
 
@@ -1452,12 +1485,12 @@ async def test_lock_exact_grant_recovers_after_a_failed_release():
     with pytest.raises(CoordinationError) as excinfo:
         await lease.release(replace(lease.grant, connection_token="lockconn:forged"))
     assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
-    assert hold_id in retained_authority_connections()
+    assert hold_id in _retained_authorities()
 
     # A second retry that still cannot prove anything keeps the hold.
     with pytest.raises(CoordinationError):
         await lease.release(lease.grant)
-    assert hold_id in retained_authority_connections()
+    assert hold_id in _retained_authorities()
 
     # The exact grant finally proves a full reverse unlock.
     connection._unlock_returns = None
@@ -1468,12 +1501,12 @@ async def test_lock_exact_grant_recovers_after_a_failed_release():
 
     # B20: the resolved hold is gone from BOTH active views, and the retained
     # connection is no longer reachable through them.
-    assert hold_id not in retained_authority_connections()
+    assert hold_id not in _retained_authorities()
     assert hold_id not in {hold.hold_id for hold in unreleased_authority_holds()}
     assert lease.unreleased_authority_hold is None
     assert all(
         retained.connection is not connection
-        for retained in retained_authority_connections().values()
+        for retained in _retained_authorities().values()
     )
     # History is immutable evidence and still records what happened.
     assert len(authority_hold_history()) > history_before
@@ -1512,7 +1545,7 @@ async def test_lock_resolving_one_hold_leaves_a_concurrent_hold_untouched():
     recovering._unlock_returns = None
     await recovering_lease.release(recovering_lease.grant)
 
-    active = retained_authority_connections()
+    active = _retained_authorities()
     assert recovering_hold.hold_id not in active
     assert stuck_hold.hold_id in active
     assert active[stuck_hold.hold_id].connection is stuck
@@ -1709,17 +1742,17 @@ async def test_lock_unprovable_rollback_retains_the_real_connection_strongly():
         unlock_returns=False,
         termination_raises=RuntimeError("cannot terminate"),
     )
-    retained_before = set(retained_authority_connections())
+    retained_before = set(_retained_authorities())
 
     with pytest.raises(CoordinationError):
         await acquire_physical_account_lease(
             keys=[-7, 5, 11], connection_factory=ConnectionFactory(connection)
         )
 
-    new_holds = set(retained_authority_connections()) - retained_before
+    new_holds = set(_retained_authorities()) - retained_before
     assert len(new_holds) == 1
     hold_id = new_holds.pop()
-    retained = retained_authority_connections()[hold_id]
+    retained = _retained_authorities()[hold_id]
 
     # The real connection object is reachable, with the real identity.
     assert retained.connection is connection
@@ -1730,7 +1763,7 @@ async def test_lock_unprovable_rollback_retains_the_real_connection_strongly():
 
     # It survives a collection, and was never closed or pool-returned.
     gc.collect()
-    assert retained_authority_connections()[hold_id].connection is connection
+    assert _retained_authorities()[hold_id].connection is connection
     assert connection.closed is False
     assert connection.terminated is False
 
@@ -1744,7 +1777,7 @@ async def test_lock_unprovable_rollback_retains_the_real_connection_strongly():
     assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
 
     # A stale/foreign hold id recovers nothing.
-    assert retained_authority_connections().get("hold:forged") is None
+    assert _retained_authorities().get("hold:forged") is None
 
 
 @pytest.mark.asyncio
@@ -1866,7 +1899,7 @@ async def test_lock_in_flight_acquisition_never_takes_the_confirmed_rollback_pat
         # Termination cannot be proven, so the authority must be retained.
         termination_raises=RuntimeError("cannot terminate"),
     )
-    retained_before = set(retained_authority_connections())
+    retained_before = set(_retained_authorities())
 
     with pytest.raises(BaseException) as excinfo:
         await acquire_physical_account_lease(
@@ -1887,9 +1920,9 @@ async def test_lock_in_flight_acquisition_never_takes_the_confirmed_rollback_pat
     assert connection.termination_calls[0][0] == 3003
 
     # The real connection is retained strongly under an opaque hold.
-    new_holds = set(retained_authority_connections()) - retained_before
+    new_holds = set(_retained_authorities()) - retained_before
     assert len(new_holds) == 1
-    retained = retained_authority_connections()[new_holds.pop()]
+    retained = _retained_authorities()[new_holds.pop()]
     assert retained.connection is connection
     assert retained.grant.backend_pid == 3003
     assert retained.grant.keys == (-7, 5)
@@ -1907,7 +1940,7 @@ async def test_lock_in_flight_acquisition_never_takes_the_confirmed_rollback_pat
 async def test_lock_in_flight_uncertainty_is_resolved_by_a_proven_termination():
     space = FakeLockSpace()
     connection = FakeLockConnection(space, pid=3003, raise_after_lock_on_key=5)
-    retained_before = set(retained_authority_connections())
+    retained_before = set(_retained_authorities())
 
     with pytest.raises(RuntimeError):
         await acquire_physical_account_lease(
@@ -1919,7 +1952,7 @@ async def test_lock_in_flight_uncertainty_is_resolved_by_a_proven_termination():
     assert connection.terminated is True
     assert connection.unlock_calls == []
     assert space.held == {}
-    assert set(retained_authority_connections()) == retained_before
+    assert set(_retained_authorities()) == retained_before
 
 
 @pytest.mark.asyncio
@@ -1932,7 +1965,7 @@ async def test_lock_explicit_false_stays_a_known_not_acquired_path():
         keys=[11], connection_factory=ConnectionFactory(blocker)
     )
     connection = FakeLockConnection(space, pid=3003)
-    retained_before = set(retained_authority_connections())
+    retained_before = set(_retained_authorities())
 
     with pytest.raises(CoordinationError) as excinfo:
         await acquire_physical_account_lease(
@@ -1946,7 +1979,7 @@ async def test_lock_explicit_false_stays_a_known_not_acquired_path():
     assert connection.closed is True
     assert connection.terminated is False
     assert connection.termination_calls == []
-    assert set(retained_authority_connections()) == retained_before
+    assert set(_retained_authorities()) == retained_before
 
 
 @pytest.mark.asyncio
@@ -1996,8 +2029,8 @@ async def test_lock_release_reattests_ownership_before_unlocking():
     hold = lease.unreleased_authority_hold
     assert hold is not None
     assert hold.termination_proven is False
-    assert hold.backend_pid == 4242
-    assert retained_authority_connections()[hold.hold_id].connection is connection
+    assert hold.key_count == 1
+    assert _retained_authorities()[hold.hold_id].connection is connection
 
 
 @pytest.mark.asyncio
@@ -2645,14 +2678,18 @@ async def test_claim_evidence_post_send_write_failure_holds_all_authority(
     assert len(new_holds) == 1
     hold_id = new_holds.pop()
     assert excinfo.value.hold_id == hold_id
-    held = held_coordination(hold_id)
-    assert isinstance(held, HeldCoordination)
+    held = _held_coordination(hold_id)
+    assert held is not None
     assert held.grant is held.lease.grant
     assert held.claim.claim_account_scope.startswith("mockpa:v1:")
     import gc
 
     gc.collect()
-    assert held_coordination(hold_id) is held
+    # The private strong reference survives; the public view stays capability-free.
+    assert _held_coordination(hold_id) is held
+    public = held_coordination(hold_id)
+    assert isinstance(public, HeldCoordinationSnapshot)
+    assert public.durable_evidence_written is False
 
     # 4. the authority hold is auditable and never says it was released
     authority_hold = held.lease.unreleased_authority_hold
@@ -2680,6 +2717,198 @@ async def test_claim_evidence_post_send_write_failure_holds_all_authority(
     # very takeover this contract forbids.
 
 
+def _windowed_stack(
+    window: str, events: list[str]
+) -> tuple[dict[str, Any], asyncio.Event, asyncio.Event]:
+    """A stack that blocks inside exactly one stage of the coordinated flow."""
+
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    stack = _default_stack(events)
+    if window in {"callback", "cancellation_retained_wait"}:
+        stack["callback"] = RecordingCallback(events=events, gate=gate, started=started)
+    elif window == "lineage_persist":
+        # The *post-send* lineage write, i.e. after the broker callback returned.
+        stack["persistence"] = RecordingPersistence(
+            events=events, gate=gate, started=started, gate_on_call=2
+        )
+    elif window == "dispatch_evidence":
+        stack["evidence"] = RecordingDispatchEvidence(
+            events=events, gate=gate, started=started
+        )
+    else:  # pragma: no cover - guarded by the parametrization
+        raise AssertionError(window)
+    return stack, gate, started
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "window",
+    ["callback", "lineage_persist", "dispatch_evidence", "cancellation_retained_wait"],
+)
+async def test_claim_public_release_is_refused_for_the_whole_held_lifetime(
+    window: str,
+):
+    """B22: the dangerous window is *before* anything is known, not after.
+
+    A durable-false hold only exists once a write has already failed. These are
+    the stages where nothing has failed yet and nothing has succeeded either —
+    the broker callback may be mid-flight — and a generic release there is the
+    most damaging one available.
+    """
+
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    stack, gate, started = _windowed_stack(window, events)
+    held_before = set(held_coordinations())
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    if window == "cancellation_retained_wait":
+        task.cancel()
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert task.done() is False
+
+    hold_id = (set(held_coordinations()) - held_before).pop()
+    held = _held_coordination(hold_id)
+    assert held is not None
+    # No durable-false hold exists yet: this is precisely the B21 blind spot.
+    assert held.lease.unreleased_authority_hold is None
+    assert held.lease.coordination_sealed is True
+    connection = stack["connection"]
+
+    for _ in range(2):
+        with pytest.raises(CoordinationError) as excinfo:
+            await held.lease.release(held.grant)
+        assert excinfo.value.reason_code is (
+            CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+        )
+        assert excinfo.value.hold_id == hold_id
+    # A forged capability object is no better than none.
+    with pytest.raises(CoordinationError):
+        await held.lease._release_with_capability(held.grant, object())
+    # And neither is a fresh wrapper around the same authority: no durable-false
+    # hold exists yet in this window, so only the held-coordination lockout can
+    # catch it.
+    with pytest.raises(CoordinationError) as clone_error:
+        PostgresAdvisoryKeysetLease(connection=connection, grant=held.grant)
+    assert clone_error.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+
+    assert connection.unlock_calls == []
+    assert connection.closed is False
+    assert connection.terminated is False
+    assert held.lease.released is False
+    assert len(stack["intents"].rows) == 1
+
+    gate.set()
+    if window == "cancellation_retained_wait":
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    else:
+        await task
+
+    # Only the coordination-owned path released it, and only at the end.
+    assert connection.unlock_calls == [held.grant.keys[0]]
+    assert connection.closed is True
+    assert events.index("evidence") < events.index("lease_unlock")
+    assert hold_id not in held_coordinations()
+
+
+@pytest.mark.asyncio
+async def test_claim_only_the_coordination_owned_path_releases_a_sealed_lease():
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    stack = _default_stack(events)
+    held_before = set(held_coordinations())
+
+    result = await _run(envelope, stack)
+
+    # Both durable writes landed, so the internal path released and unregistered.
+    assert set(held_coordinations()) == held_before
+    assert stack["connection"].unlock_calls == [result.lease_keys[0]]
+    assert stack["connection"].closed is True
+    assert events.index("evidence") < events.index("lease_unlock")
+
+
+@pytest.mark.asyncio
+async def test_lock_unsealed_standalone_lease_still_honours_the_durable_false_hold():
+    """B21 in isolation: no seal involved, so its own guard is what must fire.
+
+    Keeping this separate from the sealed path is what stops the B22 seal from
+    masking a regression in the B21 guard.
+    """
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space)
+    lease = await acquire_physical_account_lease(
+        keys=[-7], connection_factory=ConnectionFactory(connection)
+    )
+    assert lease.coordination_sealed is False
+    hold = lease._retain_authority(
+        reason_code=CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE,
+        durable_evidence_written=False,
+    )
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert excinfo.value.hold_id == hold.hold_id
+    assert connection.unlock_calls == []
+    assert connection.closed is False
+    assert lease.released is False
+
+
+@pytest.mark.asyncio
+async def test_claim_two_held_leases_do_not_share_release_authority():
+    _, first_envelope = _attempt_envelope()
+    _, second_envelope = _attempt_envelope(attempt_overrides={"cycle_id": "second"})
+    gate = asyncio.Event()
+    started = asyncio.Event()
+
+    first_stack = _default_stack()
+    first_stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(first_envelope, first_stack)
+    stuck_id = (set(held_coordinations()) - held_before).pop()
+
+    second_stack = _default_stack()
+    second_stack["callback"] = RecordingCallback(gate=gate, started=started)
+    second_task = asyncio.ensure_future(_run(second_envelope, second_stack))
+    await started.wait()
+    in_flight_id = (set(held_coordinations()) - held_before - {stuck_id}).pop()
+
+    stuck = _held_coordination(stuck_id)
+    in_flight = _held_coordination(in_flight_id)
+    assert stuck is not None and in_flight is not None
+    assert stuck_id != in_flight_id
+
+    # Neither handle can release the other, nor itself.
+    for holder, other in ((stuck, in_flight), (in_flight, stuck)):
+        with pytest.raises(CoordinationError):
+            await holder.lease.release(holder.grant)
+        with pytest.raises(CoordinationError):
+            await other.lease.release(holder.grant)
+
+    assert first_stack["connection"].unlock_calls == []
+    assert second_stack["connection"].unlock_calls == []
+
+    gate.set()
+    await second_task
+
+    # The in-flight one completed and unregistered; the stuck one is untouched.
+    assert in_flight_id not in held_coordinations()
+    assert stuck_id in held_coordinations()
+    assert first_stack["connection"].unlock_calls == []
+    assert first_stack["connection"].closed is False
+
+
 @pytest.mark.asyncio
 async def test_claim_durable_false_hold_cannot_be_released_via_the_public_handle():
     """B21: public introspection may see a stuck lease; it may not release it."""
@@ -2695,8 +2924,8 @@ async def test_claim_durable_false_hold_cannot_be_released_via_the_public_handle
     hold_id = (set(held_coordinations()) - held_before).pop()
     # One stuck authority carries one opaque id across both surfaces.
     assert coordinate_error.value.hold_id == hold_id
-    held = held_coordination(hold_id)
-    assert isinstance(held, HeldCoordination)
+    held = _held_coordination(hold_id)
+    assert held is not None
     authority_hold = held.lease.unreleased_authority_hold
     assert authority_hold is not None
     assert authority_hold.hold_id == hold_id
@@ -2762,11 +2991,11 @@ async def test_claim_durable_false_hold_does_not_disturb_a_durable_true_hold():
     recoverable_conn._unlock_returns = None
     await recoverable.release(recoverable.grant)
     assert recoverable.released is True
-    assert true_hold.hold_id not in retained_authority_connections()
+    assert true_hold.hold_id not in _retained_authorities()
 
     # The durable-false hold is completely unaffected and still unreleasable.
     assert false_hold_id in held_coordinations()
-    stuck = held_coordination(false_hold_id)
+    stuck = _held_coordination(false_hold_id)
     assert stuck is not None
     with pytest.raises(CoordinationError) as excinfo:
         await stuck.lease.release(stuck.grant)
@@ -2961,7 +3190,7 @@ async def test_claim_held_handle_is_dropped_only_after_a_proven_release():
     result = await _run(envelope, stack)
 
     assert set(held_coordinations()) == held_before
-    assert stack["connection"].unlock_calls == [result.lease_grant.keys[0]]
+    assert stack["connection"].unlock_calls == [result.lease_keys[0]]
     assert stack["connection"].closed is True
 
 
@@ -3122,6 +3351,656 @@ async def test_cancel_bare_shield_finally_release_mutant_is_red():
     with pytest.raises(asyncio.CancelledError):
         await mutant_task
     assert events.index("lease_closed") < events.index("callback_end")
+
+
+# ===========================================================================
+# §Authority ownership — B23-B32
+# ===========================================================================
+
+
+async def _durable_true_hold(space: FakeLockSpace, *, pid: int, key: int) -> Any:
+    """A lease whose *release* failed, so B20 recovery semantics apply."""
+
+    connection = FakeLockConnection(
+        space, pid=pid, termination_raises=RuntimeError("cannot terminate")
+    )
+    lease = await acquire_physical_account_lease(
+        keys=[key], connection_factory=ConnectionFactory(connection)
+    )
+    connection._unlock_returns = False
+    with pytest.raises(CoordinationError):
+        await lease.release(lease.grant)
+    hold = lease.unreleased_authority_hold
+    assert hold is not None and hold.durable_evidence_written is True
+    connection._unlock_returns = None
+    return lease, connection, hold
+
+
+@pytest.mark.asyncio
+async def test_claim_proven_termination_on_an_error_path_clears_the_held_handle():
+    """B28: a provably released authority must stop being reported as held.
+
+    The coordination-owned release fails its unlock, falls back to a positive
+    termination receipt, and then re-raises. The handle must still be gone: the
+    authority really is released, and saying otherwise is a lie that outlives
+    the process's memory of why.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    connection = stack["connection"]
+    held_before = set(held_coordinations())
+
+    async def flip_then_report() -> MutationCallbackResult:
+        # By release time the unlocks will be unprovable, forcing termination.
+        connection._unlock_returns = False
+        return MutationCallbackResult(
+            certainty=MutationCertainty.DEFINITIVE, broker_order_id="ODNO-TERM"
+        )
+
+    stack["callback"] = flip_then_report
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await _run(envelope, stack)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    # Termination was proven against the exact backend...
+    assert connection.terminated is True
+    assert connection.termination_calls[0][0] == connection._pid
+    # ...so nothing may still be reported as held, even though the call raised.
+    assert set(held_coordinations()) == held_before
+    assert all(
+        retained.connection is not connection
+        for retained in _retained_authorities().values()
+    )
+    # Both durable writes had landed, so the evidence exists; only the claim
+    # stays, because releasing that needs terminal evidence, not a lock.
+    assert stack["evidence"].calls == 1
+    assert len(stack["intents"].rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_lock_proven_unlock_resolves_the_hold_even_when_close_fails():
+    """B23: a pool-return error cannot un-prove an unlock that already happened."""
+
+    space = FakeLockSpace()
+    lease, connection, hold = await _durable_true_hold(space, pid=8001, key=811)
+    other_lease, _, other_hold = await _durable_true_hold(space, pid=8002, key=822)
+    assert hold.hold_id in _retained_authorities()
+
+    connection._close_raises = RuntimeError("pool return failed")
+    with pytest.raises(RuntimeError, match="pool return failed"):
+        await lease.release(lease.grant)
+
+    # The unlock proof stands, and the hold is honestly resolved.
+    assert connection.unlock_calls[-1] == 811
+    assert lease.unlocked_keys == (811,)
+    assert lease.released is True
+    assert hold.hold_id not in _retained_authorities()
+    assert hold.hold_id not in {h.hold_id for h in unreleased_authority_holds()}
+    # History keeps the evidence; the other hold is untouched.
+    assert hold.hold_id in {h.hold_id for h in authority_hold_history()}
+    assert other_hold.hold_id in _retained_authorities()
+    assert other_lease.released is False
+
+
+@pytest.mark.asyncio
+async def test_lock_unproven_unlock_keeps_the_hold_regardless_of_close():
+    space = FakeLockSpace()
+    lease, connection, hold = await _durable_true_hold(space, pid=8010, key=830)
+    connection._unlock_returns = False
+    connection._close_raises = RuntimeError("pool return failed")
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    assert hold.hold_id in _retained_authorities()
+    assert lease.released is False
+
+
+@pytest.mark.asyncio
+async def test_lock_hold_id_collision_never_overwrites_a_foreign_entry(monkeypatch):
+    """B24: forced collision — allocation must not adopt somebody else's id."""
+
+    space = FakeLockSpace()
+    _, victim_connection, victim_hold = await _durable_true_hold(
+        space, pid=8101, key=841
+    )
+    victim_owner = _retained_authorities()[victim_hold.hold_id].owner
+
+    # Force every fresh token to collide with the victim's id.
+    colliding = victim_hold.hold_id.removeprefix("hold:")
+    monkeypatch.setattr(coordination.secrets, "token_hex", lambda _n: colliding)
+
+    intruder = FakeLockConnection(
+        space, pid=8102, termination_raises=RuntimeError("cannot terminate")
+    )
+    intruder_lease = await acquire_physical_account_lease(
+        keys=[842], connection_factory=ConnectionFactory(intruder)
+    )
+    intruder._unlock_returns = False
+    with pytest.raises(CoordinationError) as excinfo:
+        await intruder_lease.release(intruder_lease.grant)
+    # Allocation exhausted its attempts rather than stealing the id.
+    assert excinfo.value.reason_code in {
+        CoordinationReasonCode.LEASE_LOST,
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE,
+    }
+
+    retained = _retained_authorities()[victim_hold.hold_id]
+    assert retained.connection is victim_connection
+    assert retained.owner is victim_owner
+
+
+@pytest.mark.asyncio
+async def test_lock_foreign_lease_cannot_reuse_an_exposed_hold_id():
+    space = FakeLockSpace()
+    _, victim_connection, victim_hold = await _durable_true_hold(
+        space, pid=8201, key=851
+    )
+    intruder = FakeLockConnection(space, pid=8202)
+    intruder_lease = await acquire_physical_account_lease(
+        keys=[852], connection_factory=ConnectionFactory(intruder)
+    )
+
+    with pytest.raises(CoordinationError) as excinfo:
+        intruder_lease._retain_authority(
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            durable_evidence_written=True,
+            hold_id=victim_hold.hold_id,
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert _retained_authorities()[victim_hold.hold_id].connection is victim_connection
+    assert intruder_lease.unreleased_authority_hold is None
+    await intruder_lease.release(intruder_lease.grant)
+
+
+@pytest.mark.asyncio
+async def test_claim_durable_false_state_cannot_be_promoted_by_a_caller():
+    """B25: the safety boolean is monotonic and not caller-settable."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+    hold_id = (set(held_coordinations()) - held_before).pop()
+    held = _held_coordination(hold_id)
+    assert held is not None
+
+    # Sealed, so a caller-supplied capability is refused outright...
+    with pytest.raises(CoordinationError):
+        held.lease._retain_authority(
+            reason_code=CoordinationReasonCode.LEASE_LOST,
+            durable_evidence_written=True,
+            hold_id=hold_id,
+        )
+    # ...and even holding the real capability cannot promote a false to a true.
+    capability = coordination._COORDINATION_RELEASE_CAPABILITIES[hold_id]
+    unchanged = held.lease._retain_authority(
+        reason_code=CoordinationReasonCode.LEASE_LOST,
+        durable_evidence_written=True,
+        hold_id=hold_id,
+        capability=capability,
+    )
+    assert unchanged.durable_evidence_written is False
+    assert held.lease.unreleased_authority_hold.durable_evidence_written is False
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await held.lease.release(held.grant)
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+
+
+def test_scope_capability_bearing_symbols_are_not_public():
+    """r17: a lane supplies extra keys through the coordinator, never a lease."""
+
+    for name in (
+        "PostgresAdvisoryKeysetLease",
+        "acquire_physical_account_lease",
+        "AdvisoryLeaseGrant",
+    ):
+        assert name not in coordination.__all__, name
+        # Still defined — narrowing the surface, not deleting the machinery.
+        assert hasattr(coordination, name), name
+
+    exported = set(coordination.__all__)
+    assert "coordinate_mock_order_mutation" in exported
+    # Nothing left in the public surface hands out a connection, a grant, or a
+    # release/terminate callable.
+    for name in exported:
+        value = getattr(coordination, name)
+        assert not isinstance(value, coordination.AdvisoryLeaseGrant), name
+    star: dict[str, Any] = {}
+    exec("from app.services.mock_integration.coordination import *", star)  # noqa: S102
+    for forbidden in (
+        "PostgresAdvisoryKeysetLease",
+        "acquire_physical_account_lease",
+        "AdvisoryLeaseGrant",
+        "_retained_authorities",
+        "_HeldCoordination",
+    ):
+        assert forbidden not in star, forbidden
+
+
+def test_scope_public_introspection_exposes_no_release_capability():
+    """B26: static shape — a snapshot must not carry a way to act."""
+
+    import dataclasses
+
+    forbidden = {"connection", "lease", "grant", "owner_token", "backend_pid", "pid"}
+    for record in (
+        coordination.HeldCoordinationSnapshot,
+        coordination.UnreleasedAuthorityHold,
+    ):
+        names = {field.name for field in dataclasses.fields(record)}
+        assert names.isdisjoint(forbidden), (record, names & forbidden)
+        for field in dataclasses.fields(record):
+            assert field.type not in {"LockAuthorityConnection", "AdvisoryLeaseGrant"}
+    # Neither the private ownership map nor the raw handle is exported.
+    assert "_retained_authorities" not in coordination.__all__
+    assert "HeldCoordination" not in coordination.__all__
+    assert "_HeldCoordination" not in coordination.__all__
+
+
+@pytest.mark.asyncio
+async def test_scope_public_snapshot_offers_nothing_callable_to_release_with():
+    space = FakeLockSpace()
+    lease, connection, hold = await _durable_true_hold(space, pid=8301, key=861)
+
+    snapshot = [h for h in unreleased_authority_holds() if h.hold_id == hold.hold_id]
+    assert len(snapshot) == 1
+    for name in ("connection", "lease", "grant", "terminate_backend_session"):
+        assert not hasattr(snapshot[0], name)
+    await lease.release(lease.grant)
+
+
+@pytest.mark.asyncio
+async def test_scope_held_coordination_lookup_returns_a_snapshot_not_the_handle():
+    """B26 at runtime: the public lookup must not hand back the real handle."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+    hold_id = (set(held_coordinations()) - held_before).pop()
+
+    public = held_coordination(hold_id)
+    assert isinstance(public, HeldCoordinationSnapshot)
+    assert type(public) is HeldCoordinationSnapshot
+    for name in ("lease", "grant", "connection", "claim", "envelope"):
+        assert not hasattr(public, name), name
+    assert all(
+        isinstance(value, HeldCoordinationSnapshot)
+        for value in held_coordinations().values()
+    )
+    # The real handle is reachable only through the module-private hook.
+    assert _held_coordination(hold_id) is not public
+
+
+@pytest.mark.asyncio
+async def test_lock_in_flight_grant_with_cancelled_termination_is_retained():
+    """B27: a CancelledError inside termination is 'unknown', not 'released'."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space,
+        pid=8401,
+        raise_after_lock_on_key=872,
+        raise_after_lock_error=asyncio.CancelledError(),
+        termination_raises=asyncio.CancelledError(),
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(asyncio.CancelledError):
+        await acquire_physical_account_lease(
+            keys=[871, 872], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert space.held.get(872) == 8401
+    assert connection.closed is False
+    assert connection.terminated is False
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    retained = _retained_authorities()[new_holds.pop()]
+    assert retained.connection is connection
+    assert retained.grant.backend_pid == 8401
+
+    successor = FakeLockConnection(space, pid=8402)
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[872], connection_factory=ConnectionFactory(successor)
+        )
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+
+
+@pytest.mark.asyncio
+async def test_lock_partial_acquire_hold_is_not_reported_as_recoverable():
+    """B30 §4: with no owning lease there is no in-process resolution path."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space,
+        pid=8501,
+        raise_after_lock_on_key=882,
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(RuntimeError):
+        await acquire_physical_account_lease(
+            keys=[881, 882], connection_factory=ConnectionFactory(connection)
+        )
+
+    hold_id = (set(_retained_authorities()) - retained_before).pop()
+    hold = next(h for h in unreleased_authority_holds() if h.hold_id == hold_id)
+    assert hold.recoverable_in_process is False
+    assert _retained_authorities()[hold_id].connection is connection
+
+
+@pytest.mark.asyncio
+async def test_lock_durable_true_hold_stays_resolvable_after_the_caller_drops_it():
+    """B30 §3: the retained record identifies the owner, not the caller's local."""
+
+    import gc
+
+    space = FakeLockSpace()
+    lease, connection, hold = await _durable_true_hold(space, pid=8601, key=891)
+    assert hold.recoverable_in_process is True
+    retained = _retained_authorities()[hold.hold_id]
+    owner = retained.owner
+    del lease
+    gc.collect()
+
+    # The module still owns the exact lease, so a proven release still resolves.
+    assert _retained_authorities()[hold.hold_id].owner is owner
+    await owner.release(owner.grant)
+    assert hold.hold_id not in _retained_authorities()
+    assert connection.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lock_second_wrapper_over_a_held_authority_is_refused():
+    """B29: non-releasability belongs to the authority, not to a wrapper."""
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+    hold_id = (set(held_coordinations()) - held_before).pop()
+    held = _held_coordination(hold_id)
+    assert held is not None
+    connection = stack["connection"]
+
+    with pytest.raises(CoordinationError) as excinfo:
+        PostgresAdvisoryKeysetLease(connection=connection, grant=held.grant)
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert connection.unlock_calls == []
+    assert connection.closed is False
+    assert connection.terminated is False
+    assert hold_id in held_coordinations()
+
+
+@pytest.mark.asyncio
+async def test_lock_clone_over_a_durable_true_retained_authority_is_refused():
+    """C3: the lockout is symmetric — the evidence flag is not what makes a
+    foreign wrapper unsafe. Only the owning lease may retry its own authority."""
+
+    space = FakeLockSpace()
+    lease, connection, hold = await _durable_true_hold(space, pid=9301, key=951)
+    assert hold.durable_evidence_written is True
+
+    with pytest.raises(CoordinationError) as excinfo:
+        PostgresAdvisoryKeysetLease(connection=connection, grant=lease.grant)
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert connection.unlock_calls[-1] == 951  # only the owner's failed attempt
+    assert connection.closed is False
+
+    # The owner itself is still allowed to retry, which is what makes the
+    # `recoverable_in_process=True` report honest.
+    await lease.release(lease.grant)
+    assert lease.released is True
+
+
+@pytest.mark.asyncio
+async def test_lock_single_true_unlock_is_not_full_release_of_a_stacked_lock():
+    """B31: session advisory locks are re-entrant; one unlock is not enough."""
+
+    space = FakeLockSpace()
+    connection = FakeLockConnection(
+        space, pid=8701, termination_raises=RuntimeError("cannot terminate")
+    )
+    lease = await acquire_physical_account_lease(
+        keys=[901], connection_factory=ConnectionFactory(connection)
+    )
+    # Somebody stacked a second lock on the same backend and key.
+    assert space.try_lock(901, 8701) is True
+    assert space.depth[(901, 8701)] == 2
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    # The unlock returned true, and the row is still there — not a release.
+    assert connection.unlock_calls == [901]
+    assert space.held.get(901) == 8701
+    assert connection.closed is False
+    assert lease.released is False
+    assert len(set(_retained_authorities()) - retained_before) == 1
+
+
+@pytest.mark.asyncio
+async def test_lock_acquisition_refuses_a_backend_that_already_holds_the_key():
+    space = FakeLockSpace()
+    connection = FakeLockConnection(space, pid=8801)
+    space.try_lock(911, 8801)
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await acquire_physical_account_lease(
+            keys=[911], connection_factory=ConnectionFactory(connection)
+        )
+
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE
+    )
+    assert connection.lock_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["attestation", "unlock", "termination"])
+async def test_lock_cancellation_inside_release_leaves_no_untracked_authority(
+    stage: str,
+):
+    """B32: a CancelledError in the critical section is 'unknown', not 'done'."""
+
+    space = FakeLockSpace()
+    kwargs: dict[str, Any] = {
+        "pid": 8901,
+        "termination_raises": RuntimeError("cannot terminate"),
+    }
+    if stage == "termination":
+        kwargs["termination_raises"] = asyncio.CancelledError()
+    connection = FakeLockConnection(space, **kwargs)
+    lease = await acquire_physical_account_lease(
+        keys=[921, 922], connection_factory=ConnectionFactory(connection)
+    )
+    if stage == "attestation":
+        connection._fail_sql = "pg_backend_pid"
+        connection._fail_sql_error = asyncio.CancelledError()
+    else:
+        connection._unlock_raises_on_key = 921
+        connection._unlock_raises_error = asyncio.CancelledError()
+    retained_before = set(_retained_authorities())
+
+    with pytest.raises(CoordinationError) as excinfo:
+        await lease.release(lease.grant)
+
+    assert excinfo.value.reason_code in {
+        CoordinationReasonCode.LEASE_LOST,
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE,
+    }
+    # No untracked live authority: it is retained, and nothing was closed.
+    new_holds = set(_retained_authorities()) - retained_before
+    assert len(new_holds) == 1
+    retained = _retained_authorities()[new_holds.pop()]
+    assert retained.connection is connection
+    assert retained.owner is lease
+    assert connection.closed is False
+    assert lease.released is False
+
+
+@pytest.mark.asyncio
+async def test_lock_recoverable_flag_matches_actual_retry_reachability():
+    """C1: the flag must describe a retry that exists, not the owner's type."""
+
+    space = FakeLockSpace()
+
+    # (a) standalone durable-TRUE hold: the caller holds a releasable lease.
+    lease, connection, hold = await _durable_true_hold(space, pid=9101, key=931)
+    active = {h.hold_id: h for h in unreleased_authority_holds()}
+    assert active[hold.hold_id].recoverable_in_process is True
+    # And the claim is honest: the retry really does work.
+    await lease.release(lease.grant)
+    assert lease.released is True
+
+    # (b) partial-acquisition rollback hold: no owning lease exists at all.
+    rollback_conn = FakeLockConnection(
+        space,
+        pid=9102,
+        raise_after_lock_on_key=942,
+        termination_raises=RuntimeError("cannot terminate"),
+    )
+    with pytest.raises(RuntimeError):
+        await acquire_physical_account_lease(
+            keys=[941, 942], connection_factory=ConnectionFactory(rollback_conn)
+        )
+    rollback_hold = next(
+        h
+        for h in unreleased_authority_holds()
+        if _retained_authorities()[h.hold_id].connection is rollback_conn
+    )
+    assert rollback_hold.recoverable_in_process is False
+
+    # (c) coordination-sealed durable-FALSE hold: sealed forever, so no retry.
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+    sealed_id = (set(held_coordinations()) - held_before).pop()
+    sealed_hold = next(
+        h for h in unreleased_authority_holds() if h.hold_id == sealed_id
+    )
+    assert sealed_hold.recoverable_in_process is False
+    sealed = _held_coordination(sealed_id)
+    assert sealed is not None and sealed.lease.coordination_sealed is True
+    with pytest.raises(CoordinationError):
+        await sealed.lease.release(sealed.grant)
+
+
+@pytest.mark.asyncio
+async def test_claim_durable_false_lockout_blocks_even_the_owning_lease():
+    """C2: the seal and the durable-false lockout are not substitutes.
+
+    They cover different callers. The seal stops the public path; the lockout
+    stops *every* path, the owning lease included. A refactor that treats either
+    as sufficient reopens the other's window.
+    """
+
+    _, envelope = _attempt_envelope()
+    stack = _default_stack()
+    stack["evidence"] = RecordingDispatchEvidence(fail=True)
+    held_before = set(held_coordinations())
+    with pytest.raises(CoordinationError):
+        await _run(envelope, stack)
+    hold_id = (set(held_coordinations()) - held_before).pop()
+    held = _held_coordination(hold_id)
+    assert held is not None
+
+    # The coordination hold and the durable-false hold share one opaque id...
+    assert held.lease.unreleased_authority_hold is not None
+    assert held.lease.unreleased_authority_hold.hold_id == hold_id
+    # ...so the lockout must key on the evidence flag, not on id inequality.
+    assert (
+        coordination._authority_lockout(stack["connection"], owner=held.lease)
+        == hold_id
+    )
+    # Even the real coordination capability cannot release it.
+    capability = coordination._COORDINATION_RELEASE_CAPABILITIES[hold_id]
+    with pytest.raises(CoordinationError) as excinfo:
+        await held.lease._release_with_capability(held.grant, capability)
+    assert excinfo.value.reason_code is (
+        CoordinationReasonCode.LINEAGE_PERSISTENCE_UNAVAILABLE
+    )
+    assert stack["connection"].unlock_calls == []
+    assert stack["connection"].closed is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_repeated_outer_cancellation_stays_bounded():
+    """C5: repeated external cancels must not spin the retained-wait loop."""
+
+    _, envelope = _attempt_envelope()
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    stack = _default_stack()
+    stack["callback"] = RecordingCallback(gate=gate, started=started)
+
+    task = asyncio.ensure_future(_run(envelope, stack))
+    await started.wait()
+    for _ in range(25):
+        task.cancel()
+        await asyncio.sleep(0)
+
+    assert task.done() is False
+    assert stack["connection"].unlock_calls == []
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # The inner task was never cancelled; it ran to a definite result.
+    assert stack["callback"].calls == 1
+    assert stack["evidence"].calls == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_model_premise_claim_commits_before_the_callback():
+    """The whole process-death argument rests on this ordering.
+
+    If the durable claim were written after the send, a crash mid-callback would
+    leave nothing blocking a successor's blind repost, and "process death is an
+    acceptable terminus" would stop being true.
+    """
+
+    _, envelope = _attempt_envelope()
+    events: list[str] = []
+    stack = _default_stack(events)
+    await _run(envelope, stack)
+
+    assert events.index("reserve") < events.index("callback_start")
+    assert AUTOMATIC_CLAIM_RELEASE_AVAILABLE is False
+    assert LEASE_TTL_SECONDS is None
+    # The only deletion path runs through the evidence gate.
+    source = COORDINATION_SOURCE.read_text(encoding="utf-8")
+    assert source.count("release_if_matches(") == 2  # the port and its one call
+    assert "if not evidence.authorizes_release:" in source
 
 
 # ===========================================================================
@@ -3365,7 +4244,7 @@ async def test_scope_authorized_future_consumer_may_import_and_use_the_port():
         # A broker lane supplies its own extra keys; J3A never chooses them.
         additional_advisory_keys=(4242,),
     )
-    assert result.lease_grant.keys == tuple(sorted({result.scope.advisory_key, 4242}))
+    assert result.lease_keys == tuple(sorted({result.scope.advisory_key, 4242}))
     assert stack["evidence"].only.kind is DispatchEvidenceKind.ACKNOWLEDGED
 
 


### PR DESCRIPTION
J3A of ROB-1256. Coordination for one **physical** mock/paper/demo account: a PostgreSQL session advisory lease, the existing binary send reservation, lane-owned durable evidence ports, and an **injected** mutation callback.

Three files, no more: `app/services/mock_integration/coordination.py`, its tests, and `docs/contracts/rob-1262-coordination-port.md`.

## This is NOT broker-enforced fencing

Stated in three places — the module docstring, the lease class, and a per-lane matrix in the contract doc — because *"the lease is held, therefore the broker will reject everyone else"* is the most expensive available misreading. No lane broker accepts a fencing token, so an out-of-repo process, a stale deployment, or a human at a broker console reaches the same account without ever contending.

## Load-bearing invariants

- **Scope** is an opaque SHA-256 of the canonical J2A `physical_account_id`. A caller-supplied scope is never accepted; the raw id is never logged, serialized, or stored.
- **Ownership** is proven across an explicit `COMMIT` boundary by backend PID plus the exact `pg_locks` row, with the signed key's 32-bit halves reconstructed — `objid` is never compared to a signed key.
- **Release** is an attested full reverse unlock, or a positive `pg_terminate_backend` receipt bound to the exact PID and owner token, proven from an independent observer session. `close()` and a pool return are neither, and an ambiguous driver error is not a receipt.
- **In-flight ≠ absent.** A key whose `pg_try_advisory_lock` await failed after dispatch is *uncertain*, not free — the same discipline as a broker submit that times out locally after the remote mutation already happened.
- **The post-send AND gate**: until both the lineage write and the typed dispatch evidence are durable, nothing is unlocked, closed, or dropped, and the lease is unreleasable even through the exact grant. A proven recovery then resolves exactly its own hold and no other.
- No clock, no TTL, no janitor, no retry queue, no scheduler, no schema. The eight signed reason codes are fixed; `DispatchEvidenceKind` is a separate evidence vocabulary and a test asserts the two sets are disjoint.

## Ownership boundaries

J3A supplies a **broker-neutral** ordered keyset primitive. It chooses no KIS key, edits no KIS call site, and claims no host/profile coupling — those are J3B/J3C's. `describe_claim_followup` reports capability only and can never be constructed as an authorization.

## Verification

138 focused tests (including 5 against real PostgreSQL via the run-owned test database), 339 in the neighbouring sweep, ruff/format/ty clean, and **17/17 injected mutants red** with byte-exact revert — including the brief-mandated reconnect-then-assert-owned mutant and both directions of the hold-cleanup contract.

Not ready for review: **J4-V has not run yet**, and `SAFE_TO_SPAWN_J4` stays `NO` until an independent reviewer confirms closure on these exact bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a coordination-port specification for broker-neutral physical-account coordination.
  * Documented advisory leasing, deterministic coordination scopes, durable send reservations, uncertainty handling, and evidence-based release.
  * Defined validation, ownership, cancellation, cleanup, error precedence, inspection, and retention requirements.
  * Clarified coordination boundaries and explicitly excluded broker transport, credentials, migrations, scheduling, and lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->