### PR TITLE
fix(ROB-1265): fail-closed guard against real outbound sockets in offline suite

### DIFF
--- a/docs/runbooks/hermetic-test-socket-guard.md
+++ b/docs/runbooks/hermetic-test-socket-guard.md
@@ -1,0 +1,48 @@
+# Hermetic test socket guard (ROB-1265)
+
+`tests/conftest.py::_block_external_sockets` is an autouse fixture that fails
+closed on any outbound TCP connect to a non-loopback address during the
+default (`not live`) `pytest` run. It exists because the full offline suite
+was found to silently reach real external hosts (Finnhub, open.er-api.com,
+CoinGecko, Upbit, KIS live) from tests that never intended to — the leaks
+were invisible in CI (network present, so the calls just succeeded) but made
+an offline/sandboxed run nondeterministic and, in the worst case, capable of
+touching real broker/API endpoints.
+
+## What it does
+
+- Patches `socket.socket.connect` for the duration of each test.
+- Loopback addresses (`127.0.0.1`, `::1`, `localhost`) and UNIX domain socket
+  paths (local Postgres/Redis) are always allowed.
+- Any other address raises `ExternalSocketBlocked` immediately instead of
+  letting the test hang on/actually perform a real network round trip.
+
+## Exemptions
+
+Tests marked `@pytest.mark.integration` or `@pytest.mark.live` are exempt —
+those are the two marker families the repo already uses for tests that
+intentionally cross a real boundary (DB, or `--run-live` network). Do **not**
+add a new opt-out marker for "this test happens to hit the network"; that is
+exactly the failure mode this guard exists to catch. Fix the test instead:
+
+1. Find the leaf provider function the code path actually calls (e.g.
+   `_get_finnhub_client`, `_fetch_company_profile_finnhub`,
+   `upbit_service.fetch_multiple_current_prices`, `httpx.AsyncClient`).
+2. Patch it at the module that resolves the name at call time. Because many
+   of these modules do `from ... import _fetch_company_profile_finnhub`
+   locally, patching the *original* defining module is not enough — patch
+   every module that imported it, or use
+   `tests._mcp_tooling_support._patch_runtime_attr(monkeypatch, name, value)`
+   which patches the attribute across every module in `_PATCH_MODULES`.
+3. Re-run the test with the guard active (it is on by default) to confirm no
+   `ExternalSocketBlocked` is raised.
+
+## Diagnosing a trip
+
+The raised `ExternalSocketBlocked` message includes the blocked
+`(host, port)` — that is the fastest way to identify which external service
+the test under-mocked. If the traceback lands inside `asyncio`/`anyio`
+internals with no application frames (common for `httpx.AsyncClient`'s
+happy-eyeballs connection attempts, which run as a separate anyio task), fall
+back to `pytest -k <test_name> -v` in isolation to confirm which single test
+trips it.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Pytest configuration and common fixtures for auto-trader tests.
 import asyncio
 import contextlib
 import os
+import socket
 import tempfile
 import time
 from collections.abc import Generator
@@ -471,6 +472,65 @@ def _block_tvscreener_http_boundary(request, monkeypatch):
         "app.services.tvscreener_service.TvScreenerService.fetch_with_retry",
         _raise_tvscreener_blocked,
     )
