### PR TITLE
test(ROB-1880): harden repository socket guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,8 +189,9 @@ jobs:
       # Coverage gating lives in Codecov (uploads from all shards are merged
       # per commit).
       run: |
+        mkdir -p .artifacts/socket-guard
         set +e
-        uv run pytest tests/ -m "not live" --splits 4 --group ${{ matrix.group }} --durations-path .test_durations -n 4 --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml 2>&1 | tee pytest-output.log
+        uv run pytest tests/ -m "not live" --splits 4 --group ${{ matrix.group }} --durations-path .test_durations -n 4 --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml --socket-guard-report ".artifacts/socket-guard/summary-shard${{ matrix.group }}.json" 2>&1 | tee pytest-output.log
         status=${PIPESTATUS[0]}
         if [ "$status" -ne 0 ]; then
           {
@@ -203,6 +204,14 @@ jobs:
           echo "::error title=pytest shard failed::$message"
         fi
         exit "$status"
+
+    - name: Upload socket guard evidence
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: socket-guard-evidence-${{ matrix.python-version }}-shard${{ matrix.group }}
+        path: .artifacts/socket-guard/summary-shard${{ matrix.group }}.json
+        if-no-files-found: error
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v6

--- a/docs/runbooks/hermetic-test-socket-guard.md
+++ b/docs/runbooks/hermetic-test-socket-guard.md
@@ -1,48 +1,74 @@
-# Hermetic test socket guard (ROB-1265)
+# Hermetic test socket guard (ROB-1265 / ROB-1880)
 
-`tests/conftest.py::_block_external_sockets` is an autouse fixture that fails
-closed on any outbound TCP connect to a non-loopback address during the
-default (`not live`) `pytest` run. It exists because the full offline suite
-was found to silently reach real external hosts (Finnhub, open.er-api.com,
-CoinGecko, Upbit, KIS live) from tests that never intended to — the leaks
-were invisible in CI (network present, so the calls just succeeded) but made
-an offline/sandboxed run nondeterministic and, in the worst case, capable of
-touching real broker/API endpoints.
+`tests._socket_guard_plugin` is loaded by pytest's `-p` option before test
+collection and module import. It fails closed on outbound socket operations in
+the default (`not live`) suite. The guard exists because the full suite was
+found to silently reach real external hosts (Finnhub, open.er-api.com,
+CoinGecko, Upbit, KIS live) from tests that never intended to — leaks that are
+invisible in a networked CI runner make offline runs nondeterministic and can
+touch real broker/API endpoints.
 
 ## What it does
 
-- Patches `socket.socket.connect` for the duration of each test.
-- Loopback addresses (`127.0.0.1`, `::1`, `localhost`) and UNIX domain socket
-  paths (local Postgres/Redis) are always allowed.
-- Any other address raises `ExternalSocketBlocked` immediately instead of
-  letting the test hang on/actually perform a real network round trip.
+- Installs before collection/import, including `pytest --noconftest`. A
+  missing or replaced intercept is a pytest failure, never a warning or skip.
+- Patches `socket.socket.connect`, `connect_ex`, `sendto`, and `sendmsg`. This
+  covers direct synchronous calls plus asyncio's socket connect/send paths.
+- Allows only TCP/UDP loopback literals (`127.0.0.0/8`, `::1`, `localhost`) and
+  these exact UNIX service paths: `/tmp/.s.PGSQL.5432`,
+  `/private/tmp/.s.PGSQL.5432`, `/var/run/postgresql/.s.PGSQL.5432`, and
+  `/var/run/redis/redis-server.sock`. An arbitrary `AF_UNIX` path is denied.
+- Lets an explicitly marked `integration` or `live` item cross its intentional
+  boundary while retaining the default-deny policy during collection/import.
+- Propagates an environment switch and dedicated `sitecustomize` directory into
+  child Python processes, including children started with `env={}`. Direct
+  `curl`/`wget`/`ssh`-family launchers and Python `-S`/`-E`/`-I` startup-bypass
+  flags are rejected before they start.
+- Raises `ExternalSocketBlocked` immediately for any other address instead of
+  letting the test hang on or perform a real network round trip.
 
 ## Exemptions
 
-Tests marked `@pytest.mark.integration` or `@pytest.mark.live` are exempt —
-those are the two marker families the repo already uses for tests that
-intentionally cross a real boundary (DB, or `--run-live` network). Do **not**
-add a new opt-out marker for "this test happens to hit the network"; that is
-exactly the failure mode this guard exists to catch. Fix the test instead:
+Tests marked `@pytest.mark.integration` or `@pytest.mark.live` are exempt
+during that test item's setup/call/teardown — those are the two marker families
+the repo already uses for intentional boundaries (DB, or `--run-live` network).
+Do **not** add a new opt-out marker for "this test happens to hit the network";
+that is exactly the failure mode this guard exists to catch. Fix the test
+instead:
 
 1. Find the leaf provider function the code path actually calls (e.g.
    `_get_finnhub_client`, `_fetch_company_profile_finnhub`,
    `upbit_service.fetch_multiple_current_prices`, `httpx.AsyncClient`).
 2. Patch it at the module that resolves the name at call time. Because many
-   of these modules do `from ... import _fetch_company_profile_finnhub`
-   locally, patching the *original* defining module is not enough — patch
-   every module that imported it, or use
-   `tests._mcp_tooling_support._patch_runtime_attr(monkeypatch, name, value)`
-   which patches the attribute across every module in `_PATCH_MODULES`.
+   modules do `from ... import _fetch_company_profile_finnhub` locally,
+   patching only the defining module is not enough — patch every consuming
+   module, or use
+   `tests._mcp_tooling_support._patch_runtime_attr(monkeypatch, name, value)`.
 3. Re-run the test with the guard active (it is on by default) to confirm no
    `ExternalSocketBlocked` is raised.
 
 ## Diagnosing a trip
 
-The raised `ExternalSocketBlocked` message includes the blocked
-`(host, port)` — that is the fastest way to identify which external service
-the test under-mocked. If the traceback lands inside `asyncio`/`anyio`
-internals with no application frames (common for `httpx.AsyncClient`'s
-happy-eyeballs connection attempts, which run as a separate anyio task), fall
-back to `pytest -k <test_name> -v` in isolation to confirm which single test
-trips it.
+The raised `ExternalSocketBlocked` message includes the blocked `(host, port)`
+— that is the fastest way to identify which external service the test
+under-mocked. If the traceback lands inside `asyncio`/`anyio` internals with no
+application frames (common for `httpx.AsyncClient` happy-eyeballs connection
+attempts), fall back to `pytest -k <test_name> -v` in isolation to confirm the
+single test that trips it.
+
+## CI evidence and subprocess scope
+
+CI passes `--socket-guard-report` on every xdist shard. The plugin aggregates
+worker reports at the controller and writes JSON containing guard activation,
+worker count, and per-operation blocked-attempt counters; the workflow uploads
+that JSON even when pytest fails.
+
+The child-process protection is a Python test-harness boundary, not an OS
+network namespace. Standard `subprocess.Popen` callers (and therefore
+`run`/`check_*`/asyncio subprocess helpers) receive guarded startup state for
+direct Python children, while direct common network-client launchers are
+rejected. Non-Python child environments are deliberately not rewritten. A test
+that deliberately invokes a native executable through a lower-level `exec*`
+syscall or embeds a network stack in an otherwise allowlisted native binary is
+outside what Python can intercept; such a test must be treated as an
+integration/live boundary rather than an offline test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,13 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = [
+    "-p",
+    "tests._socket_guard_plugin",
     "--strict-markers",
     "--strict-config",
 ]

--- a/tests/_socket_guard.py
+++ b/tests/_socket_guard.py
@@ -1,0 +1,422 @@
+"""Fail-closed socket guard shared by the pytest startup plugin and children.
+
+The guard deliberately lives outside ``conftest.py``: pytest imports a ``-p``
+plugin before collecting test modules, while child Python interpreters load the
+same implementation from ``sitecustomize``. Keeping the policy here makes the
+two installation paths byte-for-byte identical.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import shlex
+import socket
+import subprocess
+import threading
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+ENV_ENABLED: Final = "AUTO_TRADER_TEST_SOCKET_GUARD"
+"""Environment switch consumed by the child-process ``sitecustomize`` hook."""
+
+PROJECT_ROOT: Final = Path(__file__).resolve().parents[1]
+STARTUP_HOOK_DIRECTORY: Final = PROJECT_ROOT / "tests" / "_socket_guard_startup"
+
+# The local-service paths are intentionally finite. A bare ``AF_UNIX`` path is
+# not proof that the peer is a local test service; accepting every path was the
+# pre-ROB-1880 bypass. TCP loopback remains independently allowed.
+LOCAL_UNIX_SOCKET_ALLOWLIST: Final = frozenset(
+    {
+        "/tmp/.s.PGSQL.5432",
+        "/private/tmp/.s.PGSQL.5432",
+        "/var/run/postgresql/.s.PGSQL.5432",
+        "/var/run/redis/redis-server.sock",
+    }
+)
+
+_NETWORK_CLIENT_EXECUTABLES: Final = frozenset(
+    {
+        "curl",
+        "ftp",
+        "http",
+        "https",
+        "nc",
+        "ncat",
+        "netcat",
+        "rsync",
+        "scp",
+        "sftp",
+        "ssh",
+        "telnet",
+        "wget",
+    }
+)
+_SHELL_EXECUTABLES: Final = frozenset({"bash", "dash", "fish", "sh", "zsh"})
+_UNSAFE_PYTHON_STARTUP_FLAGS: Final = frozenset({"-E", "-I", "-S"})
+
+
+class SocketGuardInstallationError(RuntimeError):
+    """Raised when the mandatory startup patch is absent or has been replaced."""
+
+
+class ExternalSocketBlocked(AssertionError):
+    """Raised before a non-allowlisted socket operation can reach the kernel."""
+
+
+class ExternalSubprocessBlocked(AssertionError):
+    """Raised before a known network-capable subprocess can be started."""
+
+
+_INSTALL_LOCK = threading.RLock()
+_STATE_LOCK = threading.Lock()
+_INSTALLED = False
+_CURRENT_TEST_IS_EXEMPT = False
+_BLOCKED_BY_OPERATION: Counter[str] = Counter()
+
+_ORIGINAL_CONNECT = socket.socket.connect
+_ORIGINAL_CONNECT_EX = socket.socket.connect_ex
+_ORIGINAL_SENDTO = socket.socket.sendto
+_ORIGINAL_SENDMSG = getattr(socket.socket, "sendmsg", None)
+_ORIGINAL_POPEN_INIT = subprocess.Popen.__init__
+
+
+def _record_block(operation: str) -> None:
+    with _STATE_LOCK:
+        _BLOCKED_BY_OPERATION[operation] += 1
+
+
+def set_current_test_exempt(exempt: bool) -> bool:
+    """Set the marker-derived exemption and return the prior state.
+
+    Pytest executes one item per worker process at a time. A process-global
+    flag intentionally also covers helper threads created by an integration
+    test, unlike a task-local context variable would.
+    """
+
+    global _CURRENT_TEST_IS_EXEMPT
+    with _STATE_LOCK:
+        previous = _CURRENT_TEST_IS_EXEMPT
+        _CURRENT_TEST_IS_EXEMPT = exempt
+        return previous
+
+
+def is_current_test_exempt() -> bool:
+    with _STATE_LOCK:
+        return _CURRENT_TEST_IS_EXEMPT
+
+
+def _is_loopback_host(host: object) -> bool:
+    if isinstance(host, bytes):
+        host = host.decode("ascii", "ignore")
+    if not isinstance(host, str):
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        parsed = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if parsed.is_loopback:
+        return True
+    mapped = getattr(parsed, "ipv4_mapped", None)
+    return bool(mapped and mapped.is_loopback)
+
+
+def _is_allowlisted_unix_path(address: str | bytes) -> bool:
+    try:
+        path = os.fsdecode(address)
+    except TypeError:
+        return False
+    return path in LOCAL_UNIX_SOCKET_ALLOWLIST
+
+
+def is_allowed_local_address(address: object) -> bool:
+    """Return whether *address* is an exact local socket allowlist member."""
+
+    if isinstance(address, (str, bytes)):
+        return _is_allowlisted_unix_path(address)
+    if not isinstance(address, tuple) or not address:
+        return False
+    return _is_loopback_host(address[0])
+
+
+def _raise_socket_blocked(operation: str, address: object) -> None:
+    _record_block(operation)
+    raise ExternalSocketBlocked(
+        f"Blocked outbound socket.{operation} to {address!r} in a "
+        "non-integration/live test. Mock the external client at its call site "
+        "(see docs/runbooks/hermetic-test-socket-guard.md) instead of letting "
+        "the test reach a real host."
+    )
+
+
+def _assert_socket_address_allowed(operation: str, address: object) -> None:
+    if is_current_test_exempt() or is_allowed_local_address(address):
+        return
+    _raise_socket_blocked(operation, address)
+
+
+def _guarded_connect(self: socket.socket, address: object) -> None:
+    _assert_socket_address_allowed("connect", address)
+    _ORIGINAL_CONNECT(self, address)
+
+
+def _guarded_connect_ex(self: socket.socket, address: object) -> int:
+    _assert_socket_address_allowed("connect_ex", address)
+    return _ORIGINAL_CONNECT_EX(self, address)
+
+
+def _guarded_sendto(
+    self: socket.socket, data: bytes, *args: object, **kwargs: object
+) -> int:
+    address = kwargs.get("address")
+    if address is None and args:
+        # ``sendto(data, address)`` and ``sendto(data, flags, address)`` both
+        # put the peer address last.
+        address = args[-1]
+    if address is not None:
+        _assert_socket_address_allowed("sendto", address)
+    return _ORIGINAL_SENDTO(self, data, *args, **kwargs)
+
+
+def _guarded_sendmsg(
+    self: socket.socket, buffers: object, *args: object, **kwargs: object
+) -> int:
+    address = kwargs.get("address")
+    # sendmsg(buffers[, ancdata[, flags[, address]]])
+    if address is None and len(args) >= 3:
+        address = args[2]
+    if address is not None:
+        _assert_socket_address_allowed("sendmsg", address)
+    if _ORIGINAL_SENDMSG is None:  # pragma: no cover - platform defensive
+        raise SocketGuardInstallationError("socket.sendmsg is unavailable")
+    return _ORIGINAL_SENDMSG(self, buffers, *args, **kwargs)
+
+
+def _command_parts(command: object) -> tuple[str, ...]:
+    if isinstance(command, os.PathLike):
+        return (os.fspath(command),)
+    if isinstance(command, bytes):
+        return tuple(shlex.split(os.fsdecode(command)))
+    if isinstance(command, str):
+        return tuple(shlex.split(command))
+    if isinstance(command, Sequence):
+        return tuple(
+            os.fsdecode(part) if isinstance(part, bytes) else str(part)
+            for part in command
+        )
+    return ()
+
+
+def _is_python_executable(value: str) -> bool:
+    executable = Path(value).name.lower()
+    return executable == "py" or executable.startswith("python")
+
+
+def _nested_command_parts(parts: Sequence[str]) -> tuple[str, ...]:
+    """Expose a shell ``-c`` payload without attempting to execute it.
+
+    ``Popen(["sh", "-c", "curl …"])`` must not turn a direct-client deny
+    rule into a superficial one-token check.  One level is sufficient for the
+    usual shell wrapper while avoiding a speculative shell parser.
+    """
+
+    nested: list[str] = []
+    for part in parts:
+        try:
+            parsed = shlex.split(part)
+        except ValueError:
+            continue
+        if len(parsed) > 1:
+            nested.extend(parsed)
+    return tuple(nested)
+
+
+def _command_contains_python(parts: Sequence[str]) -> bool:
+    return any(
+        _is_python_executable(part) for part in (*parts, *_nested_command_parts(parts))
+    )
+
+
+def _is_shell_wrapped_python(parts: Sequence[str]) -> bool:
+    if not parts or Path(parts[0]).name.lower() not in _SHELL_EXECUTABLES:
+        return False
+    return "-c" in parts and _command_contains_python(_nested_command_parts(parts))
+
+
+def _raise_subprocess_blocked(reason: str, command: object) -> None:
+    _record_block(f"subprocess:{reason}")
+    raise ExternalSubprocessBlocked(
+        f"Blocked subprocess ({reason}) during an offline pytest run: {command!r}. "
+        "Use a mocked client or mark the test integration/live when a real "
+        "boundary is intentional."
+    )
+
+
+def _assert_subprocess_allowed(command: object) -> None:
+    parts = _command_parts(command)
+    expanded_parts = (*parts, *_nested_command_parts(parts))
+    executable_names = {Path(part).name.lower() for part in expanded_parts}
+    if _NETWORK_CLIENT_EXECUTABLES.intersection(executable_names):
+        _raise_subprocess_blocked("network-client", command)
+    for position, part in enumerate(expanded_parts):
+        if _is_python_executable(part) and _UNSAFE_PYTHON_STARTUP_FLAGS.intersection(
+            expanded_parts[position + 1 :]
+        ):
+            _raise_subprocess_blocked("python-startup-bypass", command)
+
+
+def _with_guard_environment(
+    environment: Mapping[str, str] | None, *, enabled: bool
+) -> dict[str, str]:
+    child_environment = dict(os.environ if environment is None else environment)
+    child_environment[ENV_ENABLED] = "1" if enabled else "0"
+
+    if enabled:
+        existing = [
+            entry
+            for entry in child_environment.get("PYTHONPATH", "").split(os.pathsep)
+            if entry
+        ]
+        required = [str(STARTUP_HOOK_DIRECTORY), str(PROJECT_ROOT)]
+        for entry in reversed(required):
+            if entry in existing:
+                existing.remove(entry)
+            existing.insert(0, entry)
+        child_environment["PYTHONPATH"] = os.pathsep.join(existing)
+
+    return child_environment
+
+
+def activate_child_guard_environment() -> None:
+    """Make every subsequently spawned child Python inherit the startup hook."""
+
+    os.environ.update(_with_guard_environment(os.environ, enabled=True))
+
+
+def _replace_popen_environment(
+    positional: tuple[object, ...], kwargs: dict[str, object], *, enabled: bool
+) -> tuple[tuple[object, ...], dict[str, object]]:
+    # ``env`` is the tenth argument after ``args`` in subprocess.Popen's
+    # positional signature. Keyword usage is overwhelmingly common, but
+    # supporting both prevents an explicit child environment from bypassing
+    # the inherited startup hook.
+    env_index = 9
+    if len(positional) > env_index:
+        rewritten = list(positional)
+        explicit_env = rewritten[env_index]
+        if explicit_env is not None and not isinstance(explicit_env, Mapping):
+            raise SocketGuardInstallationError("subprocess env must be a mapping")
+        rewritten[env_index] = _with_guard_environment(explicit_env, enabled=enabled)
+        return tuple(rewritten), kwargs
+
+    rewritten_kwargs = dict(kwargs)
+    explicit_env = rewritten_kwargs.get("env")
+    if explicit_env is not None and not isinstance(explicit_env, Mapping):
+        raise SocketGuardInstallationError("subprocess env must be a mapping")
+    rewritten_kwargs["env"] = _with_guard_environment(explicit_env, enabled=enabled)
+    return positional, rewritten_kwargs
+
+
+def _guarded_popen_init(
+    self: subprocess.Popen[Any], args: object, *positional: object, **kwargs: object
+) -> None:
+    exempt = is_current_test_exempt()
+    parts = _command_parts(args)
+    if not exempt:
+        _assert_subprocess_allowed(args)
+    if (parts and _is_python_executable(parts[0])) or _is_shell_wrapped_python(parts):
+        # The marker exemption applies to a direct Python child too.  The
+        # parent process has the startup hook in its own environment, so an
+        # exempt child needs an explicit off switch rather than merely leaving
+        # its environment unchanged.  The same applies to ``sh -c python``:
+        # the shell is only a launcher, not a bypass around child inheritance.
+        rewritten_positional, rewritten_kwargs = _replace_popen_environment(
+            positional, kwargs, enabled=not exempt
+        )
+    else:
+        # Do not alter the environment of non-Python tools. In particular,
+        # strict subprocess harnesses must retain byte-for-byte child-env
+        # semantics; direct network-client executables were rejected above.
+        rewritten_positional, rewritten_kwargs = positional, kwargs
+    _ORIGINAL_POPEN_INIT(self, args, *rewritten_positional, **rewritten_kwargs)
+
+
+def install() -> None:
+    """Install every intercept once, raising instead of silently degrading."""
+
+    global _INSTALLED
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            assert_installed()
+            return
+
+        socket.socket.connect = _guarded_connect
+        socket.socket.connect_ex = _guarded_connect_ex
+        socket.socket.sendto = _guarded_sendto
+        if _ORIGINAL_SENDMSG is not None:
+            socket.socket.sendmsg = _guarded_sendmsg
+        subprocess.Popen.__init__ = _guarded_popen_init
+        _INSTALLED = True
+        assert_installed()
+
+
+def is_installed() -> bool:
+    try:
+        assert_installed()
+    except SocketGuardInstallationError:
+        return False
+    return True
+
+
+def assert_installed() -> None:
+    """Assert all expected intercepts remain intact; never warn-and-continue."""
+
+    expected: tuple[tuple[object, str, object], ...] = (
+        (socket.socket, "connect", _guarded_connect),
+        (socket.socket, "connect_ex", _guarded_connect_ex),
+        (socket.socket, "sendto", _guarded_sendto),
+        (subprocess.Popen, "__init__", _guarded_popen_init),
+    )
+    if _ORIGINAL_SENDMSG is not None:
+        expected += ((socket.socket, "sendmsg", _guarded_sendmsg),)
+
+    failures = [
+        f"{owner.__name__}.{name}"
+        for owner, name, replacement in expected
+        if getattr(owner, name, None) is not replacement
+    ]
+    if not _INSTALLED or failures:
+        details = ", ".join(failures) if failures else "startup installation"
+        raise SocketGuardInstallationError(
+            "ROB-1880 socket guard is not installed correctly: " + details
+        )
+
+
+def summary() -> dict[str, object]:
+    """Return JSON-safe evidence for terminal output and CI artifacts."""
+
+    with _STATE_LOCK:
+        blocked_by_operation = dict(sorted(_BLOCKED_BY_OPERATION.items()))
+    return {
+        "guard": "rob-1880-socket-guard",
+        "active": is_installed(),
+        "pid": os.getpid(),
+        "worker_id": os.environ.get("PYTEST_XDIST_WORKER", "controller"),
+        "blocked_attempts": sum(blocked_by_operation.values()),
+        "blocked_by_operation": blocked_by_operation,
+        "local_unix_allowlist": sorted(LOCAL_UNIX_SOCKET_ALLOWLIST),
+        "child_python_startup_hook": str(STARTUP_HOOK_DIRECTORY),
+    }
+
+
+def write_report(path: str | os.PathLike[str], payload: Mapping[str, object]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )

--- a/tests/_socket_guard_plugin.py
+++ b/tests/_socket_guard_plugin.py
@@ -1,0 +1,128 @@
+"""Pytest startup plugin for the repository-wide ROB-1880 socket guard."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+import pytest
+
+from tests import _socket_guard as socket_guard
+
+_WORKER_SUMMARIES_KEY = pytest.StashKey[list[dict[str, object]]]()
+_FINAL_SUMMARY_KEY = pytest.StashKey[dict[str, object]]()
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("socket guard")
+    group.addoption(
+        "--socket-guard-report",
+        action="store",
+        default=None,
+        metavar="PATH",
+        help="write the aggregated ROB-1880 socket guard session evidence to PATH",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # ``-p tests._socket_guard_plugin`` is loaded before test collection and
+    # module import. It is intentionally not a conftest fixture.
+    socket_guard.activate_child_guard_environment()
+    socket_guard.install()
+    config.stash[_WORKER_SUMMARIES_KEY] = []
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    try:
+        socket_guard.assert_installed()
+    except socket_guard.SocketGuardInstallationError as error:
+        raise pytest.UsageError(str(error)) from error
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_protocol(item: pytest.Item, nextitem: pytest.Item | None):
+    """Allow explicit integration/live items while retaining import-time default deny."""
+
+    exempt = bool(
+        item.get_closest_marker("integration") or item.get_closest_marker("live")
+    )
+    previous = socket_guard.set_current_test_exempt(exempt)
+    try:
+        socket_guard.assert_installed()
+        yield
+    finally:
+        socket_guard.set_current_test_exempt(previous)
+        socket_guard.assert_installed()
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001
+    local_summary = socket_guard.summary()
+    worker_output = getattr(session.config, "workeroutput", None)
+    if worker_output is not None:
+        worker_output["rob1880_socket_guard"] = local_summary
+        return
+
+    aggregate = _aggregate(
+        [local_summary, *session.config.stash[_WORKER_SUMMARIES_KEY]]
+    )
+    session.config.stash[_FINAL_SUMMARY_KEY] = aggregate
+    report_path = session.config.getoption("--socket-guard-report")
+    if report_path:
+        socket_guard.write_report(report_path, aggregate)
+    if not aggregate["active"]:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node: Any, error: BaseException | None) -> None:  # noqa: ARG001
+    """Collect each xdist worker's evidence before the controller reports it."""
+
+    summary = node.workeroutput.get("rob1880_socket_guard")
+    if summary is None:
+        gateway = getattr(node, "gateway", None)
+        summary = {
+            "active": False,
+            "worker_id": gateway.id if gateway is not None else "unknown",
+            "blocked_attempts": 0,
+            "blocked_by_operation": {},
+            "error": "worker exited without socket guard evidence",
+        }
+    node.config.stash[_WORKER_SUMMARIES_KEY].append(summary)
+
+
+def pytest_terminal_summary(terminalreporter: Any) -> None:
+    summary = terminalreporter.config.stash.get(_FINAL_SUMMARY_KEY, None)
+    if summary is None:
+        return
+    terminalreporter.write_line(
+        "ROB-1880 socket guard: "
+        f"active={summary['active']} "
+        f"blocked_attempts={summary['blocked_attempts']} "
+        f"workers={summary['worker_count']}"
+    )
+
+
+def _aggregate(participants: list[dict[str, object]]) -> dict[str, object]:
+    blocked_by_operation: Counter[str] = Counter()
+    blocked_attempts = 0
+    for participant in participants:
+        blocked_attempts += int(participant.get("blocked_attempts", 0))
+        raw_counts = participant.get("blocked_by_operation", {})
+        if isinstance(raw_counts, dict):
+            blocked_by_operation.update(
+                {str(operation): int(count) for operation, count in raw_counts.items()}
+            )
+
+    worker_summaries = [
+        participant
+        for participant in participants
+        if participant.get("worker_id") not in {"controller", "master"}
+    ]
+    return {
+        "guard": "rob-1880-socket-guard",
+        "active": all(bool(participant.get("active")) for participant in participants),
+        "blocked_attempts": blocked_attempts,
+        "blocked_by_operation": dict(sorted(blocked_by_operation.items())),
+        "worker_count": len(worker_summaries),
+        "participants": participants,
+    }

--- a/tests/_socket_guard_startup/sitecustomize.py
+++ b/tests/_socket_guard_startup/sitecustomize.py
@@ -1,0 +1,20 @@
+"""Install the ROB-1880 guard in Python children spawned by pytest.
+
+The parent startup plugin prepends this directory to ``PYTHONPATH`` and sets
+``AUTO_TRADER_TEST_SOCKET_GUARD=1``. A failure here must abort interpreter
+startup rather than let a child quietly run without the guard.
+"""
+
+from __future__ import annotations
+
+import os
+
+if os.environ.get("AUTO_TRADER_TEST_SOCKET_GUARD") == "1":
+    try:
+        from tests._socket_guard import install
+
+        install()
+    except BaseException as error:  # pragma: no cover - fatal startup path
+        raise SystemExit(
+            "ROB-1880 socket guard child startup installation failed"
+        ) from error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ Pytest configuration and common fixtures for auto-trader tests.
 import asyncio
 import contextlib
 import os
-import socket
 import tempfile
 import time
 from collections.abc import Generator
@@ -472,65 +471,6 @@ def _block_tvscreener_http_boundary(request, monkeypatch):
         "app.services.tvscreener_service.TvScreenerService.fetch_with_retry",
         _raise_tvscreener_blocked,
     )
