### PR TITLE
feat(ROB-1255): abbreviate approval cards

### DIFF
--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -18,11 +18,7 @@ from app.services.order_proposals.dispatch_contract import (
     CallbackEnvelope,
     DispatchBinding,
 )
-from app.telegram_contract import (
-    TELEGRAM_SEND_MESSAGE_TEXT_LIMIT,
-    split_telegram_text,
-    telegram_text_length,
-)
+from app.telegram_contract import telegram_text_length
 
 _ALLOWED_ACTIONS = frozenset({"op", "dn", "lc", "vc", "ba"})
 _CALLBACK_PATTERN = re.compile(
@@ -47,7 +43,6 @@ _BATCH_RUNG_RESULT_LABELS = {
     "needs_reconfirm": "재확인 필요",
     "cancelled": "취소 확인",
 }
-_CONTEXT_HEADER_RESERVED_UNITS = 64
 
 
 @dataclass(frozen=True, slots=True)
@@ -451,9 +446,16 @@ def build_approval_message(
     else:
         lines.append("- 없음")
 
+    lines.append(
+        f"- 핵심 수치: {_build_order_core_metrics(group=group, rungs=sorted_rungs)}"
+    )
+
     if evidence_reference is None:
-        thesis = getattr(group, "thesis", None) or "미기재"
-        strategy = getattr(group, "strategy", None) or "미기재"
+        # §78차 ③-a: Telegram keeps only a bounded summary. The full thesis
+        # remains in the DB for the future approval-hub deep link; this job
+        # deliberately does not invent that URL or a hub route.
+        thesis = _compact_summary(getattr(group, "thesis", None))
+        strategy = _compact_summary(getattr(group, "strategy", None))
         evidence_lines = [
             f"- 투자 논지: {_escape_markdown(thesis)}",
             f"- 전략: {_escape_markdown(strategy)}",
@@ -550,58 +552,21 @@ def build_approval_dispatch_messages(
     suffix_blocks: Sequence[str] = (),
     binding: DispatchBinding,
 ) -> ApprovalDispatchMessages:
-    """Keep short cards intact; split oversized evidence before the button card."""
-    full_text, keyboard = build_approval_message(
-        group=group,
-        rungs=rungs,
-        cash_stress=cash_stress,
-        diff=diff,
-        binding=binding,
-    )
-    if suffix_blocks:
-        full_text = f"{full_text}\n\n" + "\n\n".join(suffix_blocks)
-    payload_chars = telegram_text_length(full_text)
-    if payload_chars <= TELEGRAM_SEND_MESSAGE_TEXT_LIMIT:
-        return ApprovalDispatchMessages((), full_text, keyboard, payload_chars)
-
-    thesis = str(getattr(group, "thesis", None) or "미기재")
-    strategy = str(getattr(group, "strategy", None) or "미기재")
-    evidence_body = f"투자 논지:\n{thesis}\n\n전략:\n{strategy}"
-    body_chunks = split_telegram_text(
-        evidence_body,
-        max_units=(TELEGRAM_SEND_MESSAGE_TEXT_LIMIT - _CONTEXT_HEADER_RESERVED_UNITS),
-    )
-    total = len(body_chunks)
-    proposal_short = str(getattr(group, "proposal_id", ""))[:8] or "unknown"
-    context_messages = tuple(
-        f"주문 제안 {proposal_short} 근거 원문 ({index}/{total})\n\n{chunk}"
-        for index, chunk in enumerate(body_chunks, start=1)
-    )
-    if any(
-        telegram_text_length(message) > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
-        for message in context_messages
-    ):
-        raise ValueError("approval context header exceeded reserved Telegram space")
-
-    evidence_reference = (
-        f"제안 {proposal_short}의 위 근거 메시지 {total}건 · "
-        f"투자 논지 {len(thesis)}자 / 전략 {len(strategy)}자"
-    )
+    """Render one compact card; detailed evidence belongs to the future hub."""
     approval_text, keyboard = build_approval_message(
         group=group,
         rungs=rungs,
         cash_stress=cash_stress,
         diff=diff,
-        evidence_reference=evidence_reference,
         binding=binding,
     )
     if suffix_blocks:
         approval_text = f"{approval_text}\n\n" + "\n\n".join(suffix_blocks)
     return ApprovalDispatchMessages(
-        context_messages,
+        (),
         approval_text,
         keyboard,
-        payload_chars,
+        telegram_text_length(approval_text),
     )
 
 
@@ -669,6 +634,16 @@ def build_loss_cut_confirmation_message(
             f"- 교훈: {_escape_markdown(lesson)}",
         ]
     )
+    source_asof = getattr(group, "source_asof", None)
+    second_step_window = (
+        source_asof.get("loss_cut_confirmation", {}).get("expires_at")
+        if isinstance(source_asof, Mapping)
+        and isinstance(source_asof.get("loss_cut_confirmation"), Mapping)
+        else None
+    )
+    lines.append(
+        f"- 2차 창(유효시간): {_format_datetime(second_step_window, approximate=False)}"
+    )
     approval_note = str(getattr(group, "approval_issue_id", None) or "").strip()
     if approval_note:
         lines.append(f"- 승인 감사 메모: {_escape_markdown(approval_note)}")
@@ -706,6 +681,46 @@ def build_loss_cut_confirmation_message(
     return text, keyboard
 
 
+def _build_order_core_metrics(*, group: Any, rungs: Sequence[Any]) -> str:
+    market = str(getattr(group, "market", "") or "")
+    symbol = str(getattr(group, "symbol", "") or "")
+    currency = _currency_for_market(market=market, symbol=symbol)
+    quantity_unit = "주" if market in {"equity_kr", "equity_us"} else ""
+    total_quantity = Decimal("0")
+    quantity_known = bool(rungs)
+    total_notional = Decimal("0")
+    notional_known = bool(rungs)
+    for rung in rungs:
+        quantity = _safe_decimal(getattr(rung, "quantity", None))
+        price = _safe_decimal(getattr(rung, "limit_price", None))
+        if quantity is None:
+            quantity_known = False
+        else:
+            total_quantity += quantity
+        if quantity is None or price is None:
+            notional_known = False
+        else:
+            total_notional += quantity * price
+    quantity_text = (
+        f"총수량 {_format_decimal(total_quantity)}{quantity_unit}"
+        if quantity_known
+        else "총수량 미기재"
+    )
+    price_text = (
+        f"주문금액 {_format_money(total_notional, currency=currency)}"
+        if notional_known
+        else "주문금액 시장가/미기재"
+    )
+    return f"{quantity_text} / {price_text}"
+
+
+def _compact_summary(value: object, *, limit: int = 120) -> str:
+    normalized = " ".join(str(value or "").split())
+    if not normalized:
+        return "미기재"
+    return normalized[: limit - 1] + "…" if len(normalized) > limit else normalized
+
+
 def _build_time_lines(group: Any) -> list[str]:
     source_asof = getattr(group, "source_asof", None)
     resting_deadline = (
@@ -719,11 +734,14 @@ def _build_time_lines(group: Any) -> list[str]:
         ("제출 임대", getattr(group, "commit_lease_until", None), True),
         ("주문 유지기한", resting_deadline, True),
     )
-    return [
+    lines = [
         f"- {label}: {_format_datetime(value, approximate=approximate)}"
         for label, value, approximate in fields
         if _coerce_datetime(value) is not None
     ]
+    if _coerce_datetime(getattr(group, "valid_until", None)) is None:
+        lines.insert(0, "- 유효기간: 미기재")
+    return lines
 
 
 def _build_cash_lines(cash_stress: Mapping, *, currency: str | None) -> list[str]:

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -44,8 +44,10 @@ from typing import Any
 
 from app.core.config import settings
 from app.services.order_proposals.approval_message import (
+    _build_order_core_metrics,
     _escape_inline_code,
     _escape_markdown,
+    _format_datetime,
     build_callback_data,
 )
 from app.services.order_proposals.auto_approve_audit import (
@@ -740,7 +742,9 @@ def build_auto_approved_message(
         [
             f"- 수량: {quantities}",
             f"- 가격: {prices}",
+            f"- 핵심 수치: {_build_order_core_metrics(group=group, rungs=ordered_rungs)}",
             f"- 근거: {_escape_markdown(rationale)}",
+            f"- 유효기간: {_format_datetime(getattr(group, 'valid_until', None), approximate=False)}",
             f"- `auto:policy@{policy_version}`",
         ]
     )

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -617,7 +617,7 @@ async def publish_approval_messages(
     messages: ApprovalDispatchMessages,
     chat_id: str,
 ) -> ApprovalPublication:
-    """Send every context successfully before publishing the button card."""
+    """Publish the compact button card after payload validation."""
     all_messages = (*messages.context_messages, messages.approval_text)
     if any(
         telegram_text_length(text) > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -285,32 +285,46 @@ def test_loss_cut_approval_message_shows_reason_retrospective_and_invest_link():
 
 
 @pytest.mark.unit
-def test_4444_character_thesis_is_split_losslessly_before_short_button_card():
+def test_long_thesis_is_bounded_in_card_and_not_mutated_or_sent_as_context():
     thesis = "가" * 4444
     strategy = "분할 매도"
     group = _group(thesis=thesis, strategy=strategy)
-    proposal_short = str(group.proposal_id)[:8]
-
     messages = build_approval_dispatch_messages(
         group=group,
         rungs=[_rung()],
     )
 
-    assert messages.payload_chars > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
-    assert len(messages.context_messages) == 2
+    assert messages.payload_chars < TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+    assert messages.context_messages == ()
     assert all(
         telegram_text_length(text) <= TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
         for text in (*messages.context_messages, messages.approval_text)
     )
-    reconstructed = "".join(
-        message.split("\n\n", 1)[1] for message in messages.context_messages
-    )
-    assert reconstructed == f"투자 논지:\n{thesis}\n\n전략:\n{strategy}"
+    assert f"투자 논지: {'가' * 119}…" in messages.approval_text
     assert thesis not in messages.approval_text
-    assert "투자 논지 4444자" in messages.approval_text
-    assert all(proposal_short in message for message in messages.context_messages)
-    assert proposal_short in messages.approval_text
+    assert group.thesis == thesis
     assert messages.inline_keyboard["inline_keyboard"]
+
+
+@pytest.mark.unit
+def test_compact_approval_card_has_required_contract_fields_individually():
+    group = _group(
+        symbol="JUP",
+        side="sell",
+        thesis="익절 조건과 지지선 이탈 위험을 함께 반영한 사유",
+        valid_until=datetime(2026, 7, 14, 1, 30, tzinfo=UTC),
+    )
+    text, _keyboard = build_approval_message(
+        group=group,
+        rungs=[_rung(quantity=Decimal("3"), limit_price=Decimal("99"))],
+    )
+
+    assert "종목: `JUP`" in text
+    assert "#1: 3주" in text
+    assert "× ₩99" in text
+    assert "투자 논지: 익절 조건과 지지선 이탈 위험을 함께 반영한 사유" in text
+    assert "핵심 수치: 총수량 3주 / 주문금액 ₩297" in text
+    assert "유효기간: ~10:30 KST (2026-07-14)" in text
 
 
 @pytest.mark.unit
@@ -395,6 +409,11 @@ def test_loss_cut_confirmation_callback_and_summary():
         retrospective_id=42,
         approval_issue_id="operator note: desk A",
         approval_nonce="secondnonce",
+        source_asof={
+            "loss_cut_confirmation": {
+                "expires_at": "2026-07-14T01:30:00+00:00",
+            }
+        },
     )
     text, keyboard = build_loss_cut_confirmation_message(
         group=group,
@@ -419,6 +438,7 @@ def test_loss_cut_confirmation_callback_and_summary():
     assert "99" in text
     assert "100" in text
     assert "-50.00%" in text
+    assert "2차 창(유효시간): 10:30 KST (2026-07-14)" in text
     assert "#42" in text
     assert "손절 기준을 늦추지 않는다" in text
     assert "승인 감사 메모" in text
@@ -756,7 +776,8 @@ def test_message_formats_optional_market_order_fields_stably():
     assert "#1: 0.01 × 시장가" in text
     assert "투자 논지: 미기재" in text
     assert "전략: 미기재" in text
-    assert "*시간*" not in text
+    assert "*시간*" in text
+    assert "유효기간: 미기재" in text
     assert "*현금 스트레스*" not in text
     assert "*재확인 변경사항*" not in text
 

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -13,6 +13,7 @@ import pytest
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.auto_approve import (
     AutoApproveLimits,
+    auto_veto_thesis_summary,
     build_auto_approved_message,
     evaluate_auto_approve_eligibility,
     find_approval_required_tag_matches,
@@ -831,6 +832,7 @@ def test_auto_veto_card_has_symbol_quantity_price_and_thesis_fields():
         symbol="005930",
         side="buy",
         thesis="valuation dislocation",
+        valid_until=datetime(2026, 7, 14, 1, 30, tzinfo=UTC),
     )
     binding = build_proposal_dispatch_binding(
         proposal_id=group.proposal_id,
@@ -851,7 +853,25 @@ def test_auto_veto_card_has_symbol_quantity_price_and_thesis_fields():
     assert "종목: `005930`" in text
     assert "수량: #1 2" in text
     assert "가격: #1 97000" in text
+    assert "핵심 수치: 총수량 2주 / 주문금액 ₩194,000" in text
     assert "근거: valuation dislocation" in text
+    assert "유효기간: 10:30 KST (2026-07-14)" in text
+
+
+def test_auto_veto_missing_thesis_stays_none_and_routes_to_human():
+    group = _group(thesis=" ", strategy="mean_reversion")
+
+    assert auto_veto_thesis_summary(group) is None
+    decision = _evaluate(
+        group_overrides={"thesis": " ", "strategy": "mean_reversion"},
+        limit_price=Decimal("99500"),
+        quantity=Decimal("1"),
+        preview={"success": True, "current_price": "100000"},
+    )
+    assert (decision.eligible, decision.reason) == (
+        False,
+        "thesis_required_for_veto_card",
+    )
 
 
 def test_auto_veto_card_raises_when_thesis_is_missing():

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -32,7 +32,6 @@ from app.services.order_proposals.dispatch import (
 )
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
-    ApprovalDispatchState,
     build_proposal_dispatch_binding,
 )
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
@@ -159,7 +158,7 @@ class _CommittedBatchNotifier(_FakeNotifier):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_publish_4444_thesis_requires_every_context_before_button() -> None:
+async def test_publish_long_thesis_sends_only_one_compact_button_card() -> None:
     group = OrderProposal(
         proposal_id=uuid.uuid4(),
         approval_nonce="unit-nonce1",
@@ -187,21 +186,6 @@ async def test_publish_4444_thesis_requires_every_context_before_button() -> Non
     messages = build_approval_dispatch_messages(
         group=group, rungs=[rung], binding=binding
     )
-    assert len(messages.context_messages) == 2
-
-    failed_notifier = _FailAtNotifier(fail_at=2)
-    failed = await publish_approval_messages(
-        notifier=failed_notifier,
-        messages=messages,
-        chat_id=CHAT_ID,
-    )
-
-    assert failed.card_published is False
-    assert failed.partial is True
-    assert failed.failure_code == "approval_context_dispatch_failed"
-    assert len(failed_notifier.sent_messages) == 2
-    assert all(keyboard is None for _, keyboard, _ in failed_notifier.sent_messages)
-
     successful_notifier = _FakeNotifier(message_id=9200)
     sent = await publish_approval_messages(
         notifier=successful_notifier,
@@ -210,12 +194,9 @@ async def test_publish_4444_thesis_requires_every_context_before_button() -> Non
     )
 
     assert sent.card_published is True
-    assert sent.message_id == 9202
-    assert len(successful_notifier.sent_messages) == 3
-    assert all(
-        keyboard is None for _, keyboard, _ in successful_notifier.sent_messages[:-1]
-    )
-    assert successful_notifier.sent_messages[-1][1]["inline_keyboard"]
+    assert sent.message_id == 9200
+    assert len(successful_notifier.sent_messages) == 1
+    assert successful_notifier.sent_messages[0][1]["inline_keyboard"]
 
 
 def _session_factory(db_session):
@@ -637,72 +618,38 @@ async def test_send_proposal_for_approval_send_failure_is_durable_and_invalidate
 
 
 @pytest.mark.asyncio
-async def test_4444_thesis_context_failure_withholds_button_and_retry_mints_new_nonce(
+async def test_long_thesis_dispatches_one_card_and_preserves_db_text(
     monkeypatch, db_session
 ):
     from app.core.config import settings
-    from app.services.order_proposals import dispatch as dispatch_module
 
     chat_id = f"long-thesis-{uuid.uuid4().hex}"
     monkeypatch.setattr(
         settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat_id
     )
-    nonces = iter(("firstnonce1", "secondnonce"))
-    monkeypatch.setattr(dispatch_module, "_generate_nonce", lambda: next(nonces))
+    thesis = "가" * 4444
     group = await _seed_proposal(
         db_session,
-        thesis="가" * 4444,
+        thesis=thesis,
         strategy="분할 매도",
     )
-    now = datetime(2026, 7, 23, 2, 17, 50, tzinfo=UTC)
-
-    failed_notifier = _FailAtNotifier(fail_at=2)
-    failed = await send_proposal_for_approval(
-        group.proposal_id,
-        notifier=failed_notifier,
-        now=now,
-        service_factory=_session_factory(db_session),
-    )
-
-    assert failed.ok is False
-    assert failed.failure_code == "approval_context_dispatch_failed"
-    assert failed.payload_chars > 4096
-    assert len(failed_notifier.sent_messages) == 2
-    assert all(keyboard is None for _, keyboard, _ in failed_notifier.sent_messages)
-    assert failed_notifier.parse_modes == [None, None]
-
-    service = OrderProposalsService(db_session)
-    after_failure, _ = await service.get_proposal(group.proposal_id)
-    failed_attempt_id = after_failure.approval_dispatch_attempt_id
-    assert (
-        after_failure.approval_dispatch_state
-        == ApprovalDispatchState.PARTIAL_FAILED.value
-    )
-    assert after_failure.approval_nonce is None
-
-    successful_notifier = _FakeNotifier(message_id=9100)
+    notifier = _FakeNotifier(message_id=9100)
     sent = await send_proposal_for_approval(
         group.proposal_id,
-        notifier=successful_notifier,
-        now=now.replace(second=51),
+        notifier=notifier,
+        now=datetime(2026, 7, 23, 2, 17, 50, tzinfo=UTC),
         service_factory=_session_factory(db_session),
     )
 
     assert sent.ok is True
-    assert sent.message_id == 9102
-    assert len(successful_notifier.sent_messages) == 3
-    assert all(
-        keyboard is None for _, keyboard, _ in successful_notifier.sent_messages[:-1]
+    assert sent.payload_chars < 4096
+    assert len(notifier.sent_messages) == 1
+    assert notifier.sent_messages[0][1]["inline_keyboard"]
+    assert thesis not in notifier.sent_messages[0][0]
+    refreshed, _ = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
     )
-    assert successful_notifier.sent_messages[-1][1]["inline_keyboard"]
-    assert successful_notifier.parse_modes == [None, None, "Markdown"]
-    after_retry, _ = await service.get_proposal(group.proposal_id)
-    assert (
-        after_retry.approval_dispatch_state == ApprovalDispatchState.SENT_CURRENT.value
-    )
-    assert after_retry.approval_dispatch_attempt_id != failed_attempt_id
-    assert after_retry.approval_nonce == "secondnonce"
-    assert after_retry.source_asof["approval_message_id"] == 9102
+    assert refreshed.thesis == thesis
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -693,7 +693,7 @@ async def test_create_dispatches_telegram_when_enabled_and_allowlisted(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_create_4444_thesis_returns_visible_split_dispatch_result(monkeypatch):
+async def test_create_4444_thesis_returns_compact_dispatch_result(monkeypatch):
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
     chat = _unique_chat()
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
@@ -710,10 +710,9 @@ async def test_create_4444_thesis_returns_visible_split_dispatch_result(monkeypa
     assert created["success"] is True
     assert created["approval_dispatch"]["ok"] is True
     assert created["approval_dispatch"]["state"] == "sent"
-    assert created["approval_dispatch"]["payload_chars"] > 4096
-    assert len(fake_notifier.calls) == 3
-    assert all(keyboard is None for _, keyboard, _ in fake_notifier.calls[:-1])
-    assert fake_notifier.calls[-1][1]["inline_keyboard"]
+    assert created["approval_dispatch"]["payload_chars"] < 4096
+    assert len(fake_notifier.calls) == 1
+    assert fake_notifier.calls[0][1]["inline_keyboard"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- abbreviate manual approval Telegram cards to bounded thesis/strategy summaries
- stop sending full thesis context messages; preserve full thesis in DB
- keep auto-veto missing-thesis fail-closed behavior and add core metrics/valid-until
- retain loss-cut loss-rate and second-window disclosures

## Evidence
- `uv run pytest tests/ -q -k "approval or order_proposal or loss_cut"` — 1118 passed
- related approval/auto-approve/dispatch/MCP tests — 172 passed
- `make lint` — Ruff, format, and `ty check app/ --error-on-warning` passed
- no broker, migration, scheduler, dependency, or gate changes

Draft only; verifier follow-up is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Approval notifications now use compact single-card messages, including key order metrics, validity periods, and concise thesis or strategy summaries.
  * Long approval messages remain within Telegram’s size limit while preserving the original full thesis for records.
  * Loss-cut confirmations now display the second-step validity window.
  * Auto-approval notifications now show formatted expiration details.
  * Missing validity periods are clearly labeled as “유효기간: 미기재.”


<!-- end of auto-generated comment: release notes by coderabbit.ai -->