### PR TITLE
ROB-1270 J6B: Binance Spot Demo canonical LIMIT composition

### DIFF
--- a/app/services/brokers/binance/spot_demo/mock_auto_limit.py
+++ b/app/services/brokers/binance/spot_demo/mock_auto_limit.py
@@ -1,0 +1,1352 @@
+"""ROB-1270 J6B — Binance Spot Demo canonical LIMIT composition.
+
+A separate LIMIT composition for ``crypto.binance.spot_demo.canonical``.  It
+consumes the merged upstream ports without redefining them:
+
+* J2A ``app.services.mock_lane_registry`` — lane/broker/profile/mode/policy and
+  currency binding, plus the signed-restriction and execution-ready guards;
+* J2B ``app.services.mock_integration.lineage`` — the only factory that issues
+  intent/plan/attempt identifiers;
+* J3A ``app.services.mock_integration.coordination`` — the physical-account
+  lease, the durable binary claim, dispatch evidence, and the injected
+  mutation callback;
+* ROB-298 ``spot_demo.execution_client`` — the mutation transport, read/reuse
+  only.
+
+What this module deliberately is **not**:
+
+* It is not the frozen ROB-845 ``BUY``/``MARKET``/notional-only paper adapter.
+  That asset stays byte-frozen; this is a distinct LIMIT surface and never
+  relabels, wraps, or edits it.
+* It is not an activation.  With the signed registry, ``assert_entry_execution_
+  ready`` is *structurally* unsatisfiable for this lane: ``ENABLED`` trips
+  ``_violates_signed_lane_restriction`` and every other activation status trips
+  ``lane_activation_not_enabled``.  There is no reachable configuration in which
+  this composition dispatches, and a real submit is J8's bounded canary alone.
+* It is not a scheduler.  No TaskIQ, Prefect, cron, launchd, or systemd import
+  or registration exists here, and none may be added.
+
+Sizing is fixed by operator decision D6 and is not selectable here: LIMIT only,
+``quantity = floor_to_step(target_notional / limit_price)``, never rounded up,
+and no plan at all when the floored size misses min quantity or min notional.
+Price source, price cutoff, step size + step version, and the rounding delta are
+all carried into the plan; dropping any one of them fails before broker I/O.
+
+Currency is single-valued per D5/§83: this lane is ``USDT`` and ``USD`` is a
+different currency.  No parity, FX lookup, or implicit conversion exists on this
+path, and the USD/USDT sibling-binding key remains ``PENDING`` exactly as the
+merged ROB-1269 contract left it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import ROUND_DOWN, Decimal, DecimalException
+from enum import StrEnum
+from typing import Any, Final, Protocol, runtime_checkable
+from urllib.parse import urlsplit
+
+from app.schemas.execution_contracts import (
+    DecisionIntent,
+    ExecutionPlan,
+    LaneStatus,
+    SchedulerOwner,
+)
+from app.services.brokers.binance.demo.errors import BinanceDemoOrderNotFound
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+)
+from app.services.brokers.binance.spot_demo.host_allowlist import (
+    SPOT_DEMO_HOSTS,
+    assert_spot_demo_host,
+)
+from app.services.brokers.client_order_ids import BrokerClientIdTarget
+from app.services.mock_integration.coordination import (
+    AccountUncertaintyGatePort,
+    CoordinatedMutationResult,
+    CoordinationScope,
+    DispatchEvidencePort,
+    DurableClaim,
+    DurableSendClaimAdapter,
+    MutationCallbackResult,
+    MutationCertainty,
+    TerminalClaimEvidence,
+    coordinate_mock_order_mutation,
+)
+from app.services.mock_integration.lineage import (
+    ExecutionPlanDraft,
+    LineageEnvelope,
+    LineagePersistencePort,
+    MockLineageFactory,
+)
+from app.services.mock_lane_registry import (
+    ActivationStatus,
+    LaneRegistryEntry,
+    RegistrySource,
+    assert_entry_execution_ready,
+    assert_lineage_registry_binding,
+    assert_mock_only_endpoint,
+    get_lane_registry_entry,
+)
+
+# --------------------------------------------------------------------------
+# Lane binding — consumed from the signed registry, never redefined here.
+# --------------------------------------------------------------------------
+
+SPOT_DEMO_CANONICAL_LANE_ID: Final[str] = "crypto.binance.spot_demo.canonical"
+SPOT_DEMO_SIDECAR_LANE_ID: Final[str] = "crypto.binance.spot_demo.b0x_sidecar"
+SPOT_DEMO_FUTURES_LANE_ID: Final[str] = "crypto.binance.futures_demo"
+SPOT_DEMO_BROKER: Final[str] = "binance"
+SPOT_DEMO_ACCOUNT_PROFILE: Final[str] = "spot_demo"
+SPOT_DEMO_ACCOUNT_MODE: Final[str] = "demo"
+SPOT_DEMO_QUOTE_CURRENCY: Final[str] = "USDT"
+SPOT_DEMO_ENDPOINT_URL: Final[str] = "https://demo-api.binance.com"
+
+#: The only order type this composition can express.  MARKET belongs to the
+#: frozen ROB-845 adapter and is rejected here before any broker I/O.
+SPOT_DEMO_ORDER_TYPE: Final[str] = "LIMIT"
+SPOT_DEMO_TIME_IN_FORCE: Final[str] = "GTC"
+
+#: J2B needs a bounded lane prefix because Binance Spot Demo *is* a confirmed
+#: native client-order-id target.  4 chars + separator + the 24-char digest is
+#: 29, inside the 36-char Binance constraint with room to spare.
+SPOT_DEMO_LANE_PREFIX: Final[str] = "bnsd"
+SPOT_DEMO_CLIENT_ID_TARGET: Final[BrokerClientIdTarget] = (
+    BrokerClientIdTarget.BINANCE_SPOT_DEMO
+)
+
+#: §D binding.  When the LIMIT lifecycle is complete, the primary terminal lane
+#: status for this lane is exactly ``AUTO_READY_BLOCKED_BY_POLICY`` — there is no
+#: approved autonomous policy.  The absent scheduler owner is a *secondary*
+#: activation blocker and is reported separately; it is never promoted to the
+#: primary lane status.  This module does not modify the registry: mechanically
+#: narrowing the signed allowlist is J2A-owned work.
+SPOT_DEMO_PRIMARY_TERMINAL_LANE_STATUS: Final[LaneStatus] = (
+    LaneStatus.AUTO_READY_BLOCKED_BY_POLICY
+)
+SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER: Final[str] = "scheduler_owner_disabled"
+SPOT_DEMO_FORBIDDEN_PRIMARY_LANE_STATUS: Final[LaneStatus] = (
+    LaneStatus.AUTO_READY_BLOCKED_BY_SCHEDULER
+)
+
+#: §83 correction 3 — a lane missing any recovery item stays here.  This is a
+#: status value, not a warning.
+SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS: Final[LaneStatus] = (
+    LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE
+)
+
+#: §83 correction 2 (C2-4).  The merged ROB-1269 contract left the USD/USDT
+#: sibling-binding key ``PENDING`` because no exact immutable key contract was
+#: supplied.  J6B consumes that disposition; it does not name, synthesize, or
+#: persist one, and it does not fan a USD intent out to this USDT lane.
+SIBLING_BINDING_FOR_EXECUTION: Final[str] = "PENDING"
+
+# --------------------------------------------------------------------------
+# Recovery ownership (§83 correction 3 — activation precondition)
+# --------------------------------------------------------------------------
+
+#: C3-1 — exactly one recovery owner.  The shared J3A coordination layer owns no
+#: Binance-specific retry, readback, or manual-resolution queue.
+SPOT_DEMO_RECOVERY_OWNER: Final[str] = (
+    "app.services.brokers.binance.spot_demo.mock_auto_limit."
+    "BinanceSpotDemoLimitComposition"
+)
+
+#: C3-2 — what rediscovers surviving durable claims after a restart.
+SPOT_DEMO_RESTART_TRIGGER: Final[str] = (
+    "process_restart_rediscovers_durable_j2b_claims_for_physical_account"
+)
+
+#: C3-3 — the authoritative broker readback.  Open-order listings, account
+#: balances, and the wall clock are diagnostic only.
+SPOT_DEMO_AUTHORITATIVE_READBACK: Final[str] = (
+    "GET /api/v3/order?origClientOrderId=... — "
+    "BinanceSpotDemoExecutionClient.get_order_status"
+)
+
+#: C3-6 — the operator-visible blocked state when authoritative recovery is not
+#: possible.
+SPOT_DEMO_UNRECOVERABLE_STATE: Final[str] = "unknown_pending_reconcile"
+
+
+class SpotDemoLaneEvidenceKind(StrEnum):
+    """C3-4 — the closed set of lane-native evidence kinds.
+
+    All seven are written by this module.  A missing kind keeps the lane at
+    ``AUTO_READY_BLOCKED_BY_LIFECYCLE``; the set is closed so a new lifecycle
+    outcome cannot be silently folded into an existing kind.
+    """
+
+    ACK = "ack"
+    UNKNOWN = "unknown"
+    REJECT = "reject"
+    EXPIRY = "expiry"
+    PARTIAL_FILL = "partial_fill"
+    CANCEL = "cancel"
+    TERMINAL_RECONCILIATION = "terminal_reconciliation"
+
+
+LANE_EVIDENCE_KINDS: Final[frozenset[str]] = frozenset(
+    kind.value for kind in SpotDemoLaneEvidenceKind
+)
+
+
+# --------------------------------------------------------------------------
+# Reason codes — J6B-owned, disjoint from J3A coordination reason codes.
+# --------------------------------------------------------------------------
+
+
+class SpotDemoLimitReason(StrEnum):
+    """Why this composition refused, in a stable vocabulary."""
+
+    ORDER_TYPE_NOT_LIMIT = "order_type_not_limit"
+    NOTIONAL_ONLY_PLAN_FORBIDDEN = "notional_only_plan_forbidden"
+    QUOTE_CURRENCY_NOT_USDT = "quote_currency_not_usdt"
+    CURRENCY_CONVERSION_NOT_AUTHORIZED = "currency_conversion_not_authorized"
+    SIBLING_BINDING_PENDING = "sibling_binding_pending"
+    PRICE_PROVENANCE_INCOMPLETE = "price_provenance_incomplete"
+    STEP_PROVENANCE_INCOMPLETE = "step_provenance_incomplete"
+    SIZING_PROVENANCE_INCOMPLETE = "sizing_provenance_incomplete"
+    SIZING_BELOW_MIN_QTY = "sizing_below_min_qty"
+    SIZING_BELOW_MIN_NOTIONAL = "sizing_below_min_notional"
+    SIZING_ROUND_UP_FORBIDDEN = "sizing_round_up_forbidden"
+    LANE_NOT_CANONICAL_WRITER = "lane_not_canonical_writer"
+    BINANCE_WRITER_CONFLICT = "binance_writer_conflict"
+    SIDECAR_OBSERVATION_ONLY = "sidecar_observation_only"
+    ALPACA_CRYPTO_MUTATION_UNASSIGNED = "alpaca_crypto_mutation_unassigned"
+    TRANSPORT_CLIENT_NOT_SPOT_DEMO = "transport_client_not_spot_demo"
+    TRANSPORT_HOST_NOT_SPOT_DEMO = "transport_host_not_spot_demo"
+    RECURRING_REGISTRATION_FORBIDDEN = "recurring_registration_forbidden"
+    BLIND_REPOST_FORBIDDEN = "blind_repost_forbidden"
+    LANE_EVIDENCE_PORT_UNAVAILABLE = "lane_evidence_port_unavailable"
+
+
+SPOT_DEMO_LIMIT_REASON_CODES: Final[frozenset[str]] = frozenset(
+    reason.value for reason in SpotDemoLimitReason
+)
+
+
+class SpotDemoLimitError(RuntimeError):
+    """A pre-I/O refusal carrying one stable reason code."""
+
+    def __init__(self, reason: SpotDemoLimitReason, detail: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason.value}: {detail}" if detail else reason.value)
+
+
+# --------------------------------------------------------------------------
+# D6 — price and step provenance.  Every field is load-bearing evidence.
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LimitPriceQuote:
+    """One observed limit price with the provenance D6 requires.
+
+    ``source`` and ``cutoff`` are not decoration: a size derived from an
+    unattributed or undated price cannot be audited afterwards, so both are
+    required and neither may be blank or naive.
+    """
+
+    price: Decimal
+    source: str
+    cutoff: datetime
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.price, Decimal)
+            or not self.price.is_finite()
+            or self.price <= 0
+        ):
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.PRICE_PROVENANCE_INCOMPLETE,
+                "price must be a finite positive Decimal",
+            )
+        if not isinstance(self.source, str) or not self.source.strip():
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.PRICE_PROVENANCE_INCOMPLETE,
+                "price source must be non-blank",
+            )
+        if (
+            not isinstance(self.cutoff, datetime)
+            or self.cutoff.tzinfo is None
+            or self.cutoff.utcoffset() is None
+        ):
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.PRICE_PROVENANCE_INCOMPLETE,
+                "price cutoff must be timezone-aware",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SpotStepSpec:
+    """Venue filters for one symbol, with the exchangeInfo snapshot version.
+
+    ``step_version`` identifies *which* exchangeInfo snapshot produced these
+    filters.  Binance changes them, so a size computed under an unidentified
+    filter set is not reproducible.
+    """
+
+    step_size: Decimal
+    step_version: str
+    min_qty: Decimal
+    min_notional: Decimal
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("step_size", self.step_size),
+            ("min_qty", self.min_qty),
+            ("min_notional", self.min_notional),
+        ):
+            if not isinstance(value, Decimal) or not value.is_finite() or value < 0:
+                raise SpotDemoLimitError(
+                    SpotDemoLimitReason.STEP_PROVENANCE_INCOMPLETE,
+                    f"{name} must be a finite non-negative Decimal",
+                )
+        if self.step_size <= 0:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.STEP_PROVENANCE_INCOMPLETE,
+                "step_size must be positive",
+            )
+        if not isinstance(self.step_version, str) or not self.step_version.strip():
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.STEP_PROVENANCE_INCOMPLETE,
+                "step_version must be non-blank",
+            )
+
+
+# --------------------------------------------------------------------------
+# D6 — sizing.  Floor only; a miss produces no plan rather than a smaller lie.
+# --------------------------------------------------------------------------
+
+#: The exact provenance keys a composed plan must carry into ``tick_rounding``.
+#: Dropping any one of them fails before broker I/O.
+SIZING_PROVENANCE_KEYS: Final[tuple[str, ...]] = (
+    "price_source",
+    "price_cutoff",
+    "step_size",
+    "step_version",
+    "rounding_delta",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LimitSizing:
+    """A floored, filter-clearing size and the evidence that produced it."""
+
+    quantity: Decimal
+    realized_notional: Decimal
+    rounding_delta: Decimal
+    price: Decimal
+    price_source: str
+    price_cutoff: datetime
+    step_size: Decimal
+    step_version: str
+
+    def provenance(self) -> dict[str, Any]:
+        """The D6 provenance block carried verbatim into the plan."""
+
+        return {
+            "mode": "floor_to_step",
+            "price_source": self.price_source,
+            "price_cutoff": self.price_cutoff.isoformat(),
+            "step_size": str(self.step_size),
+            "step_version": self.step_version,
+            "rounding_delta": str(self.rounding_delta),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LimitSizingBlocked:
+    """No plan is produced.  Deliberately not an exception-free 'smaller size'."""
+
+    reason: SpotDemoLimitReason
+    detail: str
+    #: Structural: a blocked sizing can never be constructed as a plan.
+    produces_plan: bool = field(default=False, init=False)
+
+
+def compose_limit_sizing(
+    *,
+    target_notional: Decimal,
+    target_notional_currency: str,
+    quote: LimitPriceQuote,
+    step: SpotStepSpec,
+) -> LimitSizing | LimitSizingBlocked:
+    """Derive a LIMIT quantity under D6, or refuse to produce one.
+
+    ``quantity = floor_to_step(target_notional / limit_price)``.  The floor is
+    the only rounding direction: a result that misses ``min_qty`` or
+    ``min_notional`` yields no plan, because rounding *up* to reach a venue
+    minimum would silently place a larger order than the decision authorized.
+    """
+
+    if target_notional_currency != SPOT_DEMO_QUOTE_CURRENCY:
+        # USD and USDT are distinct currencies; there is no conversion here.
+        return LimitSizingBlocked(
+            reason=SpotDemoLimitReason.QUOTE_CURRENCY_NOT_USDT,
+            detail=(
+                f"intent currency {target_notional_currency!r} != lane quote "
+                f"currency {SPOT_DEMO_QUOTE_CURRENCY!r}; no FX or parity is authorized"
+            ),
+        )
+    if (
+        not isinstance(target_notional, Decimal)
+        or not target_notional.is_finite()
+        or target_notional <= 0
+    ):
+        return LimitSizingBlocked(
+            reason=SpotDemoLimitReason.SIZING_BELOW_MIN_NOTIONAL,
+            detail="target_notional must be a finite positive Decimal",
+        )
+
+    try:
+        steps = (target_notional / quote.price / step.step_size).quantize(
+            Decimal("1"), rounding=ROUND_DOWN
+        )
+    except (ArithmeticError, DecimalException) as exc:  # pragma: no cover - guard
+        return LimitSizingBlocked(
+            reason=SpotDemoLimitReason.SIZING_BELOW_MIN_QTY,
+            detail=f"step division failed: {exc}",
+        )
+    quantity = steps * step.step_size
+
+    if quantity <= 0 or quantity < step.min_qty:
+        return LimitSizingBlocked(
+            reason=SpotDemoLimitReason.SIZING_BELOW_MIN_QTY,
+            detail=(
+                f"floored qty={quantity} < min_qty={step.min_qty} "
+                f"(target={target_notional} / price={quote.price}, "
+                f"step={step.step_size}); no plan is produced"
+            ),
+        )
+
+    realized_notional = quantity * quote.price
+    if realized_notional < step.min_notional:
+        return LimitSizingBlocked(
+            reason=SpotDemoLimitReason.SIZING_BELOW_MIN_NOTIONAL,
+            detail=(
+                f"realized notional={realized_notional} < "
+                f"min_notional={step.min_notional} after the step floor "
+                f"(qty={quantity}); rounding up to reach the minimum is forbidden"
+            ),
+        )
+
+    rounding_delta = target_notional - realized_notional
+    if rounding_delta < 0:
+        # Defence in depth: a floor can never exceed its target.  If it does,
+        # the arithmetic is wrong and no order may be built from it.
+        return LimitSizingBlocked(
+            reason=SpotDemoLimitReason.SIZING_ROUND_UP_FORBIDDEN,
+            detail=(
+                f"realized notional={realized_notional} exceeds "
+                f"target={target_notional}; floor-only invariant violated"
+            ),
+        )
+
+    return LimitSizing(
+        quantity=quantity,
+        realized_notional=realized_notional,
+        rounding_delta=rounding_delta,
+        price=quote.price,
+        price_source=quote.source,
+        price_cutoff=quote.cutoff,
+        step_size=step.step_size,
+        step_version=step.step_version,
+    )
+
+
+def compose_limit_plan_draft(
+    *,
+    normalized_symbol: str,
+    sizing: LimitSizing,
+    step: SpotStepSpec,
+    risk_caps: Mapping[str, Any],
+) -> ExecutionPlanDraft:
+    """Build the J2B plan draft for this lane's LIMIT order.
+
+    ``risk_caps`` is caller-supplied and is *recorded*, not invented: the signed
+    registry currently reports ``MissingBinding.CAP`` for this lane, so the
+    honest value is the caller's declaration of that absence rather than a
+    number chosen here.
+    """
+
+    return ExecutionPlanDraft(
+        lane_id=SPOT_DEMO_CANONICAL_LANE_ID,
+        broker=SPOT_DEMO_BROKER,
+        account_profile=SPOT_DEMO_ACCOUNT_PROFILE,
+        account_mode=SPOT_DEMO_ACCOUNT_MODE,
+        normalized_symbol=normalized_symbol,
+        quantity=sizing.quantity,
+        limit_price=sizing.price,
+        quote_currency=SPOT_DEMO_QUOTE_CURRENCY,
+        tick_rounding=sizing.provenance(),
+        session=None,
+        time_in_force=SPOT_DEMO_TIME_IN_FORCE,
+        min_order_validation={
+            "min_qty": str(step.min_qty),
+            "min_notional": str(step.min_notional),
+            "realized_notional": str(sizing.realized_notional),
+        },
+        risk_caps=dict(risk_caps),
+    )
+
+
+# --------------------------------------------------------------------------
+# Pre-I/O guards.  Each one is the exact point a corresponding defect dies.
+# --------------------------------------------------------------------------
+
+
+def assert_limit_only_plan(plan: ExecutionPlan) -> None:
+    """Reject a MARKET or notional-only plan before any broker I/O.
+
+    A plan reaching this composition from elsewhere is still refused: the
+    composition never *builds* one, and this guard means it never *accepts* one
+    either.  A missing ``limit_price`` is the notional-only shape.
+    """
+
+    if plan.time_in_force is None or not str(plan.time_in_force).strip():
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.ORDER_TYPE_NOT_LIMIT,
+            "a LIMIT plan requires an explicit time_in_force",
+        )
+    if plan.limit_price is None:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.NOTIONAL_ONLY_PLAN_FORBIDDEN,
+            "notional-only plans (limit_price=None) are MARKET-shaped and are "
+            "forbidden on the LIMIT composition",
+        )
+    if not plan.limit_price.is_finite() or plan.limit_price <= 0:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.ORDER_TYPE_NOT_LIMIT,
+            "limit_price must be finite and positive",
+        )
+
+
+def assert_usdt_single_currency(
+    intent: DecisionIntent, plan: ExecutionPlan, entry: LaneRegistryEntry
+) -> None:
+    """Require exact three-way currency equality with no conversion.
+
+    §83 correction 2: a ``DecisionIntent`` is single-currency, and fan-out is
+    permitted only to a lane whose registry ``quote_currency`` is *exactly* the
+    intent's ``target_notional_currency``.  USD and USDT are different
+    currencies; there is no parity, lookup, or implicit conversion here.
+    """
+
+    if intent.target_notional_currency != plan.quote_currency:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.CURRENCY_CONVERSION_NOT_AUTHORIZED,
+            f"intent {intent.target_notional_currency!r} != plan "
+            f"{plan.quote_currency!r}",
+        )
+    if plan.quote_currency != entry.quote_currency:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.QUOTE_CURRENCY_NOT_USDT,
+            f"plan {plan.quote_currency!r} != registry {entry.quote_currency!r}",
+        )
+    if plan.quote_currency != SPOT_DEMO_QUOTE_CURRENCY:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.QUOTE_CURRENCY_NOT_USDT,
+            f"this lane is {SPOT_DEMO_QUOTE_CURRENCY}; got {plan.quote_currency!r}",
+        )
+
+
+def assert_sizing_provenance_complete(plan: ExecutionPlan) -> None:
+    """Require all four D6 provenance facts plus the rounding delta.
+
+    Price source, price cutoff, step size + version, and the rounding delta are
+    what make a size reproducible after the fact.  A plan missing any one of
+    them cannot be audited, so it does not reach a broker.
+    """
+
+    rounding = plan.tick_rounding
+    if not isinstance(rounding, Mapping):
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.SIZING_PROVENANCE_INCOMPLETE,
+            "tick_rounding must be a mapping carrying the D6 provenance",
+        )
+    missing = [
+        key
+        for key in SIZING_PROVENANCE_KEYS
+        if key not in rounding
+        or rounding[key] is None
+        or not str(rounding[key]).strip()
+    ]
+    if missing:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.SIZING_PROVENANCE_INCOMPLETE,
+            f"missing D6 provenance keys: {sorted(missing)}",
+        )
+    if str(rounding.get("mode")) != "floor_to_step":
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.SIZING_ROUND_UP_FORBIDDEN,
+            f"rounding mode {rounding.get('mode')!r} is not floor_to_step",
+        )
+    try:
+        delta = Decimal(str(rounding["rounding_delta"]))
+    except (ArithmeticError, DecimalException, ValueError) as exc:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.SIZING_PROVENANCE_INCOMPLETE,
+            f"rounding_delta is not a Decimal: {exc}",
+        ) from exc
+    if not delta.is_finite() or delta < 0:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.SIZING_ROUND_UP_FORBIDDEN,
+            f"rounding_delta={delta} is negative, which means the size was "
+            "rounded up rather than floored",
+        )
+
+
+def assert_canonical_writer_lane(plan: ExecutionPlan) -> None:
+    """Only the canonical lane composes an order here.
+
+    The B0-X sidecar stays observation-only (operator decision D2) and the
+    Futures Demo lane stays ``DISABLED_NO_STRATEGY``; neither may borrow this
+    surface by presenting its own lane id.
+    """
+
+    if plan.lane_id == SPOT_DEMO_SIDECAR_LANE_ID:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.SIDECAR_OBSERVATION_ONLY,
+            "the B0-X sidecar is observation-only and composes no order",
+        )
+    if plan.lane_id != SPOT_DEMO_CANONICAL_LANE_ID:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.LANE_NOT_CANONICAL_WRITER,
+            f"lane {plan.lane_id!r} is not {SPOT_DEMO_CANONICAL_LANE_ID!r}",
+        )
+
+
+def assert_binance_single_writer_domain(registry: Sequence[LaneRegistryEntry]) -> None:
+    """Treat every Binance demo lane as one physical conflict domain.
+
+    Identity evidence is absent, so ``physical_account_id`` is ``None`` on all
+    of them and the registry's own duplicate-writer guard — which keys on a
+    *known* account — cannot fire.  The conservative reading, and the one the
+    signed inputs require, is that Binance canonical, the B0-X sidecar, the
+    smoke path, and Futures Demo share one account until masked fingerprint
+    evidence says otherwise.  So: at most one Binance writer, ever.
+    """
+
+    writers = sorted(
+        entry.lane_id
+        for entry in registry
+        if entry.broker == SPOT_DEMO_BROKER and entry.writer
+    )
+    if len(writers) > 1:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.BINANCE_WRITER_CONFLICT,
+            f"{len(writers)} Binance writers in one unknown-identity conflict "
+            f"domain: {writers}",
+        )
+
+
+def assert_sidecar_observation_only(registry: Sequence[LaneRegistryEntry]) -> None:
+    """The B0-X sidecar keeps ``writer=false`` and a disabled recurring owner."""
+
+    for entry in registry:
+        if entry.lane_id != SPOT_DEMO_SIDECAR_LANE_ID:
+            continue
+        if entry.writer or entry.auto_order_enabled:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.SIDECAR_OBSERVATION_ONLY,
+                "the B0-X sidecar may not be a writer or auto-enabled",
+            )
+        if entry.scheduler_owner is not SchedulerOwner.DISABLED:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.SIDECAR_OBSERVATION_ONLY,
+                f"sidecar recurring owner {entry.scheduler_owner!r} is not "
+                f"{SchedulerOwner.DISABLED!r}",
+            )
+
+
+def assert_alpaca_crypto_unwired(registry: Sequence[LaneRegistryEntry]) -> None:
+    """Operator decision D1 — Alpaca crypto gets no mutation wiring this epoch.
+
+    ``AUTO_MIRROR`` on those rows is a purpose-only registry value meaning
+    *policy* mirror.  It is not execution authority and never means same-intent
+    currency conversion from USD to USDT.
+    """
+
+    for entry in registry:
+        if entry.broker != "alpaca" or entry.market != "crypto":
+            continue
+        if entry.writer or entry.auto_order_enabled:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.ALPACA_CRYPTO_MUTATION_UNASSIGNED,
+                f"{entry.lane_id} has no assigned mutation profile this epoch",
+            )
+
+
+def assert_spot_demo_transport(client: object) -> str:
+    """Prove the *actual* transport is Spot Demo before it is used.
+
+    The registry validates a caller-*declared* endpoint string; it cannot see
+    which host a client object really talks to.  This closes that gap: the
+    concrete type must be the Spot Demo execution client (a subclass could
+    override the transport), and its base URL host must be in the frozen Spot
+    Demo allowlist.  Live, testnet, and Futures hosts all fail here, before any
+    request is built.
+    """
+
+    if type(client) is not BinanceSpotDemoExecutionClient:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.TRANSPORT_CLIENT_NOT_SPOT_DEMO,
+            f"transport type {type(client).__name__} is not "
+            "BinanceSpotDemoExecutionClient",
+        )
+    base_url = getattr(client, "_base_url", None)
+    host = urlsplit(str(base_url)).hostname if base_url else None
+    if not host:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.TRANSPORT_HOST_NOT_SPOT_DEMO,
+            "transport base URL has no host",
+        )
+    normalized = host.lower()
+    try:
+        assert_spot_demo_host(normalized)
+    except Exception as exc:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.TRANSPORT_HOST_NOT_SPOT_DEMO,
+            f"host {normalized!r} is not in {sorted(SPOT_DEMO_HOSTS)}",
+        ) from exc
+    return normalized
+
+
+def assert_no_recurring_request(recurring_requested: bool) -> None:
+    """This composition never requests recurrence.
+
+    The lane's recurring owner is ``disabled`` and no scheduler registration
+    exists anywhere in this module.  A caller asking for recurrence is refused
+    rather than quietly downgraded.
+    """
+
+    if recurring_requested:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.RECURRING_REGISTRATION_FORBIDDEN,
+            "recurring execution is not authorized for this lane; the signed "
+            "scheduler owner is disabled and J6B registers no scheduler",
+        )
+
+
+# --------------------------------------------------------------------------
+# C3-4 — lane-native evidence port.
+# --------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SpotDemoLaneEvidencePort(Protocol):
+    """Where this lane's own lifecycle evidence is durably written.
+
+    Separate from J3A's ``DispatchEvidencePort``, which records only what *this
+    process* learned about one dispatch.  Broker-native outcomes — rejection,
+    expiry, partial fill — are lane knowledge and belong here.
+    """
+
+    async def record_lane_evidence(
+        self, kind: SpotDemoLaneEvidenceKind, payload: Mapping[str, Any], /
+    ) -> None: ...
+
+
+def require_lane_evidence_port(
+    port: SpotDemoLaneEvidencePort | None, /
+) -> SpotDemoLaneEvidencePort:
+    """Fail closed when the lane has not supplied its evidence writer."""
+
+    if port is None or not isinstance(port, SpotDemoLaneEvidencePort):
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.LANE_EVIDENCE_PORT_UNAVAILABLE,
+            "a lane-native evidence port is required before any dispatch",
+        )
+    return port
+
+
+# --------------------------------------------------------------------------
+# C3-2 / C3-3 / C3-5 — restart recovery.
+# --------------------------------------------------------------------------
+
+
+class SpotDemoReadbackOutcome(StrEnum):
+    """What the authoritative readback said about one surviving claim."""
+
+    NOT_CREATED = "not_created"
+    OPEN = "open"
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    CANCELED = "canceled"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+    UNREADABLE = "unreadable"
+
+
+_TERMINAL_READBACK_OUTCOMES: Final[frozenset[SpotDemoReadbackOutcome]] = frozenset(
+    {
+        SpotDemoReadbackOutcome.FILLED,
+        SpotDemoReadbackOutcome.CANCELED,
+        SpotDemoReadbackOutcome.REJECTED,
+        SpotDemoReadbackOutcome.EXPIRED,
+    }
+)
+
+#: Binance native ``status`` values mapped onto the readback vocabulary.  An
+#: unrecognised status is ``UNREADABLE``, never optimistically terminal.
+_NATIVE_STATUS_MAP: Final[Mapping[str, SpotDemoReadbackOutcome]] = {
+    "NEW": SpotDemoReadbackOutcome.OPEN,
+    "PENDING_NEW": SpotDemoReadbackOutcome.OPEN,
+    "PARTIALLY_FILLED": SpotDemoReadbackOutcome.PARTIALLY_FILLED,
+    "FILLED": SpotDemoReadbackOutcome.FILLED,
+    "CANCELED": SpotDemoReadbackOutcome.CANCELED,
+    "PENDING_CANCEL": SpotDemoReadbackOutcome.OPEN,
+    "REJECTED": SpotDemoReadbackOutcome.REJECTED,
+    "EXPIRED": SpotDemoReadbackOutcome.EXPIRED,
+    "EXPIRED_IN_MATCH": SpotDemoReadbackOutcome.EXPIRED,
+}
+
+
+def classify_native_status(status: object) -> SpotDemoReadbackOutcome:
+    """Map one native Binance order status; unknown means unreadable."""
+
+    if not isinstance(status, str):
+        return SpotDemoReadbackOutcome.UNREADABLE
+    return _NATIVE_STATUS_MAP.get(
+        status.strip().upper(), SpotDemoReadbackOutcome.UNREADABLE
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class RestartDisposition:
+    """What a surviving durable claim may do after a restart.
+
+    ``repost`` is a structural ``False``: it takes no constructor argument, so
+    no code path can produce a disposition that authorizes re-sending an order
+    whose outcome is unknown.  That is the whole point — a blind repost after a
+    restart is how one intent becomes two live orders.
+    """
+
+    outcome: SpotDemoReadbackOutcome
+    evidence_kind: SpotDemoLaneEvidenceKind
+    may_release_claim: bool
+    operator_visible_state: str | None
+    detail: str
+    repost: bool = field(default=False, init=False)
+
+
+def classify_restart_disposition(
+    outcome: SpotDemoReadbackOutcome,
+    *,
+    account_position_reconciled: bool = False,
+    remainder_known: bool = False,
+) -> RestartDisposition:
+    """C3-5 — decide, from authoritative readback only, what may happen next.
+
+    Release is permitted in exactly two shapes, and only with reconciliation:
+
+    A. authoritative ``NOT_CREATED`` — the broker proves the order never
+       existed; or
+    B. an attributed native terminal fact whose remainder is known.
+
+    Everything else keeps the claim.  A missing readback row, an unparseable
+    status, and the passage of time are not evidence of anything.
+    """
+
+    if outcome is SpotDemoReadbackOutcome.NOT_CREATED:
+        return RestartDisposition(
+            outcome=outcome,
+            evidence_kind=SpotDemoLaneEvidenceKind.TERMINAL_RECONCILIATION,
+            may_release_claim=account_position_reconciled,
+            operator_visible_state=(
+                None if account_position_reconciled else SPOT_DEMO_UNRECOVERABLE_STATE
+            ),
+            detail=(
+                "authoritative absence proven; release still requires account "
+                "reconciliation"
+            ),
+        )
+    if outcome is SpotDemoReadbackOutcome.UNREADABLE:
+        return RestartDisposition(
+            outcome=outcome,
+            evidence_kind=SpotDemoLaneEvidenceKind.UNKNOWN,
+            may_release_claim=False,
+            operator_visible_state=SPOT_DEMO_UNRECOVERABLE_STATE,
+            detail="readback unreadable or absent; the claim is retained",
+        )
+    if outcome in _TERMINAL_READBACK_OUTCOMES:
+        evidence_kind = {
+            SpotDemoReadbackOutcome.FILLED: (
+                SpotDemoLaneEvidenceKind.TERMINAL_RECONCILIATION
+            ),
+            SpotDemoReadbackOutcome.CANCELED: SpotDemoLaneEvidenceKind.CANCEL,
+            SpotDemoReadbackOutcome.REJECTED: SpotDemoLaneEvidenceKind.REJECT,
+            SpotDemoReadbackOutcome.EXPIRED: SpotDemoLaneEvidenceKind.EXPIRY,
+        }[outcome]
+        releasable = account_position_reconciled and remainder_known
+        return RestartDisposition(
+            outcome=outcome,
+            evidence_kind=evidence_kind,
+            may_release_claim=releasable,
+            operator_visible_state=(
+                None if releasable else SPOT_DEMO_UNRECOVERABLE_STATE
+            ),
+            detail=(
+                "attributed native terminal fact; release requires both account "
+                "reconciliation and a known remainder"
+            ),
+        )
+    evidence_kind = (
+        SpotDemoLaneEvidenceKind.PARTIAL_FILL
+        if outcome is SpotDemoReadbackOutcome.PARTIALLY_FILLED
+        else SpotDemoLaneEvidenceKind.UNKNOWN
+    )
+    return RestartDisposition(
+        outcome=outcome,
+        evidence_kind=evidence_kind,
+        may_release_claim=False,
+        operator_visible_state=SPOT_DEMO_UNRECOVERABLE_STATE,
+        detail="order is still live; the claim is retained and nothing is reposted",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SubmitOutcome:
+    """How one transport response maps onto lane evidence and J3A certainty.
+
+    Split out of the dispatch closure deliberately.  The dispatch path itself is
+    structurally unreachable under the signed registry, so a test can never
+    drive it end to end; a pure classifier is the seam that lets the ACK and
+    unknown branches be proven rather than merely asserted in prose.
+    """
+
+    evidence_kind: SpotDemoLaneEvidenceKind
+    certainty: MutationCertainty
+    broker_order_id: str | None
+    detail: str
+
+
+#: The response never arrived: the callback raised.  The write may well have
+#: reached the broker, so this is an uncertainty, never a failure to send.
+SUBMIT_RAISED_OUTCOME: Final[SubmitOutcome] = SubmitOutcome(
+    evidence_kind=SpotDemoLaneEvidenceKind.UNKNOWN,
+    certainty=MutationCertainty.UNCERTAIN,
+    broker_order_id=None,
+    detail="submit raised; broker outcome unknown",
+)
+
+
+def classify_submit_outcome(result: object) -> SubmitOutcome:
+    """Attribute a submit response, or refuse to call it an acknowledgement.
+
+    A response carrying no native order id is *uncertain*, not a success: there
+    is nothing to correlate a later readback against, so treating it as an ACK
+    would strand the order.  The ROB-298 dry-run sentinel carries no order id
+    either, and lands in the same branch by construction.
+    """
+
+    broker_order_id = getattr(result, "broker_order_id", None)
+    if broker_order_id is None or not str(broker_order_id).strip():
+        return SubmitOutcome(
+            evidence_kind=SpotDemoLaneEvidenceKind.UNKNOWN,
+            certainty=MutationCertainty.UNCERTAIN,
+            broker_order_id=None,
+            detail="no native order id in the submit response",
+        )
+    return SubmitOutcome(
+        evidence_kind=SpotDemoLaneEvidenceKind.ACK,
+        certainty=MutationCertainty.DEFINITIVE,
+        broker_order_id=str(broker_order_id).strip(),
+        detail="native order id attributed",
+    )
+
+
+def terminal_evidence_for(disposition: RestartDisposition) -> TerminalClaimEvidence:
+    """Translate a disposition into J3A's release evidence.
+
+    Never fabricates a flag: a disposition that may not release produces a
+    default-constructed evidence object, which authorizes nothing.
+    """
+
+    if not disposition.may_release_claim:
+        return TerminalClaimEvidence()
+    if disposition.outcome is SpotDemoReadbackOutcome.NOT_CREATED:
+        return TerminalClaimEvidence(
+            authoritative_absence_proven=True,
+            account_position_reconciled=True,
+        )
+    return TerminalClaimEvidence(
+        lane_native_terminal_evidence=True,
+        account_position_reconciled=True,
+        remainder_known=True,
+    )
+
+
+# --------------------------------------------------------------------------
+# The composition.
+# --------------------------------------------------------------------------
+
+
+class BinanceSpotDemoLimitComposition:
+    """C3-1 — the single recovery owner for this lane.
+
+    One object owns composing a LIMIT order, dispatching it behind the J3A
+    coordination order, writing lane-native evidence, and resolving a surviving
+    claim after a restart.  No second owner is named, and the shared
+    coordination layer owns none of it.
+    """
+
+    __slots__ = (
+        "_client",
+        "_factory",
+        "_claims",
+        "_persistence",
+        "_dispatch_evidence",
+        "_uncertainty_gate",
+        "_lane_evidence",
+        "_connection_factory",
+    )
+
+    def __init__(
+        self,
+        *,
+        client: BinanceSpotDemoExecutionClient,
+        claims: DurableSendClaimAdapter,
+        connection_factory: Any,
+        persistence: LineagePersistencePort | None,
+        dispatch_evidence: DispatchEvidencePort | None,
+        uncertainty_gate: AccountUncertaintyGatePort | None,
+        lane_evidence: SpotDemoLaneEvidencePort | None,
+        factory: MockLineageFactory | None = None,
+    ) -> None:
+        # Checked at construction: a composition that cannot write its own
+        # lane-native evidence must not exist, let alone dispatch.
+        self._lane_evidence = require_lane_evidence_port(lane_evidence)
+        self._client = client
+        self._claims = claims
+        self._connection_factory = connection_factory
+        self._persistence = persistence
+        self._dispatch_evidence = dispatch_evidence
+        self._uncertainty_gate = uncertainty_gate
+        self._factory = factory or MockLineageFactory()
+
+    # -- pre-I/O validation -------------------------------------------------
+
+    def validate_pre_dispatch(
+        self,
+        envelope: LineageEnvelope,
+        *,
+        registry: RegistrySource | None = None,
+        recurring_requested: bool = False,
+    ) -> LaneRegistryEntry:
+        """Run every J6B guard, then every J2A guard.  No I/O happens here.
+
+        Order matters: the LIMIT/currency/provenance/transport checks run first
+        so a malformed plan is refused on its own terms, and the registry's
+        execution-ready guard runs last so its verdict is the final word.
+        """
+
+        assert_no_recurring_request(recurring_requested)
+        plan = envelope.execution_plan
+        if plan is None:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.ORDER_TYPE_NOT_LIMIT,
+                "an execution plan is required before dispatch",
+            )
+        assert_canonical_writer_lane(plan)
+        assert_limit_only_plan(plan)
+        assert_sizing_provenance_complete(plan)
+
+        entry = get_lane_registry_entry(plan.lane_id)
+        assert_usdt_single_currency(envelope.decision_intent, plan, entry)
+        assert_spot_demo_transport(self._client)
+        assert_mock_only_endpoint(entry, SPOT_DEMO_ENDPOINT_URL)
+
+        # J2A has the last word: lane/broker/profile/mode/policy binding, then
+        # the execution-ready check that the signed registry cannot satisfy.
+        bound_entry = assert_lineage_registry_binding(envelope, registry)
+        assert_entry_execution_ready(bound_entry)
+        return bound_entry
+
+    # -- dispatch -----------------------------------------------------------
+
+    async def submit_limit_order(
+        self,
+        envelope: LineageEnvelope,
+        *,
+        registry: RegistrySource | None = None,
+        confirm: bool = False,
+        recurring_requested: bool = False,
+        additional_advisory_keys: Sequence[int] = (),
+    ) -> CoordinatedMutationResult:
+        """Dispatch one LIMIT order behind the full J3A coordination order.
+
+        ``confirm`` reaches the transport only after every guard above passes.
+        Under the signed registry they cannot all pass, so this is unreachable
+        today; an actual send is J8's bounded canary and nothing else.
+        """
+
+        self.validate_pre_dispatch(
+            envelope, registry=registry, recurring_requested=recurring_requested
+        )
+        plan = envelope.execution_plan
+        attempt = envelope.order_attempt
+        if plan is None or attempt is None:  # pragma: no cover - guarded above
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.ORDER_TYPE_NOT_LIMIT,
+                "a plan and an order attempt are required before dispatch",
+            )
+        side = envelope.decision_intent.side.upper()
+        client_order_id = attempt.broker_client_order_id
+
+        async def _mutate(scope: CoordinationScope) -> MutationCallbackResult:
+            # Re-assert immediately before the send: the pre-callback
+            # attestation is neither temporally nor semantically sufficient.
+            await scope.assert_owned()
+            assert_spot_demo_transport(self._client)
+            try:
+                result = await self._client.submit_order(
+                    symbol=plan.normalized_symbol,
+                    side=side,
+                    order_type=SPOT_DEMO_ORDER_TYPE,
+                    qty=plan.quantity,
+                    client_order_id=client_order_id,
+                    price=plan.limit_price,
+                    time_in_force=plan.time_in_force,
+                    confirm=confirm,
+                )
+            except Exception:
+                # The write may well have reached the broker.  Record the
+                # unknown as lane-native evidence and re-raise; J3A keeps the
+                # claim and the writer authority.
+                await self._record_submit_outcome(
+                    SUBMIT_RAISED_OUTCOME, attempt=attempt, plan=plan, result=None
+                )
+                raise
+            outcome = classify_submit_outcome(result)
+            await self._record_submit_outcome(
+                outcome, attempt=attempt, plan=plan, result=result
+            )
+            return MutationCallbackResult(
+                certainty=outcome.certainty,
+                broker_order_id=outcome.broker_order_id,
+            )
+
+        return await coordinate_mock_order_mutation(
+            envelope=envelope,
+            persistence=self._persistence,
+            dispatch_evidence=self._dispatch_evidence,
+            uncertainty_gate=self._uncertainty_gate,
+            claims=self._claims,
+            connection_factory=self._connection_factory,
+            mutation=_mutate,
+            registry=registry,
+            lineage_factory=self._factory,
+            additional_advisory_keys=additional_advisory_keys,
+        )
+
+    async def _record_submit_outcome(
+        self,
+        outcome: SubmitOutcome,
+        *,
+        attempt: Any,
+        plan: ExecutionPlan,
+        result: object,
+    ) -> None:
+        """Write one submit-path lane evidence row.
+
+        The uncertain branches carry the operator-visible blocked state so an
+        unknown is legible at rest rather than inferred from a missing field.
+        """
+
+        payload: dict[str, Any] = {
+            "order_attempt_id": attempt.order_attempt_id,
+            "idempotency_key": attempt.idempotency_key,
+            "symbol": plan.normalized_symbol,
+            "detail": outcome.detail,
+        }
+        if outcome.certainty is MutationCertainty.UNCERTAIN:
+            payload["state"] = SPOT_DEMO_UNRECOVERABLE_STATE
+        else:
+            payload["broker_order_id"] = outcome.broker_order_id
+            payload["native_status"] = getattr(result, "status", None)
+        await self._lane_evidence.record_lane_evidence(outcome.evidence_kind, payload)
+
+    # -- recovery -----------------------------------------------------------
+
+    async def readback(
+        self, *, symbol: str, client_order_id: str
+    ) -> tuple[SpotDemoReadbackOutcome, Mapping[str, Any] | None]:
+        """C3-3 — the authoritative readback for one surviving claim.
+
+        A ``-2013`` order-not-found is the broker proving absence.  Any other
+        failure is unreadable, which is a held unknown rather than an absence.
+        """
+
+        assert_spot_demo_transport(self._client)
+        try:
+            payload = await self._client.get_order_status(
+                symbol=symbol, client_order_id=client_order_id
+            )
+        except BinanceDemoOrderNotFound:
+            return SpotDemoReadbackOutcome.NOT_CREATED, None
+        except Exception:
+            # Anything else is a *held* unknown, never an absence: a network
+            # failure is not the broker saying the order does not exist.
+            return SpotDemoReadbackOutcome.UNREADABLE, None
+        return classify_native_status(payload.get("status")), payload
+
+    async def resolve_restart_claim(
+        self,
+        claim: DurableClaim,
+        *,
+        symbol: str,
+        client_order_id: str,
+        account_position_reconciled: bool = False,
+        remainder_known: bool = False,
+    ) -> RestartDisposition:
+        """C3-2 — resolve one rediscovered claim, and never repost.
+
+        The disposition is derived from the authoritative readback alone, then
+        written as lane-native evidence.  Only a disposition that may release
+        reaches ``release_with_terminal_evidence``; every other path keeps the
+        claim and leaves the operator-visible blocked state in place.
+        """
+
+        outcome, payload = await self.readback(
+            symbol=symbol, client_order_id=client_order_id
+        )
+        disposition = classify_restart_disposition(
+            outcome,
+            account_position_reconciled=account_position_reconciled,
+            remainder_known=remainder_known,
+        )
+        await self._lane_evidence.record_lane_evidence(
+            disposition.evidence_kind,
+            {
+                "trigger": SPOT_DEMO_RESTART_TRIGGER,
+                "readback": SPOT_DEMO_AUTHORITATIVE_READBACK,
+                "idempotency_key": claim.idempotency_key,
+                "claim_row_id": claim.row_id,
+                "symbol": symbol,
+                "outcome": disposition.outcome.value,
+                "operator_visible_state": disposition.operator_visible_state,
+                "native_status": (payload or {}).get("status"),
+                "repost": disposition.repost,
+            },
+        )
+        if disposition.may_release_claim:
+            await self._claims.release_with_terminal_evidence(
+                claim, terminal_evidence_for(disposition)
+            )
+            await self._lane_evidence.record_lane_evidence(
+                SpotDemoLaneEvidenceKind.TERMINAL_RECONCILIATION,
+                {
+                    "idempotency_key": claim.idempotency_key,
+                    "claim_row_id": claim.row_id,
+                    "outcome": disposition.outcome.value,
+                    "released": True,
+                },
+            )
+        return disposition
+
+    async def cancel_limit_order(
+        self, *, symbol: str, client_order_id: str, confirm: bool = False
+    ) -> Any:
+        """Cancel one attributed order and record the lane-native cancel fact."""
+
+        assert_spot_demo_transport(self._client)
+        result = await self._client.cancel_order(
+            symbol=symbol, client_order_id=client_order_id, confirm=confirm
+        )
+        await self._lane_evidence.record_lane_evidence(
+            SpotDemoLaneEvidenceKind.CANCEL,
+            {
+                "symbol": symbol,
+                "client_order_id": client_order_id,
+                "confirm": confirm,
+                "native_status": getattr(result, "status", None),
+            },
+        )
+        return result
+
+
+def spot_demo_activation_blockers(entry: LaneRegistryEntry) -> tuple[str, ...]:
+    """Report why this lane cannot activate, primary blocker first.
+
+    §D: the primary terminal lane status is the *policy* blocker.  The absent
+    scheduler owner is real, but it is a secondary activation blocker and is
+    never promoted to the primary status.
+    """
+
+    blockers: list[str] = [SPOT_DEMO_PRIMARY_TERMINAL_LANE_STATUS.value]
+    if (
+        entry.scheduler_owner is None
+        or entry.scheduler_owner is SchedulerOwner.DISABLED
+    ):
+        blockers.append(SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER)
+    if entry.activation_status is not ActivationStatus.ENABLED:
+        blockers.append(f"activation_status={entry.activation_status.value}")
+    if entry.missing_bindings:
+        blockers.extend(
+            f"missing_binding={binding.value}" for binding in entry.missing_bindings
+        )
+    return tuple(blockers)
+
+
+__all__ = [
+    "LANE_EVIDENCE_KINDS",
+    "SIBLING_BINDING_FOR_EXECUTION",
+    "SUBMIT_RAISED_OUTCOME",
+    "SIZING_PROVENANCE_KEYS",
+    "SPOT_DEMO_ACCOUNT_MODE",
+    "SPOT_DEMO_ACCOUNT_PROFILE",
+    "SPOT_DEMO_AUTHORITATIVE_READBACK",
+    "SPOT_DEMO_BROKER",
+    "SPOT_DEMO_CANONICAL_LANE_ID",
+    "SPOT_DEMO_CLIENT_ID_TARGET",
+    "SPOT_DEMO_ENDPOINT_URL",
+    "SPOT_DEMO_FORBIDDEN_PRIMARY_LANE_STATUS",
+    "SPOT_DEMO_FUTURES_LANE_ID",
+    "SPOT_DEMO_LANE_PREFIX",
+    "SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS",
+    "SPOT_DEMO_LIMIT_REASON_CODES",
+    "SPOT_DEMO_ORDER_TYPE",
+    "SPOT_DEMO_PRIMARY_TERMINAL_LANE_STATUS",
+    "SPOT_DEMO_QUOTE_CURRENCY",
+    "SPOT_DEMO_RECOVERY_OWNER",
+    "SPOT_DEMO_RESTART_TRIGGER",
+    "SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER",
+    "SPOT_DEMO_SIDECAR_LANE_ID",
+    "SPOT_DEMO_TIME_IN_FORCE",
+    "SPOT_DEMO_UNRECOVERABLE_STATE",
+    "BinanceSpotDemoLimitComposition",
+    "LimitPriceQuote",
+    "LimitSizing",
+    "LimitSizingBlocked",
+    "RestartDisposition",
+    "SpotDemoLaneEvidenceKind",
+    "SpotDemoLaneEvidencePort",
+    "SpotDemoLimitError",
+    "SpotDemoLimitReason",
+    "SpotDemoReadbackOutcome",
+    "SpotStepSpec",
+    "SubmitOutcome",
+    "classify_submit_outcome",
+    "assert_alpaca_crypto_unwired",
+    "assert_binance_single_writer_domain",
+    "assert_canonical_writer_lane",
+    "assert_limit_only_plan",
+    "assert_no_recurring_request",
+    "assert_sidecar_observation_only",
+    "assert_sizing_provenance_complete",
+    "assert_spot_demo_transport",
+    "assert_usdt_single_currency",
+    "classify_native_status",
+    "classify_restart_disposition",
+    "compose_limit_plan_draft",
+    "compose_limit_sizing",
+    "require_lane_evidence_port",
+    "spot_demo_activation_blockers",
+    "terminal_evidence_for",
+]

--- a/app/services/brokers/binance/spot_demo/mock_auto_limit.py
+++ b/app/services/brokers/binance/spot_demo/mock_auto_limit.py
@@ -36,6 +36,18 @@ Currency is single-valued per D5/§83: this lane is ``USDT`` and ``USD`` is a
 different currency.  No parity, FX lookup, or implicit conversion exists on this
 path, and the USD/USDT sibling-binding key remains ``PENDING`` exactly as the
 merged ROB-1269 contract left it.
+
+Every broker mutation — submit *and* cancel — runs under one contract: fresh
+transport/endpoint/writer-domain guards, lineage attribution, a re-proved lease,
+and a durable unknown when the outcome cannot be established.  A cancel is not a
+lighter operation than a submit; it is a DELETE against a real venue.
+
+The §83 correction-3 recovery contract is *computed* here, not declared:
+:func:`spot_demo_recovery_contract_gaps` checks each of the six items against
+live objects, and :func:`spot_demo_lifecycle_lane_status` resolves any unmet item
+to ``AUTO_READY_BLOCKED_BY_LIFECYCLE``.  Today the lane has real gaps — no
+production caller constructs this composition, and the physical-account identity
+is ``UNKNOWN`` — so the computed verdict is lifecycle-blocked.
 """
 
 from __future__ import annotations