-
-
-class ExternalSocketBlocked(AssertionError):
-    """Raised when a non-integration/live test tries to open a real outbound socket."""
-
-
-def _is_loopback_connect_address(address: object) -> bool:
-    """True for loopback TCP/UDP addresses and UNIX domain socket paths.
-
-    ``socket.socket.connect`` receives either a ``(host, port[, ...])`` tuple
-    (AF_INET/AF_INET6 — ``host`` here is always an already-resolved literal,
-    never a hostname, since callers resolve via ``getaddrinfo`` first) or a
-    single string/bytes path (AF_UNIX, e.g. local Postgres/Redis sockets).
-    """
-    if isinstance(address, (str, bytes)):
-        return True
-    if not isinstance(address, tuple) or not address:
-        return False
-    host = address[0]
-    if isinstance(host, bytes):
-        host = host.decode("ascii", "ignore")
-    if not isinstance(host, str):
-        return False
-    return host in ("127.0.0.1", "::1", "localhost") or host.startswith("127.")
-
-
-@pytest.fixture(autouse=True)
-def _block_external_sockets(request: pytest.FixtureRequest, monkeypatch):
-    """ROB-1265: fail-closed guard against real outbound network in the offline suite.
-
-    `make test` must never depend on external hosts being reachable — a test
-    that silently reaches Finnhub/Upbit/Binance/etc. is nondeterministic
-    offline and can even hit real broker/API endpoints. `@pytest.mark.
-    integration` and `@pytest.mark.live` tests intentionally cross real
-    boundaries (DB, or --run-live network) and are exempted; everything else
-    gets a loud, immediate ``ExternalSocketBlocked`` instead of a hung/slow
-    real connection. Mock the external client at its call site instead of
-    disabling this guard.
-    """
-    if request.node.get_closest_marker(
-        "integration"
-    ) or request.node.get_closest_marker("live"):
-        yield
-        return
-
-    real_connect = socket.socket.connect
-
-    def _guarded_connect(self, address):
-        if not _is_loopback_connect_address(address):
-            raise ExternalSocketBlocked(
-                f"Blocked outbound network connect to {address!r} in a "
-                "non-integration/live test. Mock the external client at its "
-                "call site (see docs/runbooks/hermetic-test-socket-guard.md) "
-                "instead of letting the test reach a real host."
-            )
-        return real_connect(self, address)
-
-    monkeypatch.setattr(socket.socket, "connect", _guarded_connect)
-    yield
 
 
 @pytest.fixture

