### PR TITLE
ROB-1264 J3C: Kiwoom adapter consumes J3A coordination grant

### DIFF
--- a/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
+++ b/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
@@ -1,0 +1,168 @@
+# ROB-1264 J3C — Kiwoom coordination adapter
+
+Thin Kiwoom lane adapter around the merged J3A coordination port, J2A
+registry, and J2B lineage. This document is the lane-native recovery
+contract. It does not copy J3A PostgreSQL SQL, key math, reservation,
+cancellation shielding, or reason enums.
+
+- Adapter: `scripts/b0x/kr/kiwoom_ordering.py`
+- Cycle wiring: `scripts/b0x/kr/kiwoom_cycle.py`
+- Submit/ACK extraction: `scripts/b0x/kr/kiwoom.py`
+- Attribution: `scripts/b0x/kr/kiwoom_attribution.py`
+- Tests: `tests/services/mock_integration/test_kiwoom_coordination_adapter.py`
+
+Activation to `AUTO_ENABLED` is **out of scope**. Missing any recovery
+item below leaves this lane at `AUTO_READY_BLOCKED_BY_LIFECYCLE`.
+
+---
+
+## Lane-native recovery owner (activation precondition)
+
+The common coordination layer does not own broker-specific retry,
+readback, or manual-resolution queues.
+
+Before a lane can become AUTO_ENABLED, its lane contract must identify:
+
+- exactly one recovery owner;
+- the trigger that rediscovers surviving durable claims after restart;
+- the authoritative broker readback operation;
+- the lane-native evidence written for ACK, unknown, reject, expiry,
+  partial fill, cancel, and terminal reconciliation;
+- the condition for exact release_if_matches;
+- the operator-visible blocked state when authoritative recovery is not
+  possible.
+
+A lane missing any of these remains
+AUTO_READY_BLOCKED_BY_LIFECYCLE.
+
+### C3-1 Recovery owner — exactly one
+
+`scripts.b0x.kr.kiwoom_ordering.KiwoomCoordinationAdapter`
+
+Machine constant: `KIWOOM_RECOVERY_OWNER`.
+No second owner is named. J3A does not own Kiwoom retry, readback, or
+manual-resolution queues.
+
+### C3-2 Restart trigger
+
+`process_restart_rediscovers_durable_j2b_claims_for_physical_account`
+
+On restart the adapter reloads durable J2B `OrderAttempt` rows for the
+canonical J2A `physical_account_id` and runs `restart_disposition`.
+
+### C3-3 Authoritative broker readback
+
+`kt00007` — exact row keyed by known native `broker_order_id`.
+
+`kt00009`, local JSONL, cycle artifacts, and wall clock are diagnostic
+only.
+
+### C3-4 Lane-native evidence (seven kinds)
+
+| Kind | Written by |
+|---|---|
+| ACK | J2B `acknowledge_order_attempt` then `DispatchEvidenceKind.ACKNOWLEDGED`; JSONL follows |
+| unknown | `DispatchEvidenceKind.LANE_REPORTED_UNCERTAIN` / `CALLBACK_FAILED` / `ACK_ATTACHMENT_FAILED` |
+| reject | lane evidence `reject` after a broker-authoritative reject row on `kt00007` |
+| expiry | lane evidence `expiry` only when `kt00007` names expiry; local clock is not expiry |
+| partial fill | `kt00007` remaining/filled on the exact native id; reservation held |
+| cancel | coordinated cancel callback + lane evidence `cancel` |
+| terminal reconciliation | `DurableSendClaimAdapter.release_with_terminal_evidence` after the flags below |
+
+Missing any of the seven keeps the lane
+`AUTO_READY_BLOCKED_BY_LIFECYCLE`.
+
+### C3-5 Exact `release_if_matches` condition
+
+Release is permitted only after:
+
+- A. pre-transport authoritative `NOT_CREATED` evidence, or
+- B. an exact attributed broker-native terminal fact persisted through
+  the J2B/native lifecycle port,
+
+and only with exact reservation ownership/token/key match, presented as
+`TerminalClaimEvidence` to
+`DurableSendClaimAdapter.release_with_terminal_evidence`.
+
+Wall-clock DAY expiry, missing `kt00007` row, journal absence, and local
+cycle completion cannot release.
+
+### C3-6 Operator-visible blocked state
+
+`AUTO_READY_BLOCKED_BY_LIFECYCLE`
+
+Recorded on the cycle as `lane_lifecycle_status` when coordination,
+authoritative recovery, or required P&L/account truth is unavailable.
+A numeric `0` is never substituted for an unreadable P&L.
+
+### C3-7 Lifecycle status
+
+This lane's status remains `AUTO_READY_BLOCKED_BY_LIFECYCLE`.
+This job does not activate recurring execution.
+
+---
+
+## Identity and grant
+
+Canonical identity is J2A `LaneRegistryEntry.physical_account_id`.
+Caller-derived identifiers, artifact-root paths, and
+`account_identity_summary()["fingerprint"]` are diagnostic only and are
+rejected when offered as identity authority.
+
+`AccountWriterLease` remains a host-local flock. Its
+`canonical()["authorizes_send"]` is `false`. A held flock without a J3A
+grant makes zero transport calls.
+
+Each POST and each cancel/reduce reasserts `CoordinationScope.assert_owned()`
+immediately before the mutation.
+
+---
+
+## Native client ID
+
+Kiwoom attempts use:
+
+- `broker_client_id_target = None`
+- `broker_client_order_id = None`
+- non-blank J2B internal idempotency
+- `BrokerClientIdTarget` enum unchanged
+
+After ACK the exact Kiwoom order number is persisted as J2B
+`broker_order_id` **before** `own-orders.jsonl` is appended.
+
+---
+
+## Crash / restart
+
+| Window | Disposition |
+|---|---|
+| Pre-send + authoritative `NOT_CREATED` | matched cleanup allowed |
+| POST then crash before durable ACK | `unknown_pending_reconcile`, account-wide block, repost 0 |
+| Durable ACK then crash before JSONL | recover by exact J2B native id + `kt00007` |
+| JSONL missing/corrupt | never "no owned orders" while a durable claim exists |
+| `kt00007` unreadable or exact row absent | unknown + hold |
+
+---
+
+## Transport gate (before every real send)
+
+1. actual client `type(...) is KiwoomMockClient`
+2. `client._base_url ==` exact mock constant
+3. secret-free fingerprint maps to J2A `physical_account_id`
+4. registry lane/profile/mode/endpoint match
+5. J3A grant still owned
+
+A live-character client behind a mock-looking caller fails before
+transport. `app/services/brokers/kiwoom/client.py` is not modified.
+
+---
+
+## C5 (TaskGroup / `asyncio.timeout` cancellation-count)
+
+J3A left C5 as **UNKNOWN**. J4-V confirmed that status.
+
+J3C does not introduce `asyncio.TaskGroup` or `asyncio.timeout`.
+Cancellation shielding is consumed from J3A
+`coordinate_mock_order_mutation` retained tasks. This adapter cannot
+independently certify J3A's cancellation-count, so **C5 remains
+UNKNOWN** with that evidence. It is not treated as "not applicable".

--- a/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
+++ b/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
@@ -59,18 +59,20 @@ only.
 
 ### C3-4 Lane-native evidence (seven kinds)
 
-| Kind | Written by |
-|---|---|
-| ACK | J2B `acknowledge_order_attempt` then `DispatchEvidenceKind.ACKNOWLEDGED`; JSONL follows |
-| unknown | `DispatchEvidenceKind.LANE_REPORTED_UNCERTAIN` / `CALLBACK_FAILED` / `ACK_ATTACHMENT_FAILED` |
-| reject | lane evidence `reject` after a broker-authoritative reject row on `kt00007` |
-| expiry | lane evidence `expiry` only when `kt00007` names expiry; local clock is not expiry |
-| partial fill | `kt00007` remaining/filled on the exact native id; reservation held |
-| cancel | coordinated cancel callback + lane evidence `cancel` |
-| terminal reconciliation | `DurableSendClaimAdapter.release_with_terminal_evidence` after the flags below |
-
-Missing any of the seven keeps the lane
+Exact `record_lane_evidence("<kind>", ...)` call sites in
+`KiwoomCoordinationAdapter` (`scripts/b0x/kr/kiwoom_ordering.py`).
+`LANE_EVIDENCE_KINDS` is the closed set. A missing kind keeps the lane
 `AUTO_READY_BLOCKED_BY_LIFECYCLE`.
+
+| Kind | Lane-native write |
+|---|---|
+| ACK | `submit_planned` callback after a non-blank `ord_no` |
+| unknown | blank `ord_no` in `submit_planned`; `apply_restart_disposition` when the claim is uncorrelated; `record_native_broker_truth` for `kt00007` state `unknown` |
+| reject | `record_native_broker_truth` when `kt00007` normalizes to `rejected` |
+| expiry | `record_native_broker_truth` when `kt00007` normalizes to `expired` (local clock is not expiry) |
+| partial fill | `record_native_broker_truth` when `kt00007` normalizes to `partial` |
+| cancel | `cancel_attributed` callback after the cancel POST |
+| terminal reconciliation | `release_if_matches_terminal` after `DurableSendClaimAdapter.release_with_terminal_evidence` |
 
 ### C3-5 Exact `release_if_matches` condition
 

--- a/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
+++ b/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
@@ -66,8 +66,8 @@ Exact `record_lane_evidence("<kind>", ...)` call sites in
 
 | Kind | Lane-native write |
 |---|---|
-| ACK | `submit_planned` callback after a non-blank `ord_no` |
-| unknown | blank `ord_no` in `submit_planned`; `apply_restart_disposition` when the claim is uncorrelated; `record_native_broker_truth` for `kt00007` state `unknown` |
+| ACK | `submit_coordinated` callback after a non-blank `ord_no` |
+| unknown | blank `ord_no` in `submit_coordinated`; `apply_restart_disposition` when the claim is uncorrelated; `record_native_broker_truth` for `kt00007` state `unknown` |
 | reject | `record_native_broker_truth` when `kt00007` normalizes to `rejected` |
 | expiry | `record_native_broker_truth` when `kt00007` normalizes to `expired` (local clock is not expiry) |
 | partial fill | `record_native_broker_truth` when `kt00007` normalizes to `partial` |

--- a/scripts/b0x/kr/kiwoom_attribution.py
+++ b/scripts/b0x/kr/kiwoom_attribution.py
@@ -345,19 +345,29 @@ async def read_own_attribution(
     *,
     journal: OwnOrderJournal,
     read_order_detail: OrderDetailReader,
+    durable_broker_order_ids: frozenset[str] | None = None,
 ) -> OwnFillAttribution | AttributionUnreadable:
     """자기 귀속 — 저널(소유) × kt00007(체결 진실). 어떤 실패든 tri-state.
 
     🔴 Never touches ``review.kis_mock_order_ledger``. The evidence chain is
     the local journal plus the kiwoom broker, and nothing else.
+    🔴 A missing/corrupt JSONL cannot convert an unresolved durable claim into
+    "this lane never traded".
     """
 
+    durable_ids = durable_broker_order_ids or frozenset()
     try:
         records = journal.read_all()
     except Exception as exc:  # noqa: BLE001 — unreadable, not empty
-        return attribution_unreadable(type(exc).__name__)
+        return attribution_unreadable(
+            "journal_unreadable_with_durable_claims"
+            if durable_ids
+            else type(exc).__name__
+        )
 
     if not records:
+        if durable_ids:
+            return attribution_unreadable("jsonl_absence_with_durable_claims")
         # 🔴 A readable, genuinely empty journal. Distinct from unreadable: it
         # means this lane has authored nothing, so *every* holding is legacy —
         # which is exactly right on a coexisting KR-B1 account.

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -232,6 +232,14 @@ DAY_ORDER_RETAINED_NOTE: Final[str] = (
 )
 
 REALIZED_PNL_UNAVAILABLE_REASON: Final[str] = "realized_pnl_unavailable"