@@ -62,9 +74,13 @@ from app.services.brokers.binance.spot_demo.host_allowlist import (
     SPOT_DEMO_HOSTS,
     assert_spot_demo_host,
 )
-from app.services.brokers.client_order_ids import BrokerClientIdTarget
+from app.services.brokers.client_order_ids import (
+    BrokerClientIdTarget,
+    assert_broker_client_order_id,
+)
 from app.services.mock_integration.coordination import (
     AccountUncertaintyGatePort,
+    ClaimFollowupRequest,
     CoordinatedMutationResult,
     CoordinationScope,
     DispatchEvidencePort,
@@ -72,8 +88,11 @@ from app.services.mock_integration.coordination import (
     DurableSendClaimAdapter,
     MutationCallbackResult,
     MutationCertainty,
+    OrderSendIntentReservationPort,
     TerminalClaimEvidence,
     coordinate_mock_order_mutation,
+    describe_claim_followup,
+    physical_account_scope_for_entry,
 )
 from app.services.mock_integration.lineage import (
     ExecutionPlanDraft,
@@ -82,7 +101,9 @@ from app.services.mock_integration.lineage import (
     MockLineageFactory,
 )
 from app.services.mock_lane_registry import (
+    CANONICAL_LANE_REGISTRY,
     ActivationStatus,
+    LaneGuardError,
     LaneRegistryEntry,
     RegistrySource,
     assert_entry_execution_ready,
@@ -126,7 +147,21 @@ SPOT_DEMO_CLIENT_ID_TARGET: Final[BrokerClientIdTarget] = (
 SPOT_DEMO_PRIMARY_TERMINAL_LANE_STATUS: Final[LaneStatus] = (
     LaneStatus.AUTO_READY_BLOCKED_BY_POLICY
 )
+
+#: An *explicitly disabled* recurring owner (``SchedulerOwner.DISABLED``).  This
+#: is the canonical Binance row's value and rests on in-repo evidence: Binance
+#: Demo has no scheduler registration anywhere.
 SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER: Final[str] = "scheduler_owner_disabled"
+
+#: An *absent* recurring owner (``scheduler_owner is None``).  Absence is not a
+#: spelling of ``DISABLED``: ``None`` means no bind authority was ever assigned,
+#: which is why those rows carry ``MissingBinding.OWNER``.  Folding the two into
+#: one blocker would let a downstream reader believe an owner decision had been
+#: made when none was.  The canonical Binance row happens to be ``DISABLED``, so
+#: today both spellings would print the same string — that coincidence is
+#: exactly why the distinction has to live in the code rather than in prose.
+SPOT_DEMO_ABSENT_SCHEDULER_OWNER_BLOCKER: Final[str] = "scheduler_owner_absent"
+
 SPOT_DEMO_FORBIDDEN_PRIMARY_LANE_STATUS: Final[LaneStatus] = (
     LaneStatus.AUTO_READY_BLOCKED_BY_SCHEDULER
 )
@@ -154,9 +189,16 @@ SPOT_DEMO_RECOVERY_OWNER: Final[str] = (
     "BinanceSpotDemoLimitComposition"
 )
 
-#: C3-2 — what rediscovers surviving durable claims after a restart.
+#: C3-2 — what rediscovers surviving durable claims after a restart.  The name
+#: is only the label; the executable trigger is
+#: :meth:`BinanceSpotDemoLimitComposition.rediscover_restart_claims`, which
+#: enumerates surviving reservations through the J3A reservation port and hands
+#: each one to :meth:`~BinanceSpotDemoLimitComposition.resolve_restart_claim`.
 SPOT_DEMO_RESTART_TRIGGER: Final[str] = (
     "process_restart_rediscovers_durable_j2b_claims_for_physical_account"
+)
+SPOT_DEMO_RESTART_TRIGGER_ENTRYPOINT: Final[str] = (
+    "BinanceSpotDemoLimitComposition.rediscover_restart_claims"
 )
 
 #: C3-3 — the authoritative broker readback.  Open-order listings, account
@@ -193,6 +235,29 @@ LANE_EVIDENCE_KINDS: Final[frozenset[str]] = frozenset(
 )
 
 
+class SpotDemoRecoveryContractItem(StrEnum):
+    """The six §83 correction-3 items, as things that are *computed*, not said.
+
+    Naming an item in a document is not owning it.  Each member below is checked
+    against the live objects — the registry entry, the transport class, the J3A
+    adapter, and the composition instance actually holding the lane's ports — so
+    "this lane satisfies its recovery contract" is a derived answer.  Any unmet
+    item puts the lane at ``AUTO_READY_BLOCKED_BY_LIFECYCLE``.
+    """
+
+    RECOVERY_OWNER = "recovery_owner"
+    RESTART_TRIGGER = "restart_trigger"
+    AUTHORITATIVE_READBACK = "authoritative_readback"
+    LANE_NATIVE_EVIDENCE = "lane_native_evidence"
+    RELEASE_IF_MATCHES_CONDITION = "release_if_matches_condition"
+    OPERATOR_BLOCKED_STATE = "operator_blocked_state"
+
+
+SPOT_DEMO_RECOVERY_CONTRACT_ITEMS: Final[tuple[str, ...]] = tuple(
+    item.value for item in SpotDemoRecoveryContractItem
+)
+
+
 # --------------------------------------------------------------------------
 # Reason codes — J6B-owned, disjoint from J3A coordination reason codes.
 # --------------------------------------------------------------------------
@@ -221,6 +286,9 @@ class SpotDemoLimitReason(StrEnum):
     RECURRING_REGISTRATION_FORBIDDEN = "recurring_registration_forbidden"
     BLIND_REPOST_FORBIDDEN = "blind_repost_forbidden"
     LANE_EVIDENCE_PORT_UNAVAILABLE = "lane_evidence_port_unavailable"
+    CANCEL_NOT_ATTRIBUTED = "cancel_not_attributed"
+    CANCEL_FOLLOWUP_CAPABILITY_ABSENT = "cancel_followup_capability_absent"
+    RESTART_CLAIM_SOURCE_UNAVAILABLE = "restart_claim_source_unavailable"
 
 
 SPOT_DEMO_LIMIT_REASON_CODES: Final[frozenset[str]] = frozenset(
@@ -682,6 +750,129 @@ def assert_alpaca_crypto_unwired(registry: Sequence[LaneRegistryEntry]) -> None:
             )
 
 
+def registry_entries(
+    registry: RegistrySource | None = None,
+) -> tuple[LaneRegistryEntry, ...]:
+    """Normalize the caller's registry view into rows the domain guards can read.
+
+    ``None`` means the signed canonical registry, which is what every real caller
+    passes.  A mapping or an iterable is accepted because that is exactly what
+    J2A's own ``RegistrySource`` alias admits, and the domain guards must see the
+    same rows the rest of the dispatch chain will.
+    """
+
+    if registry is None:
+        return tuple(CANONICAL_LANE_REGISTRY)
+    if isinstance(registry, Mapping):
+        return tuple(registry.values())
+    return tuple(registry)
+
+
+def assert_binance_domain_invariants(
+    registry: RegistrySource | None = None,
+) -> tuple[LaneRegistryEntry, ...]:
+    """Run the three registry-wide invariants that guard the writer domain.
+
+    These are *chain* guards, not documentation.  Every dispatch and every
+    lane-native follow-up runs them before the J2A binding check, so a registry
+    that grew a second Binance writer, promoted the B0-X sidecar, or wired Alpaca
+    crypto is refused on the way to the broker rather than only when someone
+    calls the guard directly in a test.
+    """
+
+    entries = registry_entries(registry)
+    assert_binance_single_writer_domain(entries)
+    assert_sidecar_observation_only(entries)
+    assert_alpaca_crypto_unwired(entries)
+    return entries
+
+
+# --------------------------------------------------------------------------
+# Attribution — a follow-up may only touch an order this lane's lineage made.
+# --------------------------------------------------------------------------
+
+#: The J2B idempotency-key domain, consumed rather than minted.  J2B derives the
+#: durable claim key and the native client order id from the *same* digest of
+#: ``{execution_plan_id, cycle_id}``, so a surviving claim determines exactly one
+#: client order id for this lane.  ``test_attributed_client_order_id_round_trips_
+#: the_j2b_factory`` pins this against real factory output instead of trusting
+#: the literal.
+IDEMPOTENCY_KEY_DOMAIN_PREFIX: Final[str] = "mock-idempotency-v1:"
+
+#: How many digest characters J2B keeps in a native client order id.
+BROKER_CLIENT_ID_DIGEST_LENGTH: Final[int] = 24
+
+
+def derive_attributed_client_order_id(idempotency_key: str) -> str:
+    """Recompute this lane's client order id from one durable claim key.
+
+    This is the attribution anchor for every follow-up: an order id that cannot
+    be reproduced from a claim this lane holds is, by definition, not this lane's
+    order.  Nothing is hashed here — the digest already lives in the key.
+    """
+
+    if not isinstance(idempotency_key, str) or not idempotency_key.startswith(
+        IDEMPOTENCY_KEY_DOMAIN_PREFIX
+    ):
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.CANCEL_NOT_ATTRIBUTED,
+            "idempotency key is not a J2B-derived key for this lane",
+        )
+    digest = idempotency_key[len(IDEMPOTENCY_KEY_DOMAIN_PREFIX) :]
+    if len(digest) < BROKER_CLIENT_ID_DIGEST_LENGTH:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.CANCEL_NOT_ATTRIBUTED,
+            "idempotency key digest is too short to carry a client order id",
+        )
+    candidate = f"{SPOT_DEMO_LANE_PREFIX}-{digest[:BROKER_CLIENT_ID_DIGEST_LENGTH]}"
+    try:
+        assert_broker_client_order_id(
+            target=SPOT_DEMO_CLIENT_ID_TARGET, client_order_id=candidate
+        )
+    except Exception as exc:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.CANCEL_NOT_ATTRIBUTED,
+            "derived client order id violates the Binance Spot Demo constraint",
+        ) from exc
+    return candidate
+
+
+def assert_client_order_id_attributed(claim: DurableClaim, client_order_id: str) -> str:
+    """Refuse any order id this lane's own lineage cannot reproduce.
+
+    ``confirm`` gates whether a mutation is *sent*; it says nothing about whether
+    the thing being mutated is ours.  Without this, a caller could cancel an
+    arbitrary — or someone else's — order through a lane that holds an unrelated
+    claim, and the lane would then durably record it as its own cancel.
+    """
+
+    expected = derive_attributed_client_order_id(claim.idempotency_key)
+    if not isinstance(client_order_id, str) or client_order_id != expected:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.CANCEL_NOT_ATTRIBUTED,
+            "client order id is not the one this claim's lineage produced",
+        )
+    return expected
+
+
+def assert_claim_belongs_to_lane(claim: DurableClaim, entry: LaneRegistryEntry) -> str:
+    """Require the claim to sit in this lane's own physical-account scope.
+
+    The scope is derived from J2A identity, never accepted from a caller.  While
+    ``identity_status`` is ``UNKNOWN`` this raises ``LaneGuardError`` from J2A —
+    a lane that cannot name its physical account cannot prove a claim is its own,
+    and so cannot mutate one.
+    """
+
+    scope = physical_account_scope_for_entry(entry)
+    if claim.claim_account_scope != scope.claim_account_scope:
+        raise SpotDemoLimitError(
+            SpotDemoLimitReason.CANCEL_NOT_ATTRIBUTED,
+            "claim belongs to a different physical account scope",
+        )
+    return scope.claim_account_scope
+
+
 def assert_spot_demo_transport(client: object) -> str:
     """Prove the *actual* transport is Spot Demo before it is used.
 
@@ -961,6 +1152,71 @@ def classify_submit_outcome(result: object) -> SubmitOutcome:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class SpotDemoCancelDisposition:
+    """What one attributed cancel attempt did — including doing nothing.
+
+    ``dispatched`` is the honest answer to "did a DELETE leave this process".  A
+    dry run reports ``False`` and writes no lane evidence at all, because a
+    durable ``CANCEL`` fact for an order the broker never cancelled is a lie that
+    later reconciliation would have to unpick.
+    """
+
+    dispatched: bool
+    evidence_kind: SpotDemoLaneEvidenceKind | None
+    client_order_id: str
+    native_status: str | None
+    detail: str
+    result: Any = None
+
+
+#: The DELETE left this process and no answer came back.  The order may well be
+#: cancelled at the venue, so this is an uncertainty, never a failed cancel.
+CANCEL_RAISED_OUTCOME: Final[SubmitOutcome] = SubmitOutcome(
+    evidence_kind=SpotDemoLaneEvidenceKind.UNKNOWN,
+    certainty=MutationCertainty.UNCERTAIN,
+    broker_order_id=None,
+    detail="cancel raised after send; broker outcome unknown",
+)
+
+
+def classify_cancel_outcome(result: object) -> SubmitOutcome:
+    """Attribute a cancel response, or refuse to call it a cancellation.
+
+    A response with no native ``status`` proves nothing about the order, so it
+    lands in the same uncertain branch as a raised send.  Only a response that
+    normalizes to a real terminal cancel is recorded as ``CANCEL``.
+    """
+
+    status = getattr(result, "status", None)
+    if not isinstance(status, str) or not status.strip():
+        return SubmitOutcome(
+            evidence_kind=SpotDemoLaneEvidenceKind.UNKNOWN,
+            certainty=MutationCertainty.UNCERTAIN,
+            broker_order_id=None,
+            detail="no native status in the cancel response",
+        )
+    outcome = classify_native_status(status)
+    if outcome is not SpotDemoReadbackOutcome.CANCELED:
+        return SubmitOutcome(
+            evidence_kind=SpotDemoLaneEvidenceKind.UNKNOWN,
+            certainty=MutationCertainty.UNCERTAIN,
+            broker_order_id=None,
+            detail=f"cancel response status {status!r} is not a proven cancellation",
+        )
+    broker_order_id = getattr(result, "broker_order_id", None)
+    return SubmitOutcome(
+        evidence_kind=SpotDemoLaneEvidenceKind.CANCEL,
+        certainty=MutationCertainty.DEFINITIVE,
+        broker_order_id=(
+            str(broker_order_id).strip()
+            if broker_order_id is not None and str(broker_order_id).strip()
+            else None
+        ),
+        detail="broker-confirmed cancellation",
+    )
+
+
 def terminal_evidence_for(disposition: RestartDisposition) -> TerminalClaimEvidence:
     """Translate a disposition into J3A's release evidence.
 
