### PR TITLE
ROB-1280: read-only Toss market-calendar router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -50,6 +50,7 @@ from app.routers import (
     investment_snapshots,
     investment_stage_runs,
     kospi200,
+    market_calendar,
     market_events,
     news_analysis,
     news_issues,
@@ -222,6 +223,7 @@ def create_app() -> FastAPI:
     app.include_router(news_radar.router)
     app.include_router(news_issues.router)
     app.include_router(alpaca_paper_ledger.router)
+    app.include_router(market_calendar.router)
     app.include_router(market_events.router)
     app.include_router(research_reports.router)
     app.include_router(strategy_events.router)

--- a/app/routers/market_calendar.py
+++ b/app/routers/market_calendar.py
@@ -1,0 +1,118 @@
+"""Read-only market-calendar router backed by the Toss calendar (ROB-1280).
+
+GET only. No mutation. Delegates entirely to the existing
+``app.services.brokers.toss.market_calendar`` service — no new Toss token,
+credential, or client surface is introduced here.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Query
+
+from app.core.config import settings
+from app.schemas.market_calendar import (
+    MarketCalendarResponse,
+    MarketCalendarSessionWindow,
+    MarketCalendarSessionWindows,
+)
+from app.services.brokers.toss.market_calendar import (
+    TossKrMarketDay,
+    TossUsMarketDay,
+    get_toss_market_calendar,
+)
+
+router = APIRouter(prefix="/trading", tags=["market-calendar"])
+
+Market = Literal["kr", "us"]
+
+_KST = dt.timezone(dt.timedelta(hours=9))
+
+
+def _session_window(
+    window: object,
+) -> MarketCalendarSessionWindow | None:
+    if window is None:
+        return None
+    return MarketCalendarSessionWindow(start=window.start, end=window.end)
+
+
+def _is_open_and_windows(
+    day: TossKrMarketDay | TossUsMarketDay,
+) -> tuple[bool, MarketCalendarSessionWindows]:
+    if isinstance(day, TossKrMarketDay):
+        windows = MarketCalendarSessionWindows(
+            pre_market=_session_window(day.pre_market),
+            regular_market=_session_window(day.regular_market),
+            after_market=_session_window(day.after_market),
+        )
+        is_open = day.regular_market is not None
+        return is_open, windows
+
+    windows = MarketCalendarSessionWindows(
+        day_market=_session_window(day.day_market),
+        pre_market=_session_window(day.pre_market),
+        regular_market=_session_window(day.regular_market),
+        after_market=_session_window(day.after_market),
+    )
+    is_open = day.regular_market is not None
+    return is_open, windows
+
+
+@router.get(
+    "/api/market-calendar/{market}/today",
+    response_model=MarketCalendarResponse,
+)
+async def get_market_calendar_today(
+    market: Market,
+    date: Annotated[
+        dt.date | None,
+        Query(description="ISO date; default = today (KST)"),
+    ] = None,
+) -> MarketCalendarResponse:
+    query_date = date or dt.datetime.now(_KST).date()
+    as_of = dt.datetime.now(dt.UTC)
+
+    if not settings.toss_api_enabled:
+        return MarketCalendarResponse(
+            date=query_date,
+            market=market,
+            is_open=None,
+            source="toss_calendar",
+            unavailable_reason="toss_api_disabled",
+            as_of=as_of,
+        )
+
+    calendar = await get_toss_market_calendar(market, query_date)
+    if calendar is None:
+        return MarketCalendarResponse(
+            date=query_date,
+            market=market,
+            is_open=None,
+            source="toss_calendar",
+            unavailable_reason="toss_calendar_unavailable",
+            as_of=as_of,
+        )
+
+    day = calendar.day_for(query_date)
+    if day is None:
+        return MarketCalendarResponse(
+            date=query_date,
+            market=market,
+            is_open=None,
+            source="toss_calendar",
+            unavailable_reason="date_out_of_calendar_window",
+            as_of=as_of,
+        )
+
+    is_open, windows = _is_open_and_windows(day)
+    return MarketCalendarResponse(
+        date=query_date,
+        market=market,
+        is_open=is_open,
+        session_windows=windows,
+        source="toss_calendar",
+        as_of=as_of,
+    )

--- a/app/schemas/market_calendar.py
+++ b/app/schemas/market_calendar.py
@@ -1,0 +1,30 @@
+"""Read schema for the Toss-backed market calendar endpoint (ROB-1280)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class MarketCalendarSessionWindow(BaseModel):
+    start: dt.datetime
+    end: dt.datetime
+
+
+class MarketCalendarSessionWindows(BaseModel):
+    pre_market: MarketCalendarSessionWindow | None = None
+    regular_market: MarketCalendarSessionWindow | None = None
+    after_market: MarketCalendarSessionWindow | None = None
+    day_market: MarketCalendarSessionWindow | None = None
+
+
+class MarketCalendarResponse(BaseModel):
+    date: dt.date
+    market: Literal["kr", "us"]
+    is_open: bool | None
+    session_windows: MarketCalendarSessionWindows | None = None
+    source: Literal["toss_calendar"] = "toss_calendar"
+    unavailable_reason: str | None = None
+    as_of: dt.datetime

--- a/tests/routers/test_market_calendar_router.py
+++ b/tests/routers/test_market_calendar_router.py
@@ -1,0 +1,179 @@
+"""Tests for the read-only Toss-backed market-calendar router (ROB-1280)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import market_calendar
+from app.services.brokers.toss.market_calendar import (
+    TossKrMarketDay,
+    TossMarketCalendar,
+    TossSessionWindow,
+    TossUsMarketDay,
+)
+
+_KST = dt.timezone(dt.timedelta(hours=9))
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(market_calendar.router)
+    return app
+
+
+def _kr_window(hour_start: int, hour_end: int, day: dt.date) -> TossSessionWindow:
+    return TossSessionWindow(
+        start=dt.datetime(day.year, day.month, day.day, hour_start, tzinfo=_KST),
+        end=dt.datetime(day.year, day.month, day.day, hour_end, tzinfo=_KST),
+    )
+
+
+@pytest.mark.unit
+def test_toss_disabled_returns_unavailable(monkeypatch):
+    monkeypatch.setattr(market_calendar.settings, "toss_api_enabled", False)
+    client = TestClient(_app())
+
+    resp = client.get("/trading/api/market-calendar/kr/today")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_open"] is None
+    assert data["unavailable_reason"] == "toss_api_disabled"
+    assert data["source"] == "toss_calendar"
+
+
+@pytest.mark.unit
+def test_calendar_fetch_failure_returns_unavailable(monkeypatch):
+    monkeypatch.setattr(market_calendar.settings, "toss_api_enabled", True)
+
+    async def _fake_get_calendar(market, query_date):
+        return None
+
+    monkeypatch.setattr(market_calendar, "get_toss_market_calendar", _fake_get_calendar)
+    client = TestClient(_app())
+
+    resp = client.get("/trading/api/market-calendar/kr/today")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_open"] is None
+    assert data["unavailable_reason"] == "toss_calendar_unavailable"
+
+
+@pytest.mark.unit
+def test_kr_holiday_reports_closed(monkeypatch):
+    monkeypatch.setattr(market_calendar.settings, "toss_api_enabled", True)
+    query_date = dt.date(2026, 8, 17)
+    day = TossKrMarketDay(
+        date=query_date,
+        pre_market=None,
+        regular_market=None,
+        after_market=None,
+    )
+    calendar = TossMarketCalendar(market="kr", days=(day,))
+
+    async def _fake_get_calendar(market, qd):
+        assert market == "kr"
+        assert qd == query_date
+        return calendar
+
+    monkeypatch.setattr(market_calendar, "get_toss_market_calendar", _fake_get_calendar)
+    client = TestClient(_app())
+
+    resp = client.get(
+        "/trading/api/market-calendar/kr/today", params={"date": "2026-08-17"}
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["date"] == "2026-08-17"
+    assert data["is_open"] is False
+    assert data["unavailable_reason"] is None
+
+
+@pytest.mark.unit
+def test_kr_trading_day_reports_open_with_windows(monkeypatch):
+    monkeypatch.setattr(market_calendar.settings, "toss_api_enabled", True)
+    query_date = dt.date(2026, 8, 18)
+    day = TossKrMarketDay(
+        date=query_date,
+        pre_market=_kr_window(8, 9, query_date),
+        regular_market=_kr_window(9, 15, query_date),
+        after_market=_kr_window(16, 20, query_date),
+    )
+    calendar = TossMarketCalendar(market="kr", days=(day,))
+
+    async def _fake_get_calendar(market, qd):
+        return calendar
+
+    monkeypatch.setattr(market_calendar, "get_toss_market_calendar", _fake_get_calendar)
+    client = TestClient(_app())
+
+    resp = client.get(
+        "/trading/api/market-calendar/kr/today", params={"date": "2026-08-18"}
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_open"] is True
+    assert data["session_windows"]["regular_market"] is not None
+
+
+@pytest.mark.unit
+def test_us_labor_day_reports_closed(monkeypatch):
+    monkeypatch.setattr(market_calendar.settings, "toss_api_enabled", True)
+    query_date = dt.date(2026, 9, 7)
+    day = TossUsMarketDay(
+        date=query_date,
+        day_market=None,
+        pre_market=None,
+        regular_market=None,
+        after_market=None,
+    )
+    calendar = TossMarketCalendar(market="us", days=(day,))
+
+    async def _fake_get_calendar(market, qd):
+        assert market == "us"
+        return calendar
+
+    monkeypatch.setattr(market_calendar, "get_toss_market_calendar", _fake_get_calendar)
+    client = TestClient(_app())
+
+    resp = client.get(
+        "/trading/api/market-calendar/us/today", params={"date": "2026-09-07"}
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_open"] is False
+
+
+@pytest.mark.unit
+def test_date_outside_calendar_window_returns_unavailable(monkeypatch):
+    monkeypatch.setattr(market_calendar.settings, "toss_api_enabled", True)
+    other_day = TossKrMarketDay(
+        date=dt.date(2026, 8, 18),
+        pre_market=None,
+        regular_market=_kr_window(9, 15, dt.date(2026, 8, 18)),
+        after_market=None,
+    )
+    calendar = TossMarketCalendar(market="kr", days=(other_day,))
+
+    async def _fake_get_calendar(market, qd):
+        return calendar
+
+    monkeypatch.setattr(market_calendar, "get_toss_market_calendar", _fake_get_calendar)
+    client = TestClient(_app())
+
+    resp = client.get(
+        "/trading/api/market-calendar/kr/today", params={"date": "2026-08-01"}
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_open"] is None
+    assert data["unavailable_reason"] == "date_out_of_calendar_window"


### PR DESCRIPTION
## Summary
- Adds `GET /trading/api/market-calendar/{market}/today` (market ∈ kr|us, optional `?date=YYYY-MM-DD`), delegating entirely to the existing `app.services.brokers.toss.market_calendar.get_toss_market_calendar` service.
- Response: `{date, market, is_open, session_windows?, source: "toss_calendar", unavailable_reason?, as_of}`.
- No new Toss token/credential/client surface — reuses the shared `TossReadClient` + rate limiter + calendar cache (ROB-529 single-token constraint respected).
- When `TOSS_API_ENABLED` is off, the calendar fetch fails, or the queried date falls outside the returned today/prev/next-business-day window: `is_open: null` + `unavailable_reason` (never a fake open/closed).
- Scope is deliberately 1단 only (per ROB-1280): no Prefect flow changes, no static holiday-list changes/removal.

## Test plan
- [x] New unit tests: `tests/routers/test_market_calendar_router.py` (6 cases: Toss disabled, calendar fetch failure, KR holiday closed, KR trading day open+windows, US Labor Day closed, date outside calendar window) — all pass, mocked service call (no real Toss API touched, respects the offline-suite socket guard).
- [x] `ruff check .` — clean.
- [x] `ty check --error-on-warning` — clean.
- [x] `pytest tests/ -q -m "not integration"` — 60 failed / 56 errors, all pre-existing and unrelated to this diff (order_proposals, kis_mock ledger, alpaca_paper_automated_orders, binance demo_strategy_loop — traced to a pre-existing local test-DB isolation issue: `database "test_db_pytest_..." does not exist`). `git diff --stat origin/main...HEAD` touches only `app/main.py` (+2 router wiring lines) and the 3 new files.
- [ ] Live Toss verification of AC2/AC3 (KR 08-17 closed / 08-18 open, US Labor Day 09-07 closed) — **not done**: this worktree has `TOSS_API_ENABLED` unset/no Toss credentials, so a real call isn't possible from here. Needs an env with Toss creds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market-calendar endpoints for Korean and US markets.
  * View market open/closed status and trading session windows for today or a specified date.
  * Responses include session times, data source, timestamp, and availability details.
  * Clearly reports unavailable calendar data, disabled services, holidays, and dates outside the supported range.

* **Tests**
  * Added coverage for market holidays, trading days, unavailable states, date selection, and session details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->