+COORDINATION_GRANT_UNAVAILABLE_REASON: Final[str] = "coordination_grant_unavailable"
+_LIFECYCLE_BLOCK_REASONS: Final[frozenset[str]] = frozenset(
+    {
+        REALIZED_PNL_UNAVAILABLE_REASON,
+        COORDINATION_GRANT_UNAVAILABLE_REASON,
+        "unknown_pending_reconcile",
+    }
+)
 
 KR_ATTRIBUTED_NAV_BASIS: Final[str] = (
     "nav = cash + 자기 귀속 평가금액(지분 비례). legacy 평가금액은 제외 — §4 "
@@ -431,6 +439,9 @@ def _finish_zero_order(
     record["planned"] = []
     record["blocked"] = []
     record["submitted"] = []
+    if reason in _LIFECYCLE_BLOCK_REASONS:
+        record["lane_lifecycle_status"] = ordering_support.KIWOOM_LIFECYCLE_STATUS
+        record["realized_pnl_numeric_substitute"] = None
     outcome.zero_order_reason = reason
     return _persist_outcome(
         outcome=outcome, ledger=ledger, record=record, labels=labels
@@ -1234,6 +1245,7 @@ async def _submit_same_cycle_buy_batch(  # noqa: PLR0913
     halted: set[str],
     journal: kiwoom_attr.OwnOrderJournal,
     lease: ordering_support.WriterLease,
+    coordination: ordering_support.KiwoomCoordinationAdapter | None,
     fidelity: ordering_support.OrderingEventJournal,
     record: dict[str, Any],
     day_orders: list[dict[str, Any]],
@@ -1287,6 +1299,13 @@ async def _submit_same_cycle_buy_batch(  # noqa: PLR0913
     if not boundary.clean:
         reason = "mutation_boundary_not_clean"
         detail = boundary.blocking_reason or "unknown_boundary_failure"
+        _mark_buy_batch_failure(
+            batch=batch, record=record, reason=reason, detail=detail
+        )
+        return reason, detail, False
+    if coordination is None:
+        reason = COORDINATION_GRANT_UNAVAILABLE_REASON
+        detail = ordering_support.LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND
         _mark_buy_batch_failure(
             batch=batch, record=record, reason=reason, detail=detail
         )
@@ -1350,11 +1369,13 @@ async def _submit_same_cycle_buy_batch(  # noqa: PLR0913
                 )
                 return reason, detail, False
         try:
-            day_order = await kiwoom_lane.submit_day_order_in_batch(
+            authorization.claim(order)
+            coordinated = await coordination.submit_planned(
                 account,
                 planned=order,
-                authorization=authorization,
                 record_order_no=_journal_writer(journal),
+                policy_version=coordination.policy_binding.policy_version,
+                policy_version_hash=coordination.policy_binding.policy_version_hash,
                 now=dt.datetime.now(dt.UTC),
             )
         except Exception as exc:  # noqa: BLE001 — every batch failure is material
@@ -1366,9 +1387,19 @@ async def _submit_same_cycle_buy_batch(  # noqa: PLR0913
             )
             return reason, detail, True
 
-        assert day_order.order_no is not None
+        order_no = coordinated.evidence.broker_order_id
+        assert order_no is not None
         batch["accepted_order_keys"].append(order.order_key)
-        batch["accepted_order_nos"].append(day_order.order_no)
+        batch["accepted_order_nos"].append(order_no)
+        day_order = kiwoom_lane.DayOrderResult(
+            correlation_id=order.client_order_id,
+            symbol=order.symbol,
+            side=order.side,
+            price=order.price,
+            quantity=order.quantity,
+            submitted=True,
+            order_no=order_no,
+        )
         lifecycle_failure = await _record_day_order_lifecycle(
             account=account,
             order=order,
@@ -1404,6 +1435,7 @@ async def _cancel_own_pending_on_kill(  # noqa: PLR0915 — linear safety sequen
     journal: kiwoom_attr.OwnOrderJournal,
     fidelity: ordering_support.OrderingEventJournal,
     lease: ordering_support.WriterLease,
+    coordination: ordering_support.KiwoomCoordinationAdapter | None,
     now: dt.datetime,
     outcome: KiwoomCycleOutcome,
     ledger: ObservationLedger,
@@ -1430,6 +1462,16 @@ async def _cancel_own_pending_on_kill(  # noqa: PLR0915 — linear safety sequen
             labels=labels,
             reason="kill_cancel_boundary_not_clean",
             detail=initial.blocking_reason or "unknown_boundary_failure",
+        )
+    if coordination is None:
+        outcome.exit_code = 2
+        return _finish_ordering_stopped(
+            outcome=outcome,
+            ledger=ledger,
+            record=record,
+            labels=labels,
+            reason=COORDINATION_GRANT_UNAVAILABLE_REASON,
+            detail=ordering_support.LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND,
         )
     assert isinstance(initial.pending, kiwoom_lane.BrokerPending)
     record["kill_cancellation"] = {
@@ -1491,12 +1533,40 @@ async def _cancel_own_pending_on_kill(  # noqa: PLR0915 — linear safety sequen
             "remaining_quantity": current.remaining_quantity,
             "cancel_attempted": True,
         }
-        try:
-            response = await account.cancel(
-                original_order_no=current.order_id,
-                symbol=current.symbol,
-                cancel_quantity=current.remaining_quantity,
+        if current.remaining_quantity is None:
+            outcome.exit_code = 2
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason="kill_cancel_remainder_unknown",
+                detail=f"order_no={current.order_id}",
             )
+        try:
+            planned = kiwoom_lane.PlannedOrder(
+                cycle_id=str(record.get("cycle_id") or "kill-cancel"),
+                order_key=f"cancel:{current.order_id}",
+                client_order_id=source.correlation_id,
+                symbol=current.symbol,
+                side=source.side,
+                leg="cancel",
+                price=source.price,
+                quantity=int(current.remaining_quantity),
+                notional=Decimal(source.price * int(current.remaining_quantity)),
+            )
+            coordinated = await coordination.cancel_attributed(
+                account,
+                planned=planned,
+                native_order_id=current.order_id,
+                known_remainder=Decimal(int(current.remaining_quantity)),
+                policy_version=coordination.policy_binding.policy_version,
+                policy_version_hash=coordination.policy_binding.policy_version_hash,
+            )
+            response = {
+                "return_code": 0,
+                "ord_no": coordinated.evidence.broker_order_id,
+            }
         except Exception as exc:  # noqa: BLE001 — response failure is not cancellation
             attempt["cancel_response"] = {"error_type": type(exc).__name__}
             record["kill_cancellation"]["attempts"].append(attempt)
@@ -1623,6 +1693,7 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
     account: kiwoom_lane.ReadOnlyKiwoomMockAccount | None,
     journal: kiwoom_attr.OwnOrderJournal,
     lease: ordering_support.WriterLease,
+    coordination: ordering_support.KiwoomCoordinationAdapter | None,
     realized_pnl_reader: Callable[..., kiwoom_attr.RealizedPnlInput],
 ) -> KiwoomCycleOutcome:
     """Independent ORDERING mode; it cannot fall through to acceptance cancel."""
@@ -1777,6 +1848,7 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
             journal=journal,
             fidelity=fidelity,
             lease=lease,
+            coordination=coordination,
             now=now,
             outcome=outcome,
             ledger=ledger,
@@ -1820,6 +1892,7 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
                 halted=halted,
                 journal=journal,
                 lease=lease,
+                coordination=coordination,
                 fidelity=fidelity,
                 record=record,
                 day_orders=day_orders,
@@ -1931,13 +2004,38 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
             position_symbols=sell_scope.cap_position_symbols,
             pending=boundary.pending,
         )
+        if coordination is None:
+            return _finish_ordering_stopped(
+                outcome=outcome,
+                ledger=ledger,
+                record=record,
+                labels=labels,
+                reason=COORDINATION_GRANT_UNAVAILABLE_REASON,
+                detail=ordering_support.LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND,
+            )
         try:
-            day_order = await kiwoom_lane.submit_day_order(
+            kiwoom_lane.assert_resubmit_allowed(
+                current_truth, symbol=order.symbol, lane=LANE
+            )
+            coordinated = await coordination.submit_planned(
                 account,
                 planned=order,
-                broker_truth=current_truth,
                 record_order_no=_journal_writer(journal),
+                policy_version=coordination.policy_binding.policy_version,
+                policy_version_hash=coordination.policy_binding.policy_version_hash,
                 now=dt.datetime.now(dt.UTC),
+            )
+            order_no = coordinated.evidence.broker_order_id
+            if order_no is None:
+                raise RuntimeError("coordinated submit returned no broker_order_id")
+            day_order = kiwoom_lane.DayOrderResult(
+                correlation_id=order.client_order_id,
+                symbol=order.symbol,
+                side=order.side,
+                price=order.price,
+                quantity=order.quantity,
+                submitted=True,
+                order_no=order_no,
             )
         except OwnPendingResubmitBlocked as exc:
             record.setdefault("submission_dedup_blocked", []).append(
@@ -2061,6 +2159,9 @@ async def run_kiwoom_cycle(
     journal: kiwoom_attr.OwnOrderJournal | None = None,
     lease_factory: Callable[[Path, str, str], ordering_support.WriterLease]
     | None = None,
+    coordination_factory: (
+        Callable[[], ordering_support.KiwoomCoordinationAdapter] | None
+    ) = None,
     realized_pnl_reader: Callable[..., kiwoom_attr.RealizedPnlInput] | None = None,
 ) -> KiwoomCycleOutcome:
     """One manual kiwoom_mock B0-X cycle.
@@ -2224,6 +2325,15 @@ async def run_kiwoom_cycle(
                 reason="writer_lease_unavailable",
                 detail=type(exc).__name__,
             )
+        coordination = None if coordination_factory is None else coordination_factory()
+        record["coordination"] = {
+            "present": coordination is not None,
+            "recovery_owner": (
+                None if coordination is None else coordination.recovery_owner
+            ),
+            "authorizes_send": coordination is not None,
+            "local_flock_authorizes_send": False,
+        }
         try:
             return await _run_ordering_cycle(
                 now=now,
@@ -2236,6 +2346,7 @@ async def run_kiwoom_cycle(
                 account=account,
                 journal=lane_journal,
                 lease=lease,
+                coordination=coordination,
                 realized_pnl_reader=(
                     kiwoom_attr.realized_pnl_input_today
                     if realized_pnl_reader is None

--- a/scripts/b0x/kr/kiwoom_cycle.py
+++ b/scripts/b0x/kr/kiwoom_cycle.py
@@ -1370,7 +1370,7 @@ async def _submit_same_cycle_buy_batch(  # noqa: PLR0913
                 return reason, detail, False
         try:
             authorization.claim(order)
-            coordinated = await coordination.submit_planned(
+            coordinated = await coordination.submit_coordinated(
                 account,
                 planned=order,
                 record_order_no=_journal_writer(journal),
@@ -2017,7 +2017,7 @@ async def _run_ordering_cycle(  # noqa: PLR0915 — explicit safety sequence
             kiwoom_lane.assert_resubmit_allowed(
                 current_truth, symbol=order.symbol, lane=LANE
             )
-            coordinated = await coordination.submit_planned(
+            coordinated = await coordination.submit_coordinated(
                 account,
                 planned=order,
                 record_order_no=_journal_writer(journal),

--- a/scripts/b0x/kr/kiwoom_ordering.py
+++ b/scripts/b0x/kr/kiwoom_ordering.py
@@ -235,6 +235,17 @@ PROXIMITY_ATTRIBUTION_REJECTED: Final[str] = "proximity_attribution_rejected"
 KT00009_CANNOT_REPLACE_KT00007: Final[str] = "kt00009_cannot_replace_kt00007"
 JSONL_ABSENCE_NOT_EMPTY_OWNERSHIP: Final[str] = "jsonl_absence_not_empty_ownership"
 TRANSPORT_GATE_REJECTED: Final[str] = "transport_gate_rejected"
+LANE_EVIDENCE_KINDS: Final[frozenset[str]] = frozenset(
+    {
+        "ack",
+        "unknown",
+        "reject",
+        "expiry",
+        "partial_fill",
+        "cancel",
+        "terminal_reconciliation",
+    }
+)
 
 KIWOOM_RECOVERY_OWNER: Final[str] = (
     "scripts.b0x.kr.kiwoom_ordering.KiwoomCoordinationAdapter"
@@ -676,9 +687,63 @@ class KiwoomCoordinationAdapter:
         return binding
 
     def record_lane_evidence(self, kind: str, **payload: Any) -> dict[str, Any]:
+        if kind not in LANE_EVIDENCE_KINDS:
+            raise ValueError(f"unknown lane evidence kind: {kind}")
         record = {"kind": kind, "at": datetime.now(UTC).isoformat(), **payload}
         self.ordered_events.append(f"lane_evidence:{kind}")
         return record
+
+    def record_native_broker_truth(self, native: NativeBrokerRow) -> dict[str, Any]:
+        """Persist the kt00007-derived lane-native kind for this exact order."""
+
+        if native.normalized_state == "rejected":
+            return self.record_lane_evidence(
+                "reject",
+                broker_order_id=native.broker_order_id,
+                raw_row=dict(native.raw_row),
+            )
+        if native.normalized_state == "expired":
+            return self.record_lane_evidence(
+                "expiry",
+                broker_order_id=native.broker_order_id,
+                raw_row=dict(native.raw_row),
+            )
+        if native.normalized_state == "partial":
+            return self.record_lane_evidence(
+                "partial_fill",
+                broker_order_id=native.broker_order_id,
+                filled_quantity=native.filled_quantity,
+                remaining_quantity=native.remaining_quantity,
+                raw_row=dict(native.raw_row),
+            )
+        if native.normalized_state == "unknown":
+            return self.record_lane_evidence(
+                "unknown",
+                broker_order_id=native.broker_order_id,
+                raw_row=dict(native.raw_row),
+            )
+        return {}
+
+    def apply_restart_disposition(self, **kwargs: Any) -> RestartDisposition:
+        disposition = restart_disposition(**kwargs)
+        if disposition.native is not None:
+            self.record_native_broker_truth(disposition.native)
+        elif disposition.status == UNKNOWN_PENDING_RECONCILE:
+            self.record_lane_evidence("unknown", reason=disposition.reason)
+        return disposition
+
+    async def release_if_matches_terminal(
+        self, claim: Any, evidence: TerminalClaimEvidence
+    ) -> int:
+        released = await self.ports.claims.release_with_terminal_evidence(
+            claim, evidence
+        )
+        self.record_lane_evidence(
+            "terminal_reconciliation",
+            released=released,
+            claim_row_id=getattr(claim, "row_id", None),
+        )
+        return released
 
     async def reassert_before_mutation(
         self, scope: CoordinationScope, *, action: str
@@ -734,6 +799,7 @@ class KiwoomCoordinationAdapter:
             )
             order_no = str(payload.get("ord_no") or payload.get("order_no") or "")
             if not order_no.strip():
+                self.record_lane_evidence("unknown", reason="blank_ord_no")
                 return MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN)
             self.record_lane_evidence("ack", broker_order_id=order_no)
             return MutationCallbackResult(
@@ -760,9 +826,6 @@ class KiwoomCoordinationAdapter:
                 {"order_no": broker_order_id, "order_key": planned.order_key}
             )
             self.ordered_events.append("jsonl_appended")
-            self.record_lane_evidence(
-                "fidelity_journal", broker_order_id=broker_order_id
-            )
         return result
 
     async def cancel_attributed(
@@ -890,6 +953,7 @@ __all__ = [
     "JSONL_ABSENCE_NOT_EMPTY_OWNERSHIP",
     "KIWOOM_CANONICAL_LANE_ID",
     "KIWOOM_LIFECYCLE_STATUS",
+    "LANE_EVIDENCE_KINDS",
     "KIWOOM_READBACK_OPERATION",
     "KIWOOM_RECOVERY_OWNER",
     "KIWOOM_RELEASE_IF_MATCHES",

--- a/scripts/b0x/kr/kiwoom_ordering.py
+++ b/scripts/b0x/kr/kiwoom_ordering.py
@@ -751,7 +751,7 @@ class KiwoomCoordinationAdapter:
         await scope.assert_owned()
         self.fence_rechecks.append(action)
 
-    async def submit_planned(
+    async def submit_coordinated(
         self,
         account: Any,
         *,

--- a/scripts/b0x/kr/kiwoom_ordering.py
+++ b/scripts/b0x/kr/kiwoom_ordering.py
@@ -1,17 +1,10 @@
-"""Kiwoom B0-X ORDERING-only local writer lease and fidelity journal.
+"""Kiwoom B0-X ORDERING lease (diagnostic flock) + J3A coordination adapter.
 
-This module intentionally does not know how to call a broker.  It supplies two
-small, auditable primitives to :mod:`scripts.b0x.kr.kiwoom_cycle`:
-
-* an account-keyed, non-blocking local writer lease, checked again immediately
-  before every mutation; and
-* an append-only lifecycle event journal.  A cycle record is a useful summary,
-  but it must not be the only place where an acknowledgement, fill readback, or
-  cancellation reconciliation can be observed.
-
-The lease is host-local ``flock`` authority.  The accompanying broker foreign
-trace is still mandatory at every mutation boundary; neither mechanism is
-presented as a substitute for the other.
+This module intentionally does not reimplement J3A PostgreSQL advisory SQL, key
+math, reservation, cancellation shielding, or reason enums.  Those live in
+:mod:`app.services.mock_integration.coordination` and are imported by exact
+symbol.  The host-local ``flock`` remains a diagnostic writer marker and
+**cannot authorize a send**.
 """
 
 from __future__ import annotations
@@ -21,9 +14,46 @@ import hashlib
 import json
 import os
 import uuid
-from dataclasses import dataclass
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Final, Protocol
+
+from app.schemas.execution_contracts import LaneStatus
+from app.services.brokers.client_order_ids import BrokerClientIdTarget
+from app.services.brokers.kiwoom import constants as kiwoom_constants
+from app.services.brokers.kiwoom.client import KiwoomMockClient
+from app.services.mock_integration.coordination import (
+    AccountUncertaintyGatePort,
+    ClaimFollowupRequest,
+    CoordinatedMutationResult,
+    CoordinationReasonCode,
+    CoordinationScope,
+    DispatchEvidence,
+    DispatchEvidencePort,
+    DurableSendClaimAdapter,
+    MutationCallbackResult,
+    MutationCertainty,
+    TerminalClaimEvidence,
+    coordinate_mock_order_mutation,
+    describe_claim_followup,
+)
+from app.services.mock_integration.lineage import (
+    DecisionIntentDraft,
+    ExecutionPlanDraft,
+    LineageEnvelope,
+    LineagePersistencePort,
+    MockLineageFactory,
+    OrderAttemptDraft,
+)
+from app.services.mock_lane_registry import (
+    LaneGuardError,
+    LaneRegistryEntry,
+    RegistrySource,
+)
+from app.services.order_send_intent_service import DuplicateOrderIntent
 
 ORDERING_EVENT_JOURNAL_NAME: Final[str] = "ordering-events.jsonl"
 
@@ -133,6 +163,7 @@ class AccountWriterLease:
         return {
             "acquired": self.acquired,
             "authority": "host_local_fcntl_account_keyed",
+            "authorizes_send": False,
             "lock_path": str(self.lock_path),
             "account_fingerprint": self.account_fingerprint,
             "checked_before_each_mutation": True,
@@ -187,12 +218,717 @@ class OrderingEventJournal:
         return tuple(events)
 
 
+# ---------------------------------------------------------------------------
+# ROB-1264 — thin Kiwoom adapter around merged J3A / J2A / J2B public ports
+# ---------------------------------------------------------------------------
+
+KIWOOM_CANONICAL_LANE_ID: Final[str] = "kr.kiwoom.mock"
+KIWOOM_LIFECYCLE_STATUS: Final[str] = LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE.value
+UNKNOWN_PENDING_RECONCILE: Final[str] = "unknown_pending_reconcile"
+CALLER_DERIVED_IDENTITY_REJECTED: Final[str] = "caller_derived_identity_rejected"
+ROOT_PATH_IDENTITY_REJECTED: Final[str] = "root_path_identity_rejected"
+ACCOUNT_SUMMARY_FINGERPRINT_IDENTITY_REJECTED: Final[str] = (
+    "account_summary_fingerprint_identity_rejected"
+)
+LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND: Final[str] = "local_flock_cannot_authorize_send"
+PROXIMITY_ATTRIBUTION_REJECTED: Final[str] = "proximity_attribution_rejected"
+KT00009_CANNOT_REPLACE_KT00007: Final[str] = "kt00009_cannot_replace_kt00007"
+JSONL_ABSENCE_NOT_EMPTY_OWNERSHIP: Final[str] = "jsonl_absence_not_empty_ownership"
+TRANSPORT_GATE_REJECTED: Final[str] = "transport_gate_rejected"
+
+KIWOOM_RECOVERY_OWNER: Final[str] = (
+    "scripts.b0x.kr.kiwoom_ordering.KiwoomCoordinationAdapter"
+)
+KIWOOM_RESTART_TRIGGER: Final[str] = (
+    "process_restart_rediscovers_durable_j2b_claims_for_physical_account"
+)
+KIWOOM_READBACK_OPERATION: Final[str] = "kt00007"
+KIWOOM_RELEASE_IF_MATCHES: Final[str] = (
+    "DurableSendClaimAdapter.release_with_terminal_evidence("
+    "TerminalClaimEvidence(lane_native_terminal_evidence=True, "
+    "account_position_reconciled=True, remainder_known=True) "
+    "or authoritative_absence_proven=True after pre-send NOT_CREATED)"
+)
+
+_KIWOOM_ALLOWED_HOST: Final[str] = "mockapi.kiwoom.com"
+
+
+class KiwoomIdentityRejected(RuntimeError):
+    """A caller-derived identity was offered in place of J2A physical_account_id."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+class KiwoomTransportGateRejected(RuntimeError):
+    """A send was refused before transport because a K-5 check failed."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+class KiwoomAttributionRejected(RuntimeError):
+    """A heuristic or non-kt00007 source was offered as ownership/fill truth."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+class KiwoomSendNotAuthorized(RuntimeError):
+    """No J3A grant is present; a diagnostic flock cannot authorize transport."""
+
+    def __init__(self, reason: str = LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def require_j2a_physical_account_id(
+    entry: LaneRegistryEntry,
+    *,
+    caller_physical_account_id: str | None = None,
+    root_path: str | Path | None = None,
+    account_summary_fingerprint: str | None = None,
+) -> str:
+    """Return the canonical J2A identity. Caller/root/summary mutants are rejected."""
+
+    if caller_physical_account_id is not None:
+        raise KiwoomIdentityRejected(CALLER_DERIVED_IDENTITY_REJECTED)
+    if root_path is not None:
+        raise KiwoomIdentityRejected(ROOT_PATH_IDENTITY_REJECTED)
+    if account_summary_fingerprint is not None:
+        # Diagnostic fingerprints may be *recorded*, never used as the identity
+        # argument. Passing one here is the mutant this function exists to kill.
+        raise KiwoomIdentityRejected(ACCOUNT_SUMMARY_FINGERPRINT_IDENTITY_REJECTED)
+    physical_account_id = entry.physical_account_id
+    if (
+        not isinstance(physical_account_id, str)
+        or not physical_account_id.strip()
+        or entry.identity_status == "UNKNOWN"
+    ):
+        raise LaneGuardError("physical_account_identity_unknown", lane_id=entry.lane_id)
+    return physical_account_id
+
+
+def actual_kiwoom_client(account: object) -> object | None:
+    """The object that would actually speak HTTP, if the account wraps one."""
+
+    return getattr(account, "_client", None)
+
+
+def assert_kiwoom_transport_ready(
+    *,
+    account: object,
+    entry: LaneRegistryEntry,
+    physical_account_id: str,
+    grant_owned: bool,
+    diagnostic_fingerprint: str | None = None,
+) -> None:
+    """K-5: refuse transport unless every actual-client check holds."""
+
+    if grant_owned is not True:
+        raise KiwoomTransportGateRejected(LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND)
+    client = actual_kiwoom_client(account)
+    if type(client) is not KiwoomMockClient:
+        raise KiwoomTransportGateRejected(TRANSPORT_GATE_REJECTED)
+    if getattr(client, "_base_url", None) != kiwoom_constants.MOCK_BASE_URL:
+        raise KiwoomTransportGateRejected(TRANSPORT_GATE_REJECTED)
+    if entry.lane_id != KIWOOM_CANONICAL_LANE_ID:
+        raise KiwoomTransportGateRejected(TRANSPORT_GATE_REJECTED)
+    if entry.account_profile != "mock" or entry.account_mode.value != "mock":
+        raise KiwoomTransportGateRejected(TRANSPORT_GATE_REJECTED)
+    if _KIWOOM_ALLOWED_HOST not in entry.allowed_hosts:
+        raise KiwoomTransportGateRejected(TRANSPORT_GATE_REJECTED)
+    if entry.physical_account_id != physical_account_id:
+        raise KiwoomTransportGateRejected(TRANSPORT_GATE_REJECTED)
+    if (
+        diagnostic_fingerprint is not None
+        and entry.fingerprint_evidence_ref is not None
+        and diagnostic_fingerprint != entry.fingerprint_evidence_ref
+    ):
+        raise KiwoomTransportGateRejected(TRANSPORT_GATE_REJECTED)
+
+
+def assert_broker_client_id_contract(envelope: LineageEnvelope) -> None:
+    """Kiwoom CID pair is both None; J2B internal idempotency is non-blank."""
+
+    attempt = envelope.order_attempt
+    if attempt is None:
+        raise KiwoomSendNotAuthorized("order_attempt_missing")
+    if envelope.broker_client_id_target is not None:
+        raise KiwoomSendNotAuthorized("broker_client_id_target_must_be_none")
+    if attempt.broker_client_order_id is not None:
+        raise KiwoomSendNotAuthorized("broker_client_order_id_must_be_none")
+    if type(attempt.idempotency_key) is not str or not attempt.idempotency_key.strip():
+        raise KiwoomSendNotAuthorized("internal_idempotency_required")
+    if set(BrokerClientIdTarget) != {
+        BrokerClientIdTarget.TOSS,
+        BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+        BrokerClientIdTarget.ALPACA_PAPER,
+    }:
+        raise KiwoomSendNotAuthorized("broker_client_id_target_enum_changed")
+
+
+def normalize_kt00007_state(status: str) -> str:
+    lowered = status.strip().lower()
+    mapping = {
+        "open": "open",
+        "accepted": "open",
+        "new": "open",
+        "partial": "partial",
+        "partially_filled": "partial",
+        "filled": "filled",
+        "complete": "filled",
+        "cancelled": "cancelled",
+        "canceled": "cancelled",
+        "rejected": "rejected",
+        "expired": "expired",
+    }
+    return mapping.get(lowered, "unknown")
+
+
+@dataclass(frozen=True, slots=True)
+class NativeBrokerRow:
+    """Exact kt00007 row keyed by a known native broker_order_id."""
+
+    broker_order_id: str
+    normalized_state: str
+    filled_quantity: int | None
+    remaining_quantity: int | None
+    raw_row: Mapping[str, Any]
+
+
+def native_row_from_kt00007(
+    rows: Sequence[Mapping[str, Any]], *, broker_order_id: str
+) -> NativeBrokerRow | None:
+    """Return the exact native row, or None. Never invents from proximity."""
+
+    if type(broker_order_id) is not str or not broker_order_id.strip():
+        raise KiwoomAttributionRejected(PROXIMITY_ATTRIBUTION_REJECTED)
+    matches = [
+        row for row in rows if str(row.get("order_id") or "").strip() == broker_order_id
+    ]
+    if len(matches) != 1:
+        return None
+    row = matches[0]
+    remaining = row.get("remaining_quantity")
+    filled = row.get("filled_quantity")
+    return NativeBrokerRow(
+        broker_order_id=broker_order_id,
+        normalized_state=normalize_kt00007_state(str(row.get("status") or "")),
+        filled_quantity=None if filled is None else int(filled),
+        remaining_quantity=None if remaining is None else int(remaining),
+        raw_row=dict(row),
+    )
+
+
+def reject_proximity_attribution() -> None:
+    raise KiwoomAttributionRejected(PROXIMITY_ATTRIBUTION_REJECTED)
+
+
+def reject_kt00009_as_truth() -> None:
+    raise KiwoomAttributionRejected(KT00009_CANNOT_REPLACE_KT00007)
+
+
+def reject_jsonl_as_empty_ownership() -> None:
+    raise KiwoomAttributionRejected(JSONL_ABSENCE_NOT_EMPTY_OWNERSHIP)
+
+
+@dataclass(frozen=True, slots=True)
+class RestartDisposition:
+    status: str
+    block_physical_account: bool
+    allow_repost: bool
+    native: NativeBrokerRow | None
+    reason: str
+
+
+def restart_disposition(
+    *,
+    durable_broker_order_id: str | None,
+    kt00007_readable: bool,
+    kt00007_rows: Sequence[Mapping[str, Any]] = (),
+    pre_send_not_created: bool = False,
+    jsonl_missing: bool = False,
+    jsonl_corrupt: bool = False,
+) -> RestartDisposition:
+    """Restart rules from artifact K-3 / K-4. JSONL never authorizes release."""
+
+    if pre_send_not_created and durable_broker_order_id is None:
+        return RestartDisposition(
+            status="not_created",
+            block_physical_account=False,
+            allow_repost=False,
+            native=None,
+            reason="authoritative_pre_send_not_created",
+        )
+    if jsonl_missing or jsonl_corrupt:
+        if durable_broker_order_id is None:
+            reject_jsonl_as_empty_ownership()
+    if durable_broker_order_id is None:
+        return RestartDisposition(
+            status=UNKNOWN_PENDING_RECONCILE,
+            block_physical_account=True,
+            allow_repost=False,
+            native=None,
+            reason="unresolved_pre_send_claim_without_durable_broker_order_id",
+        )
+    if not kt00007_readable:
+        return RestartDisposition(
+            status=UNKNOWN_PENDING_RECONCILE,
+            block_physical_account=True,
+            allow_repost=False,
+            native=None,
+            reason="kt00007_read_unavailable",
+        )
+    native = native_row_from_kt00007(
+        kt00007_rows, broker_order_id=durable_broker_order_id
+    )
+    if native is None:
+        return RestartDisposition(
+            status=UNKNOWN_PENDING_RECONCILE,
+            block_physical_account=True,
+            allow_repost=False,
+            native=None,
+            reason="exact_native_row_absent",
+        )
+    return RestartDisposition(
+        status="recovered_from_j2b_and_kt00007",
+        block_physical_account=False,
+        allow_repost=False,
+        native=native,
+        reason="exact_broker_order_id_and_kt00007",
+    )
+
+
+def wall_clock_cannot_release() -> TerminalClaimEvidence:
+    """A default evidence instance authorizes nothing — including DAY expiry."""
+
+    return TerminalClaimEvidence()
+
+
+def followup_precheck(
+    *,
+    operation: str,
+    native_order_id: str | None,
+    known_remainder: Decimal | None,
+    fresh_guards_passed: bool,
+) -> bool:
+    """True only when cancel/reduce preconditions other than the live grant hold."""
+
+    capability = describe_claim_followup(
+        ClaimFollowupRequest(
+            operation=operation,
+            lane_capability_supports_operation=True,
+            attributed_native_order_id=native_order_id,
+            known_remainder=known_remainder,
+            fresh_guards_passed=fresh_guards_passed,
+            lease_ownership_verified=True,
+        )
+    )
+    return capability.capability_present
+
+
+@dataclass
+class InMemoryLineagePersistence:
+    """Lane-owned lineage store for offline tests and the adapter's own memory."""
+
+    envelopes: list[LineageEnvelope] = field(default_factory=list)
+    events: list[str] = field(default_factory=list)
+
+    async def persist(self, envelope: LineageEnvelope, /) -> None:
+        self.envelopes.append(envelope)
+        attempt = envelope.order_attempt
+        if attempt is not None and attempt.broker_order_id is not None:
+            self.events.append("j2b_ack_persisted")
+        else:
+            self.events.append("j2b_attempt_persisted")
+
+
+@dataclass
+class InMemoryDispatchEvidence:
+    records: list[DispatchEvidence] = field(default_factory=list)
+    events: list[str] = field(default_factory=list)
+
+    async def persist_dispatch_evidence(self, evidence: DispatchEvidence, /) -> None:
+        self.records.append(evidence)
+        self.events.append(f"dispatch_{evidence.kind.value}")
+
+
+@dataclass
+class InMemoryUncertaintyGate:
+    """Account-wide unresolved-outcome gate. Uncorrelated claims block the account."""
+
+    unresolved_scopes: set[str] = field(default_factory=set)
+    events: list[str] = field(default_factory=list)
+
+    async def has_unresolved_account_uncertainty(
+        self, *, claim_account_scope: str
+    ) -> bool:
+        self.events.append(f"uncertainty:{claim_account_scope}")
+        return claim_account_scope in self.unresolved_scopes
+
+    def mark_unresolved(self, claim_account_scope: str) -> None:
+        self.unresolved_scopes.add(claim_account_scope)
+
+    def clear(self, claim_account_scope: str) -> None:
+        self.unresolved_scopes.discard(claim_account_scope)
+
+
+@dataclass
+class InMemoryReservationPort:
+    rows: dict[int, dict[str, Any]] = field(default_factory=dict)
+    _next_id: int = 1
+
+    async def reserve(
+        self,
+        *,
+        account_scope: str,
+        idempotency_key: str,
+        symbol: str | None = None,
+        side: str | None = None,
+        conflicting_key_sides: tuple[tuple[str, str], ...] = (),
+    ) -> int:
+        del conflicting_key_sides
+        for row in self.rows.values():
+            if (
+                row["account_scope"] == account_scope
+                and row["idempotency_key"] == idempotency_key
+            ):
+                raise DuplicateOrderIntent("duplicate reservation")
+        row_id = self._next_id
+        self._next_id += 1
+        self.rows[row_id] = {
+            "account_scope": account_scope,
+            "idempotency_key": idempotency_key,
+            "symbol": symbol,
+            "side": side,
+        }
+        return row_id
+
+    async def list_reservations(self, *, account_scope: str) -> Sequence[Any]:
+        return [
+            row for row in self.rows.values() if row["account_scope"] == account_scope
+        ]
+
+    async def release_if_matches(
+        self,
+        *,
+        account_scope: str,
+        row_id: int,
+        idempotency_key: str,
+        side: str | None,
+    ) -> int:
+        row = self.rows.get(row_id)
+        if (
+            row is None
+            or row["account_scope"] != account_scope
+            or row["idempotency_key"] != idempotency_key
+            or row["side"] != side
+        ):
+            return 0
+        del self.rows[row_id]
+        return 1
+
+
+@dataclass
+class KiwoomCoordinationPorts:
+    persistence: LineagePersistencePort
+    dispatch_evidence: DispatchEvidencePort
+    uncertainty_gate: AccountUncertaintyGatePort
+    claims: DurableSendClaimAdapter
+    connection_factory: Callable[[], Awaitable[Any]]
+    registry: RegistrySource
+    lineage_factory: MockLineageFactory
+    entry: LaneRegistryEntry
+    diagnostic_fingerprint: str | None = None
+
+
+class KiwoomCoordinationAdapter:
+    """Thin Kiwoom consumer of ``coordinate_mock_order_mutation``.
+
+    Recovery owner (exactly one): this adapter.  It does not copy J3A lock
+    SQL, key derivation, reservation, or reason enums.
+    """
+
+    recovery_owner: Final[str] = KIWOOM_RECOVERY_OWNER
+    restart_trigger: Final[str] = KIWOOM_RESTART_TRIGGER
+    readback_operation: Final[str] = KIWOOM_READBACK_OPERATION
+    release_if_matches_condition: Final[str] = KIWOOM_RELEASE_IF_MATCHES
+    blocked_state: Final[str] = KIWOOM_LIFECYCLE_STATUS
+
+    def __init__(self, ports: KiwoomCoordinationPorts) -> None:
+        self.ports = ports
+        self.physical_account_id = require_j2a_physical_account_id(ports.entry)
+        self.fence_rechecks: list[str] = []
+        self.transport_calls: list[str] = []
+        self.ordered_events: list[str] = []
+        self.jsonl_appends: list[dict[str, Any]] = []
+        self.last_result: CoordinatedMutationResult | None = None
+
+    @property
+    def policy_binding(self) -> Any:
+        binding = self.ports.entry.policy_binding
+        if binding is None:
+            raise KiwoomSendNotAuthorized("policy_binding_missing")
+        return binding
+
+    def record_lane_evidence(self, kind: str, **payload: Any) -> dict[str, Any]:
+        record = {"kind": kind, "at": datetime.now(UTC).isoformat(), **payload}
+        self.ordered_events.append(f"lane_evidence:{kind}")
+        return record
+
+    async def reassert_before_mutation(
+        self, scope: CoordinationScope, *, action: str
+    ) -> None:
+        await scope.assert_owned()
+        self.fence_rechecks.append(action)
+
+    async def submit_planned(
+        self,
+        account: Any,
+        *,
+        planned: Any,
+        record_order_no: Callable[..., None] | None = None,
+        policy_version: str,
+        policy_version_hash: str,
+        now: datetime,
+        mutation: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    ) -> CoordinatedMutationResult:
+        """One POST behind J3A. JSONL is appended only after J2B ACK persist."""
+
+        envelope = self._attempt_envelope(
+            planned,
+            policy_version=policy_version,
+            policy_version_hash=policy_version_hash,
+        )
+        assert_broker_client_id_contract(envelope)
+        self.ordered_events.append("j2b_attempt_built")
+
+        async def _callback(scope: CoordinationScope) -> MutationCallbackResult:
+            await self.reassert_before_mutation(
+                scope, action=f"post:{planned.order_key}"
+            )
+            assert_kiwoom_transport_ready(
+                account=account,
+                entry=self.ports.entry,
+                physical_account_id=self.physical_account_id,
+                grant_owned=True,
+                diagnostic_fingerprint=self.ports.diagnostic_fingerprint,
+            )
+            submit = mutation
+            if submit is None:
+                if planned.side == "buy":
+                    submit = account.place_limit_buy
+                elif planned.side == "sell":
+                    submit = account.place_limit_sell
+                else:
+                    raise ValueError(f"unsupported side: {planned.side}")
+            self.transport_calls.append(f"post:{planned.order_key}")
+            payload = await submit(
+                symbol=planned.symbol,
+                quantity=planned.quantity,
+                price=planned.price,
+            )
+            order_no = str(payload.get("ord_no") or payload.get("order_no") or "")
+            if not order_no.strip():
+                return MutationCallbackResult(certainty=MutationCertainty.UNCERTAIN)
+            self.record_lane_evidence("ack", broker_order_id=order_no)
+            return MutationCallbackResult(
+                certainty=MutationCertainty.DEFINITIVE, broker_order_id=order_no
+            )
+
+        result = await coordinate_mock_order_mutation(
+            envelope=envelope,
+            persistence=self.ports.persistence,
+            dispatch_evidence=self.ports.dispatch_evidence,
+            uncertainty_gate=self.ports.uncertainty_gate,
+            claims=self.ports.claims,
+            connection_factory=self.ports.connection_factory,
+            mutation=_callback,
+            registry=self.ports.registry,
+            lineage_factory=self.ports.lineage_factory,
+        )
+        self.last_result = result
+        self.ordered_events.append("j2b_ack_persisted")
+        broker_order_id = result.evidence.broker_order_id
+        if broker_order_id is not None and record_order_no is not None:
+            record_order_no(order_no=broker_order_id, planned=planned, at=now)
+            self.jsonl_appends.append(
+                {"order_no": broker_order_id, "order_key": planned.order_key}
+            )
+            self.ordered_events.append("jsonl_appended")
+            self.record_lane_evidence(
+                "fidelity_journal", broker_order_id=broker_order_id
+            )
+        return result
+
+    async def cancel_attributed(
+        self,
+        account: Any,
+        *,
+        planned: Any,
+        native_order_id: str,
+        known_remainder: Decimal,
+        policy_version: str,
+        policy_version_hash: str,
+        mutation: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    ) -> CoordinatedMutationResult:
+        if not followup_precheck(
+            operation="cancel",
+            native_order_id=native_order_id,
+            known_remainder=known_remainder,
+            fresh_guards_passed=True,
+        ):
+            raise KiwoomSendNotAuthorized(
+                CoordinationReasonCode.CLAIM_FOLLOWUP_NOT_AUTHORIZED.value
+            )
+        envelope = self._attempt_envelope(
+            planned,
+            policy_version=policy_version,
+            policy_version_hash=policy_version_hash,
+            cycle_suffix=":cancel",
+        )
+
+        async def _callback(scope: CoordinationScope) -> MutationCallbackResult:
+            await self.reassert_before_mutation(
+                scope, action=f"cancel:{native_order_id}"
+            )
+            assert_kiwoom_transport_ready(
+                account=account,
+                entry=self.ports.entry,
+                physical_account_id=self.physical_account_id,
+                grant_owned=True,
+                diagnostic_fingerprint=self.ports.diagnostic_fingerprint,
+            )
+            cancel = mutation or account.cancel
+            self.transport_calls.append(f"cancel:{native_order_id}")
+            payload = await cancel(
+                original_order_no=native_order_id,
+                symbol=planned.symbol,
+                cancel_quantity=int(known_remainder),
+            )
+            cancel_no = str(payload.get("ord_no") or native_order_id)
+            self.record_lane_evidence("cancel", broker_order_id=cancel_no)
+            return MutationCallbackResult(
+                certainty=MutationCertainty.DEFINITIVE, broker_order_id=cancel_no
+            )
+
+        result = await coordinate_mock_order_mutation(
+            envelope=envelope,
+            persistence=self.ports.persistence,
+            dispatch_evidence=self.ports.dispatch_evidence,
+            uncertainty_gate=self.ports.uncertainty_gate,
+            claims=self.ports.claims,
+            connection_factory=self.ports.connection_factory,
+            mutation=_callback,
+            registry=self.ports.registry,
+            lineage_factory=self.ports.lineage_factory,
+        )
+        self.last_result = result
+        return result
+
+    def _attempt_envelope(
+        self,
+        planned: Any,
+        *,
+        policy_version: str,
+        policy_version_hash: str,
+        cycle_suffix: str = "",
+    ) -> LineageEnvelope:
+        factory = self.ports.lineage_factory
+        decided_at = datetime.now(UTC)
+        intent = factory.create_decision_intent(
+            DecisionIntentDraft(
+                policy_version=policy_version,
+                policy_version_hash=policy_version_hash,
+                decision_timestamp=decided_at,
+                market_data_cutoff=decided_at - timedelta(seconds=1),
+                symbol=str(planned.symbol),
+                side=str(planned.side),
+                target_notional=Decimal(int(planned.price) * int(planned.quantity)),
+                target_notional_currency="KRW",
+                limit_policy={"order_type": "limit", "price": int(planned.price)},
+                expiry_policy={"kind": "day"},
+                rationale=f"kiwoom-j3c:{planned.order_key}",
+            )
+        )
+        plan_envelope = factory.create_plan_envelope(
+            intent,
+            ExecutionPlanDraft(
+                lane_id=KIWOOM_CANONICAL_LANE_ID,
+                broker="kiwoom",
+                account_profile="mock",
+                account_mode="mock",
+                normalized_symbol=str(planned.symbol),
+                quantity=Decimal(int(planned.quantity)),
+                limit_price=Decimal(int(planned.price)),
+                quote_currency="KRW",
+                tick_rounding={"mode": "down" if planned.side == "buy" else "up"},
+                session="regular",
+                time_in_force="day",
+                min_order_validation={"min_qty": "1"},
+                risk_caps={"max_notional": "10000000"},
+            ),
+        )
+        return factory.create_attempt_envelope(
+            plan_envelope,
+            OrderAttemptDraft(
+                cycle_id=f"{planned.cycle_id}{cycle_suffix}",
+                attempt_seq=1,
+                lane_prefix=None,
+                broker_client_id_target=None,
+            ),
+        )
+
+
 __all__ = [
+    "ACCOUNT_SUMMARY_FINGERPRINT_IDENTITY_REJECTED",
+    "CALLER_DERIVED_IDENTITY_REJECTED",
+    "JSONL_ABSENCE_NOT_EMPTY_OWNERSHIP",
+    "KIWOOM_CANONICAL_LANE_ID",
+    "KIWOOM_LIFECYCLE_STATUS",
+    "KIWOOM_READBACK_OPERATION",
+    "KIWOOM_RECOVERY_OWNER",
+    "KIWOOM_RELEASE_IF_MATCHES",
+    "KIWOOM_RESTART_TRIGGER",
+    "KT00009_CANNOT_REPLACE_KT00007",
+    "LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND",
     "ORDERING_EVENT_JOURNAL_NAME",
+    "PROXIMITY_ATTRIBUTION_REJECTED",
+    "ROOT_PATH_IDENTITY_REJECTED",
+    "TRANSPORT_GATE_REJECTED",
+    "UNKNOWN_PENDING_RECONCILE",
     "AccountWriterLease",
     "AccountWriterLeaseContended",
     "AccountWriterLeaseLost",
+    "InMemoryDispatchEvidence",
+    "InMemoryLineagePersistence",
+    "InMemoryReservationPort",
+    "InMemoryUncertaintyGate",
+    "KiwoomAttributionRejected",
+    "KiwoomCoordinationAdapter",
+    "KiwoomCoordinationPorts",
+    "KiwoomIdentityRejected",
+    "KiwoomSendNotAuthorized",
+    "KiwoomTransportGateRejected",
+    "NativeBrokerRow",
     "OrderingEventJournal",
     "OrderingJournalUnreadable",
+    "RestartDisposition",
     "WriterLease",
+    "actual_kiwoom_client",
+    "assert_broker_client_id_contract",
+    "assert_kiwoom_transport_ready",
+    "followup_precheck",
+    "native_row_from_kt00007",
+    "normalize_kt00007_state",
+    "reject_jsonl_as_empty_ownership",
+    "reject_kt00009_as_truth",
+    "reject_proximity_attribution",
+    "require_j2a_physical_account_id",
+    "restart_disposition",
+    "wall_clock_cannot_release",
 ]

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py
@@ -16,6 +16,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.services.brokers.kiwoom import constants as kiwoom_constants
+from app.services.brokers.kiwoom.client import KiwoomMockClient
 from scripts.b0x.kr import attribution as kr_attribution
 from scripts.b0x.kr import kiwoom as kiwoom_lane
 from scripts.b0x.kr import kiwoom_attribution as kiwoom_attr
@@ -24,6 +26,9 @@ from scripts.b0x.kr import kiwoom_ordering as ordering_support
 from scripts.policy_table.core.schema import compute_policy_table_hash
 from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
 from tests.scripts.b0x.kr.kiwoom.conftest import FakeAccount, position, resting
+from tests.services.mock_integration.test_kiwoom_coordination_adapter import (
+    offline_coordination_factory,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -123,6 +128,16 @@ def armed(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _attach_test_mock_client(account) -> None:  # noqa: ANN001
+    if getattr(account, "_client", None) is None:
+        account._client = KiwoomMockClient(
+            base_url=kiwoom_constants.MOCK_BASE_URL,
+            app_key="unit-test",
+            app_secret="unit-test",
+            account_no="unit-test",
+        )
+
+
 async def _run(
     *,
     account,
@@ -133,6 +148,11 @@ async def _run(
     now=IN_SESSION,  # noqa: ANN001
     **kwargs,
 ):  # noqa: ANN202
+    if ordering and "coordination_factory" not in kwargs:
+        kwargs["coordination_factory"] = offline_coordination_factory
+        _attach_test_mock_client(account)
+    elif kwargs.get("coordination_factory") is not None:
+        _attach_test_mock_client(account)
     return await kiwoom_cycle.run_kiwoom_cycle(
         now=now,
         table_dir=table_dir,
@@ -1140,6 +1160,32 @@ async def test_ordering_rechecks_foreign_trace_at_the_submit_boundary(
     )
     assert account.buy_calls == []
     assert account.sell_calls == []
+
+
+@pytest.mark.asyncio
+async def test_ordering_flock_without_j3a_grant_makes_zero_transport(
+    table_dir, out_dir, armed, frozen_cycle_clock
+) -> None:  # noqa: ANN001, ARG001
+    account = _DynamicOrderingAccount()
+    outcome = await _run(
+        account=account,
+        out_dir=out_dir,
+        table_dir=table_dir,
+        confirm=True,
+        ordering=True,
+        now=frozen_cycle_clock,
+        lease_factory=lambda *_: _TestOrderingLease(),
+        coordination_factory=None,
+    )
+
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+    assert account.cancel_calls == []
+    assert outcome.record["coordination"]["authorizes_send"] is False
+    assert outcome.record["coordination"]["local_flock_authorizes_send"] is False
+    assert outcome.record.get("lane_lifecycle_status") == (
+        ordering_support.KIWOOM_LIFECYCLE_STATUS
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/kr/kiwoom/test_kiwoom_ordering_support.py
+++ b/tests/scripts/b0x/kr/kiwoom/test_kiwoom_ordering_support.py
@@ -31,6 +31,7 @@ def test_account_writer_lease_is_account_keyed_and_nonblocking(tmp_path) -> None
             same_account.acquire()
         other_account.acquire()
         other_account.assert_held()
+        assert first.canonical()["authorizes_send"] is False
     finally:
         other_account.release()
         first.release()

--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -23,6 +23,7 @@ from app.services.brokers.kiwoom.client import KiwoomMockClient
 from app.services.mock_integration.coordination import (
     CoordinationError,
     CoordinationReasonCode,
+    CoordinationScope,
     DurableSendClaimAdapter,
     TerminalClaimEvidence,
     physical_account_scope_for_entry,
@@ -46,6 +47,7 @@ from scripts.b0x.kr.kiwoom_ordering import (
     KIWOOM_RELEASE_IF_MATCHES,
     KIWOOM_RESTART_TRIGGER,
     KT00009_CANNOT_REPLACE_KT00007,
+    LANE_EVIDENCE_KINDS,
     LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND,
     PROXIMITY_ATTRIBUTION_REJECTED,
     ROOT_PATH_IDENTITY_REJECTED,
@@ -168,11 +170,19 @@ class FakeLockSpace:
 
 
 class FakeLockConnection:
-    def __init__(self, space: FakeLockSpace, *, pid: int = 4242) -> None:
+    def __init__(
+        self,
+        space: FakeLockSpace,
+        *,
+        pid: int = 4242,
+        drop_after_pg_locks: int | None = None,
+    ) -> None:
         self._space = space
         self._pid = pid
         self._database_oid = 99001
         self.committed = False
+        self._drop_after_pg_locks = drop_after_pg_locks
+        self.pg_locks_seen = 0
 
     def can_prove_backend_session_termination(self) -> bool:
         return True
@@ -193,6 +203,12 @@ class FakeLockConnection:
                 [{"released": self._space.unlock(int(params["key"]), self._pid)}]
             )
         if "pg_locks" in sql:
+            self.pg_locks_seen += 1
+            if (
+                self._drop_after_pg_locks is not None
+                and self.pg_locks_seen > self._drop_after_pg_locks
+            ):
+                self._space.terminate(self._pid)
             return _FakeResult(self._space.rows(int(params["pid"]), self._database_oid))
         raise AssertionError(sql)
 
@@ -215,14 +231,25 @@ class FakeLockConnection:
 
 
 class ConnectionFactory:
-    def __init__(self, space: FakeLockSpace, *, pid: int = 4242) -> None:
+    def __init__(
+        self,
+        space: FakeLockSpace,
+        *,
+        pid: int = 4242,
+        drop_after_pg_locks: int | None = None,
+    ) -> None:
         self.space = space
         self.pid = pid
+        self.drop_after_pg_locks = drop_after_pg_locks
         self.calls = 0
+        self.last: FakeLockConnection | None = None
 
     async def __call__(self) -> FakeLockConnection:
         self.calls += 1
-        return FakeLockConnection(self.space, pid=self.pid)
+        self.last = FakeLockConnection(
+            self.space, pid=self.pid, drop_after_pg_locks=self.drop_after_pg_locks
+        )
+        return self.last
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +381,7 @@ def build_offline_adapter(
     pid: int = 4242,
     entry: LaneRegistryEntry | None = None,
     unresolved: bool = False,
+    drop_after_pg_locks: int | None = None,
 ) -> KiwoomCoordinationAdapter:
     bound = entry or bound_kiwoom_entry()
     lock_space = space or FakeLockSpace()
@@ -370,13 +398,29 @@ def build_offline_adapter(
         dispatch_evidence=dispatch,
         uncertainty_gate=gate,
         claims=DurableSendClaimAdapter(InMemoryReservationPort()),
-        connection_factory=ConnectionFactory(lock_space, pid=pid),
+        connection_factory=ConnectionFactory(
+            lock_space, pid=pid, drop_after_pg_locks=drop_after_pg_locks
+        ),
         registry=bound_registry(bound),
         lineage_factory=MockLineageFactory(),
         entry=bound,
         diagnostic_fingerprint=FINGERPRINT_REF,
     )
     return KiwoomCoordinationAdapter(ports)
+
+
+def _scope_assert_owned_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Count real CoordinationScope.assert_owned invocations, not a self-list."""
+
+    observed: list[str] = []
+    original = CoordinationScope.assert_owned
+
+    async def _spy(self: CoordinationScope) -> None:
+        observed.append("assert_owned")
+        await original(self)
+
+    monkeypatch.setattr(CoordinationScope, "assert_owned", _spy)
+    return observed
 
 
 def offline_coordination_factory() -> KiwoomCoordinationAdapter:
@@ -474,7 +518,7 @@ async def test_two_fake_hosts_one_physical_account_one_writer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_contention_loss_stale_fence_event_loop_mismatch_zero_transport() -> None:
+async def test_durable_claim_conflict_makes_zero_transport() -> None:
     account = FakeKiwoomAccount()
     adapter = build_offline_adapter(unresolved=True)
     with pytest.raises(CoordinationError) as exc:
@@ -491,7 +535,95 @@ async def test_contention_loss_stale_fence_event_loop_mismatch_zero_transport() 
 
 
 @pytest.mark.asyncio
-async def test_batch_and_cancel_reassert_fence_before_every_mutation() -> None:
+async def test_lease_loss_before_callback_makes_zero_transport() -> None:
+    """J3A pre-callback assert sees an empty lock table → no callback POST."""
+
+    account = FakeKiwoomAccount()
+    adapter = build_offline_adapter(drop_after_pg_locks=1)
+    with pytest.raises(CoordinationError) as exc:
+        await adapter.submit_planned(
+            account,
+            planned=Planned(),
+            policy_version=POLICY_VERSION,
+            policy_version_hash=POLICY_VERSION_HASH,
+            now=datetime.now(UTC),
+        )
+    assert exc.value.reason_code in {
+        CoordinationReasonCode.LEASE_LOST,
+        CoordinationReasonCode.LOCK_AUTHORITY_UNAVAILABLE,
+    }
+    assert adapter.transport_calls == []
+    assert account.buy_calls == []
+
+
+@pytest.mark.asyncio
+async def test_stale_fence_between_preassert_and_send_makes_zero_transport() -> None:
+    """Lock disappears after J3A's pre-callback attest; lane reassert must catch it.
+
+    Removing ``scope.assert_owned()`` from the adapter lets the POST through
+    and this test fails.
+    """
+
+    account = FakeKiwoomAccount()
+    adapter = build_offline_adapter(drop_after_pg_locks=3)
+    with pytest.raises(CoordinationError) as exc:
+        await adapter.submit_planned(
+            account,
+            planned=Planned(),
+            policy_version=POLICY_VERSION,
+            policy_version_hash=POLICY_VERSION_HASH,
+            now=datetime.now(UTC),
+        )
+    assert exc.value.reason_code is CoordinationReasonCode.LEASE_LOST
+    assert adapter.transport_calls == []
+    assert account.buy_calls == []
+
+
+@pytest.mark.asyncio
+async def test_event_loop_mismatch_on_lane_reassert_makes_zero_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The lane reassert runs J3A's event-loop check; a foreign loop is zero I/O."""
+
+    account = FakeKiwoomAccount()
+    adapter = build_offline_adapter()
+    original = CoordinationScope.assert_owned
+    foreign_loop = asyncio.new_event_loop()
+
+    async def _foreign_loop_assert(self: CoordinationScope) -> None:
+        real_get = asyncio.get_running_loop
+
+        def _lie() -> asyncio.AbstractEventLoop:
+            return foreign_loop
+
+        monkeypatch.setattr(asyncio, "get_running_loop", _lie)
+        try:
+            await original(self)
+        finally:
+            monkeypatch.setattr(asyncio, "get_running_loop", real_get)
+
+    monkeypatch.setattr(CoordinationScope, "assert_owned", _foreign_loop_assert)
+    try:
+        with pytest.raises(CoordinationError) as exc:
+            await adapter.submit_planned(
+                account,
+                planned=Planned(),
+                policy_version=POLICY_VERSION,
+                policy_version_hash=POLICY_VERSION_HASH,
+                now=datetime.now(UTC),
+            )
+        assert exc.value.reason_code is CoordinationReasonCode.LEASE_EVENT_LOOP_MISMATCH
+        assert adapter.transport_calls == []
+        assert account.buy_calls == []
+    finally:
+        foreign_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_batch_and_cancel_call_assert_owned_before_every_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = _scope_assert_owned_calls(monkeypatch)
     adapter = build_offline_adapter()
     account = FakeKiwoomAccount()
     first = await adapter.submit_planned(
@@ -501,7 +633,7 @@ async def test_batch_and_cancel_reassert_fence_before_every_mutation() -> None:
         policy_version_hash=POLICY_VERSION_HASH,
         now=datetime.now(UTC),
     )
-    second = await adapter.submit_planned(
+    await adapter.submit_planned(
         account,
         planned=Planned(order_key="l2", cycle_id="batch-2"),
         policy_version=POLICY_VERSION,
@@ -516,14 +648,9 @@ async def test_batch_and_cancel_reassert_fence_before_every_mutation() -> None:
         policy_version=POLICY_VERSION,
         policy_version_hash=POLICY_VERSION_HASH,
     )
-    assert adapter.fence_rechecks == [
-        "post:l1",
-        "post:l2",
-        f"cancel:{first.evidence.broker_order_id}",
-    ]
+    assert observed == ["assert_owned", "assert_owned", "assert_owned"]
     assert len(account.buy_calls) == 2
     assert len(account.cancel_calls) == 1
-    del second
 
 
 # ---------------------------------------------------------------------------
@@ -802,7 +929,47 @@ def test_wrong_physical_profile_rejected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_exact_mock_client_reaches_transport_only_after_j3a_assert() -> None:
+async def test_submit_planned_wires_transport_gate_before_post() -> None:
+    """Removing assert_kiwoom_transport_ready from submit_planned's callback fails this."""
+
+    adapter = build_offline_adapter()
+    account = FakeKiwoomAccount(client=object())
+    with pytest.raises(KiwoomTransportGateRejected):
+        await adapter.submit_planned(
+            account,
+            planned=Planned(),
+            policy_version=POLICY_VERSION,
+            policy_version_hash=POLICY_VERSION_HASH,
+            now=datetime.now(UTC),
+        )
+    assert account.buy_calls == []
+    assert adapter.transport_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_attributed_wires_transport_gate_before_cancel() -> None:
+    """Removing assert_kiwoom_transport_ready from cancel_attributed's callback fails this."""
+
+    adapter = build_offline_adapter()
+    account = FakeKiwoomAccount(client=object())
+    with pytest.raises(KiwoomTransportGateRejected):
+        await adapter.cancel_attributed(
+            account,
+            planned=Planned(order_key="cancel-l1", cycle_id="batch-1"),
+            native_order_id="0000000001",
+            known_remainder=Decimal("1"),
+            policy_version=POLICY_VERSION,
+            policy_version_hash=POLICY_VERSION_HASH,
+        )
+    assert account.cancel_calls == []
+    assert adapter.transport_calls == []
+
+
+@pytest.mark.asyncio
+async def test_exact_mock_client_reaches_transport_only_after_j3a_assert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = _scope_assert_owned_calls(monkeypatch)
     adapter = build_offline_adapter()
     account = FakeKiwoomAccount()
     await adapter.submit_planned(
@@ -812,7 +979,7 @@ async def test_exact_mock_client_reaches_transport_only_after_j3a_assert() -> No
         policy_version_hash=POLICY_VERSION_HASH,
         now=datetime.now(UTC),
     )
-    assert adapter.fence_rechecks == ["post:buy:005930:l1"]
+    assert observed == ["assert_owned"]
     assert len(account.buy_calls) == 1
 
 
@@ -834,29 +1001,122 @@ def test_pnl_unreadable_is_explicit_block_not_numeric_zero() -> None:
     assert blocked.canonical()["value"] is None
 
 
+def _record_lane_evidence_literal_kinds(path: Path) -> set[str]:
+    """Kinds passed as string literals to record_lane_evidence(...)."""
+
+    kinds: set[str] = set()
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute) and func.attr == "record_lane_evidence"
+        ):
+            continue
+        if (
+            node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            kinds.add(node.args[0].value)
+    return kinds
+
+
 def test_recovery_contract_six_items_and_lifecycle_status() -> None:
     assert KIWOOM_RECOVERY_OWNER == (
         "scripts.b0x.kr.kiwoom_ordering.KiwoomCoordinationAdapter"
     )
     assert KIWOOM_RESTART_TRIGGER
     assert KIWOOM_READBACK_OPERATION == "kt00007"
+    assert KIWOOM_RELEASE_IF_MATCHES
+    assert KIWOOM_LIFECYCLE_STATUS == "AUTO_READY_BLOCKED_BY_LIFECYCLE"
     contract = (
         REPO_ROOT / "docs" / "contracts" / "rob-1264-kiwoom-coordination-adapter.md"
     ).read_text(encoding="utf-8")
-    for kind in (
-        "ACK",
-        "unknown",
-        "reject",
-        "expiry",
-        "partial fill",
-        "cancel",
-        "terminal reconciliation",
-    ):
-        assert kind in contract
-    assert KIWOOM_RELEASE_IF_MATCHES
-    assert KIWOOM_LIFECYCLE_STATUS == "AUTO_READY_BLOCKED_BY_LIFECYCLE"
-    assert "C5 remains" in contract or "C5 remains UNKNOWN" in contract
-    assert "UNKNOWN" in contract
+    assert "C5 remains" in contract
+    source = REPO_ROOT / "scripts" / "b0x" / "kr" / "kiwoom_ordering.py"
+    assert _record_lane_evidence_literal_kinds(source) == set(LANE_EVIDENCE_KINDS)
+
+
+@pytest.mark.asyncio
+async def test_all_seven_lane_evidence_kinds_are_written_by_code() -> None:
+    adapter = build_offline_adapter()
+    account = FakeKiwoomAccount()
+    await adapter.submit_planned(
+        account,
+        planned=Planned(),
+        policy_version=POLICY_VERSION,
+        policy_version_hash=POLICY_VERSION_HASH,
+        now=datetime.now(UTC),
+    )
+    rejected = native_row_from_kt00007(
+        [
+            {
+                "order_id": "R1",
+                "status": "rejected",
+                "filled_quantity": 0,
+                "remaining_quantity": 0,
+            }
+        ],
+        broker_order_id="R1",
+    )
+    expired = native_row_from_kt00007(
+        [
+            {
+                "order_id": "E1",
+                "status": "expired",
+                "filled_quantity": 0,
+                "remaining_quantity": 0,
+            }
+        ],
+        broker_order_id="E1",
+    )
+    partial = native_row_from_kt00007(
+        [
+            {
+                "order_id": "P1",
+                "status": "partial",
+                "filled_quantity": 1,
+                "remaining_quantity": 1,
+            }
+        ],
+        broker_order_id="P1",
+    )
+    assert rejected is not None and expired is not None and partial is not None
+    adapter.record_native_broker_truth(rejected)
+    adapter.record_native_broker_truth(expired)
+    adapter.record_native_broker_truth(partial)
+    adapter.apply_restart_disposition(
+        durable_broker_order_id=None,
+        kt00007_readable=False,
+    )
+    await adapter.cancel_attributed(
+        account,
+        planned=Planned(order_key="c1", cycle_id="c1"),
+        native_order_id="0000000001",
+        known_remainder=Decimal("1"),
+        policy_version=POLICY_VERSION,
+        policy_version_hash=POLICY_VERSION_HASH,
+    )
+    scope = physical_account_scope_for_entry(bound_kiwoom_entry())
+    claim = await adapter.ports.claims.reserve(
+        scope=scope, idempotency_key="mock-idempotency-v1:term", side="buy"
+    )
+    await adapter.release_if_matches_terminal(
+        claim,
+        TerminalClaimEvidence(
+            lane_native_terminal_evidence=True,
+            account_position_reconciled=True,
+            remainder_known=True,
+        ),
+    )
+    written = {
+        event.removeprefix("lane_evidence:")
+        for event in adapter.ordered_events
+        if event.startswith("lane_evidence:")
+    }
+    assert written == set(LANE_EVIDENCE_KINDS)
 
 
 def test_c5_remains_unknown_and_is_not_erased() -> None:
@@ -888,11 +1148,31 @@ def test_no_j3a_sql_or_reason_enum_copied() -> None:
 
 
 def test_client_py_unchanged_in_this_job() -> None:
+    import hashlib
     import subprocess
 
-    diff = subprocess.check_output(
-        ["git", "diff", "--name-only", "HEAD"],
+    client = "app/services/brokers/kiwoom/client.py"
+    base = subprocess.check_output(
+        ["git", "merge-base", "HEAD", "origin/main"],
+        cwd=REPO_ROOT,
+        text=True,
+    ).strip()
+    named = subprocess.check_output(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
         cwd=REPO_ROOT,
         text=True,
     )
-    assert "app/services/brokers/kiwoom/client.py" not in diff.splitlines()
+    assert client not in named.splitlines()
+    base_bytes = subprocess.check_output(
+        ["git", "show", f"{base}:{client}"], cwd=REPO_ROOT
+    )
+    head_bytes = subprocess.check_output(
+        ["git", "show", f"HEAD:{client}"], cwd=REPO_ROOT
+    )
+    worktree_bytes = (REPO_ROOT / client).read_bytes()
+    assert (
+        hashlib.sha256(worktree_bytes).digest() == hashlib.sha256(base_bytes).digest()
+    )
+    assert (
+        hashlib.sha256(worktree_bytes).digest() == hashlib.sha256(head_bytes).digest()
+    )

--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -492,7 +492,7 @@ async def test_two_fake_hosts_one_physical_account_one_writer() -> None:
         return payload
 
     task = asyncio.create_task(
-        first.submit_planned(
+        first.submit_coordinated(
             account_a,
             planned=Planned(cycle_id="host-a"),
             policy_version=POLICY_VERSION,
@@ -503,7 +503,7 @@ async def test_two_fake_hosts_one_physical_account_one_writer() -> None:
     )
     await entered.wait()
     with pytest.raises(CoordinationError) as exc:
-        await second.submit_planned(
+        await second.submit_coordinated(
             account_b,
             planned=Planned(cycle_id="host-b"),
             policy_version=POLICY_VERSION,
@@ -522,7 +522,7 @@ async def test_durable_claim_conflict_makes_zero_transport() -> None:
     account = FakeKiwoomAccount()
     adapter = build_offline_adapter(unresolved=True)
     with pytest.raises(CoordinationError) as exc:
-        await adapter.submit_planned(
+        await adapter.submit_coordinated(
             account,
             planned=Planned(),
             policy_version=POLICY_VERSION,
@@ -541,7 +541,7 @@ async def test_lease_loss_before_callback_makes_zero_transport() -> None:
     account = FakeKiwoomAccount()
     adapter = build_offline_adapter(drop_after_pg_locks=1)
     with pytest.raises(CoordinationError) as exc:
-        await adapter.submit_planned(
+        await adapter.submit_coordinated(
             account,
             planned=Planned(),
             policy_version=POLICY_VERSION,
@@ -567,7 +567,7 @@ async def test_stale_fence_between_preassert_and_send_makes_zero_transport() -> 
     account = FakeKiwoomAccount()
     adapter = build_offline_adapter(drop_after_pg_locks=3)
     with pytest.raises(CoordinationError) as exc:
-        await adapter.submit_planned(
+        await adapter.submit_coordinated(
             account,
             planned=Planned(),
             policy_version=POLICY_VERSION,
@@ -605,7 +605,7 @@ async def test_event_loop_mismatch_on_lane_reassert_makes_zero_transport(
     monkeypatch.setattr(CoordinationScope, "assert_owned", _foreign_loop_assert)
     try:
         with pytest.raises(CoordinationError) as exc:
-            await adapter.submit_planned(
+            await adapter.submit_coordinated(
                 account,
                 planned=Planned(),
                 policy_version=POLICY_VERSION,
@@ -626,14 +626,14 @@ async def test_batch_and_cancel_call_assert_owned_before_every_mutation(
     observed = _scope_assert_owned_calls(monkeypatch)
     adapter = build_offline_adapter()
     account = FakeKiwoomAccount()
-    first = await adapter.submit_planned(
+    first = await adapter.submit_coordinated(
         account,
         planned=Planned(order_key="l1", cycle_id="batch-1"),
         policy_version=POLICY_VERSION,
         policy_version_hash=POLICY_VERSION_HASH,
         now=datetime.now(UTC),
     )
-    await adapter.submit_planned(
+    await adapter.submit_coordinated(
         account,
         planned=Planned(order_key="l2", cycle_id="batch-2"),
         policy_version=POLICY_VERSION,
@@ -669,7 +669,7 @@ async def test_kiwoom_attempt_cid_none_and_ack_precedes_jsonl() -> None:
         adapter.ports.persistence.events.append("jsonl_callback")
         jsonl.append(order_no)
 
-    result = await adapter.submit_planned(
+    result = await adapter.submit_coordinated(
         account,
         planned=Planned(),
         record_order_no=record_order_no,
@@ -929,13 +929,13 @@ def test_wrong_physical_profile_rejected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_submit_planned_wires_transport_gate_before_post() -> None:
-    """Removing assert_kiwoom_transport_ready from submit_planned's callback fails this."""
+async def test_submit_coordinated_wires_transport_gate_before_post() -> None:
+    """Removing assert_kiwoom_transport_ready from submit_coordinated's callback fails this."""
 
     adapter = build_offline_adapter()
     account = FakeKiwoomAccount(client=object())
     with pytest.raises(KiwoomTransportGateRejected):
-        await adapter.submit_planned(
+        await adapter.submit_coordinated(
             account,
             planned=Planned(),
             policy_version=POLICY_VERSION,
@@ -972,7 +972,7 @@ async def test_exact_mock_client_reaches_transport_only_after_j3a_assert(
     observed = _scope_assert_owned_calls(monkeypatch)
     adapter = build_offline_adapter()
     account = FakeKiwoomAccount()
-    await adapter.submit_planned(
+    await adapter.submit_coordinated(
         account,
         planned=Planned(),
         policy_version=POLICY_VERSION,
@@ -1043,7 +1043,7 @@ def test_recovery_contract_six_items_and_lifecycle_status() -> None:
 async def test_all_seven_lane_evidence_kinds_are_written_by_code() -> None:
     adapter = build_offline_adapter()
     account = FakeKiwoomAccount()
-    await adapter.submit_planned(
+    await adapter.submit_coordinated(
         account,
         planned=Planned(),
         policy_version=POLICY_VERSION,

--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -1,0 +1,898 @@
+"""ROB-1264 J3C Kiwoom coordination adapter — exact §E mutants.
+
+Every zero-I/O claim asserts fake transport call count is exactly 0.
+No test opens a network socket or loads a credential value.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.schemas.execution_contracts import LaneStatus, SchedulerOwner
+from app.services.brokers.client_order_ids import BrokerClientIdTarget
+from app.services.brokers.kiwoom import constants as kiwoom_constants
+from app.services.brokers.kiwoom.client import KiwoomMockClient
+from app.services.mock_integration.coordination import (
+    CoordinationError,
+    CoordinationReasonCode,
+    DurableSendClaimAdapter,
+    TerminalClaimEvidence,
+    physical_account_scope_for_entry,
+    split_advisory_key,
+)
+from app.services.mock_integration.lineage import MockLineageFactory
+from app.services.mock_lane_registry import (
+    CANONICAL_LANE_REGISTRY,
+    ActivationStatus,
+    LaneRegistryEntry,
+    PolicyBinding,
+)
+from scripts.b0x.kr.kiwoom_ordering import (
+    ACCOUNT_SUMMARY_FINGERPRINT_IDENTITY_REJECTED,
+    CALLER_DERIVED_IDENTITY_REJECTED,
+    JSONL_ABSENCE_NOT_EMPTY_OWNERSHIP,
+    KIWOOM_CANONICAL_LANE_ID,
+    KIWOOM_LIFECYCLE_STATUS,
+    KIWOOM_READBACK_OPERATION,
+    KIWOOM_RECOVERY_OWNER,
+    KIWOOM_RELEASE_IF_MATCHES,
+    KIWOOM_RESTART_TRIGGER,
+    KT00009_CANNOT_REPLACE_KT00007,
+    LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND,
+    PROXIMITY_ATTRIBUTION_REJECTED,
+    ROOT_PATH_IDENTITY_REJECTED,
+    AccountWriterLease,
+    InMemoryDispatchEvidence,
+    InMemoryLineagePersistence,
+    InMemoryReservationPort,
+    InMemoryUncertaintyGate,
+    KiwoomAttributionRejected,
+    KiwoomCoordinationAdapter,
+    KiwoomCoordinationPorts,
+    KiwoomIdentityRejected,
+    KiwoomTransportGateRejected,
+    assert_broker_client_id_contract,
+    assert_kiwoom_transport_ready,
+    followup_precheck,
+    native_row_from_kt00007,
+    reject_jsonl_as_empty_ownership,
+    reject_kt00009_as_truth,
+    reject_proximity_attribution,
+    require_j2a_physical_account_id,
+    restart_disposition,
+    wall_clock_cannot_release,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RAW_PHYSICAL_ACCOUNT_ID = "RAW-KIWOOM-PHYSICAL-4242"
+POLICY_VERSION = "trading-policy-v9"
+POLICY_VERSION_HASH = "f" * 16
+FINGERPRINT_REF = "sha256:test-account"
+
+J3C_WRITE_FENCE = frozenset(
+    {
+        "scripts/b0x/kr/kiwoom_ordering.py",
+        "scripts/b0x/kr/kiwoom_cycle.py",
+        "scripts/b0x/kr/kiwoom.py",
+        "scripts/b0x/kr/kiwoom_attribution.py",
+        "tests/scripts/b0x/kr/kiwoom/test_kiwoom_ordering_support.py",
+        "tests/scripts/b0x/kr/kiwoom/test_kiwoom_cycle.py",
+        "tests/scripts/b0x/kr/kiwoom/test_kiwoom_round_trip.py",
+        "tests/scripts/b0x/kr/kiwoom/test_kiwoom_static_guards.py",
+        "tests/services/mock_integration/test_kiwoom_coordination_adapter.py",
+        "docs/contracts/rob-1264-kiwoom-coordination-adapter.md",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake lock authority (J3A protocol only; no real PostgreSQL)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = list(rows)
+
+    def mappings(self) -> _FakeResult:
+        return self
+
+    def one(self) -> dict[str, Any]:
+        return self._rows[0]
+
+    def all(self) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+    def scalar_one(self) -> Any:
+        return next(iter(self.one().values()))
+
+
+class FakeLockSpace:
+    def __init__(self) -> None:
+        self.held: dict[int, int] = {}
+        self.depth: dict[tuple[int, int], int] = {}
+
+    def try_lock(self, key: int, pid: int) -> bool:
+        owner = self.held.get(key)
+        if owner is None or owner == pid:
+            self.held[key] = pid
+            self.depth[(key, pid)] = self.depth.get((key, pid), 0) + 1
+            return True
+        return False
+
+    def unlock(self, key: int, pid: int) -> bool:
+        if self.held.get(key) != pid:
+            return False
+        remaining = self.depth.get((key, pid), 1) - 1
+        if remaining <= 0:
+            self.depth.pop((key, pid), None)
+            del self.held[key]
+        else:
+            self.depth[(key, pid)] = remaining
+        return True
+
+    def terminate(self, pid: int) -> None:
+        for key in [key for key, owner in self.held.items() if owner == pid]:
+            del self.held[key]
+            self.depth.pop((key, pid), None)
+
+    def rows(self, pid: int, database_oid: int) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for key, owner in self.held.items():
+            if owner != pid:
+                continue
+            classid, objid = split_advisory_key(key)
+            out.append(
+                {
+                    "locktype": "advisory",
+                    "mode": "ExclusiveLock",
+                    "granted": True,
+                    "database_oid": database_oid,
+                    "pid": owner,
+                    "objsubid": 1,
+                    "classid": classid,
+                    "objid": objid,
+                }
+            )
+        return out
+
+
+class FakeLockConnection:
+    def __init__(self, space: FakeLockSpace, *, pid: int = 4242) -> None:
+        self._space = space
+        self._pid = pid
+        self._database_oid = 99001
+        self.committed = False
+
+    def can_prove_backend_session_termination(self) -> bool:
+        return True
+
+    async def execute(self, statement: Any, parameters: Any = None, /) -> _FakeResult:
+        sql = str(statement)
+        params = dict(parameters or {})
+        if "pg_backend_pid" in sql:
+            return _FakeResult(
+                [{"backend_pid": self._pid, "database_oid": self._database_oid}]
+            )
+        if "pg_try_advisory_lock" in sql:
+            return _FakeResult(
+                [{"acquired": self._space.try_lock(int(params["key"]), self._pid)}]
+            )
+        if "pg_advisory_unlock" in sql:
+            return _FakeResult(
+                [{"released": self._space.unlock(int(params["key"]), self._pid)}]
+            )
+        if "pg_locks" in sql:
+            return _FakeResult(self._space.rows(int(params["pid"]), self._database_oid))
+        raise AssertionError(sql)
+
+    async def commit(self) -> None:
+        self.committed = True
+
+    async def close(self) -> None:
+        return None
+
+    async def terminate_backend_session(
+        self, *, expected_pid: int, owner_token: str
+    ) -> Any:
+        del expected_pid, owner_token
+        self._space.terminate(self._pid)
+        from app.services.mock_integration.coordination import BackendTerminationReceipt
+
+        return BackendTerminationReceipt(
+            backend_pid=self._pid, owner_token="x", terminated=True
+        )
+
+
+class ConnectionFactory:
+    def __init__(self, space: FakeLockSpace, *, pid: int = 4242) -> None:
+        self.space = space
+        self.pid = pid
+        self.calls = 0
+
+    async def __call__(self) -> FakeLockConnection:
+        self.calls += 1
+        return FakeLockConnection(self.space, pid=self.pid)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def bound_kiwoom_entry(**overrides: object) -> LaneRegistryEntry:
+    values: dict[str, object] = {
+        "lane_status": LaneStatus.AUTO_ENABLED,
+        "activation_status": ActivationStatus.ENABLED,
+        "activation_reason": "j3c-test fully bound",
+        "policy_binding": PolicyBinding(POLICY_VERSION, POLICY_VERSION_HASH),
+        "execution_mode": "test-only-bounded",
+        "scheduler_owner": SchedulerOwner.MANUAL,
+        "timing_owner": "test-only-timing",
+        "writer": True,
+        "auto_order_enabled": True,
+        "max_order_notional": Decimal("10000000"),
+        "max_orders_per_session": 8,
+        "max_open_orders": 8,
+        "allowed_order_types": ("limit",),
+        "allowed_time_in_force": ("day",),
+        "reconcile_required": True,
+        "physical_account_id": RAW_PHYSICAL_ACCOUNT_ID,
+        "identity_status": "KNOWN",
+        "fingerprint_evidence_ref": FINGERPRINT_REF,
+        "canary_binding": "test-only-bounded-canary",
+        "missing_bindings": (),
+    }
+    values.update(overrides)
+    canonical = next(
+        entry
+        for entry in CANONICAL_LANE_REGISTRY
+        if entry.lane_id == KIWOOM_CANONICAL_LANE_ID
+    )
+    return replace(canonical, **values)
+
+
+def bound_registry(entry: LaneRegistryEntry) -> tuple[LaneRegistryEntry, ...]:
+    return tuple(
+        entry if item.lane_id == entry.lane_id else item
+        for item in CANONICAL_LANE_REGISTRY
+    )
+
+
+@dataclass
+class Planned:
+    cycle_id: str = "cycle-j3c-1"
+    order_key: str = "buy:005930:l1"
+    client_order_id: str = "b0xkw-test-1"
+    symbol: str = "005930"
+    side: str = "buy"
+    price: int = 70000
+    quantity: int = 1
+    leg: str = "L1"
+    notional: Decimal = field(default_factory=lambda: Decimal("70000"))
+
+
+class FakeKiwoomAccount:
+    def __init__(
+        self, *, client: object | None = None, fail_read: bool = False
+    ) -> None:
+        self._client = client if client is not None else make_test_mock_client()
+        self.buy_calls: list[dict[str, Any]] = []
+        self.sell_calls: list[dict[str, Any]] = []
+        self.cancel_calls: list[dict[str, Any]] = []
+        self._next = 1
+        self.fail_read = fail_read
+        self.rows: list[dict[str, Any]] = []
+
+    async def place_limit_buy(
+        self, *, symbol: str, quantity: int, price: int
+    ) -> dict[str, Any]:
+        self.buy_calls.append({"symbol": symbol, "quantity": quantity, "price": price})
+        order_no = f"{self._next:010d}"
+        self._next += 1
+        self.rows.append(
+            {
+                "order_id": order_no,
+                "symbol": symbol,
+                "status": "open",
+                "ordered_quantity": quantity,
+                "filled_quantity": 0,
+                "remaining_quantity": quantity,
+            }
+        )
+        return {"return_code": 0, "ord_no": order_no}
+
+    async def place_limit_sell(
+        self, *, symbol: str, quantity: int, price: int
+    ) -> dict[str, Any]:
+        self.sell_calls.append({"symbol": symbol, "quantity": quantity, "price": price})
+        return {"return_code": 0, "ord_no": "0000000099"}
+
+    async def cancel(
+        self, *, original_order_no: str, symbol: str, cancel_quantity: int
+    ) -> dict[str, Any]:
+        self.cancel_calls.append(
+            {
+                "original_order_no": original_order_no,
+                "symbol": symbol,
+                "cancel_quantity": cancel_quantity,
+            }
+        )
+        return {"return_code": 0, "ord_no": original_order_no}
+
+    async def read_order_detail(
+        self, *, order_date: str | None = None, symbol: str | None = None
+    ) -> list[dict[str, Any]]:
+        del order_date, symbol
+        if self.fail_read:
+            raise RuntimeError("kt00007 unavailable")
+        return list(self.rows)
+
+
+def make_test_mock_client() -> KiwoomMockClient:
+    return KiwoomMockClient(
+        base_url=kiwoom_constants.MOCK_BASE_URL,
+        app_key="unit-test",
+        app_secret="unit-test",
+        account_no="unit-test",
+    )
+
+
+def build_offline_adapter(
+    *,
+    space: FakeLockSpace | None = None,
+    pid: int = 4242,
+    entry: LaneRegistryEntry | None = None,
+    unresolved: bool = False,
+) -> KiwoomCoordinationAdapter:
+    bound = entry or bound_kiwoom_entry()
+    lock_space = space or FakeLockSpace()
+    persistence = InMemoryLineagePersistence()
+    dispatch = InMemoryDispatchEvidence()
+    gate = InMemoryUncertaintyGate()
+    if unresolved:
+        gate.mark_unresolved(
+            physical_account_scope_for_entry(bound).claim_account_scope
+        )
+    persistence.events = persistence.events
+    ports = KiwoomCoordinationPorts(
+        persistence=persistence,
+        dispatch_evidence=dispatch,
+        uncertainty_gate=gate,
+        claims=DurableSendClaimAdapter(InMemoryReservationPort()),
+        connection_factory=ConnectionFactory(lock_space, pid=pid),
+        registry=bound_registry(bound),
+        lineage_factory=MockLineageFactory(),
+        entry=bound,
+        diagnostic_fingerprint=FINGERPRINT_REF,
+    )
+    return KiwoomCoordinationAdapter(ports)
+
+
+def offline_coordination_factory() -> KiwoomCoordinationAdapter:
+    """Used by cycle tests so ORDERING submits go through J3A."""
+
+    return build_offline_adapter()
+
+
+# ---------------------------------------------------------------------------
+# §E-1 Identity and distributed ownership
+# ---------------------------------------------------------------------------
+
+
+def test_identity_rejects_caller_root_and_summary_fingerprint_mutants() -> None:
+    entry = bound_kiwoom_entry()
+    assert require_j2a_physical_account_id(entry) == RAW_PHYSICAL_ACCOUNT_ID
+    with pytest.raises(KiwoomIdentityRejected) as caller:
+        require_j2a_physical_account_id(
+            entry, caller_physical_account_id="sha256:caller"
+        )
+    assert caller.value.reason == CALLER_DERIVED_IDENTITY_REJECTED
+    with pytest.raises(KiwoomIdentityRejected) as root:
+        require_j2a_physical_account_id(entry, root_path="/tmp/artifacts")
+    assert root.value.reason == ROOT_PATH_IDENTITY_REJECTED
+    with pytest.raises(KiwoomIdentityRejected) as summary:
+        require_j2a_physical_account_id(
+            entry, account_summary_fingerprint="sha256:test-account"
+        )
+    assert summary.value.reason == ACCOUNT_SUMMARY_FINGERPRINT_IDENTITY_REJECTED
+
+
+@pytest.mark.asyncio
+async def test_local_flock_without_j3a_grant_cannot_authorize_transport() -> None:
+    account = FakeKiwoomAccount()
+    lease = AccountWriterLease(
+        root=Path("/tmp/j3c-flock"),
+        lane="kiwoom_mock",
+        account_fingerprint="sha256:test-account",
+    )
+    # Diagnostic flock is held; no J3A grant is minted.
+    assert lease.canonical()["authorizes_send"] is False
+    with pytest.raises(KiwoomTransportGateRejected) as exc:
+        assert_kiwoom_transport_ready(
+            account=account,
+            entry=bound_kiwoom_entry(),
+            physical_account_id=RAW_PHYSICAL_ACCOUNT_ID,
+            grant_owned=False,
+        )
+    assert exc.value.reason == LOCAL_FLOCK_CANNOT_AUTHORIZE_SEND
+    assert account.buy_calls == []
+
+
+@pytest.mark.asyncio
+async def test_two_fake_hosts_one_physical_account_one_writer() -> None:
+    space = FakeLockSpace()
+    first = build_offline_adapter(space=space, pid=1001)
+    second = build_offline_adapter(space=space, pid=2002)
+    account_a = FakeKiwoomAccount()
+    account_b = FakeKiwoomAccount()
+    entered = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def held_buy(*, symbol: str, quantity: int, price: int) -> dict[str, Any]:
+        payload = await account_a.place_limit_buy(
+            symbol=symbol, quantity=quantity, price=price
+        )
+        entered.set()
+        await release_first.wait()
+        return payload
+
+    task = asyncio.create_task(
+        first.submit_planned(
+            account_a,
+            planned=Planned(cycle_id="host-a"),
+            policy_version=POLICY_VERSION,
+            policy_version_hash=POLICY_VERSION_HASH,
+            now=datetime.now(UTC),
+            mutation=held_buy,
+        )
+    )
+    await entered.wait()
+    with pytest.raises(CoordinationError) as exc:
+        await second.submit_planned(
+            account_b,
+            planned=Planned(cycle_id="host-b"),
+            policy_version=POLICY_VERSION,
+            policy_version_hash=POLICY_VERSION_HASH,
+            now=datetime.now(UTC),
+        )
+    assert exc.value.reason_code is CoordinationReasonCode.LEASE_CONTENDED
+    release_first.set()
+    await task
+    assert len(account_a.buy_calls) == 1
+    assert account_b.buy_calls == []
+
+
+@pytest.mark.asyncio
+async def test_contention_loss_stale_fence_event_loop_mismatch_zero_transport() -> None:
+    account = FakeKiwoomAccount()
+    adapter = build_offline_adapter(unresolved=True)
+    with pytest.raises(CoordinationError) as exc:
+        await adapter.submit_planned(
+            account,
+            planned=Planned(),
+            policy_version=POLICY_VERSION,
+            policy_version_hash=POLICY_VERSION_HASH,
+            now=datetime.now(UTC),
+        )
+    assert exc.value.reason_code is CoordinationReasonCode.DURABLE_CLAIM_CONFLICT
+    assert adapter.transport_calls == []
+    assert account.buy_calls == []
+
+
+@pytest.mark.asyncio
+async def test_batch_and_cancel_reassert_fence_before_every_mutation() -> None:
+    adapter = build_offline_adapter()
+    account = FakeKiwoomAccount()
+    first = await adapter.submit_planned(
+        account,
+        planned=Planned(order_key="l1", cycle_id="batch-1"),
+        policy_version=POLICY_VERSION,
+        policy_version_hash=POLICY_VERSION_HASH,
+        now=datetime.now(UTC),
+    )
+    second = await adapter.submit_planned(
+        account,
+        planned=Planned(order_key="l2", cycle_id="batch-2"),
+        policy_version=POLICY_VERSION,
+        policy_version_hash=POLICY_VERSION_HASH,
+        now=datetime.now(UTC),
+    )
+    await adapter.cancel_attributed(
+        account,
+        planned=Planned(order_key="cancel-l1", cycle_id="batch-1"),
+        native_order_id=first.evidence.broker_order_id or "",
+        known_remainder=Decimal("1"),
+        policy_version=POLICY_VERSION,
+        policy_version_hash=POLICY_VERSION_HASH,
+    )
+    assert adapter.fence_rechecks == [
+        "post:l1",
+        "post:l2",
+        f"cancel:{first.evidence.broker_order_id}",
+    ]
+    assert len(account.buy_calls) == 2
+    assert len(account.cancel_calls) == 1
+    del second
+
+
+# ---------------------------------------------------------------------------
+# §E-2 Nullable native client ID and ACK order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kiwoom_attempt_cid_none_and_ack_precedes_jsonl() -> None:
+    adapter = build_offline_adapter()
+    account = FakeKiwoomAccount()
+    jsonl: list[str] = []
+
+    def record_order_no(*, order_no: str, planned: Planned, at: datetime) -> None:
+        del planned, at
+        adapter.ports.persistence.events.append("jsonl_callback")
+        jsonl.append(order_no)
+
+    result = await adapter.submit_planned(
+        account,
+        planned=Planned(),
+        record_order_no=record_order_no,
+        policy_version=POLICY_VERSION,
+        policy_version_hash=POLICY_VERSION_HASH,
+        now=datetime.now(UTC),
+    )
+    envelope = result.envelope
+    assert_broker_client_id_contract(envelope)
+    assert envelope.broker_client_id_target is None
+    assert envelope.order_attempt is not None
+    assert envelope.order_attempt.broker_client_order_id is None
+    assert envelope.order_attempt.idempotency_key.startswith("mock-idempotency-v1:")
+    assert envelope.order_attempt.broker_order_id == jsonl[0]
+    assert set(BrokerClientIdTarget) == {
+        BrokerClientIdTarget.TOSS,
+        BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+        BrokerClientIdTarget.ALPACA_PAPER,
+    }
+    events = adapter.ports.persistence.events
+    assert events.index("j2b_ack_persisted") < events.index("jsonl_callback")
+    assert adapter.ordered_events.index(
+        "j2b_ack_persisted"
+    ) < adapter.ordered_events.index("jsonl_appended")
+
+
+# ---------------------------------------------------------------------------
+# §E-3 Crash / restart no-repost
+# ---------------------------------------------------------------------------
+
+
+def test_restart_not_created_allows_matched_cleanup() -> None:
+    disposition = restart_disposition(
+        durable_broker_order_id=None,
+        kt00007_readable=True,
+        pre_send_not_created=True,
+    )
+    assert disposition.status == "not_created"
+    assert disposition.allow_repost is False
+    assert disposition.block_physical_account is False
+
+
+def test_restart_post_before_ack_blocks_account_and_forbids_repost() -> None:
+    disposition = restart_disposition(
+        durable_broker_order_id=None,
+        kt00007_readable=True,
+        pre_send_not_created=False,
+    )
+    assert disposition.status == "unknown_pending_reconcile"
+    assert disposition.block_physical_account is True
+    assert disposition.allow_repost is False
+
+
+def test_restart_ack_without_jsonl_recovers_from_kt00007() -> None:
+    rows = [
+        {
+            "order_id": "0000000007",
+            "status": "open",
+            "filled_quantity": 0,
+            "remaining_quantity": 1,
+            "native": "raw",
+        }
+    ]
+    disposition = restart_disposition(
+        durable_broker_order_id="0000000007",
+        kt00007_readable=True,
+        kt00007_rows=rows,
+        jsonl_missing=True,
+    )
+    assert disposition.status == "recovered_from_j2b_and_kt00007"
+    assert disposition.native is not None
+    assert disposition.native.raw_row["native"] == "raw"
+    assert disposition.allow_repost is False
+
+
+def test_restart_jsonl_missing_cannot_become_empty_ownership() -> None:
+    with pytest.raises(KiwoomAttributionRejected) as exc:
+        restart_disposition(
+            durable_broker_order_id=None,
+            kt00007_readable=True,
+            jsonl_missing=True,
+        )
+    assert exc.value.reason == JSONL_ABSENCE_NOT_EMPTY_OWNERSHIP
+
+
+def test_restart_broker_read_or_missing_row_holds() -> None:
+    unread = restart_disposition(
+        durable_broker_order_id="0000000007",
+        kt00007_readable=False,
+    )
+    assert unread.status == "unknown_pending_reconcile"
+    assert unread.block_physical_account is True
+    missing = restart_disposition(
+        durable_broker_order_id="0000000007",
+        kt00007_readable=True,
+        kt00007_rows=[],
+    )
+    assert missing.status == "unknown_pending_reconcile"
+    assert missing.block_physical_account is True
+
+
+# ---------------------------------------------------------------------------
+# §E-4 Attribution mutants
+# ---------------------------------------------------------------------------
+
+
+def test_proximity_match_without_broker_id_rejected() -> None:
+    with pytest.raises(KiwoomAttributionRejected) as exc:
+        reject_proximity_attribution()
+    assert exc.value.reason == PROXIMITY_ATTRIBUTION_REJECTED
+    with pytest.raises(KiwoomAttributionRejected):
+        native_row_from_kt00007(
+            [{"symbol": "005930", "side": "buy", "order_id": "x"}],
+            broker_order_id="",
+        )
+
+
+def test_kt00009_cannot_replace_kt00007() -> None:
+    with pytest.raises(KiwoomAttributionRejected) as exc:
+        reject_kt00009_as_truth()
+    assert exc.value.reason == KT00009_CANNOT_REPLACE_KT00007
+
+
+def test_foreign_collision_not_attributed_from_jsonl() -> None:
+    rows = [
+        {
+            "order_id": "FOREIGN-1",
+            "symbol": "005930",
+            "status": "open",
+            "filled_quantity": 0,
+            "remaining_quantity": 1,
+        }
+    ]
+    assert native_row_from_kt00007(rows, broker_order_id="OURS-1") is None
+    with pytest.raises(KiwoomAttributionRejected):
+        reject_jsonl_as_empty_ownership()
+
+
+def test_native_raw_row_preserved_beside_normalized_state() -> None:
+    raw = {
+        "order_id": "0000000042",
+        "status": "partially_filled",
+        "filled_quantity": 1,
+        "remaining_quantity": 2,
+        "broker_raw": {"ord_remnq": "2"},
+    }
+    native = native_row_from_kt00007([raw], broker_order_id="0000000042")
+    assert native is not None
+    assert native.normalized_state == "partial"
+    assert native.raw_row["broker_raw"] == {"ord_remnq": "2"}
+
+
+# ---------------------------------------------------------------------------
+# §E-5 Terminal / remainder
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_normalization_and_partial_holds_claim() -> None:
+    assert (
+        native_row_from_kt00007(
+            [
+                {
+                    "order_id": "1",
+                    "status": "open",
+                    "remaining_quantity": 1,
+                    "filled_quantity": 0,
+                }
+            ],
+            broker_order_id="1",
+        ).normalized_state
+        == "open"
+    )
+    partial = native_row_from_kt00007(
+        [
+            {
+                "order_id": "2",
+                "status": "partial",
+                "remaining_quantity": 1,
+                "filled_quantity": 1,
+            }
+        ],
+        broker_order_id="2",
+    )
+    assert partial is not None
+    assert partial.normalized_state == "partial"
+    assert followup_precheck(
+        operation="cancel",
+        native_order_id="2",
+        known_remainder=Decimal(partial.remaining_quantity or 0),
+        fresh_guards_passed=True,
+    )
+    assert not followup_precheck(
+        operation="cancel",
+        native_order_id="2",
+        known_remainder=None,
+        fresh_guards_passed=True,
+    )
+
+
+def test_wall_clock_journal_absence_cannot_release() -> None:
+    evidence = wall_clock_cannot_release()
+    assert evidence.authorizes_release is False
+    assert evidence.lane_native_terminal_evidence is False
+
+
+@pytest.mark.asyncio
+async def test_release_requires_terminal_evidence_and_owner_match() -> None:
+    port = InMemoryReservationPort()
+    claims = DurableSendClaimAdapter(port)
+    from app.services.mock_integration.coordination import DurableClaim
+
+    scope = physical_account_scope_for_entry(bound_kiwoom_entry())
+    claim = await claims.reserve(
+        scope=scope, idempotency_key="mock-idempotency-v1:abc", side="buy"
+    )
+    assert isinstance(claim, DurableClaim)
+    with pytest.raises(CoordinationError):
+        await claims.release_with_terminal_evidence(claim, TerminalClaimEvidence())
+    assert port.rows
+    released = await claims.release_with_terminal_evidence(
+        claim,
+        TerminalClaimEvidence(
+            lane_native_terminal_evidence=True,
+            account_position_reconciled=True,
+            remainder_known=True,
+        ),
+    )
+    assert released == 1
+    assert port.rows == {}
+
+
+# ---------------------------------------------------------------------------
+# §E-6 Actual transport gate
+# ---------------------------------------------------------------------------
+
+
+def test_live_character_client_rejected_before_transport() -> None:
+    account = FakeKiwoomAccount(client=object())
+    with pytest.raises(KiwoomTransportGateRejected):
+        assert_kiwoom_transport_ready(
+            account=account,
+            entry=bound_kiwoom_entry(),
+            physical_account_id=RAW_PHYSICAL_ACCOUNT_ID,
+            grant_owned=True,
+        )
+
+
+def test_wrong_physical_profile_rejected() -> None:
+    account = FakeKiwoomAccount()
+    with pytest.raises(KiwoomTransportGateRejected):
+        assert_kiwoom_transport_ready(
+            account=account,
+            entry=bound_kiwoom_entry(),
+            physical_account_id="SOME-OTHER-ACCOUNT",
+            grant_owned=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_exact_mock_client_reaches_transport_only_after_j3a_assert() -> None:
+    adapter = build_offline_adapter()
+    account = FakeKiwoomAccount()
+    await adapter.submit_planned(
+        account,
+        planned=Planned(),
+        policy_version=POLICY_VERSION,
+        policy_version_hash=POLICY_VERSION_HASH,
+        now=datetime.now(UTC),
+    )
+    assert adapter.fence_rechecks == ["post:buy:005930:l1"]
+    assert len(account.buy_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# §E-7 Blocked lifecycle and static safety
+# ---------------------------------------------------------------------------
+
+
+def test_pnl_unreadable_is_explicit_block_not_numeric_zero() -> None:
+    from scripts.b0x.kr.kiwoom_attribution import RealizedPnlInput
+
+    blocked = RealizedPnlInput(
+        value=None,
+        source="own_order_journal",
+        reason="own_order_activity_exists_today_without_dedicated_realized_pnl_source",
+    )
+    assert blocked.readable is False
+    assert blocked.value is None
+    assert blocked.canonical()["value"] is None
+
+
+def test_recovery_contract_six_items_and_lifecycle_status() -> None:
+    assert KIWOOM_RECOVERY_OWNER == (
+        "scripts.b0x.kr.kiwoom_ordering.KiwoomCoordinationAdapter"
+    )
+    assert KIWOOM_RESTART_TRIGGER
+    assert KIWOOM_READBACK_OPERATION == "kt00007"
+    contract = (
+        REPO_ROOT / "docs" / "contracts" / "rob-1264-kiwoom-coordination-adapter.md"
+    ).read_text(encoding="utf-8")
+    for kind in (
+        "ACK",
+        "unknown",
+        "reject",
+        "expiry",
+        "partial fill",
+        "cancel",
+        "terminal reconciliation",
+    ):
+        assert kind in contract
+    assert KIWOOM_RELEASE_IF_MATCHES
+    assert KIWOOM_LIFECYCLE_STATUS == "AUTO_READY_BLOCKED_BY_LIFECYCLE"
+    assert "C5 remains" in contract or "C5 remains UNKNOWN" in contract
+    assert "UNKNOWN" in contract
+
+
+def test_c5_remains_unknown_and_is_not_erased() -> None:
+    contract = (
+        REPO_ROOT / "docs" / "contracts" / "rob-1264-kiwoom-coordination-adapter.md"
+    ).read_text(encoding="utf-8")
+    assert "C5 remains" in contract
+    source = (REPO_ROOT / "scripts" / "b0x" / "kr" / "kiwoom_ordering.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+    assert "TaskGroup" not in names
+    assert "timeout" not in names or "DEFAULT_TIMEOUT" in names
+
+
+def test_no_j3a_sql_or_reason_enum_copied() -> None:
+    source = (REPO_ROOT / "scripts" / "b0x" / "kr" / "kiwoom_ordering.py").read_text(
+        encoding="utf-8"
+    )
+    assert "pg_try_advisory_lock" not in source
+    assert "mock-physical-account-v1" not in source
+    assert "class CoordinationReasonCode" not in source
+
+
+def test_client_py_unchanged_in_this_job() -> None:
+    import subprocess
+
+    diff = subprocess.check_output(
+        ["git", "diff", "--name-only", "HEAD"],
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    assert "app/services/brokers/kiwoom/client.py" not in diff.splitlines()

--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -1147,32 +1147,20 @@ def test_no_j3a_sql_or_reason_enum_copied() -> None:
     assert "class CoordinationReasonCode" not in source
 
 
+# SHA-256 of app/services/brokers/kiwoom/client.py at the J3C dispatch
+# base (origin/main 03beecc5f). Git history is not consulted: CI checkouts
+# are shallow and merge-base/origin/main are not guaranteed to exist.
+_KIWOOM_CLIENT_PY_SHA256: str = (
+    "b9bb2ce3c9cb09cb6ba3013f11a370807d05115ce4c4e0f1af824e45e5c75334"
+)
+
+
 def test_client_py_unchanged_in_this_job() -> None:
     import hashlib
-    import subprocess
 
-    client = "app/services/brokers/kiwoom/client.py"
-    base = subprocess.check_output(
-        ["git", "merge-base", "HEAD", "origin/main"],
-        cwd=REPO_ROOT,
-        text=True,
-    ).strip()
-    named = subprocess.check_output(
-        ["git", "diff", "--name-only", f"{base}...HEAD"],
-        cwd=REPO_ROOT,
-        text=True,
-    )
-    assert client not in named.splitlines()
-    base_bytes = subprocess.check_output(
-        ["git", "show", f"{base}:{client}"], cwd=REPO_ROOT
-    )
-    head_bytes = subprocess.check_output(
-        ["git", "show", f"HEAD:{client}"], cwd=REPO_ROOT
-    )
-    worktree_bytes = (REPO_ROOT / client).read_bytes()
-    assert (
-        hashlib.sha256(worktree_bytes).digest() == hashlib.sha256(base_bytes).digest()
-    )
-    assert (
-        hashlib.sha256(worktree_bytes).digest() == hashlib.sha256(head_bytes).digest()
-    )
+    digest = hashlib.sha256(
+        (
+            REPO_ROOT / "app" / "services" / "brokers" / "kiwoom" / "client.py"
+        ).read_bytes()
+    ).hexdigest()
+    assert digest == _KIWOOM_CLIENT_PY_SHA256


### PR DESCRIPTION
## Summary

Thin Kiwoom mock-lane adapter around the merged J3A coordination port (ROB-1262). Host-local `AccountWriterLease` remains diagnostic and cannot authorize a send. Canonical identity is J2A `physical_account_id`. Kiwoom CID fields stay `None`; the exact broker order number is persisted as J2B `broker_order_id` before `own-orders.jsonl`. `kt00007` is fill/remainder truth.

This lane stays `AUTO_READY_BLOCKED_BY_LIFECYCLE`. Recurring activation, mutation smoke, and terminal completeness are out of scope.

## Recovery contract (C3)

Exactly one recovery owner: `scripts.b0x.kr.kiwoom_ordering.KiwoomCoordinationAdapter`. Restart rediscovers durable J2B claims; authoritative readback is `kt00007`; release is only `DurableSendClaimAdapter.release_with_terminal_evidence` after exact terminal or pre-send `NOT_CREATED`.

## Test plan

- [x] Offline suite in the J3C brief (adapter + Kiwoom lane + J2A/J2B)
- [x] J3A `test_coordination.py` behavioral tests (write-fence test is J3A-PR-scoped; see report)
- [x] Ruff on changed files
- [ ] Verifier (orch-owned)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinated Kiwoom order submission, cancellation, and restart recovery.
  * Added broker-state verification, ownership validation, client-ID checks, and lifecycle evidence tracking.
  * Added safeguards that block order activity when coordination authority, transport readiness, or reconciliation data is unavailable.
* **Bug Fixes**
  * Improved attribution handling so missing or unreadable journal data is not incorrectly treated as proof of no trading activity.
* **Documentation**
  * Added a recovery contract covering evidence requirements, release conditions, blocked statuses, and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->