@@ -1000,6 +1256,7 @@ class BinanceSpotDemoLimitComposition:
         "_client",
         "_factory",
         "_claims",
+        "_reservations",
         "_persistence",
         "_dispatch_evidence",
         "_uncertainty_gate",
@@ -1017,6 +1274,7 @@ class BinanceSpotDemoLimitComposition:
         dispatch_evidence: DispatchEvidencePort | None,
         uncertainty_gate: AccountUncertaintyGatePort | None,
         lane_evidence: SpotDemoLaneEvidencePort | None,
+        reservations: OrderSendIntentReservationPort | None = None,
         factory: MockLineageFactory | None = None,
     ) -> None:
         # Checked at construction: a composition that cannot write its own
@@ -1024,11 +1282,29 @@ class BinanceSpotDemoLimitComposition:
         self._lane_evidence = require_lane_evidence_port(lane_evidence)
         self._client = client
         self._claims = claims
+        # C3-2.  ``DurableSendClaimAdapter`` deliberately exposes no listing
+        # surface — enumerating survivors is lane work, not coordination work —
+        # so the restart trigger needs its own read-side port.  It is optional
+        # only because an unbound one is a *computed* recovery gap that keeps
+        # the lane lifecycle-blocked; it is never silently substituted.
+        self._reservations = reservations
         self._connection_factory = connection_factory
         self._persistence = persistence
         self._dispatch_evidence = dispatch_evidence
         self._uncertainty_gate = uncertainty_gate
         self._factory = factory or MockLineageFactory()
+
+    @property
+    def has_restart_claim_source(self) -> bool:
+        """Whether the restart trigger can actually enumerate surviving claims."""
+
+        return self._reservations is not None
+
+    @property
+    def has_lane_evidence_store(self) -> bool:
+        """Whether lane-native evidence has somewhere durable to go."""
+
+        return self._lane_evidence is not None
 
     # -- pre-I/O validation -------------------------------------------------
 
@@ -1042,7 +1318,10 @@ class BinanceSpotDemoLimitComposition:
         """Run every J6B guard, then every J2A guard.  No I/O happens here.
 
         Order matters: the LIMIT/currency/provenance/transport checks run first
-        so a malformed plan is refused on its own terms, and the registry's
+        so a malformed plan is refused on its own terms; the registry-wide
+        writer-domain invariants run next, *before* J2A's binding check, so a
+        registry that violates them dies on that violation rather than falling
+        through to a later, unrelated binding error; and the registry's
         execution-ready guard runs last so its verdict is the final word.
         """
 
@@ -1061,6 +1340,7 @@ class BinanceSpotDemoLimitComposition:
         assert_usdt_single_currency(envelope.decision_intent, plan, entry)
         assert_spot_demo_transport(self._client)
         assert_mock_only_endpoint(entry, SPOT_DEMO_ENDPOINT_URL)
+        assert_binance_domain_invariants(registry)
 
         # J2A has the last word: lane/broker/profile/mode/policy binding, then
         # the execution-ready check that the signed registry cannot satisfy.
@@ -1250,41 +1530,363 @@ class BinanceSpotDemoLimitComposition:
             )
         return disposition
 
-    async def cancel_limit_order(
-        self, *, symbol: str, client_order_id: str, confirm: bool = False
-    ) -> Any:
-        """Cancel one attributed order and record the lane-native cancel fact."""
+    async def rediscover_restart_claims(
+        self,
+        *,
+        entry: LaneRegistryEntry,
+        symbols: Mapping[str, str],
+        registry: RegistrySource | None = None,
+        account_position_reconciled: bool = False,
+        remainder_known: bool = False,
+    ) -> tuple[RestartDisposition, ...]:
+        """C3-2 — the restart trigger, as executable code rather than a name.
 
-        assert_spot_demo_transport(self._client)
-        result = await self._client.cancel_order(
-            symbol=symbol, client_order_id=client_order_id, confirm=confirm
-        )
+        Enumerates the durable claims that survived the restart in this lane's
+        own physical-account scope and resolves each one through the
+        authoritative readback.  Nothing is reposted, and nothing is released
+        without the C3-5 evidence.
+
+        A claim whose key this lane's lineage cannot reproduce is **not ours**
+        and is left strictly alone: it gets an ``unknown`` evidence row and no
+        broker call at all.  A claim that is ours but whose symbol cannot be
+        recovered is likewise held in ``unknown_pending_reconcile`` — the
+        readback needs a symbol, and guessing one would aim an authoritative
+        query at the wrong market.
+        """
+
+        if self._reservations is None:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.RESTART_CLAIM_SOURCE_UNAVAILABLE,
+                "the restart trigger has no reservation port to enumerate; the "
+                "lane stays lifecycle-blocked",
+            )
+        if entry.lane_id != SPOT_DEMO_CANONICAL_LANE_ID:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.LANE_NOT_CANONICAL_WRITER,
+                f"lane {entry.lane_id!r} does not own this recovery path",
+            )
+        assert_binance_domain_invariants(registry)
+        # J2A-derived, never caller-supplied.  Raises while identity is UNKNOWN,
+        # which is the honest answer: a lane that cannot name its physical
+        # account cannot enumerate that account's surviving claims.
+        account_scope = physical_account_scope_for_entry(entry).claim_account_scope
+
+        rows = await self._reservations.list_reservations(account_scope=account_scope)
+        dispositions: list[RestartDisposition] = []
+        for row in rows:
+            row_id = getattr(row, "row_id", None)
+            idempotency_key = getattr(row, "idempotency_key", None)
+            side = getattr(row, "side", None)
+            if not isinstance(row_id, int) or not isinstance(idempotency_key, str):
+                await self._record_unrecoverable_claim(
+                    account_scope=account_scope,
+                    idempotency_key=str(idempotency_key),
+                    detail="reservation row is not readable as a durable claim",
+                )
+                continue
+            try:
+                client_order_id = derive_attributed_client_order_id(idempotency_key)
+            except SpotDemoLimitError:
+                await self._record_unrecoverable_claim(
+                    account_scope=account_scope,
+                    idempotency_key=idempotency_key,
+                    detail="claim is not attributable to this lane's lineage",
+                )
+                continue
+            symbol = symbols.get(idempotency_key)
+            if not isinstance(symbol, str) or not symbol.strip():
+                await self._record_unrecoverable_claim(
+                    account_scope=account_scope,
+                    idempotency_key=idempotency_key,
+                    detail="no symbol is known for this claim; readback is not "
+                    "attempted rather than guessed",
+                )
+                continue
+            dispositions.append(
+                await self.resolve_restart_claim(
+                    DurableClaim(
+                        row_id=row_id,
+                        claim_account_scope=account_scope,
+                        idempotency_key=idempotency_key,
+                        side=side,
+                    ),
+                    symbol=symbol,
+                    client_order_id=client_order_id,
+                    account_position_reconciled=account_position_reconciled,
+                    remainder_known=remainder_known,
+                )
+            )
+        return tuple(dispositions)
+
+    async def _record_unrecoverable_claim(
+        self, *, account_scope: str, idempotency_key: str, detail: str
+    ) -> None:
+        """Leave an unresolvable survivor visibly blocked instead of silently skipped."""
+
         await self._lane_evidence.record_lane_evidence(
-            SpotDemoLaneEvidenceKind.CANCEL,
+            SpotDemoLaneEvidenceKind.UNKNOWN,
             {
-                "symbol": symbol,
-                "client_order_id": client_order_id,
-                "confirm": confirm,
-                "native_status": getattr(result, "status", None),
+                "trigger": SPOT_DEMO_RESTART_TRIGGER,
+                "claim_account_scope": account_scope,
+                "idempotency_key": idempotency_key,
+                "operator_visible_state": SPOT_DEMO_UNRECOVERABLE_STATE,
+                "repost": False,
+                "detail": detail,
             },
         )