--- a/tests/test_rob1880_socket_guard.py
+++ b/tests/test_rob1880_socket_guard.py
@@ -1,0 +1,199 @@
+"""Durable negative controls for the repository-wide ROB-1880 socket guard."""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+import socket
+import subprocess
+import sys
+
+import pytest
+
+from tests import _socket_guard as socket_guard
+
+IPV4_EXTERNAL_HTTPS = ("203.0.113.1", 443)
+IPV6_EXTERNAL_HTTPS = ("2001:db8::1", 443, 0, 0)
+
+
+@pytest.mark.parametrize(
+    ("family", "address", "operation"),
+    [
+        (socket.AF_INET, IPV4_EXTERNAL_HTTPS, "connect"),
+        (socket.AF_INET6, IPV6_EXTERNAL_HTTPS, "connect"),
+        (socket.AF_INET, IPV4_EXTERNAL_HTTPS, "connect_ex"),
+        (socket.AF_INET6, IPV6_EXTERNAL_HTTPS, "connect_ex"),
+    ],
+)
+def test_sync_external_tcp_operations_fail_closed(
+    family: socket.AddressFamily, address: tuple[object, ...], operation: str
+) -> None:
+    with socket.socket(family, socket.SOCK_STREAM) as sock:
+        with pytest.raises(socket_guard.ExternalSocketBlocked):
+            getattr(sock, operation)(address)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("family", "address", "operation"),
+    [
+        (socket.AF_INET, IPV4_EXTERNAL_HTTPS, "connect"),
+        (socket.AF_INET6, IPV6_EXTERNAL_HTTPS, "connect"),
+        (socket.AF_INET, IPV4_EXTERNAL_HTTPS, "connect_ex"),
+        (socket.AF_INET6, IPV6_EXTERNAL_HTTPS, "connect_ex"),
+    ],
+)
+async def test_async_external_tcp_operations_fail_closed(
+    family: socket.AddressFamily, address: tuple[object, ...], operation: str
+) -> None:
+    with socket.socket(family, socket.SOCK_STREAM) as sock:
+        with pytest.raises(socket_guard.ExternalSocketBlocked):
+            if operation == "connect":
+                await asyncio.get_running_loop().sock_connect(sock, address)
+            else:
+                await asyncio.to_thread(sock.connect_ex, address)
+
+
+def test_sync_udp_sendto_fails_closed() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        with pytest.raises(socket_guard.ExternalSocketBlocked):
+            sock.sendto(b"guard-probe", IPV4_EXTERNAL_HTTPS)
+
+
+@pytest.mark.asyncio
+async def test_async_udp_sendto_fails_closed() -> None:
+    with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
+        with pytest.raises(socket_guard.ExternalSocketBlocked):
+            await asyncio.get_running_loop().sock_sendto(
+                sock, b"guard-probe", IPV6_EXTERNAL_HTTPS
+            )
+
+
+def test_local_allowlist_is_exact() -> None:
+    assert socket_guard.is_allowed_local_address(("127.0.0.1", 5432))
+    assert socket_guard.is_allowed_local_address(("::1", 5432, 0, 0))
+    assert socket_guard.is_allowed_local_address("/tmp/.s.PGSQL.5432")
+    assert not socket_guard.is_allowed_local_address("/tmp/rob1880-unlisted.sock")
+    assert not socket_guard.is_allowed_local_address(("203.0.113.1", 443))
+
+
+def test_unlisted_unix_socket_path_fails_closed() -> None:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        with pytest.raises(socket_guard.ExternalSocketBlocked):
+            sock.connect("/tmp/rob1880-unlisted.sock")
+
+
+def test_replaced_installation_is_a_hard_failure(monkeypatch) -> None:
+    monkeypatch.setattr(socket.socket, "connect", socket_guard._ORIGINAL_CONNECT)
+
+    with pytest.raises(socket_guard.SocketGuardInstallationError, match="connect"):
+        socket_guard.assert_installed()
+
+
+def test_child_python_inherits_guard_even_with_an_explicit_empty_env() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import socket; socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(('203.0.113.1', 443))",
+        ],
+        capture_output=True,
+        env={},
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "ExternalSocketBlocked" in (result.stdout + result.stderr)
+
+
+def test_direct_network_client_subprocess_is_rejected_before_startup() -> None:
+    with pytest.raises(socket_guard.ExternalSubprocessBlocked, match="network-client"):
+        subprocess.run(["curl", "https://203.0.113.1"], check=True)
+
+
+def test_shell_wrapped_network_client_subprocess_is_rejected_before_startup() -> None:
+    with pytest.raises(socket_guard.ExternalSubprocessBlocked, match="network-client"):
+        subprocess.run(["sh", "-c", "curl https://203.0.113.1"], check=True)
+
+
+def test_shell_wrapped_child_python_inherits_guard_with_an_empty_env() -> None:
+    script = " ".join(
+        [
+            shlex.quote(sys.executable),
+            "-c",
+            shlex.quote(
+                "import socket; socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(('203.0.113.1', 443))"
+            ),
+        ]
+    )
+    result = subprocess.run(
+        ["sh", "-c", script],
+        capture_output=True,
+        env={},
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "ExternalSocketBlocked" in (result.stdout + result.stderr)
+
+
+def test_child_python_cannot_disable_sitecustomize() -> None:
+    with pytest.raises(
+        socket_guard.ExternalSubprocessBlocked, match="python-startup-bypass"
+    ):
+        subprocess.run([sys.executable, "-S", "-c", "print('unreachable')"], check=True)
+
+
+def test_import_phase_and_conftest_unloaded_mutant_are_fail_closed(tmp_path) -> None:
+    """The startup hook, not conftest, must reject an import-time socket call."""
+
+    config_path = tmp_path / "pytest.ini"
+    config_path.write_text("[pytest]\n", encoding="utf-8")
+    probe_path = tmp_path / "test_import_phase_socket.py"
+    probe_path.write_text(
+        "import socket\n"
+        "socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(('203.0.113.1', 443))\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--noconftest",
+            "-c",
+            str(config_path),
+            str(probe_path),
+            "-q",
+            "-s",
+        ],
+        capture_output=True,
+        env={},
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "ExternalSocketBlocked" in (result.stdout + result.stderr)
+
+
+@pytest.mark.integration
+def test_integration_marker_enables_the_explicit_test_boundary() -> None:
+    assert socket_guard.is_current_test_exempt()
+
+
+@pytest.mark.integration
+def test_integration_marker_is_preserved_for_a_direct_python_child() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from tests._socket_guard import is_installed; print(is_installed())",
+        ],
+        capture_output=True,
+        env={},
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "False"


### PR DESCRIPTION
## Summary
- install the fail-closed socket guard before pytest collection/import
- cover IPv4/IPv6 connect, connect_ex, UDP, child Python, and direct network clients
- emit xdist-safe guard activation/count evidence as a CI artifact

## Verification
- focused guard controls, xdist aggregation, and PostgreSQL integration pass
- exact non-integration full suite was executed; it remains red on pre-existing local DB/worktree harness failures and is documented in the implementation report

NEEDS_VERIFY