+
+
+class ExternalSocketBlocked(AssertionError):
+    """Raised when a non-integration/live test tries to open a real outbound socket."""
+
+
+def _is_loopback_connect_address(address: object) -> bool:
+    """True for loopback TCP/UDP addresses and UNIX domain socket paths.
+
+    ``socket.socket.connect`` receives either a ``(host, port[, ...])`` tuple
+    (AF_INET/AF_INET6 — ``host`` here is always an already-resolved literal,
+    never a hostname, since callers resolve via ``getaddrinfo`` first) or a
+    single string/bytes path (AF_UNIX, e.g. local Postgres/Redis sockets).
+    """
+    if isinstance(address, (str, bytes)):
+        return True
+    if not isinstance(address, tuple) or not address:
+        return False
+    host = address[0]
+    if isinstance(host, bytes):
+        host = host.decode("ascii", "ignore")
+    if not isinstance(host, str):
+        return False
+    return host in ("127.0.0.1", "::1", "localhost") or host.startswith("127.")
+
+
+@pytest.fixture(autouse=True)
+def _block_external_sockets(request: pytest.FixtureRequest, monkeypatch):
+    """ROB-1265: fail-closed guard against real outbound network in the offline suite.
+
+    `make test` must never depend on external hosts being reachable — a test
+    that silently reaches Finnhub/Upbit/Binance/etc. is nondeterministic
+    offline and can even hit real broker/API endpoints. `@pytest.mark.
+    integration` and `@pytest.mark.live` tests intentionally cross real
+    boundaries (DB, or --run-live network) and are exempted; everything else
+    gets a loud, immediate ``ExternalSocketBlocked`` instead of a hung/slow
+    real connection. Mock the external client at its call site instead of
+    disabling this guard.
+    """
+    if request.node.get_closest_marker(
+        "integration"
+    ) or request.node.get_closest_marker("live"):
+        yield
+        return
+
+    real_connect = socket.socket.connect
+
+    def _guarded_connect(self, address):
+        if not _is_loopback_connect_address(address):
+            raise ExternalSocketBlocked(
+                f"Blocked outbound network connect to {address!r} in a "
+                "non-integration/live test. Mock the external client at its "
+                "call site (see docs/runbooks/hermetic-test-socket-guard.md) "
+                "instead of letting the test reach a real host."
+            )
+        return real_connect(self, address)
+
+    monkeypatch.setattr(socket.socket, "connect", _guarded_connect)
+    yield
 
 
 @pytest.fixture

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -1636,6 +1636,7 @@ async def test_toss_api_home_reader_maps_read_only_holdings_and_cash(monkeypatch
     monkeypatch.setattr(
         readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
     )
+    monkeypatch.setattr(readers, "get_usd_krw_rate", AsyncMock(return_value=1_350.0))
     # ROB-549: mutations disabled (default) -> reference-only.
     from app.core.config import settings as _cfg
 

--- a/tests/test_merged_portfolio_service.py
+++ b/tests/test_merged_portfolio_service.py
@@ -494,9 +494,17 @@ class TestBuildMergedPortfolio:
 
     @pytest.mark.asyncio
     async def test_toss_only_stock_gets_current_price(
-        self, merged_portfolio_service, mock_kis_client
+        self, merged_portfolio_service, mock_kis_client, monkeypatch
     ):
         """TOSS만 있는 종목이 현재가를 정상 조회하는지 확인"""
+        # _build_merged_portfolio always fetches USD/KRW (even for KR-market
+        # holdings) — fake it so the test never reaches the real exchange
+        # rate provider.
+        monkeypatch.setattr(
+            "app.services.merged_portfolio_service.get_usd_krw_rate",
+            AsyncMock(return_value=1300.0),
+        )
+
         # KIS 보유 종목 없음
         mock_kis_client.fetch_my_stocks = AsyncMock(return_value=[])
 
@@ -538,9 +546,17 @@ class TestBuildMergedPortfolio:
 
     @pytest.mark.asyncio
     async def test_mixed_kis_and_toss_holdings(
-        self, merged_portfolio_service, mock_kis_client
+        self, merged_portfolio_service, mock_kis_client, monkeypatch
     ):
         """KIS와 TOSS 혼합 보유 종목"""
+        # _build_merged_portfolio always fetches USD/KRW (even for KR-market
+        # holdings) — fake it so the test never reaches the real exchange
+        # rate provider.
+        monkeypatch.setattr(
+            "app.services.merged_portfolio_service.get_usd_krw_rate",
+            AsyncMock(return_value=1300.0),
+        )
+
         # KIS 보유 종목 (삼성전자만)
         kis_stocks = [
             {

--- a/tests/test_portfolio_overview_service.py
+++ b/tests/test_portfolio_overview_service.py
@@ -988,6 +988,11 @@ async def test_get_overview_excludes_non_tradable_manual_crypto_everywhere(
         "get_active_upbit_markets",
         AsyncMock(return_value=["KRW-BTC"]),
     )
+    monkeypatch.setattr(
+        portfolio_overview_module,
+        "get_usd_krw_rate",
+        AsyncMock(return_value=1350.0),
+    )
 
     overview = await service.get_overview(user_id=7)
 


### PR DESCRIPTION
## Summary
- The full offline `pytest tests/ -m "not live"` suite silently reached real external hosts (Finnhub company-profile/news, open.er-api.com exchange rate, CoinGecko, Upbit) — invisible in CI (network present, so calls just succeeded) but nondeterministic offline and capable of touching real endpoints.
- Root cause: several `app/mcp_server/tooling/*` modules do `from ...fundamentals_sources_finnhub import _fetch_company_profile_finnhub` as a **local** import; tests that patch one importer's copy don't intercept another importer's call site. `merged_portfolio_service`/`portfolio_overview_service`/`invest_home_readers` unconditionally call `get_usd_krw_rate()` even for KR-only holdings, which several tests never mocked.
- Added an autouse `_block_external_sockets` fixture in `tests/conftest.py` (same pattern as the existing `_block_tvscreener_http_boundary` guard) that fails closed on any non-loopback `socket.connect` during non-`integration`/non-`live` tests. The block surfaces as a provider failure the app already tolerates (`asyncio.gather(..., return_exceptions=True)`), so most leaking tests pass unchanged; 4 tests that specifically asserted "no degraded-provider warning" needed an explicit `get_usd_krw_rate` mock.
- Runbook: `docs/runbooks/hermetic-test-socket-guard.md`.

## Test plan
- [x] Instrumented socket probe reproduced real connects to `api.finnhub.io`, `open.er-api.com`, `api.coingecko.com`, `api.upbit.com` before the fix (partial full-suite run).
- [x] Full guarded suite run (19,896 collected): 24 failed → 20 failed after the 4 fixes, all 20 remaining failures reproduce identically on `origin/main` (pre-existing worktree-`.venv`/alembic-binary and env issues, unrelated to sockets) — confirmed via `git stash` A/B compare.
- [x] Re-ran the full suite with the same passive socket-probe instrumentation post-fix: the only non-loopback connects left are from `@pytest.mark.integration`-marked tests (KIS/Upbit/exchange-rate), which are the guard's explicit, by-design exemption — same category the repo's existing `integration` marker already carves out for real-DB/real-boundary tests.
- [x] Negative proof the guard actually fires: a throwaway test opening a socket to `8.8.8.8:443` raises `ExternalSocketBlocked`; loopback connects are unaffected.
- [x] `make lint` (ruff check, ruff format, ty check) — all clean.
- [x] `git diff --stat origin/main...HEAD` — only `tests/conftest.py`, 3 test files, and a new runbook touched. No migration/pyproject/uv.lock/scheduler/broker changes; no touch to `app/services/mock_integration/coordination.py` or its test/contract doc.