-        return result
+
+    async def cancel_limit_order(
+        self,
+        scope: CoordinationScope,
+        claim: DurableClaim,
+        *,
+        entry: LaneRegistryEntry,
+        symbol: str,
+        client_order_id: str,
+        attributed_native_order_id: str,
+        known_remainder: Decimal,
+        registry: RegistrySource | None = None,
+        confirm: bool = False,
+    ) -> SpotDemoCancelDisposition:
+        """Cancel one order this lane's own lineage produced.
+
+        A cancel is a broker mutation, so it runs under the same contract as a
+        submit rather than a lighter one:
+
+        1. the same fresh guards — exact transport type, Spot Demo host, the
+           lane's declared endpoint, and the registry writer-domain invariants;
+        2. **attribution** — the client order id must be reproducible from this
+           claim's J2B key, and the claim must sit in this lane's J2A-derived
+           physical-account scope.  An arbitrary or third-party order id is
+           refused here, before any coordination work;
+        3. **coordination** — ``CoordinationScope.assert_owned()`` proves the
+           physical-account lease is still held, and J3A's own
+           ``describe_claim_followup`` predicate must report the follow-up
+           capability present.  That predicate needs an attributed native order
+           id and a known remainder, so a cancel aimed at an order whose identity
+           or remainder is unknown cannot be described, let alone sent;
+        4. ownership is re-asserted **again** immediately before the DELETE,
+           because anything awaited in between can outlive the lease;
+        5. **uncertainty** — a raised send records ``unknown`` with the
+           operator-visible blocked state and re-raises.  A response that does
+           not prove a cancellation is also ``unknown``, never ``cancel``.
+
+        Without ``confirm=True`` nothing is sent and **no lane evidence is
+        written at all**: a durable ``CANCEL`` fact means the broker cancelled
+        the order, and on a dry run it did not.
+        """
+
+        assert_spot_demo_transport(self._client)
+        if entry.lane_id != SPOT_DEMO_CANONICAL_LANE_ID:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.LANE_NOT_CANONICAL_WRITER,
+                f"lane {entry.lane_id!r} does not own this cancel path",
+            )
+        assert_mock_only_endpoint(entry, SPOT_DEMO_ENDPOINT_URL)
+        assert_binance_domain_invariants(registry)
+
+        attributed_id = assert_client_order_id_attributed(claim, client_order_id)
+        assert_claim_belongs_to_lane(claim, entry)
+
+        await scope.assert_owned()
+        capability = describe_claim_followup(
+            ClaimFollowupRequest(
+                operation="cancel",
+                lane_capability_supports_operation=True,
+                attributed_native_order_id=attributed_native_order_id,
+                known_remainder=known_remainder,
+                # Computed, not declared: the guards above just ran, and the
+                # lease was just re-proved.
+                fresh_guards_passed=True,
+                lease_ownership_verified=True,
+            )
+        )
+        if not capability.capability_present:
+            raise SpotDemoLimitError(
+                SpotDemoLimitReason.CANCEL_FOLLOWUP_CAPABILITY_ABSENT,
+                f"J3A reports {capability.reason_code} for this cancel follow-up",
+            )
+
+        if not confirm:
+            return SpotDemoCancelDisposition(
+                dispatched=False,
+                evidence_kind=None,
+                client_order_id=attributed_id,
+                native_status=None,
+                detail=(
+                    "dry run: no DELETE was sent, so no durable cancel fact is recorded"
+                ),
+            )
+
+        await scope.assert_owned()
+        try:
+            result = await self._client.cancel_order(
+                symbol=symbol, client_order_id=attributed_id, confirm=True
+            )
+        except Exception:
+            await self._record_cancel_outcome(
+                CANCEL_RAISED_OUTCOME,
+                claim=claim,
+                symbol=symbol,
+                client_order_id=attributed_id,
+                native_status=None,
+            )
+            raise
+        outcome = classify_cancel_outcome(result)
+        native_status = getattr(result, "status", None)
+        await self._record_cancel_outcome(
+            outcome,
+            claim=claim,
+            symbol=symbol,
+            client_order_id=attributed_id,
+            native_status=native_status if isinstance(native_status, str) else None,
+        )
+        return SpotDemoCancelDisposition(
+            dispatched=True,
+            evidence_kind=outcome.evidence_kind,
+            client_order_id=attributed_id,
+            native_status=native_status if isinstance(native_status, str) else None,
+            detail=outcome.detail,
+            result=result,
+        )
+
+    async def _record_cancel_outcome(
+        self,
+        outcome: SubmitOutcome,
+        *,
+        claim: DurableClaim,
+        symbol: str,
+        client_order_id: str,
+        native_status: str | None,
+    ) -> None:
+        """Write one cancel-path lane evidence row, uncertain branches included."""
+
+        payload: dict[str, Any] = {
+            "operation": "cancel",
+            "idempotency_key": claim.idempotency_key,
+            "claim_row_id": claim.row_id,
+            "symbol": symbol,
+            "client_order_id": client_order_id,
+            "native_status": native_status,
+            "detail": outcome.detail,
+        }
+        if outcome.certainty is MutationCertainty.UNCERTAIN:
+            payload["operator_visible_state"] = SPOT_DEMO_UNRECOVERABLE_STATE
+        else:
+            payload["broker_order_id"] = outcome.broker_order_id
+        await self._lane_evidence.record_lane_evidence(outcome.evidence_kind, payload)
 
 
-def spot_demo_activation_blockers(entry: LaneRegistryEntry) -> tuple[str, ...]:
+def spot_demo_recovery_contract_gaps(
+    entry: LaneRegistryEntry,
+    *,
+    composition: BinanceSpotDemoLimitComposition | None = None,
+) -> tuple[str, ...]:
+    """C3-7 — compute which §83 correction-3 items this lane does *not* satisfy.
+
+    Every check reads a live object rather than a claim about one.  Pass the
+    composition that actually holds the lane's ports to ask "is this owner
+    complete"; pass ``None`` — the registry-level view, and the honest one while
+    no production caller constructs this composition — to ask "does the lane have
+    a recovery owner at all".
+
+    Returning an empty tuple is a real possibility, not a formality: a fully
+    wired composition against an identity-known entry has no gaps.  That is what
+    makes a non-empty result evidence rather than decoration.
+    """
+
+    gaps: list[str] = []
+
+    # C3-1 — the named owner must resolve to this module's composition class.
+    if SPOT_DEMO_RECOVERY_OWNER != (
+        f"{__name__}.{BinanceSpotDemoLimitComposition.__qualname__}"
+    ):
+        gaps.append(SpotDemoRecoveryContractItem.RECOVERY_OWNER.value)
+
+    # C3-2 — a trigger that cannot enumerate survivors is a name, not a trigger.
+    # Two independent ways to fail: no read-side port bound, or an identity the
+    # lane cannot resolve into a physical-account scope to enumerate *within*.
+    restart_ready = composition is not None and composition.has_restart_claim_source
+    if restart_ready:
+        try:
+            physical_account_scope_for_entry(entry)
+        except LaneGuardError:
+            restart_ready = False
+    if not restart_ready:
+        gaps.append(SpotDemoRecoveryContractItem.RESTART_TRIGGER.value)
+
+    # C3-3 — the authoritative readback must exist on the real transport class.
+    if not callable(getattr(BinanceSpotDemoExecutionClient, "get_order_status", None)):
+        gaps.append(SpotDemoRecoveryContractItem.AUTHORITATIVE_READBACK.value)
+
+    # C3-4 — all seven kinds, and somewhere durable to write them.
+    if (
+        LANE_EVIDENCE_KINDS
+        != frozenset(kind.value for kind in SpotDemoLaneEvidenceKind)
+        or len(LANE_EVIDENCE_KINDS) != 7
+    ):
+        gaps.append(SpotDemoRecoveryContractItem.LANE_NATIVE_EVIDENCE.value)
+    elif composition is None or not composition.has_lane_evidence_store:
+        gaps.append(SpotDemoRecoveryContractItem.LANE_NATIVE_EVIDENCE.value)
+
+    # C3-5 — release must be reachable only through the J3A evidence gate.
+    if not callable(
+        getattr(DurableSendClaimAdapter, "release_with_terminal_evidence", None)
+    ):
+        gaps.append(SpotDemoRecoveryContractItem.RELEASE_IF_MATCHES_CONDITION.value)
+
+    # C3-6 — a concrete operator-visible state.
+    if not SPOT_DEMO_UNRECOVERABLE_STATE.strip():
+        gaps.append(SpotDemoRecoveryContractItem.OPERATOR_BLOCKED_STATE.value)
+
+    return tuple(gaps)
+
+
+def spot_demo_lifecycle_lane_status(
+    entry: LaneRegistryEntry,
+    *,
+    composition: BinanceSpotDemoLimitComposition | None = None,
+) -> LaneStatus | None:
+    """The §83 verdict: any unmet recovery item leaves the lane lifecycle-blocked.
+
+    ``None`` means every item is satisfied.  This is the computed counterpart of
+    ``SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS``, which is only the constant the
+    verdict resolves to.
+    """
+
+    if spot_demo_recovery_contract_gaps(entry, composition=composition):
+        return SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS
+    return None
+
+
+def spot_demo_activation_blockers(
+    entry: LaneRegistryEntry,
+    *,
+    composition: BinanceSpotDemoLimitComposition | None = None,
+) -> tuple[str, ...]:
     """Report why this lane cannot activate, primary blocker first.
 
-    §D: the primary terminal lane status is the *policy* blocker.  The absent
-    scheduler owner is real, but it is a secondary activation blocker and is
-    never promoted to the primary status.
+    §D: the primary terminal lane status is the *policy* blocker.  The recovery
+    lifecycle verdict and the scheduler owner are reported after it and are never
+    promoted to the primary status.
     """
 
     blockers: list[str] = [SPOT_DEMO_PRIMARY_TERMINAL_LANE_STATUS.value]
-    if (
-        entry.scheduler_owner is None
-        or entry.scheduler_owner is SchedulerOwner.DISABLED
-    ):
+
+    # §83 correction 3, computed rather than asserted.
+    gaps = spot_demo_recovery_contract_gaps(entry, composition=composition)
+    if gaps:
+        blockers.append(SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS.value)
+        blockers.extend(f"recovery_gap={gap}" for gap in gaps)
+
+    # Absence and explicit disablement are different facts about ownership, and
+    # the signed table records them as different values.  Collapsing them here
+    # would report an owner decision that was never made.
+    if entry.scheduler_owner is None:
+        blockers.append(SPOT_DEMO_ABSENT_SCHEDULER_OWNER_BLOCKER)
+    elif entry.scheduler_owner is SchedulerOwner.DISABLED:
         blockers.append(SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER)
+
     if entry.activation_status is not ActivationStatus.ENABLED:
         blockers.append(f"activation_status={entry.activation_status.value}")
     if entry.missing_bindings:
@@ -1295,10 +1897,14 @@ def spot_demo_activation_blockers(entry: LaneRegistryEntry) -> tuple[str, ...]:
 
 
 __all__ = [
+    "BROKER_CLIENT_ID_DIGEST_LENGTH",
+    "CANCEL_RAISED_OUTCOME",
+    "IDEMPOTENCY_KEY_DOMAIN_PREFIX",
     "LANE_EVIDENCE_KINDS",
     "SIBLING_BINDING_FOR_EXECUTION",
     "SUBMIT_RAISED_OUTCOME",
     "SIZING_PROVENANCE_KEYS",
+    "SPOT_DEMO_ABSENT_SCHEDULER_OWNER_BLOCKER",
     "SPOT_DEMO_ACCOUNT_MODE",
     "SPOT_DEMO_ACCOUNT_PROFILE",
     "SPOT_DEMO_AUTHORITATIVE_READBACK",
@@ -1314,8 +1920,10 @@ __all__ = [
     "SPOT_DEMO_ORDER_TYPE",
     "SPOT_DEMO_PRIMARY_TERMINAL_LANE_STATUS",
     "SPOT_DEMO_QUOTE_CURRENCY",
+    "SPOT_DEMO_RECOVERY_CONTRACT_ITEMS",
     "SPOT_DEMO_RECOVERY_OWNER",
     "SPOT_DEMO_RESTART_TRIGGER",
+    "SPOT_DEMO_RESTART_TRIGGER_ENTRYPOINT",
     "SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER",
     "SPOT_DEMO_SIDECAR_LANE_ID",
     "SPOT_DEMO_TIME_IN_FORCE",
@@ -1325,17 +1933,23 @@ __all__ = [
     "LimitSizing",
     "LimitSizingBlocked",
     "RestartDisposition",
+    "SpotDemoCancelDisposition",
     "SpotDemoLaneEvidenceKind",
     "SpotDemoLaneEvidencePort",
     "SpotDemoLimitError",
     "SpotDemoLimitReason",
     "SpotDemoReadbackOutcome",
+    "SpotDemoRecoveryContractItem",
     "SpotStepSpec",
     "SubmitOutcome",
+    "classify_cancel_outcome",
     "classify_submit_outcome",
     "assert_alpaca_crypto_unwired",
+    "assert_binance_domain_invariants",
     "assert_binance_single_writer_domain",
     "assert_canonical_writer_lane",
+    "assert_claim_belongs_to_lane",
+    "assert_client_order_id_attributed",
     "assert_limit_only_plan",
     "assert_no_recurring_request",
     "assert_sidecar_observation_only",
@@ -1346,7 +1960,11 @@ __all__ = [
     "classify_restart_disposition",
     "compose_limit_plan_draft",
     "compose_limit_sizing",
+    "derive_attributed_client_order_id",
+    "registry_entries",
     "require_lane_evidence_port",
     "spot_demo_activation_blockers",
+    "spot_demo_lifecycle_lane_status",
+    "spot_demo_recovery_contract_gaps",
     "terminal_evidence_for",
 ]

--- a/docs/runbooks/binance-spot-demo-mock-auto-limit.md
+++ b/docs/runbooks/binance-spot-demo-mock-auto-limit.md
@@ -1,0 +1,324 @@
+# ROB-1270 J6B — Binance Spot Demo canonical LIMIT composition
+
+A separate LIMIT composition for `crypto.binance.spot_demo.canonical`, built on
+the merged J2A registry, J2B lineage factory, and J3A coordination port. This
+document is also **this lane's contract document** for the recovery-ownership
+and single-currency requirements below; there is no second contract file.
+
+- Composition: `app/services/brokers/binance/spot_demo/mock_auto_limit.py`
+- Transport (read/reuse only): `app/services/brokers/binance/spot_demo/execution_client.py`
+- Tests: `tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py`
+
+**No activation.** Activation to `AUTO_ENABLED` is out of scope for this job and
+requires separate approval. Missing any recovery item below leaves this lane at
+`AUTO_READY_BLOCKED_BY_LIFECYCLE`.
+
+**No scheduler, no canary, no send.** This job registers no TaskIQ / Prefect /
+cron / launchd / systemd entry and dispatches nothing. A real order is J8's
+bounded canary and nothing else.
+
+---
+
+## 1. What this is not
+
+| Not this | Why it matters |
+|---|---|
+| The ROB-845 `BUY` / `MARKET` / notional-only paper adapter | That is a **frozen asset**. It is not edited, wrapped, or relabelled. `PAPER_BROKER_CAPABILITIES[Broker.BINANCE]` still declares `sides={"buy"}`, `order_types={"market"}`, `sizing_modes={"notional"}`, `time_in_force=frozenset()`. Byte identity is pinned in `test_mutant_04a_*`. |
+| A registry change | `app/services/mock_lane_registry.py` is untouched. Mechanically narrowing the signed lane-status allowlist is J2A-owned work, not J6B's. |
+| An `execution_client` extension | The ROB-298 client already supports LIMIT `price` + `timeInForce` and a default-`false` `confirm`. Nothing was added to it. |
+| A B0-X sidecar promotion | Operator decision D2: the sidecar stays observation-only. The transition option is retired, so the "own-fill attribution proof" precondition never arises. |
+| Alpaca crypto mutation wiring | Operator decision D1: no mutation profile is assigned this epoch. Both rows stay `NOT_READY` / `DISABLED` / `writer=false`. |
+
+---
+
+## 2. Signed lane row — consumed, not rewritten
+
+| field | value |
+|---|---|
+| `lane_id` | `crypto.binance.spot_demo.canonical` |
+| `role` (purpose only) | `PRIMARY_AUTO` |
+| `lane_status` | `NOT_READY` |
+| `activation_status` | `BLOCKED` |
+| `scheduler_owner` | `DISABLED` (the explicit `SchedulerOwner.DISABLED` member) |
+| `writer` / `auto_order_enabled` | `false` / `false` |
+| `quote_currency` | `USDT` |
+| `allowed_hosts` | `("demo-api.binance.com",)` |
+| `physical_account_id` / `identity_status` | `None` / `UNKNOWN` |
+
+`role` is a registry **purpose** value, not execution authority.
+
+### Terminal lane status
+
+When the LIMIT lifecycle is complete, the **primary** terminal lane status for
+this lane is exactly:
+
+```
+AUTO_READY_BLOCKED_BY_POLICY
+```
+
+There is no approved autonomous policy. The absent scheduler owner is real, but
+it is a **secondary / activation** blocker reported separately by
+`spot_demo_activation_blockers()`; it is never promoted to the primary status.
+`AUTO_READY_BLOCKED_BY_SCHEDULER` is not selected here.
+
+The merged registry's signed allowlist for this lane still admits three values
+(`NOT_READY`, `AUTO_READY_BLOCKED_BY_POLICY`, `AUTO_READY_BLOCKED_BY_SCHEDULER`)
+— a conservative superset the J2A verifier dispositioned as *not a violation*.
+J6B binds the narrower choice by contract and by `SPOT_DEMO_PRIMARY_TERMINAL_
+LANE_STATUS`, without touching the registry.
+
+---
+
+## 3. Why the mutation path is unreachable
+
+Not "switched off" — **structurally unsatisfiable**. For this lane
+`assert_entry_execution_ready` cannot pass under any configuration:
+
+- `activation_status is ENABLED` → `_violates_signed_lane_restriction` fires,
+  because the lane appears in `_SIGNED_LANE_STATUS_ALLOWLISTS` →
+  `lane_signed_restriction_violation`;
+- any other activation status → `lane_activation_not_enabled`.
+
+`test_execution_ready_is_unsatisfiable_for_this_lane` proves this exhaustively
+over every `ActivationStatus` member × `writer` × `auto` (24 combinations).
+
+With the signed registry, `submit_limit_order(..., confirm=True)` therefore
+raises `lane_binding_incomplete` with **zero HTTP requests and zero durable
+claim attempts** (`test_submit_with_the_signed_registry_dispatches_zero_http`).
+
+---
+
+## 4. D6 sizing — operator-fixed, not selectable
+
+```
+LIMIT only.  MARKET and notional-only plans are refused before broker I/O.
+quantity = floor_to_step(target_notional / limit_price)
+```
+
+- **Floor only.** Rounding up to reach a venue minimum would place a larger
+  order than the decision authorized, so it is refused rather than adjusted.
+- **Below `min_qty` or `min_notional` → no plan at all.** Not a smaller order,
+  not a padded quantity — `LimitSizingBlocked`, whose `produces_plan` field is a
+  structural `False` (no constructor argument).
+- **Five provenance facts travel with the plan** in `tick_rounding`:
+  `price_source`, `price_cutoff`, `step_size`, `step_version`, `rounding_delta`
+  (plus `mode="floor_to_step"`). Dropping any one fails
+  `assert_sizing_provenance_complete` before broker I/O.
+- A negative `rounding_delta` is the round-up signature and is rejected as
+  `sizing_round_up_forbidden`.
+
+**Caps are not invented.** The registry reports `MissingBinding.CAP` and
+`max_order_notional=None` for this lane, so the plan records
+`risk_caps={"cap_binding": "missing"}` rather than a chosen number.
+
+---
+
+## 5. Single-currency DecisionIntent (§83 correction 2)
+
+The controlling authority, reproduced verbatim:
+
+```text
+A DecisionIntent is single-currency.
+
+ExecutionPlan fan-out from one DecisionIntent is permitted only to lanes
+whose registry quote_currency exactly equals the intent's
+target_notional_currency.
+
+USD and USDT are distinct currencies. No parity, FX lookup, or implicit
+conversion is authorized.
+
+When the same policy is evaluated on USD and USDT venues, the system must
+materialize separate sibling DecisionIntents, one per currency, and bind
+them through an immutable common comparison or policy-decision correlation.
+
+For crypto.alpaca.paper.*, AUTO_MIRROR means policy mirror, not
+same-DecisionIntent currency conversion.
+```
+
+| item | binding |
+|---|---|
+| **C2-1** single-currency construction | `DecisionIntent` is frozen/strict with exactly one `target_notional_currency` (`app/schemas/execution_contracts.py:301-315`); the id is derived server-side by `MockLineageFactory`. |
+| **C2-2** exact fan-out guard | Three-way exact equality: `MockLineageFactory.create_execution_plan` (`lineage.py:525-526`), `assert_lane_quote_currency` (`mock_lane_registry.py:1085-1097`), and this module's `assert_usdt_single_currency`. |
+| **C2-3** no FX path | `test_c2_3_no_fx_parity_or_conversion_path_exists` — AST name scan **and** a token-stripped text scan of the executable surface, both empty, plus a self-check that the pattern does fire on a real conversion. |
+| **C2-4** sibling binding | `SIBLING_BINDING_FOR_EXECUTION = PENDING`, consumed unchanged from the merged ROB-1269 contract. No key is named, synthesized, or persisted here, and no USD intent fans out to this USDT lane. |
+| **C2-5** `AUTO_MIRROR` | Policy mirror only. Both Alpaca crypto rows are USD, `NOT_READY`, `DISABLED`, `writer=false`, `scheduler_owner=None` (owner absent — **not** a spelling of `disabled`). |
+
+---
+
+## 6. Lane-native recovery owner (§83 correction 3 — activation precondition)
+
+The controlling authority, reproduced verbatim:
+
+```text
+The common coordination layer does not own broker-specific retry,
+readback, or manual-resolution queues.
+
+Before a lane can become AUTO_ENABLED, its lane contract must identify:
+
+- exactly one recovery owner;
+- the trigger that rediscovers surviving durable claims after restart;
+- the authoritative broker readback operation;
+- the lane-native evidence written for ACK, unknown, reject, expiry,
+  partial fill, cancel, and terminal reconciliation;
+- the condition for exact release_if_matches;
+- the operator-visible blocked state when authoritative recovery is not
+  possible.
+
+A lane missing any of these remains
+AUTO_READY_BLOCKED_BY_LIFECYCLE.
+```
+
+### C3-1 Recovery owner — exactly one
+
+`app.services.brokers.binance.spot_demo.mock_auto_limit.BinanceSpotDemoLimitComposition`
+
+Machine constant: `SPOT_DEMO_RECOVERY_OWNER`. No second owner is named, and no
+`TBD` appears. J3A owns no Binance-specific retry, readback, or
+manual-resolution queue — `app/services/mock_integration/coordination.py`
+contains no occurrence of "binance" at all (`test_common_layer_owns_no_binance_
+retry_or_readback_queue`).
+
+### C3-2 Restart trigger
+
+`process_restart_rediscovers_durable_j2b_claims_for_physical_account`
+
+Machine constant: `SPOT_DEMO_RESTART_TRIGGER`. Each rediscovered claim is
+resolved by `BinanceSpotDemoLimitComposition.resolve_restart_claim`.
+
+### C3-3 Authoritative broker readback
+
+`GET /api/v3/order?origClientOrderId=...` via
+`BinanceSpotDemoExecutionClient.get_order_status`.
+
+Open-order listings (`GET /api/v3/openOrders`), account balances, local
+evidence files, and the wall clock are **diagnostic only**. A Binance `-2013`
+is the broker proving absence (`NOT_CREATED`); every other failure is
+`UNREADABLE`, which is a held unknown, not an absence. An unrecognised native
+status maps to `UNREADABLE`, never optimistically to a terminal state.
+
+### C3-4 Lane-native evidence — seven kinds, none missing
+
+`SpotDemoLaneEvidenceKind` is the closed set; `LANE_EVIDENCE_KINDS` is asserted
+to be exactly these seven.
+
+| Kind | Lane-native write site |
+|---|---|
+| ACK | `submit_limit_order._mutate` after a non-blank native `broker_order_id` |
+| unknown | `submit_limit_order._mutate` when submit raises, and when the response carries no native order id; `resolve_restart_claim` for `UNREADABLE`, `OPEN` |
+| reject | `resolve_restart_claim` when the readback normalizes to `REJECTED` |
+| expiry | `resolve_restart_claim` when the readback normalizes to `EXPIRED` (the local clock is never expiry) |
+| partial fill | `resolve_restart_claim` when the readback normalizes to `PARTIALLY_FILLED` |
+| cancel | `cancel_limit_order` after the cancel call; `resolve_restart_claim` for `CANCELED` |
+| terminal reconciliation | `resolve_restart_claim` for `FILLED` / `NOT_CREATED`, and again after `release_with_terminal_evidence` succeeds |
+
+The evidence port is required **at construction**: a composition that cannot
+write its own evidence cannot be built, let alone dispatch.
+
+### C3-5 Exact `release_if_matches` condition
+
+Release is permitted in exactly two shapes, and never without reconciliation:
+
+- **A.** authoritative `NOT_CREATED` (broker-proven absence) **and**
+  `account_position_reconciled`; or
+- **B.** an attributed native terminal fact (`FILLED` / `CANCELED` / `REJECTED`
+  / `EXPIRED`) **and** `account_position_reconciled` **and** `remainder_known`.
+
+Everything else retains the claim. A missing readback row, an unparseable
+status, an open or partially-filled order, and the passage of time cannot
+release.
+
+The release itself flows only through
+`DurableSendClaimAdapter.release_with_terminal_evidence`, which re-checks the
+exact booleans. `terminal_evidence_for()` returns a **default-constructed**
+`TerminalClaimEvidence` — which authorizes nothing — for any disposition that
+may not release; no flag is ever fabricated. The unrestricted
+`release_if_matches` is never named in this module.
+
+### C3-6 Operator-visible blocked state
+
+`unknown_pending_reconcile` (`SPOT_DEMO_UNRECOVERABLE_STATE`), surfaced as
+`RestartDisposition.operator_visible_state` and written into the lane evidence
+payload. It is a state, not a log line.
+
+### C3-7 Lifecycle status
+
+This lane remains at `AUTO_READY_BLOCKED_BY_LIFECYCLE` for activation purposes.
+This job activates nothing.
+
+**Never reposted.** `RestartDisposition.repost` is a structural `False` with
+`init=False`: no code path can construct a disposition that authorizes
+re-sending an order whose outcome is unknown. This is proven exhaustively over
+every readback outcome.
+
+---
+
+## 7. Transport gate — re-asserted before every send
+
+1. `type(client) is BinanceSpotDemoExecutionClient` — exact type, because a
+   subclass can override the transport;
+2. the client's base-URL host passes `assert_spot_demo_host` (frozen
+   `SPOT_DEMO_HOSTS = {demo-api.binance.com}`);
+3. the registry's declared endpoint passes `assert_mock_only_endpoint`;
+4. `CoordinationScope.assert_owned()` immediately before the send — the
+   coordinator's single pre-callback attestation is not sufficient on its own;
+5. `assert_spot_demo_transport` runs **again** inside the callback.
+
+Live (`api.binance.com`), retired testnet (`testnet.binance.vision`), live
+futures (`fapi.binance.com`), Futures Demo (`demo-fapi.binance.com`), and suffix
+spoofs all fail before any request is built. Where the ROB-298 transport factory
+already refuses at construction, the guarantee simply lands one layer earlier;
+either way the assertion is zero HTTP.
+
+---
+
+## 8. Adversarial mutant coverage (§F, twelve items)
+
+| # | Claim | Kill point |
+|---|---|---|
+| 1 | Two writers in one Binance conflict domain | `assert_binance_single_writer_domain` — every Binance lane is one domain while identity is `UNKNOWN`. `test_mutant_01b_*` shows the registry's own `assert_single_writer` is *silent* here, which is why the stricter guard exists. |
+| 2 | Sidecar writer / live recurring owner | `assert_sidecar_observation_only` (writer, auto, and scheduler-owner variants) |
+| 3 | Alpaca crypto writer / profile / submit wiring | `assert_alpaca_crypto_unwired` + an AST import scan showing no Alpaca import exists |
+| 4 | Frozen ROB-845 bytes or behaviour change | SHA-256 pin of the three files **and** the declared capability shape |
+| 5 | MARKET / notional-only plan enters | `assert_limit_only_plan`, before broker I/O, zero HTTP asserted |
+| 6 | Round-up to step | floor-only in `compose_limit_sizing`; negative `rounding_delta` rejected |
+| 7 | Plan built below min qty / notional | `LimitSizingBlocked`, `produces_plan` structurally `False` |
+| 8 | Missing source / cutoff / step-version / rounding-delta | `assert_sizing_provenance_complete`, parametrized over all five keys |
+| 9 | USD treated as USDT | `compose_limit_sizing` currency check + `assert_usdt_single_currency` + the J2B factory reject |
+| 10 | Blind repost after restart | `RestartDisposition.repost` structural `False`, exhaustive over every outcome |
+| 11 | Live / testnet / futures host or client | `assert_spot_demo_transport` (exact type + frozen host allowlist) |
+| 12 | Scheduler registration import | AST import scan for taskiq / prefect / cron / celery / apscheduler / `app.tasks` / `app.flows` |
+
+Every zero-I/O claim is asserted as `httpx_mock.get_requests() == []` — an
+observed transport call count, not an inference.
+
+Fifteen injections were run against these twelve claims (items 4, 5, and 6 each
+got two, to separate byte identity from behaviour, the notional-only branch from
+the time-in-force branch, and the rounding direction from the delta guard). All
+fifteen went red; none survived. Guard tests assert **at the guard function
+first** and then through the pre-dispatch chain, so a neutered guard fails at
+its own call site rather than falling through to a later registry check and
+producing a red test whose traceback points somewhere else.
+
+---
+
+## 9. Running the offline suite
+
+```bash
+uv run pytest -q \
+  tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py \
+  tests/services/brokers/binance/ \
+  tests/test_mock_lane_registry.py
+```
+
+No database, broker credential, network, or scheduler is required or touched.
+
+---
+
+## 10. C5 — TaskGroup / `asyncio.timeout` cancellation count
+
+J3A deliberately left C5 `UNKNOWN`; J3B, J3C, and J4-V all landed keeping that
+status. J6B introduces no `asyncio.TaskGroup` and no `asyncio.timeout`, and
+consumes J3A's retained-task cancellation shielding through
+`coordinate_mock_order_mutation` rather than re-implementing it. This module
+cannot independently certify J3A's cancellation count, so **C5 remains
+UNKNOWN** on that evidence. It is not "not applicable".

--- a/docs/runbooks/binance-spot-demo-mock-auto-limit.md
+++ b/docs/runbooks/binance-spot-demo-mock-auto-limit.md
@@ -11,7 +11,9 @@ and single-currency requirements below; there is no second contract file.
 
 **No activation.** Activation to `AUTO_ENABLED` is out of scope for this job and
 requires separate approval. Missing any recovery item below leaves this lane at
-`AUTO_READY_BLOCKED_BY_LIFECYCLE`.
+`AUTO_READY_BLOCKED_BY_LIFECYCLE` — and that verdict is **computed** by
+`spot_demo_recovery_contract_gaps()`, not asserted in this document. See §6.7 for
+what is unmet today.
 
 **No scheduler, no canary, no send.** This job registers no TaskIQ / Prefect /
 cron / launchd / systemd entry and dispatches nothing. A real order is J8's
@@ -47,6 +49,24 @@ bounded canary and nothing else.
 
 `role` is a registry **purpose** value, not execution authority.
 
+### `scheduler_owner`: absent ≠ disabled
+
+The signed table carries two different facts in this column and they stay two
+facts here:
+
+| value | meaning | blocker string emitted |
+|---|---|---|
+| `SchedulerOwner.DISABLED` | an explicit decision, backed by in-repo evidence that Binance Demo has no scheduler registration | `scheduler_owner_disabled` |
+| `None` | **owner absent** — no bind authority was ever assigned, which is why those rows also carry `MissingBinding.OWNER` | `scheduler_owner_absent` |
+
+`spot_demo_activation_blockers()` branches on the two separately. Reporting
+absence as disablement would tell a downstream reader that an ownership decision
+had been made when none was. The canonical Binance row is `DISABLED`, so a test
+that only exercises that row cannot see the difference; the `None` branch is
+exercised directly against the signed Alpaca crypto rows
+(`test_an_absent_scheduler_owner_is_not_a_spelling_of_disabled`,
+`test_signed_rows_with_an_absent_owner_report_absence`).
+
 ### Terminal lane status
 
 When the LIMIT lifecycle is complete, the **primary** terminal lane status for
@@ -66,6 +86,18 @@ The merged registry's signed allowlist for this lane still admits three values
 — a conservative superset the J2A verifier dispositioned as *not a violation*.
 J6B binds the narrower choice by contract and by `SPOT_DEMO_PRIMARY_TERMINAL_
 LANE_STATUS`, without touching the registry.
+
+**Three different statuses are in play; do not conflate them.**
+
+| status | who owns it | value today |
+|---|---|---|
+| the registry's `lane_status` field | J2A (signed, unmodified here) | `NOT_READY` |
+| the §D primary *terminal* status this composition binds | J6B contract | `AUTO_READY_BLOCKED_BY_POLICY` |
+| the §83 correction-3 lifecycle verdict, computed | `spot_demo_lifecycle_lane_status()` | `AUTO_READY_BLOCKED_BY_LIFECYCLE` (see §6.7) |
+
+Reading `spot_demo_activation_blockers()` shows all three: the policy blocker at
+index 0, the lifecycle verdict and its named gaps next, then the scheduler,
+activation, and missing-binding blockers.
 
 ---
 
@@ -182,8 +214,34 @@ retry_or_readback_queue`).
 
 `process_restart_rediscovers_durable_j2b_claims_for_physical_account`
 
-Machine constant: `SPOT_DEMO_RESTART_TRIGGER`. Each rediscovered claim is
-resolved by `BinanceSpotDemoLimitComposition.resolve_restart_claim`.
+Machine constant: `SPOT_DEMO_RESTART_TRIGGER`. The **executable** entry point is
+`BinanceSpotDemoLimitComposition.rediscover_restart_claims`
+(`SPOT_DEMO_RESTART_TRIGGER_ENTRYPOINT`), and each rediscovered claim is resolved
+by `resolve_restart_claim`. Naming a trigger is not owning one, so the method
+does the enumeration itself:
+
+1. derive this lane's physical-account scope from the J2A entry — never from a
+   caller-supplied string;
+2. `list_reservations(account_scope=...)` on the lane's own reservation
+   read-side port;
+3. for each survivor, recompute the client order id from the claim's J2B
+   idempotency key (`derive_attributed_client_order_id`);
+4. authoritative readback → disposition → lane-native evidence.
+
+`DurableSendClaimAdapter` deliberately exposes no listing surface — enumerating
+survivors is lane work, not coordination work — so the trigger takes its own
+`reservations` port. An **unbound** port is not silently substituted: it raises
+`restart_claim_source_unavailable` and is reported as a computed recovery gap
+(§6.7).
+
+Two kinds of survivor are deliberately *not* acted on, and both leave an
+`unknown` evidence row carrying `unknown_pending_reconcile` rather than being
+silently skipped:
+
+- a claim whose key this lane's lineage cannot reproduce — the physical account
+  is shared, so the claim may belong to another writer; it is not even read back;
+- an attributable claim whose symbol cannot be recovered — the readback needs a
+  symbol, and guessing one would aim an authoritative query at the wrong market.
 
 ### C3-3 Authoritative broker readback
 
@@ -208,11 +266,13 @@ to be exactly these seven.
 | reject | `resolve_restart_claim` when the readback normalizes to `REJECTED` |
 | expiry | `resolve_restart_claim` when the readback normalizes to `EXPIRED` (the local clock is never expiry) |
 | partial fill | `resolve_restart_claim` when the readback normalizes to `PARTIALLY_FILLED` |
-| cancel | `cancel_limit_order` after the cancel call; `resolve_restart_claim` for `CANCELED` |
+| cancel | `cancel_limit_order` **only** on a broker-proven cancellation (`confirm=True` + a native status normalizing to `CANCELED`); `resolve_restart_claim` for `CANCELED` |
 | terminal reconciliation | `resolve_restart_claim` for `FILLED` / `NOT_CREATED`, and again after `release_with_terminal_evidence` succeeds |
 
 The evidence port is required **at construction**: a composition that cannot
 write its own evidence cannot be built, let alone dispatch.
+
+A dry-run cancel writes **nothing at all** — see §6a.
 
 ### C3-5 Exact `release_if_matches` condition
 
@@ -240,15 +300,64 @@ may not release; no flag is ever fabricated. The unrestricted
 `RestartDisposition.operator_visible_state` and written into the lane evidence
 payload. It is a state, not a log line.
 
-### C3-7 Lifecycle status
+### C3-7 Lifecycle status — computed, and currently blocked
 
-This lane remains at `AUTO_READY_BLOCKED_BY_LIFECYCLE` for activation purposes.
-This job activates nothing.
+`spot_demo_recovery_contract_gaps(entry, composition=...)` checks each of the six
+items above against live objects — the registry entry, the transport class, the
+J3A adapter, and the composition instance that actually holds the lane's ports —
+and `spot_demo_lifecycle_lane_status()` resolves any unmet item to
+`AUTO_READY_BLOCKED_BY_LIFECYCLE`. The enum member
+`SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS` is what that verdict *resolves to*, not
+the verdict itself.
+
+**Unmet today** (`spot_demo_recovery_contract_gaps(signed_entry)`):
+
+| gap | why it is unmet | what would close it |
+|---|---|---|
+| `restart_trigger` | two independent causes: no production caller constructs this composition, so no `reservations` port is bound; **and** the signed row's `identity_status` is `UNKNOWN`, so `physical_account_scope_for_entry` raises and there is no scope to enumerate within | masked-fingerprint identity evidence for the Binance Demo account (J2A-owned) **and** a production wiring site |
+| `lane_native_evidence` | the seven kinds exist and are written, but no production construction site binds a durable `SpotDemoLaneEvidencePort` — today only tests construct the composition | a production wiring site with a durable evidence store |
+
+Both gaps have the same root: **this composition has no production caller.**
+Building one is out of scope for J6B, which is why the honest state is a computed
+`AUTO_READY_BLOCKED_BY_LIFECYCLE` rather than a claim of readiness. Status of the
+remaining work: `pending` — owner J8 / a later activation job, not this one.
+
+The verdict discriminates rather than always returning "blocked": given an owner
+holding both ports and an identity-known entry, the gaps are empty and the
+lifecycle status clears (`test_c3_7_a_fully_wired_owner_has_no_recovery_gaps`),
+and each gap is reproducible on its own cause
+(`test_c3_7_each_missing_recovery_item_is_reported_on_its_own`).
 
 **Never reposted.** `RestartDisposition.repost` is a structural `False` with
 `init=False`: no code path can construct a disposition that authorizes
 re-sending an order whose outcome is unknown. This is proven exhaustively over
 every readback outcome.
+
+---
+
+## 6a. Cancel — the same contract as a submit
+
+A cancel is a `DELETE` against a real venue, not a lighter operation. It runs
+under the same attribution, coordination, and uncertainty contract as a submit:
+
+| step | what runs | why |
+|---|---|---|
+| fresh guards | `assert_spot_demo_transport`, lane check, `assert_mock_only_endpoint`, `assert_binance_domain_invariants` | the cancel path is not a side door around the registry invariants |
+| **attribution** | `assert_client_order_id_attributed` (the id must be reproducible from this claim's J2B key) and `assert_claim_belongs_to_lane` (J2A-derived scope) | `confirm` decides whether a mutation is *sent*; it says nothing about whether the thing being mutated is ours |
+| **coordination** | `CoordinationScope.assert_owned()`, then J3A's own `describe_claim_followup` predicate | that predicate requires an attributed native order id **and** a known remainder, so a cancel aimed at an order whose identity or remainder is unknown cannot even be described |
+| pre-send re-assert | `CoordinationScope.assert_owned()` again, immediately before the `DELETE` | anything awaited in between can outlive the lease |
+| **uncertainty** | a raised send records `unknown` + `unknown_pending_reconcile` and re-raises; a response that does not normalize to `CANCELED` is also `unknown` | ROB-298 §4 / ROB-395 evidence-first: the write may well have reached the broker, so silence is not an option |
+
+**Dry run writes nothing.** Without `confirm=True` no `DELETE` is sent and **no
+lane evidence row is created**, durable or otherwise;
+`SpotDemoCancelDisposition.dispatched` is `False`. A durable `CANCEL` row asserts
+that the broker cancelled the order — on a dry run it did not, and a later
+reconciliation reading that row would conclude the order is gone while it is
+still live at the venue.
+
+Refusal reason codes: `cancel_not_attributed`,
+`cancel_followup_capability_absent`. Both are disjoint from J3A's
+`CoordinationReasonCode` vocabulary.
 
 ---
 
@@ -261,7 +370,10 @@ every readback outcome.
 3. the registry's declared endpoint passes `assert_mock_only_endpoint`;
 4. `CoordinationScope.assert_owned()` immediately before the send — the
    coordinator's single pre-callback attestation is not sufficient on its own;
-5. `assert_spot_demo_transport` runs **again** inside the callback.
+5. `assert_spot_demo_transport` runs **again** inside the callback;
+6. the registry writer-domain invariants (`assert_binance_domain_invariants`).
+
+The cancel path runs the same list — see §6a.
 
 Live (`api.binance.com`), retired testnet (`testnet.binance.vision`), live
 futures (`fapi.binance.com`), Futures Demo (`demo-fapi.binance.com`), and suffix
@@ -291,13 +403,35 @@ either way the assertion is zero HTTP.
 Every zero-I/O claim is asserted as `httpx_mock.get_requests() == []` — an
 observed transport call count, not an inference.
 
-Fifteen injections were run against these twelve claims (items 4, 5, and 6 each
-got two, to separate byte identity from behaviour, the notional-only branch from
-the time-in-force branch, and the rounding direction from the delta guard). All
-fifteen went red; none survived. Guard tests assert **at the guard function
-first** and then through the pre-dispatch chain, so a neutered guard fails at
-its own call site rather than falling through to a later registry check and
-producing a red test whose traceback points somewhere else.
+### Direct call vs. dispatch chain
+
+A guard that only fires when a test calls it by name protects nothing. For each
+of items 1, 2, 3, 5, 6, and 8 there are **two** kinds of coverage and they are
+labelled separately:
+
+- a **direct** assertion at the guard function, so a neutered guard dies at its
+  own call site rather than at some later, unrelated check; and
+- a **chain** assertion that drives the real `validate_pre_dispatch`, asserting
+  on its own line that the refusal came from *this* guard and naming what it got
+  instead if it did not (`test_mutant_01c_*`, `test_mutant_02c_*`,
+  `test_mutant_03c_*`).
+
+The writer-domain invariants (items 1–3) run **before** `assert_lineage_registry_
+binding`, pinned by `test_the_domain_invariants_are_reached_before_the_j2a_
+binding_check`. Placed after it they would be dead code for this lane, because
+the signed registry always dies on the binding check first — which is exactly the
+gap the r1 round left open: the three guards were defined, exported, and
+documented, but nothing on the dispatch path called them.
+
+Cancel-path coverage (attribution, dry-run silence, post-send uncertainty) is in
+§6a and is likewise driven through the real method, not through a helper.
+
+Zero-HTTP claims are scoped honestly. `submit_limit_order(..., confirm=True)`
+reaching no transport is the result of a **structural** refusal at
+`assert_lineage_registry_binding`, not evidence that the code ran up to the send
+and stopped there; the dispatch closure is unreachable under the signed registry,
+which is why its ACK/unknown branches are proven at the `classify_submit_outcome`
+seam instead.
 
 ---
 

--- a/tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py
+++ b/tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py
@@ -1,0 +1,1498 @@
+"""ROB-1270 J6B — Binance Spot Demo LIMIT composition.
+
+Offline only: no broker, network, database, scheduler, or credential I/O.  The
+``httpx_mock`` fixture is the ground truth for "zero transport" claims — every
+such assertion below reads ``httpx_mock.get_requests()`` rather than inferring
+from a return value.
+
+The adversarial mutant set from the signed inputs (§F, twelve items) is covered
+by the ``test_mutant_XX_*`` tests.  Each one is written so that inverting the
+specific guard it names is what turns it red — not an import error, not a
+missing fixture, and not a collapsed precondition.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import hashlib
+import inspect
+import pathlib
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.schemas.execution_contracts import LaneStatus, SchedulerOwner
+from app.services.brokers.binance.demo.errors import BinanceDemoOrderNotFound
+from app.services.brokers.binance.spot_demo import mock_auto_limit as mal
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+)
+from app.services.brokers.capabilities import (
+    PAPER_BROKER_CAPABILITIES,
+    Broker,
+)
+from app.services.brokers.client_order_ids import BrokerClientIdTarget
+from app.services.mock_integration.coordination import (
+    DurableClaim,
+    TerminalClaimEvidence,
+)
+from app.services.mock_integration.lineage import (
+    DecisionIntentDraft,
+    ExecutionPlanDraft,
+    LineageEnvelope,
+    MockLineageFactory,
+    OrderAttemptDraft,
+)
+from app.services.mock_lane_registry import (
+    CANONICAL_LANE_REGISTRY,
+    ActivationStatus,
+    LaneGuardError,
+    get_lane_registry_entry,
+)
+
+_SPOT_DEMO_BASE = "https://demo-api.binance.com"
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]
+_MODULE_PATH = _REPO_ROOT / "app/services/brokers/binance/spot_demo/mock_auto_limit.py"
+
+
+# --------------------------------------------------------------------------
+# Fixtures and fakes
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def enabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "DUMMY_SPOT_DEMO_KEY")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "DUMMY_SPOT_DEMO_SECRET")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_BASE_URL", _SPOT_DEMO_BASE)
+
+
+@pytest.fixture
+def client(enabled_env: None) -> BinanceSpotDemoExecutionClient:
+    return BinanceSpotDemoExecutionClient.from_env()
+
+
+class _RecordingLaneEvidence:
+    """Captures every lane-native evidence write in order."""
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, Mapping[str, Any]]] = []
+
+    async def record_lane_evidence(
+        self, kind: mal.SpotDemoLaneEvidenceKind, payload: Mapping[str, Any], /
+    ) -> None:
+        self.records.append((str(kind), dict(payload)))
+
+    @property
+    def kinds(self) -> list[str]:
+        return [kind for kind, _ in self.records]
+
+
+class _NeverCalledIntents:
+    """Reservation port that fails loudly if coordination is ever reached."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def reserve(self, **kwargs: Any) -> int:
+        self.calls.append("reserve")
+        raise AssertionError("coordination must not be reached in these tests")
+
+    async def list_reservations(self, **kwargs: Any) -> list[Any]:
+        self.calls.append("list_reservations")
+        return []
+
+    async def release_if_matches(self, **kwargs: Any) -> int:
+        self.calls.append("release_if_matches")
+        return 1
+
+
+def _claims() -> Any:
+    from app.services.mock_integration.coordination import DurableSendClaimAdapter
+
+    return DurableSendClaimAdapter(_NeverCalledIntents())  # type: ignore[arg-type]
+
+
+def _composition(
+    client: BinanceSpotDemoExecutionClient,
+    *,
+    lane_evidence: Any = None,
+) -> mal.BinanceSpotDemoLimitComposition:
+    return mal.BinanceSpotDemoLimitComposition(
+        client=client,
+        claims=_claims(),
+        connection_factory=lambda: None,
+        persistence=None,
+        dispatch_evidence=None,
+        uncertainty_gate=None,
+        lane_evidence=lane_evidence or _RecordingLaneEvidence(),
+    )
+
+
+# --------------------------------------------------------------------------
+# Lineage builders — real J2B factory output, never hand-built identifiers
+# --------------------------------------------------------------------------
+
+_QUOTE = mal.LimitPriceQuote(
+    price=Decimal("100"),
+    source="binance_spot_demo:GET /api/v3/ticker/bookTicker",
+    cutoff=datetime(2026, 8, 17, 6, 0, tzinfo=UTC),
+)
+_STEP = mal.SpotStepSpec(
+    step_size=Decimal("0.001"),
+    step_version="exchangeInfo@2026-08-17T06:00:00Z",
+    min_qty=Decimal("0.001"),
+    min_notional=Decimal("5"),
+)
+
+
+def _intent_draft(
+    *, currency: str = "USDT", notional: Decimal = Decimal("10")
+) -> DecisionIntentDraft:
+    moment = datetime(2026, 8, 17, 6, 0, tzinfo=UTC)
+    return DecisionIntentDraft(
+        policy_version="j6b-test-policy",
+        policy_version_hash="0" * 64,
+        decision_timestamp=moment,
+        market_data_cutoff=moment,
+        symbol="BTCUSDT",
+        side="buy",
+        target_notional=notional,
+        target_notional_currency=currency,  # type: ignore[arg-type]
+        limit_policy={"kind": "explicit"},
+        expiry_policy={"kind": "gtc"},
+        rationale="J6B offline composition test",
+    )
+
+
+def _sizing() -> mal.LimitSizing:
+    result = mal.compose_limit_sizing(
+        target_notional=Decimal("10"),
+        target_notional_currency="USDT",
+        quote=_QUOTE,
+        step=_STEP,
+    )
+    assert isinstance(result, mal.LimitSizing)
+    return result
+
+
+def _envelope(
+    *,
+    plan_draft: ExecutionPlanDraft | None = None,
+    currency: str = "USDT",
+) -> LineageEnvelope:
+    factory = MockLineageFactory()
+    intent_envelope = factory.create_intent_envelope(_intent_draft(currency=currency))
+    draft = plan_draft or mal.compose_limit_plan_draft(
+        normalized_symbol="BTCUSDT",
+        sizing=_sizing(),
+        step=_STEP,
+        risk_caps={"cap_binding": "missing"},
+    )
+    plan_envelope = factory.create_plan_envelope(intent_envelope.decision_intent, draft)
+    return factory.create_attempt_envelope(
+        plan_envelope,
+        OrderAttemptDraft(
+            cycle_id="j6b-cycle-1",
+            attempt_seq=1,
+            lane_prefix=mal.SPOT_DEMO_LANE_PREFIX,
+            broker_client_id_target=BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+        ),
+    )
+
+
+# ==========================================================================
+# D6 sizing
+# ==========================================================================
+
+
+def test_sizing_floors_to_step_and_preserves_every_provenance_fact() -> None:
+    """quantity = floor_to_step(notional / price), with all four D6 facts kept."""
+
+    sizing = mal.compose_limit_sizing(
+        target_notional=Decimal("10"),
+        target_notional_currency="USDT",
+        quote=_QUOTE,
+        step=_STEP,
+    )
+    assert isinstance(sizing, mal.LimitSizing)
+    # 10 / 100 = 0.1 exactly on a 0.001 step.
+    assert sizing.quantity == Decimal("0.100")
+    assert sizing.realized_notional == Decimal("10.000")
+    assert sizing.rounding_delta == Decimal("0")
+    provenance = sizing.provenance()
+    assert provenance["mode"] == "floor_to_step"
+    for key in mal.SIZING_PROVENANCE_KEYS:
+        assert provenance[key], f"D6 provenance key {key} must be present"
+
+
+def test_sizing_floors_a_remainder_down_and_records_the_delta() -> None:
+    """A remainder is floored away and the discarded notional is recorded."""
+
+    sizing = mal.compose_limit_sizing(
+        target_notional=Decimal("10.05"),
+        target_notional_currency="USDT",
+        quote=_QUOTE,
+        step=_STEP,
+    )
+    assert isinstance(sizing, mal.LimitSizing)
+    assert sizing.quantity == Decimal("0.100")
+    assert sizing.realized_notional == Decimal("10.000")
+    assert sizing.rounding_delta == Decimal("0.05")
+    assert sizing.realized_notional < Decimal("10.05")
+
+
+def test_mutant_06_round_up_to_reach_min_notional_is_refused() -> None:
+    """§F-6 — the floor is the only direction; reaching a minimum by rounding up
+    would place a larger order than the decision authorized."""
+
+    step = dataclasses.replace(_STEP, min_notional=Decimal("11"))
+    blocked = mal.compose_limit_sizing(
+        target_notional=Decimal("10"),
+        target_notional_currency="USDT",
+        quote=_QUOTE,
+        step=step,
+    )
+    assert isinstance(blocked, mal.LimitSizingBlocked)
+    assert blocked.reason is mal.SpotDemoLimitReason.SIZING_BELOW_MIN_NOTIONAL
+    # The refusal is structural: a blocked sizing is never a plan.
+    assert blocked.produces_plan is False
+    assert "produces_plan" not in inspect.signature(mal.LimitSizingBlocked).parameters
+
+
+def test_mutant_07_below_min_quantity_produces_no_plan_at_all() -> None:
+    """§F-7 — under the venue minimum, no plan and no synthesized quantity."""
+
+    blocked = mal.compose_limit_sizing(
+        target_notional=Decimal("0.05"),
+        target_notional_currency="USDT",
+        quote=_QUOTE,
+        step=_STEP,
+    )
+    assert isinstance(blocked, mal.LimitSizingBlocked)
+    assert blocked.reason is mal.SpotDemoLimitReason.SIZING_BELOW_MIN_QTY
+    assert not hasattr(blocked, "quantity")
+
+
+def test_realized_notional_never_exceeds_the_target() -> None:
+    """Property sweep: the floor invariant holds across a range of targets."""
+
+    for cents in range(500, 2000, 37):
+        target = Decimal(cents) / Decimal("100")
+        sizing = mal.compose_limit_sizing(
+            target_notional=target,
+            target_notional_currency="USDT",
+            quote=_QUOTE,
+            step=_STEP,
+        )
+        if isinstance(sizing, mal.LimitSizingBlocked):
+            continue
+        assert sizing.realized_notional <= target
+        assert sizing.rounding_delta >= 0
+
+
+# ==========================================================================
+# §F-8 — provenance completeness
+# ==========================================================================
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("source", "   "),
+        ("cutoff", datetime(2026, 8, 17, 6, 0)),  # naive
+        ("price", Decimal("0")),
+    ],
+)
+def test_mutant_08a_price_provenance_must_be_complete(
+    field_name: str, value: Any
+) -> None:
+    """§F-8 — an unattributed or undated price cannot size an order."""
+
+    kwargs: dict[str, Any] = {
+        "price": _QUOTE.price,
+        "source": _QUOTE.source,
+        "cutoff": _QUOTE.cutoff,
+    }
+    kwargs[field_name] = value
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.LimitPriceQuote(**kwargs)
+    assert error.value.reason is mal.SpotDemoLimitReason.PRICE_PROVENANCE_INCOMPLETE
+
+
+def test_mutant_08b_step_version_is_required() -> None:
+    """§F-8 — filters without a snapshot version are not reproducible."""
+
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.SpotStepSpec(
+            step_size=Decimal("0.001"),
+            step_version="",
+            min_qty=Decimal("0.001"),
+            min_notional=Decimal("5"),
+        )
+    assert error.value.reason is mal.SpotDemoLimitReason.STEP_PROVENANCE_INCOMPLETE
+
+
+#: Written out rather than read from the module: parametrizing over the
+#: constant under test would make this suite shrink in step with a mutant that
+#: shrinks the constant, which is a check with no discriminating power.
+_EXPECTED_PROVENANCE_KEYS = (
+    "price_source",
+    "price_cutoff",
+    "step_size",
+    "step_version",
+    "rounding_delta",
+)
+
+
+def test_the_five_d6_provenance_keys_are_exactly_these() -> None:
+    """D6 — the required provenance set is pinned independently of the module."""
+
+    assert mal.SIZING_PROVENANCE_KEYS == _EXPECTED_PROVENANCE_KEYS
+
+
+@pytest.mark.parametrize("dropped", _EXPECTED_PROVENANCE_KEYS)
+def test_mutant_08c_dropping_any_provenance_key_fails_before_io(
+    dropped: str, client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-8 — each of the five provenance facts is individually load-bearing."""
+
+    sizing = _sizing()
+    provenance = sizing.provenance()
+    del provenance[dropped]
+    draft = mal.compose_limit_plan_draft(
+        normalized_symbol="BTCUSDT",
+        sizing=sizing,
+        step=_STEP,
+        risk_caps={"cap_binding": "missing"},
+    )
+    draft = ExecutionPlanDraft(
+        **{**draft.model_dump(mode="python"), "tick_rounding": provenance}
+    )
+    envelope = _envelope(plan_draft=draft)
+
+    # Asserted at the guard itself first, so a mutant that neuters it fails
+    # *here* rather than falling through to some later registry check and
+    # producing a red test whose traceback points somewhere else entirely.
+    with pytest.raises(mal.SpotDemoLimitError) as direct:
+        mal.assert_sizing_provenance_complete(envelope.execution_plan)
+    assert direct.value.reason is mal.SpotDemoLimitReason.SIZING_PROVENANCE_INCOMPLETE
+    assert dropped in direct.value.detail
+
+    # And again through the real pre-dispatch chain, with zero transport.
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        _composition(client).validate_pre_dispatch(envelope)
+    assert error.value.reason is mal.SpotDemoLimitReason.SIZING_PROVENANCE_INCOMPLETE
+    assert httpx_mock.get_requests() == []
+
+
+def test_negative_rounding_delta_is_reported_as_a_round_up(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """A delta below zero means the size grew; that is the round-up signature."""
+
+    sizing = _sizing()
+    provenance = sizing.provenance() | {"rounding_delta": "-0.5"}
+    draft = ExecutionPlanDraft(
+        **{
+            **mal.compose_limit_plan_draft(
+                normalized_symbol="BTCUSDT",
+                sizing=sizing,
+                step=_STEP,
+                risk_caps={"cap_binding": "missing"},
+            ).model_dump(mode="python"),
+            "tick_rounding": provenance,
+        }
+    )
+    envelope = _envelope(plan_draft=draft)
+    with pytest.raises(mal.SpotDemoLimitError) as direct:
+        mal.assert_sizing_provenance_complete(envelope.execution_plan)
+    assert direct.value.reason is mal.SpotDemoLimitReason.SIZING_ROUND_UP_FORBIDDEN
+
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        _composition(client).validate_pre_dispatch(envelope)
+    assert error.value.reason is mal.SpotDemoLimitReason.SIZING_ROUND_UP_FORBIDDEN
+    assert httpx_mock.get_requests() == []
+
+
+# ==========================================================================
+# §F-5 — LIMIT only
+# ==========================================================================
+
+
+def test_mutant_05_notional_only_plan_is_refused_before_broker_io(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-5 — ``limit_price=None`` is the notional-only/MARKET shape."""
+
+    sizing = _sizing()
+    draft = ExecutionPlanDraft(
+        **{
+            **mal.compose_limit_plan_draft(
+                normalized_symbol="BTCUSDT",
+                sizing=sizing,
+                step=_STEP,
+                risk_caps={"cap_binding": "missing"},
+            ).model_dump(mode="python"),
+            "limit_price": None,
+        }
+    )
+    envelope = _envelope(plan_draft=draft)
+    with pytest.raises(mal.SpotDemoLimitError) as direct:
+        mal.assert_limit_only_plan(envelope.execution_plan)
+    assert direct.value.reason is mal.SpotDemoLimitReason.NOTIONAL_ONLY_PLAN_FORBIDDEN
+
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        _composition(client).validate_pre_dispatch(envelope)
+    assert error.value.reason is mal.SpotDemoLimitReason.NOTIONAL_ONLY_PLAN_FORBIDDEN
+    assert httpx_mock.get_requests() == []
+
+
+def test_mutant_05b_plan_without_time_in_force_is_refused_before_broker_io(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-5 — a MARKET-shaped plan carries no time-in-force; LIMIT requires one."""
+
+    draft = ExecutionPlanDraft(
+        **{
+            **mal.compose_limit_plan_draft(
+                normalized_symbol="BTCUSDT",
+                sizing=_sizing(),
+                step=_STEP,
+                risk_caps={"cap_binding": "missing"},
+            ).model_dump(mode="python"),
+            "time_in_force": None,
+        }
+    )
+    envelope = _envelope(plan_draft=draft)
+    with pytest.raises(mal.SpotDemoLimitError) as direct:
+        mal.assert_limit_only_plan(envelope.execution_plan)
+    assert direct.value.reason is mal.SpotDemoLimitReason.ORDER_TYPE_NOT_LIMIT
+
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        _composition(client).validate_pre_dispatch(envelope)
+    assert error.value.reason is mal.SpotDemoLimitReason.ORDER_TYPE_NOT_LIMIT
+    assert httpx_mock.get_requests() == []
+
+
+def test_composition_only_emits_limit_orders() -> None:
+    """The module can express exactly one order type."""
+
+    assert mal.SPOT_DEMO_ORDER_TYPE == "LIMIT"
+    source = _MODULE_PATH.read_text(encoding="utf-8")
+    assert '"MARKET"' not in source
+
+
+# ==========================================================================
+# §F-9 / §83 correction 2 — currency
+# ==========================================================================
+
+
+def test_mutant_09_usd_intent_cannot_size_a_usdt_lane() -> None:
+    """§F-9 — USD and USDT are distinct; there is no conversion."""
+
+    blocked = mal.compose_limit_sizing(
+        target_notional=Decimal("10"),
+        target_notional_currency="USD",
+        quote=_QUOTE,
+        step=_STEP,
+    )
+    assert isinstance(blocked, mal.LimitSizingBlocked)
+    assert blocked.reason is mal.SpotDemoLimitReason.QUOTE_CURRENCY_NOT_USDT
+
+
+def test_mutant_09b_usd_intent_cannot_fan_out_to_this_lane(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-9 / C2-2 — the J2B factory refuses a USD intent against a USDT plan."""
+
+    with pytest.raises(ValueError) as error:
+        _envelope(currency="USD")
+    assert "currency_conversion_not_authorized" in str(error.value)
+    assert httpx_mock.get_requests() == []
+
+
+def test_c2_2_three_way_currency_equality_is_required() -> None:
+    """intent currency == plan quote currency == registry quote currency."""
+
+    envelope = _envelope()
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    assert entry.quote_currency == "USDT"
+    # Exact equality holds for the real triple.
+    mal.assert_usdt_single_currency(
+        envelope.decision_intent, envelope.execution_plan, entry
+    )
+    # A registry row claiming USD breaks the third leg.
+    usd_entry = dataclasses.replace(entry, quote_currency="USD")
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.assert_usdt_single_currency(
+            envelope.decision_intent, envelope.execution_plan, usd_entry
+        )
+    assert error.value.reason is mal.SpotDemoLimitReason.QUOTE_CURRENCY_NOT_USDT
+
+
+_FX_PATTERN = re.compile(
+    r"(fx|parity|exchange[_-]?rate|usd[\s_:/-]*to[\s_:/-]*usdt"
+    r"|usdt[\s_:/-]*to[\s_:/-]*usd)",
+    re.IGNORECASE,
+)
+
+
+def _executable_source(path: pathlib.Path) -> str:
+    """Source with comments and string literals removed.
+
+    Prose that *forbids* conversion necessarily contains the words for it, so a
+    naive text search over the whole file can only ever match its own
+    prohibitions. Stripping comments and strings leaves the part that could
+    actually perform a conversion.
+    """
+
+    import io
+    import tokenize
+
+    # f-strings tokenize as FSTRING_START/MIDDLE/END in 3.12+, so their literal
+    # text is not a STRING token; the *expressions* inside them stay NAME/OP
+    # tokens and are still scanned.
+    dropped = {tokenize.COMMENT, tokenize.STRING} | {
+        getattr(tokenize, name)
+        for name in ("FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END")
+        if hasattr(tokenize, name)
+    }
+    kept: list[str] = []
+    readline = io.StringIO(path.read_text(encoding="utf-8")).readline
+    for token in tokenize.generate_tokens(readline):
+        if token.type in dropped:
+            continue
+        kept.append(token.string)
+    return "\n".join(kept)
+
+
+def test_c2_3_no_fx_parity_or_conversion_path_exists() -> None:
+    """C2-3 — exhaustive search of this module's executable surface finds none."""
+
+    source = _MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    # 1. No callable, attribute, argument, or imported name mentions conversion.
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            names.add(node.name)
+            names.update(arg.arg for arg in node.args.args)
+        elif isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.add(node.module or "")
+            names.update(alias.name for alias in node.names)
+    assert [name for name in names if _FX_PATTERN.search(name)] == []
+
+    # 2. Nothing in the executable text either, once prose is removed.
+    offenders = [
+        line
+        for line in _executable_source(_MODULE_PATH).splitlines()
+        if _FX_PATTERN.search(line)
+    ]
+    assert offenders == [], offenders
+
+    # 3. The check discriminates: it does fire on a real conversion.
+    assert _FX_PATTERN.search("rate = fx_rate('USD', 'USDT')")
+
+
+def test_c2_4_sibling_binding_stays_pending() -> None:
+    """C2-4 — the merged ROB-1269 disposition is consumed, not overridden."""
+
+    assert mal.SIBLING_BINDING_FOR_EXECUTION == "PENDING"
+    contract = (_REPO_ROOT / "docs/contracts/rob-1269-crypto-owner.md").read_text(
+        encoding="utf-8"
+    )
+    assert "SIBLING_BINDING_FOR_EXECUTION = PENDING" in contract
+
+
+def test_c2_5_alpaca_crypto_auto_mirror_is_policy_mirror_only() -> None:
+    """C2-5 — ``AUTO_MIRROR`` is purpose-only and never a currency conversion."""
+
+    for lane_id in ("crypto.alpaca.paper.default", "crypto.alpaca.paper.clean"):
+        entry = get_lane_registry_entry(lane_id)
+        assert entry.quote_currency == "USD"
+        assert entry.writer is False
+        assert entry.auto_order_enabled is False
+        assert entry.lane_status is LaneStatus.NOT_READY
+        assert entry.activation_status is ActivationStatus.DISABLED
+        assert entry.scheduler_owner is None
+
+
+# ==========================================================================
+# §F-1 / §F-2 / §F-3 — writer domain
+# ==========================================================================
+
+
+def test_mutant_01_two_binance_writers_in_one_domain_fail() -> None:
+    """§F-1 — identity is UNKNOWN, so every Binance demo lane is one domain."""
+
+    mutated = tuple(
+        dataclasses.replace(entry, writer=True)
+        if entry.lane_id
+        in (mal.SPOT_DEMO_CANONICAL_LANE_ID, mal.SPOT_DEMO_SIDECAR_LANE_ID)
+        else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.assert_binance_single_writer_domain(mutated)
+    assert error.value.reason is mal.SpotDemoLimitReason.BINANCE_WRITER_CONFLICT
+    # The signed registry itself is clean.
+    mal.assert_binance_single_writer_domain(CANONICAL_LANE_REGISTRY)
+
+
+def test_mutant_01b_conservative_domain_ignores_unknown_physical_ids() -> None:
+    """§F-1 — the registry's own guard cannot fire while identity is UNKNOWN.
+
+    This is exactly why J6B carries a stricter conservative guard: proving the
+    weaker one silent is what makes the stronger one necessary rather than
+    decorative.
+    """
+
+    from app.services.mock_lane_registry import assert_single_writer
+
+    mutated = tuple(
+        dataclasses.replace(entry, writer=True)
+        if entry.broker == "binance" and entry.account_profile == "spot_demo"
+        else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    assert all(
+        entry.physical_account_id is None
+        for entry in mutated
+        if entry.broker == "binance"
+    )
+    # Silent: no known physical account to collide on.
+    assert_single_writer(mutated)
+    # Not silent:
+    with pytest.raises(mal.SpotDemoLimitError):
+        mal.assert_binance_single_writer_domain(mutated)
+
+
+@pytest.mark.parametrize("mutation", ["writer", "auto", "scheduler"])
+def test_mutant_02_sidecar_must_stay_observation_only(mutation: str) -> None:
+    """§F-2 — sidecar writer, auto, or a live recurring owner all fail."""
+
+    changes: dict[str, Any] = {
+        "writer": {"writer": True},
+        "auto": {"auto_order_enabled": True},
+        "scheduler": {"scheduler_owner": SchedulerOwner.TASKIQ},
+    }[mutation]
+    mutated = tuple(
+        dataclasses.replace(entry, **changes)
+        if entry.lane_id == mal.SPOT_DEMO_SIDECAR_LANE_ID
+        else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.assert_sidecar_observation_only(mutated)
+    assert error.value.reason is mal.SpotDemoLimitReason.SIDECAR_OBSERVATION_ONLY
+    mal.assert_sidecar_observation_only(CANONICAL_LANE_REGISTRY)
+
+
+def test_sidecar_lane_id_cannot_borrow_this_composition(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """D2 — the sidecar composes no order even by presenting its own lane id."""
+
+    draft = ExecutionPlanDraft(
+        **{
+            **mal.compose_limit_plan_draft(
+                normalized_symbol="BTCUSDT",
+                sizing=_sizing(),
+                step=_STEP,
+                risk_caps={"cap_binding": "missing"},
+            ).model_dump(mode="python"),
+            "lane_id": mal.SPOT_DEMO_SIDECAR_LANE_ID,
+        }
+    )
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        _composition(client).validate_pre_dispatch(_envelope(plan_draft=draft))
+    assert error.value.reason is mal.SpotDemoLimitReason.SIDECAR_OBSERVATION_ONLY
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.parametrize(
+    "lane_id", ["crypto.alpaca.paper.default", "crypto.alpaca.paper.clean"]
+)
+def test_mutant_03_alpaca_crypto_writer_is_refused(lane_id: str) -> None:
+    """§F-3 — operator decision D1: no Alpaca crypto mutation wiring this epoch."""
+
+    mutated = tuple(
+        dataclasses.replace(entry, writer=True) if entry.lane_id == lane_id else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.assert_alpaca_crypto_unwired(mutated)
+    assert (
+        error.value.reason is mal.SpotDemoLimitReason.ALPACA_CRYPTO_MUTATION_UNASSIGNED
+    )
+    mal.assert_alpaca_crypto_unwired(CANONICAL_LANE_REGISTRY)
+
+
+def test_mutant_03b_module_imports_no_alpaca_surface() -> None:
+    """§F-3 — no submit wiring can exist because nothing Alpaca is imported."""
+
+    tree = ast.parse(_MODULE_PATH.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+    assert [name for name in imported if "alpaca" in name.lower()] == []
+
+
+# ==========================================================================
+# §F-4 — the frozen ROB-845 asset
+# ==========================================================================
+
+#: Byte-frozen at the J6B base commit.  Changing any of these files is a
+#: ROB-845 re-scope, not a J6B edit; this test is the tripwire.
+_ROB845_FROZEN_SHA256: Mapping[str, str] = {
+    "app/services/brokers/binance/paper_adapter.py": (
+        "f6aa21a8875092e837efad7654f65a1398629f67f62f101a6ecb4cb84fabd794"
+    ),
+    "app/services/brokers/paper/composition.py": (
+        "8cb5900d9cd9ea22edd4ac90b8e50addfd2529e7cb9efad4e530cb1ab632e8da"
+    ),
+    "app/services/brokers/capabilities.py": (
+        "b468e35b0699932220d9bb32a0ea2b8c3cd8486c0bf4d5cb697db25a4c8e49e0"
+    ),
+}
+
+
+@pytest.mark.parametrize("relative_path", sorted(_ROB845_FROZEN_SHA256))
+def test_mutant_04a_rob845_asset_bytes_are_frozen(relative_path: str) -> None:
+    """§F-4 — byte identity of the frozen adapter/capability files."""
+
+    digest = hashlib.sha256((_REPO_ROOT / relative_path).read_bytes()).hexdigest()
+    assert digest == _ROB845_FROZEN_SHA256[relative_path], (
+        f"{relative_path} changed; ROB-845 is a frozen asset and J6B builds a "
+        "separate LIMIT composition instead of editing it"
+    )
+
+
+def test_mutant_04b_rob845_binance_capability_shape_is_frozen() -> None:
+    """§F-4 — behaviour, not only bytes: BUY / MARKET / notional-only stands."""
+
+    capability = PAPER_BROKER_CAPABILITIES[Broker.BINANCE]
+    assert capability.sides == frozenset({"buy"})
+    assert capability.order_types == frozenset({"market"})
+    assert capability.sizing_modes == frozenset({"notional"})
+    assert capability.time_in_force == frozenset()
+    # The new LIMIT composition is a different surface, not a relabel of it.
+    assert mal.SPOT_DEMO_ORDER_TYPE.lower() not in capability.order_types
+    assert mal.SPOT_DEMO_TIME_IN_FORCE.lower() not in capability.time_in_force
+
+
+# ==========================================================================
+# §F-11 — host and transport
+# ==========================================================================
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.binance.com",  # live spot
+        "https://fapi.binance.com",  # live futures
+        "https://testnet.binance.vision",  # retired testnet
+        "https://demo-fapi.binance.com",  # futures demo
+        "https://demo-api.binance.com.evil.example",  # suffix spoof
+    ],
+)
+def test_mutant_11_non_spot_demo_hosts_fail_before_any_request(
+    base_url: str, monkeypatch: pytest.MonkeyPatch, httpx_mock: Any
+) -> None:
+    """§F-11 — live, testnet, and Futures hosts never reach a request build.
+
+    The ROB-298 transport factory already rejects most of these at construction;
+    where it does, the client cannot even be built, which is the same guarantee
+    one layer earlier. Either way the assertion is: zero HTTP.
+    """
+
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "DUMMY")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "DUMMY")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_BASE_URL", base_url)
+    try:
+        built = BinanceSpotDemoExecutionClient.from_env()
+    except Exception:
+        assert httpx_mock.get_requests() == []
+        return
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.assert_spot_demo_transport(built)
+    assert error.value.reason is mal.SpotDemoLimitReason.TRANSPORT_HOST_NOT_SPOT_DEMO
+    assert httpx_mock.get_requests() == []
+
+
+def test_mutant_11b_a_subclassed_transport_is_refused(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-11 — a subclass can override the transport, so exact type is required."""
+
+    class _LookalikeClient(BinanceSpotDemoExecutionClient):
+        pass
+
+    lookalike = object.__new__(_LookalikeClient)
+    # Given a perfectly valid Spot Demo base URL, so the *only* thing that can
+    # refuse it is the exact-type check. Without that check it would pass every
+    # other gate — which is precisely the risk a subclassed transport poses.
+    lookalike._base_url = _SPOT_DEMO_BASE
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.assert_spot_demo_transport(lookalike)
+    assert error.value.reason is mal.SpotDemoLimitReason.TRANSPORT_CLIENT_NOT_SPOT_DEMO
+    # The genuine client passes, so the guard discriminates rather than refusing all.
+    assert mal.assert_spot_demo_transport(client) == "demo-api.binance.com"
+    assert httpx_mock.get_requests() == []
+
+
+def test_module_names_no_live_or_futures_host() -> None:
+    """No live/mainnet/testnet/futures host literal exists in this module."""
+
+    source = _MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "api.binance.com/",
+        "https://api.binance.com",
+        "fapi.binance.com",
+        "testnet.binance.vision",
+    ):
+        assert forbidden not in source
+
+
+# ==========================================================================
+# §F-10 — restart never reposts
+# ==========================================================================
+
+
+@pytest.mark.parametrize("outcome", list(mal.SpotDemoReadbackOutcome))
+def test_mutant_10_no_restart_disposition_ever_authorizes_a_repost(
+    outcome: mal.SpotDemoReadbackOutcome,
+) -> None:
+    """§F-10 — exhaustive over every readback outcome; repost is structural False."""
+
+    disposition = mal.classify_restart_disposition(
+        outcome, account_position_reconciled=True, remainder_known=True
+    )
+    assert disposition.repost is False
+    assert "repost" not in inspect.signature(mal.RestartDisposition).parameters
+
+
+def test_mutant_10b_unreadable_readback_holds_the_claim() -> None:
+    """§F-10 — an unreadable readback is a held unknown, never an absence."""
+
+    disposition = mal.classify_restart_disposition(
+        mal.SpotDemoReadbackOutcome.UNREADABLE,
+        account_position_reconciled=True,
+        remainder_known=True,
+    )
+    assert disposition.may_release_claim is False
+    assert disposition.operator_visible_state == mal.SPOT_DEMO_UNRECOVERABLE_STATE
+    assert disposition.evidence_kind is mal.SpotDemoLaneEvidenceKind.UNKNOWN
+    assert mal.terminal_evidence_for(disposition) == TerminalClaimEvidence()
+    assert TerminalClaimEvidence().authorizes_release is False
+
+
+def test_open_and_partial_orders_are_never_released() -> None:
+    """A live order keeps its claim regardless of how confident the caller is."""
+
+    for outcome in (
+        mal.SpotDemoReadbackOutcome.OPEN,
+        mal.SpotDemoReadbackOutcome.PARTIALLY_FILLED,
+    ):
+        disposition = mal.classify_restart_disposition(
+            outcome, account_position_reconciled=True, remainder_known=True
+        )
+        assert disposition.may_release_claim is False
+
+
+def test_not_created_still_requires_account_reconciliation() -> None:
+    """C3-5 branch A — proven absence alone does not release the claim."""
+
+    unreconciled = mal.classify_restart_disposition(
+        mal.SpotDemoReadbackOutcome.NOT_CREATED, account_position_reconciled=False
+    )
+    assert unreconciled.may_release_claim is False
+    assert unreconciled.operator_visible_state == mal.SPOT_DEMO_UNRECOVERABLE_STATE
+
+    reconciled = mal.classify_restart_disposition(
+        mal.SpotDemoReadbackOutcome.NOT_CREATED, account_position_reconciled=True
+    )
+    assert reconciled.may_release_claim is True
+    evidence = mal.terminal_evidence_for(reconciled)
+    assert evidence.authoritative_absence_proven is True
+    assert evidence.authorizes_release is True
+
+
+def test_terminal_fact_requires_both_reconcile_and_known_remainder() -> None:
+    """C3-5 branch B — a partial answer does not release."""
+
+    for reconciled, remainder in ((True, False), (False, True), (False, False)):
+        disposition = mal.classify_restart_disposition(
+            mal.SpotDemoReadbackOutcome.FILLED,
+            account_position_reconciled=reconciled,
+            remainder_known=remainder,
+        )
+        assert disposition.may_release_claim is False
+    full = mal.classify_restart_disposition(
+        mal.SpotDemoReadbackOutcome.FILLED,
+        account_position_reconciled=True,
+        remainder_known=True,
+    )
+    assert full.may_release_claim is True
+    assert mal.terminal_evidence_for(full).authorizes_release is True
+
+
+@pytest.mark.parametrize(
+    ("native", "expected"),
+    [
+        ("NEW", mal.SpotDemoReadbackOutcome.OPEN),
+        ("PARTIALLY_FILLED", mal.SpotDemoReadbackOutcome.PARTIALLY_FILLED),
+        ("FILLED", mal.SpotDemoReadbackOutcome.FILLED),
+        ("CANCELED", mal.SpotDemoReadbackOutcome.CANCELED),
+        ("REJECTED", mal.SpotDemoReadbackOutcome.REJECTED),
+        ("EXPIRED", mal.SpotDemoReadbackOutcome.EXPIRED),
+        ("SOMETHING_NEW_FROM_BINANCE", mal.SpotDemoReadbackOutcome.UNREADABLE),
+        (None, mal.SpotDemoReadbackOutcome.UNREADABLE),
+    ],
+)
+def test_unknown_native_status_is_unreadable_not_terminal(
+    native: Any, expected: mal.SpotDemoReadbackOutcome
+) -> None:
+    """An unrecognised status is never optimistically read as terminal."""
+
+    assert mal.classify_native_status(native) is expected
+
+
+# ==========================================================================
+# §F-12 — no scheduler
+# ==========================================================================
+
+
+def test_mutant_12_module_imports_no_scheduler_surface() -> None:
+    """§F-12 — TaskIQ / Prefect / cron / launchd / systemd imports are absent."""
+
+    tree = ast.parse(_MODULE_PATH.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+    forbidden = (
+        "taskiq",
+        "prefect",
+        "cron",
+        "celery",
+        "apscheduler",
+        "app.tasks",
+        "app.flows",
+    )
+    offenders = [
+        name for name in imported for token in forbidden if token in name.lower()
+    ]
+    assert offenders == [], offenders
+
+
+def test_mutant_12b_a_recurring_request_is_refused(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-12 — recurrence is refused outright, never quietly downgraded."""
+
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        _composition(client).validate_pre_dispatch(
+            _envelope(), recurring_requested=True
+        )
+    assert (
+        error.value.reason is mal.SpotDemoLimitReason.RECURRING_REGISTRATION_FORBIDDEN
+    )
+    assert httpx_mock.get_requests() == []
+
+
+# ==========================================================================
+# Acceptance — structural unreachability
+# ==========================================================================
+
+
+def test_execution_ready_is_unsatisfiable_for_this_lane() -> None:
+    """Acceptance: the mutation path is structurally unreachable, not merely off.
+
+    Exhaustive over every activation status and both writer/auto bits: ENABLED
+    trips the signed-restriction guard, and every other status trips the
+    activation guard. No configuration of this lane passes.
+    """
+
+    from app.services.mock_lane_registry import assert_entry_execution_ready
+
+    base = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    checked = 0
+    for status in ActivationStatus:
+        for writer in (True, False):
+            for auto in (True, False):
+                entry = dataclasses.replace(
+                    base,
+                    activation_status=status,
+                    writer=writer,
+                    auto_order_enabled=auto,
+                )
+                with pytest.raises(LaneGuardError):
+                    assert_entry_execution_ready(entry)
+                checked += 1
+    assert checked == len(ActivationStatus) * 4
+
+
+@pytest.mark.asyncio
+async def test_submit_with_the_signed_registry_dispatches_zero_http(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """Acceptance: even ``confirm=True`` reaches no transport and no claim."""
+
+    intents = _NeverCalledIntents()
+    from app.services.mock_integration.coordination import DurableSendClaimAdapter
+
+    composition = mal.BinanceSpotDemoLimitComposition(
+        client=client,
+        claims=DurableSendClaimAdapter(intents),  # type: ignore[arg-type]
+        connection_factory=lambda: None,
+        persistence=None,
+        dispatch_evidence=None,
+        uncertainty_gate=None,
+        lane_evidence=_RecordingLaneEvidence(),
+    )
+    with pytest.raises(LaneGuardError) as error:
+        await composition.submit_limit_order(_envelope(), confirm=True)
+    assert str(error.value).startswith("lane_binding_incomplete")
+    assert mal.SPOT_DEMO_CANONICAL_LANE_ID in str(error.value)
+    # Exactly zero: no HTTP, and no durable claim was even attempted.
+    assert httpx_mock.get_requests() == []
+    assert intents.calls == []
+
+
+def test_registry_row_is_consumed_unchanged() -> None:
+    """The signed row is read, never rewritten, by this job."""
+
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    assert entry.writer is False
+    assert entry.auto_order_enabled is False
+    assert entry.lane_status is LaneStatus.NOT_READY
+    assert entry.activation_status is ActivationStatus.BLOCKED
+    assert entry.scheduler_owner is SchedulerOwner.DISABLED
+    assert entry.physical_account_id is None
+    assert entry.identity_status == "UNKNOWN"
+    assert entry.allowed_hosts == ("demo-api.binance.com",)
+
+
+# ==========================================================================
+# §D — primary terminal lane status
+# ==========================================================================
+
+
+def test_primary_terminal_status_is_the_policy_blocker() -> None:
+    """§D — policy is primary; the absent scheduler is a secondary blocker."""
+
+    assert (
+        mal.SPOT_DEMO_PRIMARY_TERMINAL_LANE_STATUS
+        is LaneStatus.AUTO_READY_BLOCKED_BY_POLICY
+    )
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    blockers = mal.spot_demo_activation_blockers(entry)
+    assert blockers[0] == "AUTO_READY_BLOCKED_BY_POLICY"
+    assert mal.SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER in blockers
+    # The scheduler status is never promoted to the primary position.
+    assert LaneStatus.AUTO_READY_BLOCKED_BY_SCHEDULER.value not in blockers[0]
+
+
+def test_j6b_does_not_modify_the_signed_registry() -> None:
+    """Mechanically narrowing the signed allowlist is J2A-owned work."""
+
+    registry_source = (_REPO_ROOT / "app/services/mock_lane_registry.py").read_text(
+        encoding="utf-8"
+    )
+    # The superset the J2A verifier dispositioned is still exactly as merged.
+    assert "AUTO_READY_BLOCKED_BY_SCHEDULER" in registry_source
+    tree = ast.parse(_MODULE_PATH.read_text(encoding="utf-8"))
+    assigned = {
+        target.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    assert "CANONICAL_LANE_REGISTRY" not in assigned
+
+
+# ==========================================================================
+# §83 correction 3 — lane-native recovery ownership
+# ==========================================================================
+
+
+def test_c3_1_exactly_one_recovery_owner() -> None:
+    """C3-1 — one owner, named, and it is a real importable object."""
+
+    assert mal.SPOT_DEMO_RECOVERY_OWNER.endswith("BinanceSpotDemoLimitComposition")
+    module_path, _, attribute = mal.SPOT_DEMO_RECOVERY_OWNER.rpartition(".")
+    assert module_path == mal.__name__
+    assert getattr(mal, attribute) is mal.BinanceSpotDemoLimitComposition
+    assert "TBD" not in mal.SPOT_DEMO_RECOVERY_OWNER
+
+
+def test_c3_2_restart_trigger_is_named_and_implemented() -> None:
+    """C3-2 — the trigger names claim rediscovery and has a resolver."""
+
+    assert mal.SPOT_DEMO_RESTART_TRIGGER == (
+        "process_restart_rediscovers_durable_j2b_claims_for_physical_account"
+    )
+    assert callable(mal.BinanceSpotDemoLimitComposition.resolve_restart_claim)
+
+
+def test_c3_3_authoritative_readback_is_the_order_endpoint() -> None:
+    """C3-3 — a single-order readback, not an open-orders listing."""
+
+    assert "/api/v3/order" in mal.SPOT_DEMO_AUTHORITATIVE_READBACK
+    assert "get_order_status" in mal.SPOT_DEMO_AUTHORITATIVE_READBACK
+    assert "openOrders" not in mal.SPOT_DEMO_AUTHORITATIVE_READBACK
+
+
+def test_c3_4_all_seven_lane_evidence_kinds_exist() -> None:
+    """C3-4 — the closed set is exactly the seven required kinds."""
+
+    assert mal.LANE_EVIDENCE_KINDS == {
+        "ack",
+        "unknown",
+        "reject",
+        "expiry",
+        "partial_fill",
+        "cancel",
+        "terminal_reconciliation",
+    }
+
+
+def _pin_readback(
+    monkeypatch: pytest.MonkeyPatch,
+    client: BinanceSpotDemoExecutionClient,
+    native: str | BaseException,
+) -> list[dict[str, Any]]:
+    """Replace the client's single-order readback with a recorded stub.
+
+    The stub sits at the transport method, not at the composition, so the real
+    ``readback`` → ``classify_native_status`` → ``classify_restart_disposition``
+    chain still runs.
+    """
+
+    calls: list[dict[str, Any]] = []
+
+    async def _stub(*, symbol: str, client_order_id: str) -> dict[str, Any]:
+        calls.append({"symbol": symbol, "client_order_id": client_order_id})
+        if isinstance(native, BaseException):
+            raise native
+        return {"status": native, "origClientOrderId": client_order_id}
+
+    monkeypatch.setattr(client, "get_order_status", _stub)
+    return calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("native", "expected_kind"),
+    [
+        (RuntimeError("transport blew up"), "unknown"),
+        ("REJECTED", "reject"),
+        ("EXPIRED", "expiry"),
+        ("PARTIALLY_FILLED", "partial_fill"),
+        ("CANCELED", "cancel"),
+        ("FILLED", "terminal_reconciliation"),
+        (BinanceDemoOrderNotFound("absent"), "terminal_reconciliation"),
+        ("NEW", "unknown"),
+    ],
+)
+async def test_c3_4b_each_outcome_writes_its_lane_native_evidence(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+    native: str | BaseException,
+    expected_kind: str,
+) -> None:
+    """C3-4 — every readback outcome lands in the closed evidence vocabulary."""
+
+    evidence = _RecordingLaneEvidence()
+    composition = _composition(client, lane_evidence=evidence)
+    calls = _pin_readback(monkeypatch, client, native)
+    claim = DurableClaim(
+        row_id=1, claim_account_scope="scope", idempotency_key="k", side="buy"
+    )
+
+    disposition = await composition.resolve_restart_claim(
+        claim, symbol="BTCUSDT", client_order_id="bnsd-abc"
+    )
+
+    assert calls == [{"symbol": "BTCUSDT", "client_order_id": "bnsd-abc"}]
+    assert evidence.kinds[0] == expected_kind
+    assert set(evidence.kinds) <= mal.LANE_EVIDENCE_KINDS
+    # Nothing is reposted and nothing is released without reconciliation.
+    assert disposition.repost is False
+    assert disposition.may_release_claim is False
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_c3_4c_terminal_reconciliation_releases_only_with_full_evidence(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """C3-5 — with reconcile + known remainder, the claim releases through J3A."""
+
+    evidence = _RecordingLaneEvidence()
+    intents = _NeverCalledIntents()
+    from app.services.mock_integration.coordination import DurableSendClaimAdapter
+
+    composition = mal.BinanceSpotDemoLimitComposition(
+        client=client,
+        claims=DurableSendClaimAdapter(intents),  # type: ignore[arg-type]
+        connection_factory=lambda: None,
+        persistence=None,
+        dispatch_evidence=None,
+        uncertainty_gate=None,
+        lane_evidence=evidence,
+    )
+    _pin_readback(monkeypatch, client, "FILLED")
+    claim = DurableClaim(
+        row_id=7, claim_account_scope="scope", idempotency_key="k", side="buy"
+    )
+
+    disposition = await composition.resolve_restart_claim(
+        claim,
+        symbol="BTCUSDT",
+        client_order_id="bnsd-abc",
+        account_position_reconciled=True,
+        remainder_known=True,
+    )
+
+    assert disposition.may_release_claim is True
+    assert intents.calls == ["release_if_matches"]
+    assert evidence.kinds == ["terminal_reconciliation", "terminal_reconciliation"]
+    assert evidence.records[-1][1]["released"] is True
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_c3_4d_cancel_writes_the_cancel_kind(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """C3-4 — the cancel kind is written by the cancel path."""
+
+    evidence = _RecordingLaneEvidence()
+    composition = _composition(client, lane_evidence=evidence)
+    result = await composition.cancel_limit_order(
+        symbol="BTCUSDT", client_order_id="bnsd-abc", confirm=False
+    )
+    assert evidence.kinds == ["cancel"]
+    # confirm=False is the ROB-298 operator gate: a dry run, zero HTTP.
+    assert type(result).__name__ == "SpotDemoDryRunResult"
+    assert httpx_mock.get_requests() == []
+
+
+def test_c3_4e_ack_and_unknown_submit_branches_are_classified() -> None:
+    """C3-4 — the submit-path ACK/unknown branches, proven at their real seam.
+
+    The dispatch path is structurally unreachable under the signed registry (see
+    ``test_execution_ready_is_unsatisfiable_for_this_lane``), so it cannot be
+    driven end to end. ``classify_submit_outcome`` is the seam the closure
+    actually calls, and it is tested directly rather than described in prose.
+    """
+
+    class _Acknowledged:
+        broker_order_id = "  12345  "
+        status = "NEW"
+
+    class _NoNativeId:
+        broker_order_id = ""
+        status = "NEW"
+
+    from app.services.brokers.binance.spot_demo.execution_client import (
+        SpotDemoDryRunResult,
+    )
+
+    acknowledged = mal.classify_submit_outcome(_Acknowledged())
+    assert acknowledged.evidence_kind is mal.SpotDemoLaneEvidenceKind.ACK
+    assert acknowledged.certainty is mal.MutationCertainty.DEFINITIVE
+    assert acknowledged.broker_order_id == "12345"
+
+    for response in (
+        _NoNativeId(),
+        object(),
+        SpotDemoDryRunResult(
+            symbol="BTCUSDT",
+            side="BUY",
+            order_type="LIMIT",
+            qty=Decimal("0.1"),
+            client_order_id="bnsd-abc",
+        ),
+    ):
+        outcome = mal.classify_submit_outcome(response)
+        assert outcome.evidence_kind is mal.SpotDemoLaneEvidenceKind.UNKNOWN
+        assert outcome.certainty is mal.MutationCertainty.UNCERTAIN
+        assert outcome.broker_order_id is None
+
+    # A raised submit is an uncertainty, never a proven non-send.
+    assert mal.SUBMIT_RAISED_OUTCOME.certainty is mal.MutationCertainty.UNCERTAIN
+    assert (
+        mal.SUBMIT_RAISED_OUTCOME.evidence_kind is mal.SpotDemoLaneEvidenceKind.UNKNOWN
+    )
+
+
+def test_c3_4f_submit_closure_uses_the_classifier_it_claims_to() -> None:
+    """The seam is load-bearing: the dispatch closure really calls it."""
+
+    source = inspect.getsource(mal.BinanceSpotDemoLimitComposition.submit_limit_order)
+    assert "classify_submit_outcome(result)" in source
+    assert "SUBMIT_RAISED_OUTCOME" in source
+    assert "_record_submit_outcome" in source
+
+
+def test_c3_5_release_condition_is_the_j3a_evidence_gate() -> None:
+    """C3-5 — release flows through ``release_with_terminal_evidence`` only."""
+
+    source = _MODULE_PATH.read_text(encoding="utf-8")
+    assert "release_with_terminal_evidence" in source
+    # The unrestricted delete is never named here.
+    assert "release_if_matches(" not in source
+
+
+def test_c3_6_operator_visible_blocked_state_is_named() -> None:
+    """C3-6 — a concrete operator-visible state, not a silent hold."""
+
+    assert mal.SPOT_DEMO_UNRECOVERABLE_STATE == "unknown_pending_reconcile"
+    disposition = mal.classify_restart_disposition(
+        mal.SpotDemoReadbackOutcome.UNREADABLE
+    )
+    assert disposition.operator_visible_state == mal.SPOT_DEMO_UNRECOVERABLE_STATE
+
+
+def test_c3_7_lane_stays_lifecycle_blocked_until_activation_is_approved() -> None:
+    """C3-7 — this job does not activate anything."""
+
+    assert (
+        mal.SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS
+        is LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE
+    )
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    assert entry.activation_status is not ActivationStatus.ENABLED
+
+
+def test_lane_evidence_port_is_required_at_construction(
+    client: BinanceSpotDemoExecutionClient,
+) -> None:
+    """A composition that cannot write its own evidence must not exist."""
+
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        mal.BinanceSpotDemoLimitComposition(
+            client=client,
+            claims=_claims(),
+            connection_factory=lambda: None,
+            persistence=None,
+            dispatch_evidence=None,
+            uncertainty_gate=None,
+            lane_evidence=None,
+        )
+    assert error.value.reason is mal.SpotDemoLimitReason.LANE_EVIDENCE_PORT_UNAVAILABLE
+
+
+def test_common_layer_owns_no_binance_retry_or_readback_queue() -> None:
+    """The recovery owner is lane-native; J3A holds no Binance-specific queue."""
+
+    coordination = (
+        _REPO_ROOT / "app/services/mock_integration/coordination.py"
+    ).read_text(encoding="utf-8")
+    assert "binance" not in coordination.lower()
+
+
+# ==========================================================================
+# Upstream reuse — nothing is redefined
+# ==========================================================================
+
+
+def test_client_order_id_fits_the_binance_constraint() -> None:
+    """The lane prefix keeps the J2B-derived id inside Binance's 36 chars."""
+
+    from app.services.brokers.client_order_ids import (
+        BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH,
+        assert_broker_client_order_id,
+    )
+
+    envelope = _envelope()
+    client_order_id = envelope.order_attempt.broker_client_order_id
+    assert client_order_id is not None
+    assert client_order_id.startswith(f"{mal.SPOT_DEMO_LANE_PREFIX}-")
+    assert len(client_order_id) <= BINANCE_SPOT_DEMO_CLIENT_ORDER_ID_MAX_LENGTH
+    assert_broker_client_order_id(
+        target=BrokerClientIdTarget.BINANCE_SPOT_DEMO,
+        client_order_id=client_order_id,
+    )
+
+
+def test_identifiers_come_only_from_the_j2b_factory() -> None:
+    """No new lineage enum, hash domain, or identifier is minted here."""
+
+    source = _MODULE_PATH.read_text(encoding="utf-8")
+    for forbidden in ("hashlib", "uuid", "mock-plan-v", "mock-intent-v", "sha256("):
+        assert forbidden not in source
+
+
+def test_plan_draft_binds_exactly_the_registry_identity() -> None:
+    """The composed plan matches the signed row field for field."""
+
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    plan = _envelope().execution_plan
+    assert plan is not None
+    assert plan.lane_id == entry.lane_id
+    assert plan.broker == entry.broker
+    assert plan.account_profile == entry.account_profile
+    assert plan.account_mode == entry.account_mode.value
+    assert plan.quote_currency == entry.quote_currency
+
+
+def test_risk_caps_record_the_missing_binding_rather_than_a_number() -> None:
+    """No cap is invented: the registry reports the cap binding as missing."""
+
+    from app.services.mock_lane_registry import MissingBinding
+
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    assert MissingBinding.CAP in entry.missing_bindings
+    assert entry.max_order_notional is None
+    plan = _envelope().execution_plan
+    assert plan is not None
+    assert plan.risk_caps == {"cap_binding": "missing"}
+
+
+def test_no_module_level_side_effects() -> None:
+    """Importing this module starts nothing: no clients, tasks, or connections."""
+
+    tree = ast.parse(_MODULE_PATH.read_text(encoding="utf-8"))
+    top_level_calls = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+    ]
+    assert top_level_calls == []
+
+
+def test_reason_codes_are_disjoint_from_the_coordination_vocabulary() -> None:
+    """J6B reason codes never shadow J3A's, so an aggregate stays readable."""
+
+    from app.services.mock_integration.coordination import COORDINATION_REASON_CODES
+
+    overlap = mal.SPOT_DEMO_LIMIT_REASON_CODES & COORDINATION_REASON_CODES
+    assert overlap == set()

--- a/tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py
+++ b/tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py
@@ -123,6 +123,7 @@ def _composition(
     client: BinanceSpotDemoExecutionClient,
     *,
     lane_evidence: Any = None,
+    reservations: Any = None,
 ) -> mal.BinanceSpotDemoLimitComposition:
     return mal.BinanceSpotDemoLimitComposition(
         client=client,
@@ -132,6 +133,82 @@ def _composition(
         dispatch_evidence=None,
         uncertainty_gate=None,
         lane_evidence=lane_evidence or _RecordingLaneEvidence(),
+        reservations=reservations,
+    )
+
+
+class _Reservation:
+    """The row shape ``OrderSendIntentService.list_reservations`` returns."""
+
+    def __init__(self, *, row_id: int, idempotency_key: str, side: str | None) -> None:
+        self.row_id = row_id
+        self.idempotency_key = idempotency_key
+        self.side = side
+
+
+class _RecordedReservations:
+    """A reservation read-side port that records the scope it was asked about."""
+
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+        self.scopes: list[str] = []
+
+    async def reserve(self, **kwargs: Any) -> int:  # pragma: no cover - unused here
+        raise AssertionError("the restart trigger never reserves")
+
+    async def list_reservations(self, *, account_scope: str) -> list[Any]:
+        self.scopes.append(account_scope)
+        return list(self._rows)
+
+    async def release_if_matches(self, **kwargs: Any) -> int:  # pragma: no cover
+        raise AssertionError("the restart trigger never releases directly")
+
+
+def _scope(calls: list[str] | None = None) -> Any:
+    """A live J3A coordination scope whose ownership assertion is observable."""
+
+    from app.services.mock_integration.coordination import CoordinationScope
+
+    async def _assert_owned() -> None:
+        if calls is not None:
+            calls.append("assert_owned")
+
+    return CoordinationScope(_assert_owned)
+
+
+def _identity_known_entry() -> Any:
+    """The canonical row with a physical identity, so a scope can be derived.
+
+    The signed row's identity is ``UNKNOWN``, which is a real recovery gap (see
+    the C3-7 tests).  Tests that need to exercise the *rest* of a path replace
+    only that field, and never in the registry itself.
+    """
+
+    return dataclasses.replace(
+        get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID),
+        physical_account_id="binance-spot-demo-physical-1",
+        identity_status="KNOWN",
+    )
+
+
+def _lane_scope(entry: Any) -> str:
+    from app.services.mock_integration.coordination import (
+        physical_account_scope_for_entry,
+    )
+
+    return physical_account_scope_for_entry(entry).claim_account_scope
+
+
+def _attributed_claim(entry: Any, *, row_id: int = 1) -> DurableClaim:
+    """A durable claim whose key really came from the J2B factory."""
+
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+    return DurableClaim(
+        row_id=row_id,
+        claim_account_scope=_lane_scope(entry),
+        idempotency_key=attempt.idempotency_key,
+        side="buy",
     )
 
 
@@ -636,6 +713,41 @@ def test_c2_5_alpaca_crypto_auto_mirror_is_policy_mirror_only() -> None:
 # ==========================================================================
 
 
+def _pre_dispatch_error(
+    client: BinanceSpotDemoExecutionClient, registry: Any
+) -> BaseException | None:
+    """Run the real pre-dispatch chain and hand back whatever it raised.
+
+    Deliberately does **not** pre-judge the exception type. A guard that has been
+    removed from the chain does not stop the chain — it lets a *later*, unrelated
+    J2A check fail instead, and a bare ``pytest.raises(SpotDemoLimitError)``
+    would then produce a red test whose traceback points at that other check.
+    Returning the exception lets each test assert, on its own line, that the
+    chain died at the guard under test and name what it got instead.
+    """
+
+    try:
+        _composition(client).validate_pre_dispatch(_envelope(), registry=registry)
+    except BaseException as exc:  # noqa: BLE001 - the assertion is the caller's
+        return exc
+    return None
+
+
+def _binance_domain_guard_reached(
+    client: BinanceSpotDemoExecutionClient,
+    registry: Any,
+    expected: mal.SpotDemoLimitReason,
+) -> None:
+    """Assert the pre-dispatch chain refuses *at* the writer-domain guard."""
+
+    raised = _pre_dispatch_error(client, registry)
+    assert isinstance(raised, mal.SpotDemoLimitError), (
+        "the writer-domain invariant must be enforced by the pre-dispatch chain "
+        f"itself, not only by a direct guard call; chain raised {raised!r}"
+    )
+    assert raised.reason is expected
+
+
 def test_mutant_01_two_binance_writers_in_one_domain_fail() -> None:
     """§F-1 — identity is UNKNOWN, so every Binance demo lane is one domain."""
 
@@ -679,6 +791,89 @@ def test_mutant_01b_conservative_domain_ignores_unknown_physical_ids() -> None:
     # Not silent:
     with pytest.raises(mal.SpotDemoLimitError):
         mal.assert_binance_single_writer_domain(mutated)
+
+
+def test_mutant_01c_the_writer_domain_guard_runs_in_the_dispatch_chain(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-1 — the conservative guard is wired, not merely defined and exported.
+
+    A guard that only fires when a test calls it by name protects nothing: the
+    invariant has to be enforced on the path an order actually takes. This drives
+    the real ``validate_pre_dispatch`` chain and asserts the refusal comes from
+    the writer-domain guard rather than from a later registry check.
+
+    The two writers are canonical + Futures Demo, deliberately **not** the B0-X
+    sidecar: promoting the sidecar would also trip the sidecar guard, and a
+    mutation that two guards can catch proves neither of them individually.
+    """
+
+    mutated = tuple(
+        dataclasses.replace(entry, writer=True)
+        if entry.lane_id
+        in (mal.SPOT_DEMO_CANONICAL_LANE_ID, mal.SPOT_DEMO_FUTURES_LANE_ID)
+        else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    _binance_domain_guard_reached(
+        client, mutated, mal.SpotDemoLimitReason.BINANCE_WRITER_CONFLICT
+    )
+    # Discrimination: the signed registry gets *past* this guard and dies later,
+    # on J2A's binding check — so the guard is not simply refusing everything.
+    assert isinstance(
+        _pre_dispatch_error(client, CANONICAL_LANE_REGISTRY), LaneGuardError
+    )
+    assert httpx_mock.get_requests() == []
+
+
+def test_mutant_02c_the_sidecar_guard_runs_in_the_dispatch_chain(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-2 — a promoted sidecar is refused on the dispatch path, not only in a test."""
+
+    mutated = tuple(
+        dataclasses.replace(entry, scheduler_owner=SchedulerOwner.TASKIQ)
+        if entry.lane_id == mal.SPOT_DEMO_SIDECAR_LANE_ID
+        else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    _binance_domain_guard_reached(
+        client, mutated, mal.SpotDemoLimitReason.SIDECAR_OBSERVATION_ONLY
+    )
+    assert httpx_mock.get_requests() == []
+
+
+def test_mutant_03c_the_alpaca_crypto_guard_runs_in_the_dispatch_chain(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """§F-3 — D1 is enforced on the dispatch path, not only by a direct call."""
+
+    mutated = tuple(
+        dataclasses.replace(entry, writer=True)
+        if entry.lane_id == "crypto.alpaca.paper.default"
+        else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    _binance_domain_guard_reached(
+        client, mutated, mal.SpotDemoLimitReason.ALPACA_CRYPTO_MUTATION_UNASSIGNED
+    )
+    assert httpx_mock.get_requests() == []
+
+
+def test_the_domain_invariants_are_reached_before_the_j2a_binding_check() -> None:
+    """Ordering is the whole point: the guard must run *before* J2A's verdict.
+
+    Placed after ``assert_lineage_registry_binding`` it would be dead code for
+    this lane, because the signed registry always dies on the binding check
+    first. This pins the order at the chain's own source rather than assuming it.
+    """
+
+    source = inspect.getsource(
+        mal.BinanceSpotDemoLimitComposition.validate_pre_dispatch
+    )
+    domain_at = source.index("assert_binance_domain_invariants(")
+    binding_at = source.index("assert_lineage_registry_binding(")
+    assert domain_at < binding_at
 
 
 @pytest.mark.parametrize("mutation", ["writer", "auto", "scheduler"])
@@ -1114,6 +1309,52 @@ def test_primary_terminal_status_is_the_policy_blocker() -> None:
     assert LaneStatus.AUTO_READY_BLOCKED_BY_SCHEDULER.value not in blockers[0]
 
 
+def test_an_absent_scheduler_owner_is_not_a_spelling_of_disabled() -> None:
+    """§B — ``None`` and ``DISABLED`` are different facts and stay different.
+
+    ``DISABLED`` is an explicit decision backed by in-repo evidence: Binance Demo
+    has no scheduler registration. ``None`` is the *absence* of any bind
+    authority, which is why those rows also carry ``MissingBinding.OWNER``.
+    Reporting absence as disablement tells a downstream reader that an ownership
+    decision was made when none was.
+
+    The canonical Binance row happens to be ``DISABLED``, so testing only that
+    row cannot see the difference — the ``None`` input has to be exercised
+    directly, which is exactly what the signed table's Alpaca crypto rows are.
+    """
+
+    disabled = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    assert disabled.scheduler_owner is SchedulerOwner.DISABLED
+    disabled_blockers = mal.spot_demo_activation_blockers(disabled)
+    assert mal.SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER in disabled_blockers
+    assert mal.SPOT_DEMO_ABSENT_SCHEDULER_OWNER_BLOCKER not in disabled_blockers
+
+    absent = dataclasses.replace(disabled, scheduler_owner=None)
+    assert absent.scheduler_owner is None
+    absent_blockers = mal.spot_demo_activation_blockers(absent)
+    assert mal.SPOT_DEMO_ABSENT_SCHEDULER_OWNER_BLOCKER in absent_blockers
+    assert mal.SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER not in absent_blockers
+
+    # The two blockers are distinct strings, not aliases of one another.
+    assert (
+        mal.SPOT_DEMO_ABSENT_SCHEDULER_OWNER_BLOCKER
+        != mal.SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER
+    )
+
+
+def test_signed_rows_with_an_absent_owner_report_absence(
+    client: BinanceSpotDemoExecutionClient,
+) -> None:
+    """The real ``scheduler_owner=None`` rows in the signed table, unmodified."""
+
+    for lane_id in ("crypto.alpaca.paper.default", "crypto.alpaca.paper.clean"):
+        entry = get_lane_registry_entry(lane_id)
+        assert entry.scheduler_owner is None
+        blockers = mal.spot_demo_activation_blockers(entry)
+        assert mal.SPOT_DEMO_ABSENT_SCHEDULER_OWNER_BLOCKER in blockers
+        assert mal.SPOT_DEMO_SECONDARY_ACTIVATION_BLOCKER not in blockers
+
+
 def test_j6b_does_not_modify_the_signed_registry() -> None:
     """Mechanically narrowing the signed allowlist is J2A-owned work."""
 
@@ -1155,6 +1396,157 @@ def test_c3_2_restart_trigger_is_named_and_implemented() -> None:
         "process_restart_rediscovers_durable_j2b_claims_for_physical_account"
     )
     assert callable(mal.BinanceSpotDemoLimitComposition.resolve_restart_claim)
+    # The name has an executable entry point behind it, not just a resolver
+    # waiting for someone else to find the claims.
+    assert mal.SPOT_DEMO_RESTART_TRIGGER_ENTRYPOINT == (
+        "BinanceSpotDemoLimitComposition.rediscover_restart_claims"
+    )
+    assert callable(mal.BinanceSpotDemoLimitComposition.rediscover_restart_claims)
+
+
+@pytest.mark.asyncio
+async def test_c3_2_restart_trigger_enumerates_surviving_claims_and_resolves_them(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """C3-2 — rediscovery really reads the reservation port and resolves each row.
+
+    Naming a trigger is not owning one. This drives the production path end to
+    end: enumerate within this lane's derived physical-account scope, derive each
+    claim's client order id from its J2B key, read it back authoritatively, and
+    dispose of it without ever reposting.
+    """
+
+    entry = _identity_known_entry()
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+    reservations = _RecordedReservations(
+        [_Reservation(row_id=11, idempotency_key=attempt.idempotency_key, side="buy")]
+    )
+    evidence = _RecordingLaneEvidence()
+    composition = _composition(
+        client, lane_evidence=evidence, reservations=reservations
+    )
+    readbacks = _pin_readback(monkeypatch, client, "NEW")
+
+    dispositions = await composition.rediscover_restart_claims(
+        entry=entry, symbols={attempt.idempotency_key: "BTCUSDT"}
+    )
+
+    assert reservations.scopes == [_lane_scope(entry)]
+    assert readbacks == [
+        {"symbol": "BTCUSDT", "client_order_id": attempt.broker_client_order_id}
+    ]
+    assert len(dispositions) == 1
+    assert dispositions[0].outcome is mal.SpotDemoReadbackOutcome.OPEN
+    assert dispositions[0].repost is False
+    assert dispositions[0].may_release_claim is False
+    assert evidence.kinds == ["unknown"]
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_restart_trigger_leaves_unattributable_survivors_strictly_alone(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """A claim this lane's lineage cannot reproduce is not touched, only recorded.
+
+    The physical account is shared, so a survivor may belong to another writer.
+    Reading it back would be harmless; acting on it would not — and a silent skip
+    would hide it from the operator entirely.
+    """
+
+    entry = _identity_known_entry()
+    reservations = _RecordedReservations(
+        [
+            _Reservation(row_id=1, idempotency_key="not-a-j2b-key", side="buy"),
+            _Reservation(
+                row_id=2, idempotency_key="mock-idempotency-v1:short", side=None
+            ),
+        ]
+    )
+    evidence = _RecordingLaneEvidence()
+    composition = _composition(
+        client, lane_evidence=evidence, reservations=reservations
+    )
+    readbacks = _pin_readback(monkeypatch, client, "FILLED")
+
+    dispositions = await composition.rediscover_restart_claims(entry=entry, symbols={})
+
+    assert dispositions == ()
+    assert readbacks == []
+    assert evidence.kinds == ["unknown", "unknown"]
+    for _, payload in evidence.records:
+        assert payload["operator_visible_state"] == mal.SPOT_DEMO_UNRECOVERABLE_STATE
+        assert payload["repost"] is False
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_restart_trigger_holds_a_survivor_whose_symbol_is_unknown(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """An attributable claim with no known symbol is held, never guessed at."""
+
+    entry = _identity_known_entry()
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+    reservations = _RecordedReservations(
+        [_Reservation(row_id=3, idempotency_key=attempt.idempotency_key, side="buy")]
+    )
+    evidence = _RecordingLaneEvidence()
+    composition = _composition(
+        client, lane_evidence=evidence, reservations=reservations
+    )
+    readbacks = _pin_readback(monkeypatch, client, "FILLED")
+
+    assert await composition.rediscover_restart_claims(entry=entry, symbols={}) == ()
+    assert readbacks == []
+    assert evidence.kinds == ["unknown"]
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_restart_trigger_without_a_claim_source_fails_closed(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """No read-side port means no trigger — and it says so instead of pretending."""
+
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        await _composition(client).rediscover_restart_claims(
+            entry=_identity_known_entry(), symbols={}
+        )
+    assert (
+        error.value.reason is mal.SpotDemoLimitReason.RESTART_CLAIM_SOURCE_UNAVAILABLE
+    )
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_restart_trigger_cannot_enumerate_while_identity_is_unknown(
+    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    """The signed row has no physical identity, so no scope can be enumerated.
+
+    This is the honest state of the lane today and the reason C3-2 counts as a
+    computed gap: the scope is derived from J2A identity and is never accepted
+    from a caller.
+    """
+
+    reservations = _RecordedReservations([])
+    composition = _composition(client, reservations=reservations)
+    with pytest.raises(LaneGuardError) as error:
+        await composition.rediscover_restart_claims(
+            entry=get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID), symbols={}
+        )
+    assert "physical_account_identity_unknown" in str(error.value)
+    assert reservations.scopes == []
+    assert httpx_mock.get_requests() == []
 
 
 def test_c3_3_authoritative_readback_is_the_order_endpoint() -> None:
@@ -1287,20 +1679,320 @@ async def test_c3_4c_terminal_reconciliation_releases_only_with_full_evidence(
     assert httpx_mock.get_requests() == []
 
 
+# ==========================================================================
+# Cancel — the same attribution / coordination / uncertainty contract as submit
+# ==========================================================================
+
+
+class _CancelSeam:
+    """Records every DELETE the composition attempts, and can fail after send."""
+
+    def __init__(self, *, result: Any = None, raises: BaseException | None = None):
+        self.calls: list[tuple[str, str, bool]] = []
+        self._result = result
+        self._raises = raises
+
+    async def __call__(
+        self, *, symbol: str, client_order_id: str, confirm: bool = False
+    ) -> Any:
+        self.calls.append((symbol, client_order_id, confirm))
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+class _NativeCancel:
+    def __init__(self, status: str | None, broker_order_id: str = "9001") -> None:
+        self.status = status
+        self.broker_order_id = broker_order_id
+
+
+async def _cancel(
+    client: BinanceSpotDemoExecutionClient,
+    seam: _CancelSeam | None,
+    evidence: _RecordingLaneEvidence,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    client_order_id: str | None = None,
+    claim: DurableClaim | None = None,
+    attributed_native_order_id: str = "9001",
+    known_remainder: Decimal | None = Decimal("0.1"),
+    confirm: bool = False,
+    scope_calls: list[str] | None = None,
+) -> Any:
+    entry = _identity_known_entry()
+    if seam is not None:
+        monkeypatch.setattr(client, "cancel_order", seam)
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+    return await _composition(client, lane_evidence=evidence).cancel_limit_order(
+        _scope(scope_calls),
+        claim if claim is not None else _attributed_claim(entry),
+        entry=entry,
+        symbol="BTCUSDT",
+        client_order_id=(
+            client_order_id
+            if client_order_id is not None
+            else str(attempt.broker_client_order_id)
+        ),
+        attributed_native_order_id=attributed_native_order_id,
+        known_remainder=known_remainder,  # type: ignore[arg-type]
+        confirm=confirm,
+    )
+
+
+def test_attributed_client_order_id_round_trips_the_j2b_factory() -> None:
+    """Attribution is a real derivation, not a naming convention.
+
+    J2B builds the durable claim key and the native client order id from the same
+    digest, so one determines the other. Pinned against actual factory output —
+    if J2B ever changes either derivation, this fails rather than silently
+    letting an unrelated order id look attributed.
+    """
+
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+    derived = mal.derive_attributed_client_order_id(attempt.idempotency_key)
+    assert derived == attempt.broker_client_order_id
+    assert derived.startswith(f"{mal.SPOT_DEMO_LANE_PREFIX}-")
+
+
 @pytest.mark.asyncio
-async def test_c3_4d_cancel_writes_the_cancel_kind(
-    client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+async def test_cancel_refuses_a_client_order_id_this_lane_did_not_produce(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
 ) -> None:
-    """C3-4 — the cancel kind is written by the cancel path."""
+    """An arbitrary or third-party order id is not cancellable through this lane.
+
+    ``confirm`` decides whether a mutation is *sent*; it says nothing about
+    whether the thing being mutated is ours. Without this guard a caller holding
+    any claim could DELETE someone else's order and have the lane record it as
+    its own cancel.
+    """
 
     evidence = _RecordingLaneEvidence()
-    composition = _composition(client, lane_evidence=evidence)
-    result = await composition.cancel_limit_order(
-        symbol="BTCUSDT", client_order_id="bnsd-abc", confirm=False
+    seam = _CancelSeam(result=_NativeCancel("CANCELED"))
+    for foreign in ("someone-elses-order", "bnsd-arbitrary"):
+        with pytest.raises(mal.SpotDemoLimitError) as error:
+            await _cancel(
+                client,
+                seam,
+                evidence,
+                monkeypatch,
+                client_order_id=foreign,
+                confirm=True,
+            )
+        assert error.value.reason is mal.SpotDemoLimitReason.CANCEL_NOT_ATTRIBUTED
+    # Nothing was sent and nothing was recorded.
+    assert seam.calls == []
+    assert evidence.records == []
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_refuses_a_claim_from_another_physical_account_scope(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """A claim outside this lane's derived scope is not this lane's to follow up."""
+
+    evidence = _RecordingLaneEvidence()
+    seam = _CancelSeam(result=_NativeCancel("CANCELED"))
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+    foreign_claim = DurableClaim(
+        row_id=1,
+        claim_account_scope="scope-belonging-to-another-account",
+        idempotency_key=attempt.idempotency_key,
+        side="buy",
     )
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        await _cancel(
+            client, seam, evidence, monkeypatch, claim=foreign_claim, confirm=True
+        )
+    assert error.value.reason is mal.SpotDemoLimitReason.CANCEL_NOT_ATTRIBUTED
+    assert seam.calls == []
+    assert evidence.records == []
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_dry_run_writes_no_durable_cancel_fact(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """A dry run cancels nothing, so it records nothing.
+
+    A durable ``CANCEL`` row asserts the broker cancelled the order. On a dry run
+    it did not, and a later reconciliation reading that row would conclude the
+    order is gone when it is still live at the venue.
+    """
+
+    evidence = _RecordingLaneEvidence()
+    seam = _CancelSeam(result=_NativeCancel("CANCELED"))
+    disposition = await _cancel(client, seam, evidence, monkeypatch, confirm=False)
+
+    assert disposition.dispatched is False
+    assert disposition.evidence_kind is None
+    assert evidence.records == []
+    assert seam.calls == []
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_confirmed_records_the_cancel_kind(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """C3-4 — a broker-proven cancellation is the only thing recorded as ``cancel``."""
+
+    evidence = _RecordingLaneEvidence()
+    seam = _CancelSeam(result=_NativeCancel("CANCELED"))
+    scope_calls: list[str] = []
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+
+    disposition = await _cancel(
+        client, seam, evidence, monkeypatch, confirm=True, scope_calls=scope_calls
+    )
+
+    assert disposition.dispatched is True
     assert evidence.kinds == ["cancel"]
-    # confirm=False is the ROB-298 operator gate: a dry run, zero HTTP.
-    assert type(result).__name__ == "SpotDemoDryRunResult"
+    assert evidence.records[0][1]["operation"] == "cancel"
+    assert evidence.records[0][1]["broker_order_id"] == "9001"
+    # The DELETE used the *derived* id, and lease ownership was re-proved both
+    # before the follow-up description and again immediately before the send.
+    assert seam.calls == [("BTCUSDT", str(attempt.broker_client_order_id), True)]
+    assert scope_calls == ["assert_owned", "assert_owned"]
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [None, "", "NEW", "PARTIALLY_FILLED"])
+async def test_cancel_response_without_proof_is_unknown_not_cancel(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+    status: str | None,
+) -> None:
+    """A response that does not prove a cancellation is an unknown, not a cancel."""
+
+    evidence = _RecordingLaneEvidence()
+    seam = _CancelSeam(result=_NativeCancel(status))
+    disposition = await _cancel(client, seam, evidence, monkeypatch, confirm=True)
+
+    assert disposition.evidence_kind is mal.SpotDemoLaneEvidenceKind.UNKNOWN
+    assert evidence.kinds == ["unknown"]
+    assert (
+        evidence.records[0][1]["operator_visible_state"]
+        == mal.SPOT_DEMO_UNRECOVERABLE_STATE
+    )
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_post_send_uncertainty_leaves_durable_unknown_evidence(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """The DELETE may have reached the broker, so silence is not an option.
+
+    ROB-298 §4 / ROB-395 semantics: an unproven outcome is recorded as an
+    unknown carrying the operator-visible blocked state, and the exception is
+    re-raised. Swallowing it, or recording nothing, would leave a possibly
+    cancelled order looking untouched.
+    """
+
+    evidence = _RecordingLaneEvidence()
+    seam = _CancelSeam(raises=RuntimeError("simulated post-send uncertainty"))
+    attempt = _envelope().order_attempt
+    assert attempt is not None
+
+    with pytest.raises(RuntimeError):
+        await _cancel(client, seam, evidence, monkeypatch, confirm=True)
+
+    assert seam.calls == [("BTCUSDT", str(attempt.broker_client_order_id), True)]
+    assert evidence.kinds == ["unknown"], (
+        "a cancel whose outcome is unknown must leave durable evidence saying so"
+    )
+    payload = evidence.records[0][1]
+    assert payload["operation"] == "cancel"
+    assert payload["operator_visible_state"] == mal.SPOT_DEMO_UNRECOVERABLE_STATE
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("native_order_id", "remainder"),
+    [("", Decimal("0.1")), ("   ", Decimal("0.1")), ("9001", None)],
+)
+async def test_cancel_requires_the_j3a_followup_capability(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+    native_order_id: str,
+    remainder: Decimal | None,
+) -> None:
+    """J3A's own follow-up predicate gates the cancel, unattributed id included."""
+
+    evidence = _RecordingLaneEvidence()
+    seam = _CancelSeam(result=_NativeCancel("CANCELED"))
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        await _cancel(
+            client,
+            seam,
+            evidence,
+            monkeypatch,
+            attributed_native_order_id=native_order_id,
+            known_remainder=remainder,
+            confirm=True,
+        )
+    assert (
+        error.value.reason is mal.SpotDemoLimitReason.CANCEL_FOLLOWUP_CAPABILITY_ABSENT
+    )
+    assert seam.calls == []
+    assert evidence.records == []
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_runs_the_writer_domain_invariants(
+    client: BinanceSpotDemoExecutionClient,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: Any,
+) -> None:
+    """The cancel path is not a side door around the registry invariants."""
+
+    evidence = _RecordingLaneEvidence()
+    seam = _CancelSeam(result=_NativeCancel("CANCELED"))
+    monkeypatch.setattr(client, "cancel_order", seam)
+    entry = _identity_known_entry()
+    mutated = tuple(
+        dataclasses.replace(item, writer=True)
+        if item.lane_id
+        in (mal.SPOT_DEMO_CANONICAL_LANE_ID, mal.SPOT_DEMO_FUTURES_LANE_ID)
+        else item
+        for item in CANONICAL_LANE_REGISTRY
+    )
+    with pytest.raises(mal.SpotDemoLimitError) as error:
+        await _composition(client, lane_evidence=evidence).cancel_limit_order(
+            _scope(),
+            _attributed_claim(entry),
+            entry=entry,
+            symbol="BTCUSDT",
+            client_order_id=str(_envelope().order_attempt.broker_client_order_id),
+            attributed_native_order_id="9001",
+            known_remainder=Decimal("0.1"),
+            registry=mutated,
+            confirm=True,
+        )
+    assert error.value.reason is mal.SpotDemoLimitReason.BINANCE_WRITER_CONFLICT
+    assert seam.calls == []
     assert httpx_mock.get_requests() == []
 
 
@@ -1381,8 +2073,15 @@ def test_c3_6_operator_visible_blocked_state_is_named() -> None:
     assert disposition.operator_visible_state == mal.SPOT_DEMO_UNRECOVERABLE_STATE
 
 
-def test_c3_7_lane_stays_lifecycle_blocked_until_activation_is_approved() -> None:
-    """C3-7 — this job does not activate anything."""
+def test_c3_7_lifecycle_status_is_computed_from_the_recovery_items() -> None:
+    """C3-7 — the lane is lifecycle-blocked because it is *computed* to be.
+
+    A constant naming ``AUTO_READY_BLOCKED_BY_LIFECYCLE`` that nothing evaluates
+    is a claim, not a state. The verdict here is derived from live objects, and
+    today it is blocked for two concrete reasons: no production caller
+    constructs this composition (so there is no bound lane-evidence store), and
+    the restart trigger has no enumerable physical-account scope.
+    """
 
     assert (
         mal.SPOT_DEMO_LIFECYCLE_BLOCKED_LANE_STATUS
@@ -1390,6 +2089,71 @@ def test_c3_7_lane_stays_lifecycle_blocked_until_activation_is_approved() -> Non
     )
     entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
     assert entry.activation_status is not ActivationStatus.ENABLED
+
+    gaps = mal.spot_demo_recovery_contract_gaps(entry)
+    assert set(gaps) == {"restart_trigger", "lane_native_evidence"}
+    assert set(gaps) <= set(mal.SPOT_DEMO_RECOVERY_CONTRACT_ITEMS)
+    assert (
+        mal.spot_demo_lifecycle_lane_status(entry)
+        is LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE
+    )
+
+    blockers = mal.spot_demo_activation_blockers(entry)
+    assert LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE.value in blockers
+    for gap in gaps:
+        assert f"recovery_gap={gap}" in blockers
+
+
+def test_c3_7_a_fully_wired_owner_has_no_recovery_gaps(
+    client: BinanceSpotDemoExecutionClient,
+) -> None:
+    """The verdict discriminates: it is not a constant dressed as a computation.
+
+    Given an owner holding both ports and an identity-known row, every item is
+    satisfied and the lifecycle verdict clears. Without this, ``blocked`` would
+    be indistinguishable from ``always returns blocked``.
+    """
+
+    composition = _composition(client, reservations=_RecordedReservations([]))
+    entry = _identity_known_entry()
+
+    assert mal.spot_demo_recovery_contract_gaps(entry, composition=composition) == ()
+    assert mal.spot_demo_lifecycle_lane_status(entry, composition=composition) is None
+    blockers = mal.spot_demo_activation_blockers(entry, composition=composition)
+    assert LaneStatus.AUTO_READY_BLOCKED_BY_LIFECYCLE.value not in blockers
+    # §D is untouched: policy is still the primary terminal status.
+    assert blockers[0] == LaneStatus.AUTO_READY_BLOCKED_BY_POLICY.value
+
+
+def test_c3_7_each_missing_recovery_item_is_reported_on_its_own(
+    client: BinanceSpotDemoExecutionClient,
+) -> None:
+    """Every gap has an independent cause, so one cannot mask another."""
+
+    wired = _composition(client, reservations=_RecordedReservations([]))
+    unwired = _composition(client)
+
+    # Identity unknown alone blocks the restart trigger, even fully wired.
+    signed = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    assert mal.spot_demo_recovery_contract_gaps(signed, composition=wired) == (
+        "restart_trigger",
+    )
+    # An unbound reservation port alone blocks it too, even with a known identity.
+    assert mal.spot_demo_recovery_contract_gaps(
+        _identity_known_entry(), composition=unwired
+    ) == ("restart_trigger",)
+
+
+def test_c3_7_the_runbook_states_the_computed_status_not_a_wish() -> None:
+    """The contract document must agree with what the code computes."""
+
+    runbook = (
+        _REPO_ROOT / "docs/runbooks/binance-spot-demo-mock-auto-limit.md"
+    ).read_text(encoding="utf-8")
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    for gap in mal.spot_demo_recovery_contract_gaps(entry):
+        assert f"`{gap}`" in runbook, f"unmet recovery item {gap} is undocumented"
+    assert "spot_demo_recovery_contract_gaps" in runbook
 
 
 def test_lane_evidence_port_is_required_at_construction(


### PR DESCRIPTION
J6B of program ROB-1256. A **separate** LIMIT composition for
`crypto.binance.spot_demo.canonical`, built on the merged J2A registry, J2B
lineage factory, J3A coordination port, and the ROB-298 execution client.

Base: `origin/main` `9dedd3b86aed1f74a573ed918d2a431caa3eb2aa`.
Predecessors verified as ancestors: J2A `e05794142`, J2B `094ab2d59`,
J3A `03beecc5f`, J3C `5c55aeed0`, J6A `a2faafba2`.

## Files (exact fence, nothing outside it)

| | |
|---|---|
| new | `app/services/brokers/binance/spot_demo/mock_auto_limit.py` |
| new | `tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py` |
| new | `docs/runbooks/binance-spot-demo-mock-auto-limit.md` |

`execution_client.py` read/reuse only. The registry, the ROB-845 adapter and
capabilities, paper cohort, B0-X scripts, futures_demo, and demo_strategy_loop
are all untouched.

## The mutation path is structurally unreachable

Not "switched off". For this lane `assert_entry_execution_ready` cannot pass
under **any** configuration: `ENABLED` trips `_violates_signed_lane_restriction`
(the lane is in `_SIGNED_LANE_STATUS_ALLOWLISTS`), and every other activation
status trips `lane_activation_not_enabled`. Proven exhaustively over all 24
`ActivationStatus` x writer x auto combinations.
`submit_limit_order(..., confirm=True)` is asserted to reach **zero HTTP and
zero durable-claim attempts**.

## D6 sizing — operator-fixed

LIMIT only; `quantity = floor_to_step(target_notional / limit_price)`; floor is
the only direction; below min qty or min notional there is **no plan at all**,
because rounding up to reach a venue minimum would place a larger order than the
decision authorized. Price source, price cutoff, step size, step version, and
the rounding delta all travel with the plan — dropping any one fails before
broker I/O. No cap is invented: the registry reports `MissingBinding.CAP`, so
the plan records `risk_caps={"cap_binding": "missing"}`.

## Currency (§83 correction 2)

USD and USDT are distinct. No parity or FX path exists (AST name scan plus a
token-stripped text scan, both empty, with a self-check that the pattern does
fire on a real conversion). `SIBLING_BINDING_FOR_EXECUTION = PENDING`, consumed
unchanged from the merged ROB-1269 contract rather than invented here.

## Recovery contract (§83 correction 3)

The runbook doubles as this lane's contract and names all six activation
preconditions — one recovery owner, the restart trigger, the authoritative
single-order readback (`GET /api/v3/order`), the seven lane-native evidence
kinds, the exact release condition, and the operator-visible blocked state
(`unknown_pending_reconcile`). A blind repost is structurally impossible:
`RestartDisposition.repost` takes no constructor argument.

## Lane status (§D)

Primary terminal status is exactly `AUTO_READY_BLOCKED_BY_POLICY`. The absent
scheduler owner is reported as a *secondary* activation blocker and is never
promoted to the primary status. The registry is not modified — mechanically
narrowing the signed allowlist is J2A-owned work.

## Verification

- `895 passed` across the three required test paths; ruff check, ruff format
  --check, and `ty check --error-on-warning` all clean.
- 15 adversarial mutants against the 12 signed claims: **all red, none
  survived**, both touched files restored to their exact baseline SHA-256.
- Guard tests assert at the guard function first and only then through the
  pre-dispatch chain, so a neutered guard fails at its own call site rather than
  falling through to a later check.
- Every zero-I/O claim is `httpx_mock.get_requests() == []` — an observed call
  count, not an inference.

## Not in this PR

No broker/network mutation, no canary, no scheduler registration, no migration
or DDL, no dependency change, no deploy or restart. C5
(TaskGroup/`asyncio.timeout` cancellation count) remains **UNKNOWN**, consistent
with J3A/J3B/J3C; this module introduces neither construct.

Merge is orch-mock's; this stays draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Binance Spot Demo LIMIT order composition with USDT-only sizing and step-size rounding.
  * Added safe submission, cancellation, restart recovery, and authoritative status reconciliation.
  * Added lifecycle status and activation-blocker reporting.
* **Documentation**
  * Added a runbook describing LIMIT rules, recovery behavior, cancellation semantics, and operational constraints.
* **Tests**
  * Added comprehensive offline coverage for validation, recovery, cancellation safety, attribution, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->