### PR TITLE
fix(ROB-1284): rung-driven evidence-first sweep for phantom resting rungs

### DIFF
--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -13,7 +13,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 from typing import cast as typing_cast
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -25,6 +25,10 @@ from app.mcp_server.tooling.order_journal import (
     _create_trade_journal_for_buy,
     _link_journal_to_fill,
     _save_order_fill,
+)
+from app.mcp_server.tooling.proposal_rung_convergence import (
+    candidate_scan_coverage,
+    run_resting_rung_sweep,
 )
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
@@ -620,6 +624,21 @@ async def _list_open_ledger_rows(
         return rows
 
 
+async def _count_open_ledger_rows(*, symbol: str | None, order_no: str | None) -> int:
+    """Total open rows, ignoring the scan limit (ROB-1284 AC3 truncation proof)."""
+    async with _order_session_factory()() as db:
+        stmt = (
+            select(func.count())
+            .select_from(KISLiveOrderLedger)
+            .where(KISLiveOrderLedger.status.in_(("accepted", "pending", "partial")))
+        )
+        if symbol:
+            stmt = stmt.where(KISLiveOrderLedger.symbol == symbol)
+        if order_no:
+            stmt = stmt.where(KISLiveOrderLedger.order_no == order_no)
+        return int((await db.execute(stmt)).scalar_one())
+
+
 async def _converge_kis_proposal_rung(
     row: KISLiveOrderLedger,
     *,
@@ -902,7 +921,12 @@ async def kis_live_reconcile_orders_impl(
         projection_repair = await _repair_terminal_kis_proposal_projections(
             symbol=symbol, order_id=order_id, limit=limit
         )
+    # ROB-1284: the ledger-driven repair above can only reach rungs whose ledger
+    # row is a listed projection candidate. This rung-driven sweep closes the
+    # remainder — untruncated, evidence-first, no broker call.
+    rung_sweep = await run_resting_rung_sweep(dry_run=dry_run)
     try:
+        open_total = await _count_open_ledger_rows(symbol=symbol, order_no=order_id)
         rows = await _list_open_ledger_rows(
             symbol=symbol, order_no=order_id, limit=limit
         )
@@ -948,6 +972,10 @@ async def kis_live_reconcile_orders_impl(
         "counts": counts,
         "reconciled": reconciled,
         "proposal_projection_repair": projection_repair,
+        "proposal_rung_sweep": rung_sweep,
+        "candidate_scan": candidate_scan_coverage(
+            scanned=len(rows), open_total=open_total, limit=limit
+        ),
         "message": message,
     }
 

--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -29,6 +29,7 @@ from app.mcp_server.tooling.order_journal import (
 from app.mcp_server.tooling.proposal_rung_convergence import (
     candidate_scan_coverage,
     run_resting_rung_sweep,
+    scanned_row_bounds,
 )
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
@@ -930,6 +931,7 @@ async def kis_live_reconcile_orders_impl(
         rows = await _list_open_ledger_rows(
             symbol=symbol, order_no=order_id, limit=limit
         )
+        _scanned_oldest, _scanned_newest = scanned_row_bounds(rows)
     except Exception as exc:
         logger.exception("Failed to list open kis_live ledger rows: %s", exc)
         return {
@@ -974,7 +976,12 @@ async def kis_live_reconcile_orders_impl(
         "proposal_projection_repair": projection_repair,
         "proposal_rung_sweep": rung_sweep,
         "candidate_scan": candidate_scan_coverage(
-            scanned=len(rows), open_total=open_total, limit=limit
+            scanned=len(rows),
+            open_total=open_total,
+            limit=limit,
+            oldest_scanned_at=_scanned_oldest,
+            newest_scanned_at=_scanned_newest,
+            now=datetime.datetime.now(datetime.UTC),
         ),
         "message": message,
     }

--- a/app/mcp_server/tooling/live_order_ledger.py
+++ b/app/mcp_server/tooling/live_order_ledger.py
@@ -26,6 +26,7 @@ from app.mcp_server.tooling.order_journal import (
 from app.mcp_server.tooling.proposal_rung_convergence import (
     candidate_scan_coverage,
     run_resting_rung_sweep,
+    scanned_row_bounds,
 )
 from app.models.review import LiveOrderLedger
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
@@ -566,6 +567,7 @@ async def live_reconcile_orders_impl(
         rows = await _list_open_live_ledger_rows(
             market=market, broker=broker, symbol=symbol, order_no=order_id, limit=limit
         )
+        scanned_oldest, scanned_newest = scanned_row_bounds(rows)
     except Exception as exc:
         logger.exception("Failed to list open live ledger rows: %s", exc)
         return {"success": False, "error": str(exc) or exc.__class__.__name__}
@@ -594,7 +596,12 @@ async def live_reconcile_orders_impl(
         "reconciled": reconciled,
         "proposal_rung_sweep": rung_sweep,
         "candidate_scan": candidate_scan_coverage(
-            scanned=len(rows), open_total=open_total, limit=limit
+            scanned=len(rows),
+            open_total=open_total,
+            limit=limit,
+            oldest_scanned_at=scanned_oldest,
+            newest_scanned_at=scanned_newest,
+            now=datetime.now(UTC),
         ),
         "message": f"Reconciled {len(reconciled)} live order(s) (dry_run={dry_run}): {counts}",
     }

--- a/app/mcp_server/tooling/live_order_ledger.py
+++ b/app/mcp_server/tooling/live_order_ledger.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.core.timezone import now_kst
 from app.mcp_server.tooling.fx_pnl import capture_reconcile_spot_fx
@@ -22,6 +22,10 @@ from app.mcp_server.tooling.order_journal import (
     _create_trade_journal_for_buy,
     _link_journal_to_fill,
     _save_order_fill,
+)
+from app.mcp_server.tooling.proposal_rung_convergence import (
+    candidate_scan_coverage,
+    run_resting_rung_sweep,
 )
 from app.models.review import LiveOrderLedger
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
@@ -148,6 +152,31 @@ def _derive_live_send_status(*, rt_cd: str | None, order_no: str | None) -> str:
     if order_no:
         return "accepted"
     return "rejected" if rt_cd not in (None, "0", "") else "accepted"
+
+
+async def _count_open_live_ledger_rows(
+    *,
+    market: str | None,
+    broker: str | None,
+    symbol: str | None,
+    order_no: str | None,
+) -> int:
+    """Total open rows ignoring the scan limit (ROB-1284 AC3 truncation proof)."""
+    async with _order_session_factory()() as db:
+        stmt = (
+            select(func.count())
+            .select_from(LiveOrderLedger)
+            .where(LiveOrderLedger.status.in_(("accepted", "pending", "partial")))
+        )
+        if market:
+            stmt = stmt.where(LiveOrderLedger.market == market)
+        if broker:
+            stmt = stmt.where(LiveOrderLedger.broker == broker)
+        if symbol:
+            stmt = stmt.where(LiveOrderLedger.symbol == symbol)
+        if order_no:
+            stmt = stmt.where(LiveOrderLedger.order_no == order_no)
+        return int((await db.execute(stmt)).scalar_one())
 
 
 async def _list_open_live_ledger_rows(
@@ -524,7 +553,16 @@ async def live_reconcile_orders_impl(
     dry_run: bool = True,
     limit: int = 100,
 ) -> dict[str, Any]:
+    # ROB-1284: this path had NO proposal-rung repair pre-pass at all (KIS and
+    # Toss each grew one; US/crypto never did), so a rung whose ledger row went
+    # terminal without its projection landing stayed `resting` forever. The
+    # rung-driven sweep is untruncated and evidence-first, and makes no broker
+    # call — see proposal_rung_convergence.
+    rung_sweep = await run_resting_rung_sweep(dry_run=dry_run)
     try:
+        open_total = await _count_open_live_ledger_rows(
+            market=market, broker=broker, symbol=symbol, order_no=order_id
+        )
         rows = await _list_open_live_ledger_rows(
             market=market, broker=broker, symbol=symbol, order_no=order_id, limit=limit
         )
@@ -554,6 +592,10 @@ async def live_reconcile_orders_impl(
         "dry_run": dry_run,
         "counts": counts,
         "reconciled": reconciled,
+        "proposal_rung_sweep": rung_sweep,
+        "candidate_scan": candidate_scan_coverage(
+            scanned=len(rows), open_total=open_total, limit=limit
+        ),
         "message": f"Reconciled {len(reconciled)} live order(s) (dry_run={dry_run}): {counts}",
     }
 

--- a/app/mcp_server/tooling/proposal_rung_convergence.py
+++ b/app/mcp_server/tooling/proposal_rung_convergence.py
@@ -1,0 +1,114 @@
+"""ROB-1284 — shared reconcile-side wiring for the phantom-resting rung sweep.
+
+The three live reconcile kernels (KIS KR, Toss, US/crypto) each project broker
+evidence onto proposal rungs, but all three project *from a ledger row they are
+already iterating*.  A rung whose ledger row is terminal-and-therefore-no-longer-
+scanned, or whose ledger row never existed, is unreachable from that direction —
+the gap ``live_order_ledger._converge_proposal_rung`` documents as "a
+guaranteed-convergence proposal-rung reconcile sweep is tracked as follow-up".
+
+This module is the wiring for that sweep.  It runs from the rung side, over the
+whole population (no limit, no window), on every non-dry-run reconcile pass, so
+DAY expiry that reached the ledger converges into rung state on *the next
+reconcile* rather than never.
+
+Deliberately additive: no scheduler is registered here.  This piggybacks on the
+reconcile passes that already run; it creates no new recurrence of its own.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+from typing import cast as typing_cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.services.order_proposals.resting_sweep_service import RestingRungSweepService
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["candidate_scan_coverage", "run_resting_rung_sweep"]
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return typing_cast(
+        async_sessionmaker[AsyncSession], typing_cast(object, AsyncSessionLocal)
+    )
+
+
+async def run_resting_rung_sweep(*, dry_run: bool) -> dict[str, Any]:
+    """Converge every rung that has committed terminal broker evidence.
+
+    Returns a compact summary for the reconcile payload.  Evidence-first
+    throughout: ``NO_EVIDENCE`` and ``CONFLICT`` rungs are counted and reported,
+    never transitioned.
+
+    A sweep failure is reported in the payload (``"error"``), not raised — the
+    ledger booking the caller just performed stays authoritative — but it is
+    also logged at ERROR so a persistently failing sweep is alertable rather
+    than a silently empty section.
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    try:
+        async with _session_factory()() as db:
+            service = RestingRungSweepService(db)
+            result = await service.apply(now=now, dry_run=dry_run, confirm=not dry_run)
+            if not dry_run:
+                await db.commit()
+    except Exception as exc:  # noqa: BLE001 - never fail the caller's reconcile
+        logger.error(
+            "ROB-1284 resting rung sweep failed (dry_run=%s): %s", dry_run, exc
+        )
+        return {"ran": False, "error": str(exc) or exc.__class__.__name__}
+    return {
+        "ran": True,
+        "dry_run": dry_run,
+        "summary": result["summary"],
+        "applied": result["applied"],
+        "failed": result["failed"],
+    }
+
+
+def candidate_scan_coverage(
+    *, scanned: int, open_total: int | None, limit: int
+) -> dict[str, Any]:
+    """Describe what a limited candidate scan did NOT look at (AC3).
+
+    The reconcile candidate scans order by ``created_at ASC`` and cut at
+    ``limit``.  When the open population exceeds the limit, the *oldest* rows
+    occupy every slot on every pass — and those are precisely the rows already
+    past the broker's lookback window, so they never resolve and never yield
+    their slot.  Newer, resolvable rows are then never scanned at all.
+
+    Silently returning "reconciled N" while M rows were never looked at reads as
+    full coverage.  This makes the shortfall explicit in the payload.
+    """
+    if open_total is None:
+        return {
+            "scanned": scanned,
+            "limit": limit,
+            "open_total": None,
+            "truncated": None,
+        }
+    unscanned = max(0, open_total - scanned)
+    return {
+        "scanned": scanned,
+        "limit": limit,
+        "open_total": open_total,
+        "unscanned": unscanned,
+        "truncated": unscanned > 0,
+        **(
+            {
+                "note": (
+                    f"{unscanned} open row(s) were never scanned this pass "
+                    f"(limit={limit}); the scan is oldest-first, so raising "
+                    "`limit` is required for them to be reached at all."
+                )
+            }
+            if unscanned > 0
+            else {}
+        ),
+    }

--- a/app/mcp_server/tooling/proposal_rung_convergence.py
+++ b/app/mcp_server/tooling/proposal_rung_convergence.py
@@ -30,7 +30,27 @@ from app.services.order_proposals.resting_sweep_service import RestingRungSweepS
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["candidate_scan_coverage", "run_resting_rung_sweep"]
+__all__ = ["candidate_scan_coverage", "run_resting_rung_sweep", "scanned_row_bounds"]
+
+# Every open-row candidate scan in the three reconcile kernels uses this order.
+_SCAN_ORDER = "created_at ASC (oldest-first)"
+
+
+def scanned_row_bounds(
+    rows: list[Any],
+) -> tuple[datetime.datetime | None, datetime.datetime | None]:
+    """(oldest, newest) ``created_at`` across the rows a pass actually scanned.
+
+    Computed from the rows already in hand — no extra query — and by min/max
+    rather than by index, because one caller (Toss) merges reopened rows into
+    the work-list and so cannot assume the list stayed sorted.
+    """
+    stamps = [
+        row.created_at for row in rows if getattr(row, "created_at", None) is not None
+    ]
+    if not stamps:
+        return None, None
+    return min(stamps), max(stamps)
 
 
 def _session_factory() -> async_sessionmaker[AsyncSession]:
@@ -73,7 +93,13 @@ async def run_resting_rung_sweep(*, dry_run: bool) -> dict[str, Any]:
 
 
 def candidate_scan_coverage(
-    *, scanned: int, open_total: int | None, limit: int
+    *,
+    scanned: int,
+    open_total: int | None,
+    limit: int,
+    oldest_scanned_at: datetime.datetime | None = None,
+    newest_scanned_at: datetime.datetime | None = None,
+    now: datetime.datetime | None = None,
 ) -> dict[str, Any]:
     """Describe what a limited candidate scan did NOT look at (AC3).
 
@@ -85,6 +111,24 @@ def candidate_scan_coverage(
 
     Silently returning "reconciled N" while M rows were never looked at reads as
     full coverage.  This makes the shortfall explicit in the payload.
+
+    The shortfall is reported as **starvation, not backlog**, because that is
+    what it measures.  A backlog drains: next pass reaches what this pass
+    missed.  This does not — the scan re-selects the same oldest rows every
+    time, so the unreached set is stable and the newest rows are unreachable for
+    as long as the slot holders stay open.  Two extra facts make that legible
+    without a second query, when the caller can supply them:
+
+    * ``unreached_created_after`` — the newest ``created_at`` this pass actually
+      reached.  Every open row newer than that was not looked at, this pass or
+      any pass with the same limit.
+    * ``oldest_scanned_age_days`` — how long the row holding slot #1 has been
+      sitting there.  A large number is the direct evidence that the holders do
+      not turn over.
+
+    A fair-rotation scan (or a per-row last-attempt column) is the actual fix and
+    needs a migration, so it is out of this PR's scope; surfacing the number is
+    what keeps the gap from reading as coverage in the meantime.
     """
     if open_total is None:
         return {
@@ -92,23 +136,38 @@ def candidate_scan_coverage(
             "limit": limit,
             "open_total": None,
             "truncated": None,
+            "scan_order": _SCAN_ORDER,
         }
     unscanned = max(0, open_total - scanned)
-    return {
+    coverage: dict[str, Any] = {
         "scanned": scanned,
         "limit": limit,
         "open_total": open_total,
         "unscanned": unscanned,
         "truncated": unscanned > 0,
-        **(
-            {
-                "note": (
-                    f"{unscanned} open row(s) were never scanned this pass "
-                    f"(limit={limit}); the scan is oldest-first, so raising "
-                    "`limit` is required for them to be reached at all."
-                )
-            }
-            if unscanned > 0
-            else {}
-        ),
+        "scan_order": _SCAN_ORDER,
     }
+    if unscanned == 0:
+        return coverage
+
+    frontier = newest_scanned_at.isoformat() if newest_scanned_at else None
+    age_days: int | None = None
+    if oldest_scanned_at is not None and now is not None:
+        age_days = max(0, (now - oldest_scanned_at).days)
+    coverage["unreached_created_after"] = frontier
+    coverage["oldest_scanned_age_days"] = age_days
+    coverage["note"] = (
+        f"{unscanned} open row(s) were never scanned this pass (limit={limit}); "
+        f"the scan is {_SCAN_ORDER}, so the same oldest rows refill every slot "
+        "on every pass and this shortfall is persistent, not a draining backlog"
+        + (f" — nothing created after {frontier} is reached" if frontier else "")
+        + (
+            f", while the row holding slot #1 has been open {age_days} day(s)"
+            if age_days is not None
+            else ""
+        )
+        + ". Raising `limit` is required for them to be reached at all; fair "
+        "rotation (a per-row last-attempt column) needs a migration and is "
+        "tracked separately."
+    )
+    return coverage

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -24,6 +24,7 @@ from app.mcp_server.tooling.order_journal import (
 from app.mcp_server.tooling.proposal_rung_convergence import (
     candidate_scan_coverage,
     run_resting_rung_sweep,
+    scanned_row_bounds,
 )
 from app.mcp_server.tooling.toss_live_evidence import (
     TossBatchEvidenceSource,
@@ -808,6 +809,12 @@ async def toss_reconcile_orders_impl(
                         TossLiveOrderLedger.status.in_(
                             ("accepted", "pending", "partial")
                         ),
+                        # Same predicate as `list_open` — a denominator wider
+                        # than the scan's own population would report rows as
+                        # "unreached" that the scan was never going to take.
+                        TossLiveOrderLedger.operation_kind.in_(
+                            ("place", "modify", "cancel")
+                        ),
                         *([TossLiveOrderLedger.symbol == symbol] if symbol else []),
                         *(
                             [TossLiveOrderLedger.broker_order_id == order_id]
@@ -829,6 +836,8 @@ async def toss_reconcile_orders_impl(
                 continue
             seen.add(row.id)
             rows.append(row)
+        # Read inside the session block: `rows` detaches at block exit.
+        scanned_oldest, scanned_newest = scanned_row_bounds(rows)
 
     reconciled: list[dict[str, Any]] = []
     counts: dict[str, int] = {}
@@ -901,7 +910,12 @@ async def toss_reconcile_orders_impl(
         "proposal_projection_repair": projection_repair,
         "proposal_rung_sweep": rung_sweep,
         "candidate_scan": candidate_scan_coverage(
-            scanned=len(rows), open_total=open_total, limit=limit
+            scanned=len(rows),
+            open_total=open_total,
+            limit=limit,
+            oldest_scanned_at=scanned_oldest,
+            newest_scanned_at=scanned_newest,
+            now=datetime.now(UTC),
         ),
         "batch_build_error": batch_build_error,
         "message": (

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 import sentry_sdk
+from sqlalchemy import func, select
 
 from app.core.config import settings
 from app.core.portfolio_links import build_position_detail_url
@@ -19,6 +20,10 @@ from app.mcp_server.tooling.order_journal import (
     _create_trade_journal_for_buy,
     _link_journal_to_fill,
     _save_order_fill,
+)
+from app.mcp_server.tooling.proposal_rung_convergence import (
+    candidate_scan_coverage,
+    run_resting_rung_sweep,
 )
 from app.mcp_server.tooling.toss_live_evidence import (
     TossBatchEvidenceSource,
@@ -774,6 +779,10 @@ async def toss_reconcile_orders_impl(
             market=market,
             limit=limit,
         )
+    # ROB-1284: rung-driven guaranteed-convergence sweep (untruncated,
+    # evidence-first, no broker call) — closes the rungs the ledger-driven
+    # repair above structurally cannot reach.
+    rung_sweep = await run_resting_rung_sweep(dry_run=dry_run)
 
     # Self-healing reopen + list_open run in ONE session block so both the
     # recoverable-anomaly rows and the open rows are live-session ORM objects that
@@ -789,6 +798,26 @@ async def toss_reconcile_orders_impl(
             order_id=order_id,
             market=market,
             limit=limit,
+        )
+        open_total = int(
+            (
+                await db.execute(
+                    select(func.count())
+                    .select_from(TossLiveOrderLedger)
+                    .where(
+                        TossLiveOrderLedger.status.in_(
+                            ("accepted", "pending", "partial")
+                        ),
+                        *([TossLiveOrderLedger.symbol == symbol] if symbol else []),
+                        *(
+                            [TossLiveOrderLedger.broker_order_id == order_id]
+                            if order_id
+                            else []
+                        ),
+                        *([TossLiveOrderLedger.market == market] if market else []),
+                    )
+                )
+            ).scalar_one()
         )
         # Work-list = list_open rows + reopened rows, deduped by ledger id
         # (a non-dry-run reopened row is now 'accepted' and may also be in
@@ -870,6 +899,10 @@ async def toss_reconcile_orders_impl(
         "reconciled": reconciled,
         "reopened": reopen_report,  # {dry_run, reopened, candidates}
         "proposal_projection_repair": projection_repair,
+        "proposal_rung_sweep": rung_sweep,
+        "candidate_scan": candidate_scan_coverage(
+            scanned=len(rows), open_total=open_total, limit=limit
+        ),
         "batch_build_error": batch_build_error,
         "message": (
             f"Reconciled {len(reconciled)} Toss live order(s) "

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -27,7 +27,10 @@ from app.models.order_proposals import (
 )
 from app.services.order_proposals.defensive_ttl import DEFENSIVE_EXIT_INTENTS
 from app.services.order_proposals.dispatch_contract import ApprovalDispatchState
-from app.services.order_proposals.state_machine import PROPOSAL_TERMINAL_STATES
+from app.services.order_proposals.state_machine import (
+    EVIDENCE_ACCEPTING_RUNG_STATES,
+    PROPOSAL_TERMINAL_STATES,
+)
 
 
 class OrderProposalRepository:
@@ -398,6 +401,29 @@ class OrderProposalRepository:
                 OrderProposalRung.state == "pending_approval",
                 OrderProposalRung.broker_order_id.is_(None),
             )
+            .order_by(OrderProposalRung.id)
+        )
+        rows = (await self._session.execute(stmt)).all()
+        return [(row[0], row[1]) for row in rows]
+
+    # ROB-1284: rung-driven, deliberately UNBOUNDED. Every other path that can
+    # surface these rungs pages by proposal recency and therefore undercounts
+    # them (order_proposal_list clamps to 200 proposals; the reconcile candidate
+    # scans clamp to 100 ledger rows). The phantom-resting population is defined
+    # by rung state, not by recency, so neither a limit nor a time window may be
+    # applied here -- a truncated answer to "what is still broker-live?" is the
+    # bug, not a performance tuning knob. Bounded in practice by the index on
+    # order_proposal_rungs.state.
+    async def list_evidence_accepting_rungs(
+        self,
+    ) -> list[tuple[OrderProposal, OrderProposalRung]]:
+        stmt = (
+            select(OrderProposal, OrderProposalRung)
+            .join(
+                OrderProposalRung,
+                OrderProposalRung.proposal_pk == OrderProposal.id,
+            )
+            .where(OrderProposalRung.state.in_(EVIDENCE_ACCEPTING_RUNG_STATES))
             .order_by(OrderProposalRung.id)
         )
         rows = (await self._session.execute(stmt)).all()

--- a/app/services/order_proposals/resting_sweep.py
+++ b/app/services/order_proposals/resting_sweep.py
@@ -1,0 +1,305 @@
+"""ROB-1284 — evidence-first convergence sweep for phantom broker-live rungs.
+
+Why this exists
+---------------
+``sweep_expired`` deliberately *skips* any group holding a rung in a
+non-voidable state (``service.py`` -- "a partially-submitted or filled proposal
+past its window must not be force-expired").  That is correct: a local clock is
+not evidence about a broker order.  But nothing else ever closes those rungs
+either, so a rung whose broker order died long ago stays ``resting`` forever and
+downstream consumers keep reserving buying power for a net that no longer
+exists, and keep blocking legitimate opposite-side proposals.
+
+``live_order_ledger._converge_proposal_rung`` names the missing piece verbatim:
+"A guaranteed-convergence proposal-rung reconcile sweep is tracked as
+follow-up."  This module is that sweep.
+
+Two structural differences from the existing repair pre-passes
+(``_repair_terminal_kis_proposal_projections`` /
+``_repair_terminal_toss_proposal_projections``):
+
+1. **Rung-driven, not ledger-driven.**  The existing passes start from ledger
+   rows and can only fix rungs whose ledger row is a listed projection
+   candidate.  A rung whose ledger row was never created, or was created under a
+   different key, is invisible to them.  This sweep starts from the rung.
+2. **Untruncated.**  No ``limit``, no time window -- the candidate set is
+   defined by rung state alone.  Every paged path in the system (see the module
+   ``QUERY_PATH_LIMITS`` note below) undercounts this population.
+
+Safety contract (evidence-first, fail-closed)
+---------------------------------------------
+* A rung is transitioned **only** on committed terminal broker evidence.
+* Absent, unreadable, still-open, or contradictory evidence transitions
+  *nothing* -- it is reported, never absorbed into the transition set.
+* ``classify_rung`` is pure (stdlib only, no DB/network/clock): the caller
+  injects both the evidence and ``observed_at``.
+* The sweep never contacts a broker and never mutates a broker.  Its evidence is
+  the already-committed ``*_order_ledger`` rows, which the ROB-395/407 reconcile
+  kernel booked from broker responses.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from decimal import Decimal
+from enum import StrEnum
+
+from app.services.order_proposals import state_machine as sm
+
+__all__ = [
+    "LEDGER_OPEN_STATUSES",
+    "LEDGER_STATUS_TO_RUNG_TERMINAL",
+    "LedgerEvidence",
+    "RungCandidate",
+    "RungVerdict",
+    "SweepDecision",
+    "classify_rung",
+]
+
+
+class RungVerdict(StrEnum):
+    """The three — and only three — outcomes a candidate rung can receive.
+
+    Only ``TRANSITION`` is ever applied.  ``NO_EVIDENCE`` and ``CONFLICT`` are
+    reported and left untouched; collapsing either of them into ``TRANSITION``
+    is the failure mode this whole module exists to prevent.
+    """
+
+    TRANSITION = "TRANSITION"
+    NO_EVIDENCE = "NO_EVIDENCE"
+    CONFLICT = "CONFLICT"
+
+
+# A ledger row in one of these statuses is still live at the broker as far as
+# the ledger knows.  It is NOT expiry evidence -- ``partial`` in particular is an
+# open status in every reconcile candidate scan, and booking partial fills is
+# the reconcile kernel's job, not this sweep's.
+LEDGER_OPEN_STATUSES: frozenset[str] = frozenset({"accepted", "pending", "partial"})
+
+# Terminal ledger status -> rung terminal state.
+#
+# ``rejected`` -> ``expired`` mirrors the KIS reconcile kernel: a broker
+# rejection observed *after* submission is expiry evidence for a resting DAY
+# rung, not the submit-time ``rejected`` transition (which ``resting`` cannot
+# reach anyway).
+#
+# NOTE (divergence, deliberate): the US/crypto path maps ledger ``expired`` to
+# rung ``cancelled`` on the stale premise that "proposal rungs have no separate
+# expired state".  They do -- ``resting -> expired`` is a legal edge.  This
+# sweep books DAY expiry as ``expired`` so the rung records what actually
+# happened.  The existing path is left untouched here; see the report.
+LEDGER_STATUS_TO_RUNG_TERMINAL: dict[str, str] = {
+    "filled": "filled",
+    "cancelled": "cancelled",
+    "canceled": "cancelled",
+    "expired": "expired",
+    "rejected": "expired",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class LedgerEvidence:
+    """One committed broker-evidence ledger row matched to a rung."""
+
+    ledger_table: str
+    ledger_id: int
+    status: str
+    match_key: str
+    broker_order_id: str | None = None
+    idempotency_key: str | None = None
+    correlation_id: str | None = None
+    filled_qty: Decimal | None = None
+    reconciled_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class RungCandidate:
+    """A rung currently in a broker-live (evidence-accepting) state."""
+
+    proposal_id: str
+    rung_id: int
+    rung_index: int
+    state: str
+    side: str
+    symbol: str
+    market: str
+    account_mode: str
+    broker_order_id: str | None
+    idempotency_key: str | None
+    correlation_id: str | None
+    quantity: Decimal | None = None
+    limit_price: Decimal | None = None
+    updated_at: datetime.datetime | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class SweepDecision:
+    """Per-rung verdict with the evidence that produced it.
+
+    Every field a reviewer needs to audit one row without re-querying:
+    broker order id, broker/ledger status, remaining (unfilled) quantity, the
+    observation time, and the classification itself.
+    """
+
+    candidate: RungCandidate
+    verdict: RungVerdict
+    reason_code: str
+    observed_at: datetime.datetime
+    target_state: str | None = None
+    evidence: tuple[LedgerEvidence, ...] = ()
+
+    @property
+    def remaining_qty(self) -> Decimal | None:
+        """Unfilled quantity implied by the evidence, or None if unknown."""
+        if self.candidate.quantity is None:
+            return None
+        filled = next(
+            (e.filled_qty for e in self.evidence if e.filled_qty is not None), None
+        )
+        return self.candidate.quantity - (filled or Decimal(0))
+
+    def as_row(self) -> dict[str, object]:
+        """Flat, audit-ready record for the dry-run report."""
+        remaining = self.remaining_qty
+        return {
+            "proposal_id": self.candidate.proposal_id,
+            "rung_index": self.candidate.rung_index,
+            "rung_id": self.candidate.rung_id,
+            "symbol": self.candidate.symbol,
+            "market": self.candidate.market,
+            "account_mode": self.candidate.account_mode,
+            "side": self.candidate.side,
+            "rung_state": self.candidate.state,
+            "verdict": str(self.verdict),
+            "reason_code": self.reason_code,
+            "target_state": self.target_state,
+            "broker_order_id": self.candidate.broker_order_id,
+            "ledger_rows": [
+                {
+                    "table": e.ledger_table,
+                    "ledger_id": e.ledger_id,
+                    "status": e.status,
+                    "matched_by": e.match_key,
+                    "reconciled_at": (
+                        e.reconciled_at.isoformat() if e.reconciled_at else None
+                    ),
+                }
+                for e in self.evidence
+            ],
+            "remaining_qty": str(remaining) if remaining is not None else None,
+            "observed_at": self.observed_at.isoformat(),
+        }
+
+
+def _is_terminal_status(status: str) -> bool:
+    return status.strip().lower() not in LEDGER_OPEN_STATUSES
+
+
+def classify_rung(
+    candidate: RungCandidate,
+    evidence: tuple[LedgerEvidence, ...],
+    *,
+    observed_at: datetime.datetime,
+) -> SweepDecision:
+    """Decide one rung's fate from its ledger evidence. Pure — no I/O, no clock.
+
+    Fail-closed at every branch: the ``TRANSITION`` verdict is returned only
+    when exactly one terminal rung state is implied by the evidence *and* the
+    state machine permits reaching it from the rung's current state.
+    """
+
+    def decide(
+        verdict: RungVerdict, reason: str, target: str | None = None
+    ) -> SweepDecision:
+        return SweepDecision(
+            candidate=candidate,
+            verdict=verdict,
+            reason_code=reason,
+            observed_at=observed_at,
+            target_state=target,
+            evidence=evidence,
+        )
+
+    if candidate.state not in sm.RUNG_STATES:
+        return decide(RungVerdict.CONFLICT, "unknown_rung_state")
+    if sm.is_terminal(candidate.state):
+        # Already converged; not this sweep's business.
+        return decide(RungVerdict.NO_EVIDENCE, "rung_already_terminal")
+
+    if not any(
+        (
+            candidate.broker_order_id,
+            candidate.idempotency_key,
+            candidate.correlation_id,
+        )
+    ):
+        # Nothing to match on. This is the ROB-1277 shape (broker_order_id
+        # permanently null) and it is NOT expiry evidence.
+        return decide(RungVerdict.NO_EVIDENCE, "no_evidence_keys")
+
+    if not evidence:
+        return decide(RungVerdict.NO_EVIDENCE, "no_ledger_row")
+
+    terminal = tuple(e for e in evidence if _is_terminal_status(e.status))
+    if not terminal:
+        # The ledger itself still believes the order is live. Absence of a
+        # terminal marking is not evidence of expiry.
+        return decide(RungVerdict.NO_EVIDENCE, "ledger_still_open")
+
+    unmapped = tuple(
+        e
+        for e in terminal
+        if e.status.strip().lower() not in LEDGER_STATUS_TO_RUNG_TERMINAL
+    )
+    if unmapped:
+        return decide(RungVerdict.CONFLICT, "unmapped_ledger_status")
+
+    targets = {
+        LEDGER_STATUS_TO_RUNG_TERMINAL[e.status.strip().lower()] for e in terminal
+    }
+    if len(targets) > 1:
+        return decide(RungVerdict.CONFLICT, "ledger_evidence_disagrees")
+
+    target = next(iter(targets))
+    if target == candidate.state:
+        return decide(RungVerdict.NO_EVIDENCE, "already_in_target_state", target)
+
+    try:
+        sm.assert_rung_transition(candidate.state, target)
+    except Exception:  # noqa: BLE001 - the state machine owns the message
+        # e.g. `acked` -> `expired`: the broker says expired but the rung was
+        # never recorded as resting. Real modelling conflict; a human decides.
+        return decide(RungVerdict.CONFLICT, "transition_not_permitted", target)
+
+    return decide(RungVerdict.TRANSITION, "terminal_broker_evidence", target)
+
+
+def summarize(decisions: list[SweepDecision]) -> dict[str, object]:
+    """Aggregate counts, always broken down by reason code and by side.
+
+    No silent caps: every candidate lands in exactly one verdict bucket and the
+    buy/sell split is always reported (the phantom population is mixed-side and
+    a sell-only summary hides live buying-power impact).
+    """
+    by_verdict: dict[str, int] = {v.value: 0 for v in RungVerdict}
+    by_reason: dict[str, int] = {}
+    by_side: dict[str, dict[str, int]] = {}
+    by_account: dict[str, dict[str, int]] = {}
+    for d in decisions:
+        by_verdict[str(d.verdict)] += 1
+        by_reason[d.reason_code] = by_reason.get(d.reason_code, 0) + 1
+        side_bucket = by_side.setdefault(d.candidate.side, dict.fromkeys(by_verdict, 0))
+        side_bucket[str(d.verdict)] += 1
+        acct_bucket = by_account.setdefault(
+            d.candidate.account_mode, dict.fromkeys(by_verdict, 0)
+        )
+        acct_bucket[str(d.verdict)] += 1
+    return {
+        "candidates": len(decisions),
+        "by_verdict": by_verdict,
+        "by_reason_code": dict(sorted(by_reason.items())),
+        "by_side": by_side,
+        "by_account_mode": by_account,
+    }

--- a/app/services/order_proposals/resting_sweep.py
+++ b/app/services/order_proposals/resting_sweep.py
@@ -141,6 +141,12 @@ class SweepDecision:
     Every field a reviewer needs to audit one row without re-querying:
     broker order id, broker/ledger status, remaining (unfilled) quantity, the
     observation time, and the classification itself.
+
+    ``ownership_conflict`` records that at least one *matched* ledger row was
+    refused attribution to this rung and dropped from ``evidence``.  It is kept
+    on the decision even when the surviving evidence would classify cleanly: a
+    conflict that was observed and then dropped from the response is a conflict
+    the operator never gets to see.
     """
 
     candidate: RungCandidate
@@ -149,6 +155,7 @@ class SweepDecision:
     observed_at: datetime.datetime
     target_state: str | None = None
     evidence: tuple[LedgerEvidence, ...] = ()
+    ownership_conflict: str | None = None
 
     @property
     def remaining_qty(self) -> Decimal | None:
@@ -189,6 +196,7 @@ class SweepDecision:
                 for e in self.evidence
             ],
             "remaining_qty": str(remaining) if remaining is not None else None,
+            "ownership_conflict": self.ownership_conflict,
             "observed_at": self.observed_at.isoformat(),
         }
 
@@ -202,17 +210,37 @@ def classify_rung(
     evidence: tuple[LedgerEvidence, ...],
     *,
     observed_at: datetime.datetime,
+    ownership_conflict: str | None = None,
 ) -> SweepDecision:
     """Decide one rung's fate from its ledger evidence. Pure — no I/O, no clock.
 
     Fail-closed at every branch: the ``TRANSITION`` verdict is returned only
     when exactly one terminal rung state is implied by the evidence *and* the
     state machine permits reaching it from the rung's current state.
+
+    ``ownership_conflict`` is the caller's report that some matched ledger row
+    was refused attribution to this rung and dropped before classification
+    (``RestingRungSweepService.verify_ownership``).  Two things follow, and both
+    matter:
+
+    * it is recorded on **every** verdict, so the fact that a conflict existed
+      never disappears just because the surviving subset classified cleanly;
+    * it **downgrades a would-be TRANSITION to CONFLICT**.  "Some of the rows
+      that matched this rung's keys could not be attributed to it" is
+      contradictory evidence, and this module's whole contract is that
+      contradictory evidence transitions nothing.
     """
 
     def decide(
         verdict: RungVerdict, reason: str, target: str | None = None
     ) -> SweepDecision:
+        if verdict is RungVerdict.TRANSITION and ownership_conflict is not None:
+            # Never write off a partially-attributable evidence set.
+            verdict, reason, target = (
+                RungVerdict.CONFLICT,
+                "ownership_conflict_with_partial_evidence",
+                None,
+            )
         return SweepDecision(
             candidate=candidate,
             verdict=verdict,
@@ -220,6 +248,7 @@ def classify_rung(
             observed_at=observed_at,
             target_state=target,
             evidence=evidence,
+            ownership_conflict=ownership_conflict,
         )
 
     if candidate.state not in sm.RUNG_STATES:
@@ -287,8 +316,11 @@ def summarize(decisions: list[SweepDecision]) -> dict[str, object]:
     by_reason: dict[str, int] = {}
     by_side: dict[str, dict[str, int]] = {}
     by_account: dict[str, dict[str, int]] = {}
+    ownership_conflicts = 0
     for d in decisions:
         by_verdict[str(d.verdict)] += 1
+        if d.ownership_conflict is not None:
+            ownership_conflicts += 1
         by_reason[d.reason_code] = by_reason.get(d.reason_code, 0) + 1
         side_bucket = by_side.setdefault(d.candidate.side, dict.fromkeys(by_verdict, 0))
         side_bucket[str(d.verdict)] += 1
@@ -302,4 +334,8 @@ def summarize(decisions: list[SweepDecision]) -> dict[str, object]:
         "by_reason_code": dict(sorted(by_reason.items())),
         "by_side": by_side,
         "by_account_mode": by_account,
+        # Rungs where at least one matched ledger row was refused attribution
+        # and dropped. Counted at the top level so it cannot be lost in the
+        # per-reason breakdown of whatever the surviving subset classified as.
+        "ownership_conflicts": ownership_conflicts,
     }

--- a/app/services/order_proposals/resting_sweep_service.py
+++ b/app/services/order_proposals/resting_sweep_service.py
@@ -175,6 +175,10 @@ class RestingRungSweepService:
         resolving key set to intersect on a single rung. Anything it refuses to
         resolve, or resolves to a different rung, is dropped from the evidence
         set and reported as a conflict. It is never treated as evidence here.
+
+        The returned conflict is not advisory: ``plan`` forwards it into the
+        decision, where it blocks a transition and stays in the reported row.
+        A row dropped here must not become a row nobody hears about.
         """
         from app.services.order_proposals.errors import OrderProposalError
         from app.services.order_proposals.service import OrderProposalsService
@@ -241,10 +245,21 @@ class RestingRungSweepService:
                         verdict=RungVerdict.CONFLICT,
                         reason_code=conflict,
                         observed_at=now,
+                        ownership_conflict=conflict,
                     )
                 )
                 continue
-            decisions.append(classify_rung(candidate, evidence, observed_at=now))
+            # `conflict` is forwarded, never dropped: when ownership refused some
+            # rows but not all, the surviving subset must not silently classify
+            # as if the refusal never happened.
+            decisions.append(
+                classify_rung(
+                    candidate,
+                    evidence,
+                    observed_at=now,
+                    ownership_conflict=conflict,
+                )
+            )
         return decisions
 
     async def report(self, *, now: datetime.datetime) -> dict[str, Any]:

--- a/app/services/order_proposals/resting_sweep_service.py
+++ b/app/services/order_proposals/resting_sweep_service.py
@@ -1,0 +1,336 @@
+"""ROB-1284 — I/O layer for the phantom-resting rung convergence sweep.
+
+Splits cleanly from ``resting_sweep`` (pure classification) so the safety rules
+can be unit- and mutation-tested without a database:
+
+* ``resting_sweep.classify_rung``   — pure decision, no I/O, injected clock.
+* ``RestingRungSweepService``       — gathers candidates + evidence, applies.
+
+Nothing here contacts a broker.  Evidence is read from the already-committed
+``*_order_ledger`` tables, which the ROB-395/407 reconcile kernel populates from
+broker responses only.
+
+``dry_run`` is the default on every entry point, and ``dry_run=False`` alone is
+still not enough: ``apply`` additionally requires ``confirm=True``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import (
+    KISLiveOrderLedger,
+    LiveOrderLedger,
+    TossLiveOrderLedger,
+)
+from app.services.order_proposals.resting_sweep import (
+    LedgerEvidence,
+    RungCandidate,
+    RungVerdict,
+    SweepDecision,
+    classify_rung,
+    summarize,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RestingRungSweepService", "SweepNotConfirmed"]
+
+
+class SweepNotConfirmed(RuntimeError):
+    """Raised when a write was requested without the explicit operator confirm."""
+
+
+# (model, table label, broker-order-id column, client-key column or None)
+_LEDGER_SOURCES: tuple[tuple[Any, str, Any, Any], ...] = (
+    (
+        KISLiveOrderLedger,
+        "review.kis_live_order_ledger",
+        KISLiveOrderLedger.order_no,
+        KISLiveOrderLedger.idempotency_key,
+    ),
+    (
+        TossLiveOrderLedger,
+        "review.toss_live_order_ledger",
+        TossLiveOrderLedger.broker_order_id,
+        TossLiveOrderLedger.client_order_id,
+    ),
+    (
+        LiveOrderLedger,
+        "review.live_order_ledger",
+        LiveOrderLedger.order_no,
+        LiveOrderLedger.idempotency_key,
+    ),
+)
+
+
+class RestingRungSweepService:
+    """Rung-driven, untruncated, evidence-first convergence sweep."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    # ---------------------------------------------------------------- collect
+
+    async def collect_candidates(self) -> list[RungCandidate]:
+        """Every rung in a broker-live state. No limit, no time window."""
+        from app.services.order_proposals.service import OrderProposalsService
+
+        pairs = await OrderProposalsService(
+            self._session
+        ).list_evidence_accepting_rungs()
+        return [
+            RungCandidate(
+                proposal_id=str(group.proposal_id),
+                rung_id=rung.id,
+                rung_index=rung.rung_index,
+                state=rung.state,
+                side=rung.side,
+                symbol=group.symbol,
+                market=group.market,
+                account_mode=group.account_mode,
+                broker_order_id=rung.broker_order_id,
+                idempotency_key=rung.idempotency_key,
+                correlation_id=rung.correlation_id,
+                quantity=rung.quantity,
+                limit_price=rung.limit_price,
+                updated_at=rung.updated_at,
+            )
+            for group, rung in pairs
+        ]
+
+    async def fetch_evidence(
+        self, candidate: RungCandidate
+    ) -> tuple[LedgerEvidence, ...]:
+        """Collect every committed ledger row matching this rung's keys.
+
+        All matches across all three ledgers are returned -- deliberately not
+        "the first one".  Disagreement between two rows is a CONFLICT the
+        operator must see, and a first-match-wins read would hide it.
+        """
+        found: list[LedgerEvidence] = []
+        for model, label, order_col, client_col in _LEDGER_SOURCES:
+            keys: list[tuple[Any, str, str]] = []
+            if candidate.broker_order_id:
+                keys.append((order_col, candidate.broker_order_id, "broker_order_id"))
+            if candidate.idempotency_key and client_col is not None:
+                keys.append((client_col, candidate.idempotency_key, "idempotency_key"))
+            if candidate.correlation_id:
+                keys.append(
+                    (
+                        model.correlation_id,
+                        candidate.correlation_id,
+                        "correlation_id",
+                    )
+                )
+            for column, value, match_key in keys:
+                rows = (
+                    (await self._session.execute(select(model).where(column == value)))
+                    .scalars()
+                    .all()
+                )
+                for row in rows:
+                    if any(
+                        e.ledger_table == label and e.ledger_id == row.id for e in found
+                    ):
+                        continue
+                    found.append(
+                        LedgerEvidence(
+                            ledger_table=label,
+                            ledger_id=row.id,
+                            status=row.status,
+                            match_key=match_key,
+                            broker_order_id=str(getattr(row, order_col.key, None) or "")
+                            or None,
+                            idempotency_key=(
+                                getattr(row, client_col.key, None)
+                                if client_col is not None
+                                else None
+                            ),
+                            correlation_id=getattr(row, "correlation_id", None),
+                            filled_qty=getattr(row, "filled_qty", None),
+                            reconciled_at=getattr(row, "reconciled_at", None),
+                            updated_at=getattr(row, "updated_at", None),
+                        )
+                    )
+        return tuple(found)
+
+    async def verify_ownership(
+        self, candidate: RungCandidate, evidence: tuple[LedgerEvidence, ...]
+    ) -> tuple[tuple[LedgerEvidence, ...], str | None]:
+        """Keep only ledger rows that unambiguously belong to THIS rung.
+
+        Matching on any single key is not enough. A ledger row can carry an
+        ``order_no`` belonging to one rung and a ``correlation_id`` belonging to
+        another (the ROB-900 conflict case); reading it as evidence for either
+        one silently re-attributes a fill across proposals.
+
+        So ownership is delegated to the existing, proven disambiguator —
+        ``find_unambiguous_evidence_rung_id`` — which requires every *nonempty*
+        resolving key set to intersect on a single rung. Anything it refuses to
+        resolve, or resolves to a different rung, is dropped from the evidence
+        set and reported as a conflict. It is never treated as evidence here.
+        """
+        from app.services.order_proposals.errors import OrderProposalError
+        from app.services.order_proposals.service import OrderProposalsService
+
+        if not evidence:
+            return (), None
+        service = OrderProposalsService(self._session)
+        owned: list[LedgerEvidence] = []
+        conflict: str | None = None
+        for row in evidence:
+            try:
+                rung_id = await service.find_unambiguous_evidence_rung_id(
+                    correlation_id=row.correlation_id,
+                    broker_order_id=row.broker_order_id,
+                    idempotency_key=row.idempotency_key,
+                    account_mode=candidate.account_mode,
+                    symbol=candidate.symbol,
+                    market=candidate.market,
+                )
+            except OrderProposalError as exc:
+                # e.g. proposal_evidence_conflict / _ambiguous / broker_id_duplicate
+                conflict = conflict or (str(exc) or exc.__class__.__name__)
+                continue
+            if rung_id == candidate.rung_id:
+                owned.append(row)
+            elif rung_id is not None:
+                conflict = conflict or "evidence_owned_by_other_rung"
+        return tuple(owned), conflict
+
+    # ------------------------------------------------------------------ plan
+
+    async def plan(self, *, now: datetime.datetime) -> list[SweepDecision]:
+        """Read-only classification of every candidate. Never mutates."""
+        decisions: list[SweepDecision] = []
+        for candidate in await self.collect_candidates():
+            try:
+                evidence = await self.fetch_evidence(candidate)
+            except Exception as exc:  # noqa: BLE001 - a read failure is not evidence
+                # Fail-closed and LOUD: an unreadable ledger must never be
+                # mistaken for "no terminal evidence, leave it resting" in a
+                # way the operator cannot see.
+                logger.error(
+                    "ROB-1284 evidence read failed rung_id=%s proposal_id=%s: %s",
+                    candidate.rung_id,
+                    candidate.proposal_id,
+                    exc,
+                )
+                decisions.append(
+                    SweepDecision(
+                        candidate=candidate,
+                        verdict=RungVerdict.CONFLICT,
+                        reason_code="evidence_read_failed",
+                        observed_at=now,
+                    )
+                )
+                continue
+            evidence, conflict = await self.verify_ownership(candidate, evidence)
+            if conflict is not None and not evidence:
+                # Evidence exists but cannot be attributed to this rung. That is
+                # a conflict for a human, never a transition.
+                decisions.append(
+                    SweepDecision(
+                        candidate=candidate,
+                        verdict=RungVerdict.CONFLICT,
+                        reason_code=conflict,
+                        observed_at=now,
+                    )
+                )
+                continue
+            decisions.append(classify_rung(candidate, evidence, observed_at=now))
+        return decisions
+
+    async def report(self, *, now: datetime.datetime) -> dict[str, Any]:
+        """Full dry-run payload: summary + every row's classification basis."""
+        decisions = await self.plan(now=now)
+        return {
+            "dry_run": True,
+            "truncated": False,
+            "summary": summarize(decisions),
+            "rows": [d.as_row() for d in decisions],
+        }
+
+    # ----------------------------------------------------------------- apply
+
+    async def apply(
+        self,
+        *,
+        now: datetime.datetime,
+        dry_run: bool = True,
+        confirm: bool = False,
+    ) -> dict[str, Any]:
+        """Transition only the ``TRANSITION`` rungs. Double-gated.
+
+        ``dry_run=True`` (the default) plans and returns without writing.
+        ``dry_run=False`` additionally requires ``confirm=True``; a caller that
+        merely flips ``dry_run`` gets ``SweepNotConfirmed``, not a write.
+        """
+        decisions = await self.plan(now=now)
+        payload: dict[str, Any] = {
+            "dry_run": dry_run,
+            "truncated": False,
+            "summary": summarize(decisions),
+            "rows": [d.as_row() for d in decisions],
+            "applied": 0,
+            "failed": 0,
+        }
+        if dry_run:
+            return payload
+        if not confirm:
+            raise SweepNotConfirmed(
+                "ROB-1284 sweep write requires confirm=True in addition to "
+                "dry_run=False"
+            )
+
+        from app.services.order_proposals.service import OrderProposalsService
+
+        service = OrderProposalsService(self._session)
+        for decision in decisions:
+            if decision.verdict is not RungVerdict.TRANSITION:
+                continue
+            candidate = decision.candidate
+            try:
+                rung = await service.record_fill_evidence_for_rung(
+                    rung_id=candidate.rung_id,
+                    correlation_id=candidate.correlation_id,
+                    broker_order_id=candidate.broker_order_id,
+                    idempotency_key=candidate.idempotency_key,
+                    # cancelled/expired carry no fill quantity, preserving a
+                    # partial booked before the terminal evidence arrived.
+                    filled_qty=None
+                    if decision.target_state in {"cancelled", "expired"}
+                    else next(
+                        (
+                            e.filled_qty
+                            for e in decision.evidence
+                            if e.filled_qty is not None
+                        ),
+                        None,
+                    ),
+                    terminal_state=decision.target_state,  # type: ignore[arg-type]
+                    now=now,
+                    account_mode=candidate.account_mode,
+                    symbol=candidate.symbol,
+                    market=candidate.market,
+                )
+            except Exception as exc:  # noqa: BLE001 - surface, never swallow
+                logger.error(
+                    "ROB-1284 sweep transition failed rung_id=%s proposal_id=%s "
+                    "target=%s: %s",
+                    candidate.rung_id,
+                    candidate.proposal_id,
+                    decision.target_state,
+                    exc,
+                )
+                payload["failed"] += 1
+                continue
+            if rung is not None:
+                payload["applied"] += 1
+        return payload

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -348,13 +348,9 @@ _UNVERIFIED_VOID_SETTLEMENT_GRACE = timedelta(minutes=5)
 _VOIDABLE_RUNG_STATES = frozenset(
     {"draft", "pending_approval", "revalidating", "needs_reconfirm", "approved"}
 )
-# Rung states that can legally absorb broker fill/cancel evidence. Every state
-# here has ``filled``/``partially_filled``/``cancelled`` reachable in the
-# transition graph (see state_machine._ALLOWED); terminal states are excluded so
-# re-delivered evidence short-circuits instead of raising.
-_EVIDENCE_ACCEPTING_RUNG_STATES = frozenset(
-    {"acked", "resting", "partially_filled", "unverified"}
-)
+# Canonical set now lives in state_machine (ROB-1284: the repository's
+# rung-driven candidate scan needs it too). Aliased here to keep call sites.
+_EVIDENCE_ACCEPTING_RUNG_STATES = sm.EVIDENCE_ACCEPTING_RUNG_STATES
 _LOSS_CUT_CONFIRMATION_KEY = "loss_cut_confirmation"
 _LOSS_CUT_CONFIRMABLE_RUNG_STATES = frozenset({"pending_approval", "needs_reconfirm"})
 _SUPERSEDE_INVALIDATABLE_RUNG_STATES = frozenset(
@@ -1024,6 +1020,17 @@ class OrderProposalsService:
             limit=limit, symbol=symbol, lifecycle_state=lifecycle_state
         )
         return [(g, await self._repo.list_rungs(g.id)) for g in groups]
+
+    async def list_evidence_accepting_rungs(
+        self,
+    ) -> list[tuple[OrderProposal, OrderProposalRung]]:
+        """Every rung still believed to be live at a broker (ROB-1284).
+
+        Read-only and deliberately unbounded -- see the repository method for
+        why a limit or window here would reintroduce the undercount this exists
+        to remove.
+        """
+        return await self._repo.list_evidence_accepting_rungs()
 
     async def transition_rung(
         self,

--- a/app/services/order_proposals/state_machine.py
+++ b/app/services/order_proposals/state_machine.py
@@ -74,6 +74,15 @@ _ALLOWED: dict[str, frozenset[str]] = {
 }
 
 RUNG_STATES: frozenset[str] = frozenset(_ALLOWED.keys())
+
+# Rung states that can legally absorb broker fill/cancel/expiry evidence. Every
+# state here has a terminal successor in the graph above; terminal states are
+# excluded so re-delivered evidence short-circuits instead of raising. Lives
+# here (not in service.py) because the repository's ROB-1284 candidate scan
+# needs it and must not import the service that imports it.
+EVIDENCE_ACCEPTING_RUNG_STATES: frozenset[str] = frozenset(
+    {"acked", "resting", "partially_filled", "unverified"}
+)
 PROPOSAL_TERMINAL_STATES: frozenset[str] = frozenset(
     s for s, nxt in _ALLOWED.items() if not nxt
 )

--- a/scripts/rob1284_resting_rung_sweep.py
+++ b/scripts/rob1284_resting_rung_sweep.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+"""ROB-1284 — phantom-resting rung convergence sweep (dry-run by default).
+
+Answers three questions with evidence, in this order:
+
+1. **How many rungs are actually broker-live?** (``--census``) — untruncated,
+   rung-state-driven, plus the truncation proof: the same population counted
+   through progressively larger proposal-recency pages, so the point where the
+   number stops growing is visible rather than assumed.
+2. **What does the broker evidence say about each one?** (default) — every
+   candidate classified ``TRANSITION`` / ``NO_EVIDENCE`` / ``CONFLICT`` with the
+   fields a reviewer needs to audit the call.
+3. **Apply it** (``--apply --confirm``) — transitions only ``TRANSITION`` rows.
+
+Safety:
+  * dry-run is the default; ``--apply`` alone is refused without ``--confirm``.
+  * no broker call, no broker mutation — evidence is the committed ledger rows.
+  * ``NO_EVIDENCE`` and ``CONFLICT`` are reported, never transitioned.
+
+Usage:
+    ENV_FILE=.env.prod uv run python scripts/rob1284_resting_rung_sweep.py --census
+    ENV_FILE=.env.prod uv run python scripts/rob1284_resting_rung_sweep.py
+    ENV_FILE=.env.prod uv run python scripts/rob1284_resting_rung_sweep.py --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import func, select  # noqa: E402
+
+from app.core.db import AsyncSessionLocal  # noqa: E402
+from app.models.order_proposals import OrderProposal, OrderProposalRung  # noqa: E402
+from app.services.order_proposals.resting_sweep import RungVerdict  # noqa: E402
+from app.services.order_proposals.resting_sweep_service import (  # noqa: E402
+    RestingRungSweepService,
+)
+from app.services.order_proposals.state_machine import (  # noqa: E402
+    EVIDENCE_ACCEPTING_RUNG_STATES,
+)
+
+_PAGES = (50, 100, 200, 500, 1000, 5000)
+
+
+async def _census(db) -> dict:
+    """Prove the true N and prove that no page size or window is cutting it."""
+    live = OrderProposalRung.state.in_(EVIDENCE_ACCEPTING_RUNG_STATES)
+
+    true_n = int(
+        (
+            await db.execute(
+                select(func.count()).select_from(OrderProposalRung).where(live)
+            )
+        ).scalar_one()
+    )
+    total_groups = int(
+        (await db.execute(select(func.count()).select_from(OrderProposal))).scalar_one()
+    )
+    bounds = (
+        await db.execute(
+            select(
+                func.min(OrderProposal.created_at), func.max(OrderProposal.created_at)
+            )
+        )
+    ).one()
+
+    # Truncation proof: count the SAME population inside the newest-N-proposals
+    # page that every recency-paged surface uses. Where this plateaus at true_n
+    # is where the page stops hiding rows.
+    by_page: list[dict] = []
+    for page in _PAGES:
+        sub = select(OrderProposal.id).order_by(OrderProposal.id.desc()).limit(page)
+        visible = int(
+            (
+                await db.execute(
+                    select(func.count())
+                    .select_from(OrderProposalRung)
+                    .where(live, OrderProposalRung.proposal_pk.in_(sub))
+                )
+            ).scalar_one()
+        )
+        by_page.append(
+            {"page_limit": page, "visible": visible, "hidden": true_n - visible}
+        )
+
+    # Window proof: widen the created_at floor; a stable count means the window
+    # is not the thing bounding the answer.
+    by_window: list[dict] = []
+    for since in ("2026-08-01", "2026-07-11", "2026-07-01", "2026-01-01", "2000-01-01"):
+        floor = datetime.datetime.fromisoformat(since).replace(tzinfo=datetime.UTC)
+        n = int(
+            (
+                await db.execute(
+                    select(func.count())
+                    .select_from(OrderProposalRung)
+                    .join(
+                        OrderProposal, OrderProposal.id == OrderProposalRung.proposal_pk
+                    )
+                    .where(live, OrderProposal.created_at >= floor)
+                )
+            ).scalar_one()
+        )
+        by_window.append({"since": since, "n": n})
+
+    return {
+        "true_n": true_n,
+        "rung_states_counted": sorted(EVIDENCE_ACCEPTING_RUNG_STATES),
+        "total_proposal_groups": total_groups,
+        "proposals_created_between": [
+            bounds[0].isoformat() if bounds[0] else None,
+            bounds[1].isoformat() if bounds[1] else None,
+        ],
+        "truncation_proof_by_page": by_page,
+        "truncation_proof_by_window": by_window,
+    }
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description="ROB-1284 resting rung sweep")
+    ap.add_argument("--census", action="store_true", help="only the TRUE_N census")
+    ap.add_argument("--apply", action="store_true", help="write (needs --confirm)")
+    ap.add_argument("--confirm", action="store_true", help="second gate for --apply")
+    ap.add_argument("--json", type=str, default=None, help="write full payload here")
+    ap.add_argument("--show", type=int, default=25, help="rows to print (0 = all)")
+    args = ap.parse_args()
+
+    if args.apply and not args.confirm:
+        print("REFUSED: --apply requires --confirm (ROB-1284 double gate)")
+        return 2
+
+    now = datetime.datetime.now(datetime.UTC)
+    async with AsyncSessionLocal() as db:
+        census = await _census(db)
+        print("=== CENSUS (untruncated) ===")
+        print(json.dumps(census, indent=2, ensure_ascii=False))
+        if args.census:
+            return 0
+
+        service = RestingRungSweepService(db)
+        result = await service.apply(
+            now=now, dry_run=not args.apply, confirm=args.confirm
+        )
+        if args.apply:
+            await db.commit()
+
+    print("\n=== SWEEP SUMMARY ===")
+    print(json.dumps(result["summary"], indent=2, ensure_ascii=False))
+    print(
+        f"\ndry_run={result['dry_run']}  applied={result['applied']}  failed={result['failed']}"
+    )
+
+    rows = result["rows"]
+    if census["true_n"] != len(rows):
+        print(
+            f"\n!! census true_n={census['true_n']} but sweep classified {len(rows)} "
+            "— investigate before trusting this run"
+        )
+    print("\n=== TRANSITION candidates (the only rows --apply would touch) ===")
+    trans = [r for r in rows if r["verdict"] == RungVerdict.TRANSITION.value]
+    if not trans:
+        print("  (none — no rung has committed terminal broker evidence)")
+    shown = trans if args.show == 0 else trans[: args.show]
+    for r in shown:
+        print(
+            f"  {r['proposal_id'][:8]}#{r['rung_index']} {r['symbol']:<10} "
+            f"{r['account_mode']:<10} {r['side']:<4} {r['rung_state']:>16} -> "
+            f"{r['target_state']:<10} broker_id={r['broker_order_id']} "
+            f"remaining={r['remaining_qty']} ledger={r['ledger_rows']}"
+        )
+    if args.show and len(trans) > args.show:
+        print(f"  ... {len(trans) - args.show} more (use --show 0)")
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                {"census": census, **result}, indent=2, ensure_ascii=False, default=str
+            )
+        )
+        print(f"\nfull payload -> {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/services/order_proposals/test_rob1284_resting_sweep.py
+++ b/tests/services/order_proposals/test_rob1284_resting_sweep.py
@@ -1,0 +1,258 @@
+"""ROB-1284 — evidence-first guarantees for the phantom-resting rung sweep.
+
+The safety property under test is one sentence: *a rung is transitioned only on
+committed terminal broker evidence*. Every other outcome — no evidence, an
+still-open ledger, contradictory evidence, an illegal transition — must leave
+the rung exactly where it was.
+
+These are pure-function tests: ``classify_rung`` takes its clock and its
+evidence as arguments, so nothing here needs a database or a broker.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.order_proposals.errors import (
+    OrderProposalInvalidStateTransition,
+)
+from app.services.order_proposals.resting_sweep import (
+    LEDGER_OPEN_STATUSES,
+    LEDGER_STATUS_TO_RUNG_TERMINAL,
+    LedgerEvidence,
+    RungCandidate,
+    RungVerdict,
+    classify_rung,
+    summarize,
+)
+from app.services.order_proposals.state_machine import (
+    EVIDENCE_ACCEPTING_RUNG_STATES,
+    assert_rung_transition,
+)
+
+NOW = datetime.datetime(2026, 8, 18, 1, 0, tzinfo=datetime.UTC)
+
+pytestmark = pytest.mark.unit
+
+
+def _candidate(**over) -> RungCandidate:
+    base = {
+        "proposal_id": "6e13b685-0000-0000-0000-000000000000",
+        "rung_id": 1,
+        "rung_index": 1,
+        "state": "resting",
+        "side": "sell",
+        "symbol": "257720",
+        "market": "equity_kr",
+        "account_mode": "kis_live",
+        "broker_order_id": "0023769000",
+        "idempotency_key": "idem-1",
+        "correlation_id": "corr-1",
+        "quantity": Decimal("10"),
+        "limit_price": Decimal("43800"),
+    }
+    base.update(over)
+    return RungCandidate(**base)
+
+
+def _evidence(status: str, **over) -> LedgerEvidence:
+    base = {
+        "ledger_table": "review.kis_live_order_ledger",
+        "ledger_id": 150,
+        "status": status,
+        "match_key": "broker_order_id",
+        "broker_order_id": "0023769000",
+    }
+    base.update(over)
+    return LedgerEvidence(**base)
+
+
+# --------------------------------------------------------------- TRANSITION
+
+
+@pytest.mark.parametrize(
+    ("ledger_status", "expected"),
+    [
+        ("expired", "expired"),
+        ("cancelled", "cancelled"),
+        ("filled", "filled"),
+        # A broker rejection seen after submission is expiry evidence for a
+        # resting DAY rung, never the submit-time `rejected` transition.
+        ("rejected", "expired"),
+    ],
+)
+def test_terminal_broker_evidence_transitions(ledger_status, expected):
+    d = classify_rung(_candidate(), (_evidence(ledger_status),), observed_at=NOW)
+    assert d.verdict is RungVerdict.TRANSITION
+    assert d.target_state == expected
+    assert d.reason_code == "terminal_broker_evidence"
+
+
+def test_transition_carries_auditable_evidence_fields():
+    """A reviewer must be able to audit one row without re-querying."""
+    d = classify_rung(
+        _candidate(),
+        (_evidence("expired", filled_qty=Decimal("4")),),
+        observed_at=NOW,
+    )
+    row = d.as_row()
+    assert row["broker_order_id"] == "0023769000"
+    assert row["ledger_rows"][0]["status"] == "expired"
+    assert row["remaining_qty"] == "6"  # 10 ordered - 4 filled
+    assert row["observed_at"] == NOW.isoformat()
+    assert row["verdict"] == "TRANSITION"
+
+
+# --------------------------------------------------------------- NO_EVIDENCE
+
+
+def test_no_ledger_row_is_never_a_transition():
+    d = classify_rung(_candidate(), (), observed_at=NOW)
+    assert d.verdict is RungVerdict.NO_EVIDENCE
+    assert d.reason_code == "no_ledger_row"
+    assert d.target_state is None
+
+
+@pytest.mark.parametrize("open_status", sorted(LEDGER_OPEN_STATUSES))
+def test_still_open_ledger_is_never_a_transition(open_status):
+    """Absence of a terminal marking is not evidence of expiry."""
+    d = classify_rung(_candidate(), (_evidence(open_status),), observed_at=NOW)
+    assert d.verdict is RungVerdict.NO_EVIDENCE
+    assert d.reason_code == "ledger_still_open"
+
+
+def test_partial_is_treated_as_open_not_as_terminal_evidence():
+    """`partial` is an open status in every reconcile scan; booking partial
+    fills belongs to the reconcile kernel, not to this sweep."""
+    assert "partial" in LEDGER_OPEN_STATUSES
+    assert "partial" not in LEDGER_STATUS_TO_RUNG_TERMINAL
+    d = classify_rung(_candidate(), (_evidence("partial"),), observed_at=NOW)
+    assert d.verdict is RungVerdict.NO_EVIDENCE
+
+
+def test_rung_without_any_evidence_key_is_not_transitioned():
+    """The ROB-1277 shape: broker_order_id permanently null. Not expiry."""
+    d = classify_rung(
+        _candidate(broker_order_id=None, idempotency_key=None, correlation_id=None),
+        (_evidence("expired"),),
+        observed_at=NOW,
+    )
+    assert d.verdict is RungVerdict.NO_EVIDENCE
+    assert d.reason_code == "no_evidence_keys"
+
+
+# ------------------------------------------------------------------ CONFLICT
+
+
+def test_contradictory_ledger_rows_conflict_and_do_not_transition():
+    d = classify_rung(
+        _candidate(),
+        (_evidence("expired"), _evidence("filled", ledger_id=151)),
+        observed_at=NOW,
+    )
+    assert d.verdict is RungVerdict.CONFLICT
+    assert d.reason_code == "ledger_evidence_disagrees"
+    assert d.target_state is None
+
+
+def test_illegal_transition_is_a_conflict_not_a_forced_write():
+    """`acked` has no `expired` edge. The broker says expired; the rung was
+    never recorded resting. That is a modelling conflict for a human, not a
+    reason to force the state machine."""
+    with pytest.raises(OrderProposalInvalidStateTransition):
+        assert_rung_transition("acked", "expired")
+    d = classify_rung(
+        _candidate(state="acked"), (_evidence("expired"),), observed_at=NOW
+    )
+    assert d.verdict is RungVerdict.CONFLICT
+    assert d.reason_code == "transition_not_permitted"
+
+
+def test_unknown_ledger_status_is_a_conflict():
+    d = classify_rung(_candidate(), (_evidence("something_new"),), observed_at=NOW)
+    assert d.verdict is RungVerdict.CONFLICT
+    assert d.reason_code == "unmapped_ledger_status"
+
+
+def test_agreeing_duplicate_rows_still_transition():
+    """Two ledgers agreeing is not a conflict — only disagreement is."""
+    d = classify_rung(
+        _candidate(),
+        (
+            _evidence("expired"),
+            _evidence(
+                "expired", ledger_id=999, ledger_table="review.live_order_ledger"
+            ),
+        ),
+        observed_at=NOW,
+    )
+    assert d.verdict is RungVerdict.TRANSITION
+
+
+# ------------------------------------------------------------- invariants
+
+
+@pytest.mark.parametrize("state", sorted(EVIDENCE_ACCEPTING_RUNG_STATES))
+def test_every_candidate_state_survives_classification(state):
+    """No candidate state may crash or silently vanish."""
+    d = classify_rung(_candidate(state=state), (), observed_at=NOW)
+    assert d.verdict in set(RungVerdict)
+
+
+@pytest.mark.parametrize("state", sorted(EVIDENCE_ACCEPTING_RUNG_STATES))
+def test_declared_target_is_always_reachable_from_the_rung_state(state):
+    """Whenever the sweep says TRANSITION, the state machine agrees."""
+    for ledger_status in LEDGER_STATUS_TO_RUNG_TERMINAL:
+        d = classify_rung(
+            _candidate(state=state), (_evidence(ledger_status),), observed_at=NOW
+        )
+        if d.verdict is RungVerdict.TRANSITION:
+            assert d.target_state is not None
+            assert_rung_transition(state, d.target_state)  # must not raise
+
+
+def test_summary_accounts_for_every_row_and_splits_buy_sell():
+    """Mixed-side population: a sell-only summary hides buying-power impact."""
+    decisions = [
+        classify_rung(
+            _candidate(side="sell"), (_evidence("expired"),), observed_at=NOW
+        ),
+        classify_rung(_candidate(side="buy"), (), observed_at=NOW),
+        classify_rung(
+            _candidate(side="buy"),
+            (_evidence("expired"), _evidence("filled", ledger_id=2)),
+            observed_at=NOW,
+        ),
+    ]
+    s = summarize(decisions)
+    assert s["candidates"] == 3
+    assert sum(s["by_verdict"].values()) == 3
+    assert s["by_verdict"] == {"TRANSITION": 1, "NO_EVIDENCE": 1, "CONFLICT": 1}
+    assert s["by_side"]["buy"]["TRANSITION"] == 0
+    assert s["by_side"]["sell"]["TRANSITION"] == 1
+    assert sum(s["by_reason_code"].values()) == 3
+
+
+# ------------------------------------------------- cross-key attribution (R1)
+
+
+def test_evidence_from_a_different_rung_must_not_transition_this_one():
+    """Regression: matching on ANY single key re-attributes evidence.
+
+    A ledger row can carry an ``order_no`` belonging to one rung and a
+    ``correlation_id`` belonging to another. Reading it as evidence for either
+    one books a terminal state onto a rung the broker never spoke about. The
+    ownership check (``RestingRungSweepService.verify_ownership``, delegating to
+    ``find_unambiguous_evidence_rung_id``) drops such a row before it reaches
+    ``classify_rung`` — so with the row correctly dropped, the verdict must be
+    NO_EVIDENCE, not a transition.
+
+    The first version of this sweep did not do that and turned a `resting` rung
+    into `filled` off another rung's fill; two ROB-900 conflict tests caught it.
+    """
+    d = classify_rung(_candidate(), (), observed_at=NOW)
+    assert d.verdict is RungVerdict.NO_EVIDENCE
+    assert d.reason_code == "no_ledger_row"

--- a/tests/services/order_proposals/test_rob1284_resting_sweep.py
+++ b/tests/services/order_proposals/test_rob1284_resting_sweep.py
@@ -256,3 +256,82 @@ def test_evidence_from_a_different_rung_must_not_transition_this_one():
     d = classify_rung(_candidate(), (), observed_at=NOW)
     assert d.verdict is RungVerdict.NO_EVIDENCE
     assert d.reason_code == "no_ledger_row"
+
+
+# ----------------------------------------- ownership conflict is never dropped
+
+
+def test_ownership_conflict_downgrades_an_otherwise_clean_transition():
+    """Partially-attributable evidence is contradictory evidence.
+
+    Terminal evidence that would transition on its own must not transition when
+    the caller also reports that some matched row was refused attribution to
+    this rung. "Most of the rows point one way" is not the standard here.
+    """
+    d = classify_rung(
+        _candidate(),
+        (_evidence("expired"),),
+        observed_at=NOW,
+        ownership_conflict="proposal_evidence_conflict",
+    )
+    assert d.verdict is RungVerdict.CONFLICT
+    assert d.reason_code == "ownership_conflict_with_partial_evidence"
+    assert d.target_state is None
+    assert d.ownership_conflict == "proposal_evidence_conflict"
+
+
+@pytest.mark.parametrize(
+    ("evidence", "expected_reason"),
+    [
+        ((), "no_ledger_row"),
+        ((_evidence("accepted"),), "ledger_still_open"),
+    ],
+)
+def test_ownership_conflict_rides_along_on_non_transition_verdicts(
+    evidence, expected_reason
+):
+    """The refusal stays visible even when the verdict was never a write.
+
+    The non-transition reason is the more informative one, so it is kept — but
+    the conflict travels with the row instead of vanishing from the report.
+    """
+    d = classify_rung(
+        _candidate(),
+        evidence,
+        observed_at=NOW,
+        ownership_conflict="evidence_owned_by_other_rung",
+    )
+    assert d.verdict is RungVerdict.NO_EVIDENCE
+    assert d.reason_code == expected_reason
+    assert d.ownership_conflict == "evidence_owned_by_other_rung"
+    assert d.as_row()["ownership_conflict"] == "evidence_owned_by_other_rung"
+
+
+def test_summary_counts_ownership_conflicts_at_the_top_level():
+    """A per-reason breakdown alone would hide conflicts under their verdict."""
+    decisions = [
+        classify_rung(_candidate(), (_evidence("expired"),), observed_at=NOW),
+        classify_rung(
+            _candidate(),
+            (_evidence("expired"),),
+            observed_at=NOW,
+            ownership_conflict="proposal_evidence_conflict",
+        ),
+        classify_rung(
+            _candidate(),
+            (_evidence("accepted"),),
+            observed_at=NOW,
+            ownership_conflict="evidence_owned_by_other_rung",
+        ),
+    ]
+    s = summarize(decisions)
+    assert s["ownership_conflicts"] == 2
+    assert s["by_verdict"]["TRANSITION"] == 1
+
+
+def test_no_ownership_conflict_leaves_the_verdict_untouched():
+    """Default path is unchanged: absence of a conflict must not invent one."""
+    d = classify_rung(_candidate(), (_evidence("expired"),), observed_at=NOW)
+    assert d.verdict is RungVerdict.TRANSITION
+    assert d.ownership_conflict is None
+    assert d.as_row()["ownership_conflict"] is None

--- a/tests/services/order_proposals/test_rob1284_sweep_gates.py
+++ b/tests/services/order_proposals/test_rob1284_sweep_gates.py
@@ -6,15 +6,30 @@ Two properties:
   2. A bounded candidate scan must say what it did not look at. "Reconciled N"
      with M rows never scanned reads as full coverage, and that is how a
      phantom population stays invisible for weeks.
+
+**Every gate assertion here runs with candidates > 0.** A gate exercised against
+an empty candidate list is not a gate test: ``applied == 0`` is then true for a
+service that writes on every row, and a mutant that deletes the ``dry_run``
+early return survives it. The ``_NoCandidates`` fixture is kept only for the
+``SweepNotConfirmed`` raise, which is candidate-independent by construction; the
+write-suppression properties use ``_OneTransition`` / ``_EvidenceReadFails``,
+whose plans contain rows the sweep *would* write if a gate were removed.
 """
 
 from __future__ import annotations
 
 import datetime
+from decimal import Decimal
+from typing import Any
 
 import pytest
 
 from app.mcp_server.tooling.proposal_rung_convergence import candidate_scan_coverage
+from app.services.order_proposals.resting_sweep import (
+    LedgerEvidence,
+    RungCandidate,
+    RungVerdict,
+)
 from app.services.order_proposals.resting_sweep_service import (
     RestingRungSweepService,
     SweepNotConfirmed,
@@ -25,6 +40,87 @@ pytestmark = pytest.mark.unit
 NOW = datetime.datetime(2026, 8, 18, 1, 0, tzinfo=datetime.UTC)
 
 
+def _candidate(**over) -> RungCandidate:
+    """A rung whose keys and state make it eligible for a real transition."""
+    base = {
+        "proposal_id": "6e13b685-0000-0000-0000-000000000000",
+        "rung_id": 1,
+        "rung_index": 1,
+        "state": "resting",
+        "side": "sell",
+        "symbol": "257720",
+        "market": "equity_kr",
+        "account_mode": "kis_live",
+        "broker_order_id": "0023769000",
+        "idempotency_key": "idem-1",
+        "correlation_id": "corr-1",
+        "quantity": Decimal("10"),
+        "limit_price": Decimal("43800"),
+    }
+    base.update(over)
+    return RungCandidate(**base)
+
+
+def _terminal_evidence() -> LedgerEvidence:
+    return LedgerEvidence(
+        ledger_table="review.kis_live_order_ledger",
+        ledger_id=150,
+        status="expired",
+        match_key="broker_order_id",
+        broker_order_id="0023769000",
+    )
+
+
+class _EmptyResult:
+    """Whatever a write path asks of a result, it gets nothing back."""
+
+    def one_or_none(self) -> None:
+        return None
+
+    def scalar_one_or_none(self) -> None:
+        return None
+
+    def first(self) -> None:
+        return None
+
+    def scalars(self) -> _EmptyResult:
+        return self
+
+    def all(self) -> list[Any]:
+        return []
+
+
+class _RecordingSession:
+    """A session that records every DB verb instead of performing it.
+
+    This is the write detector. ``RestingRungSweepService.apply`` reaches the
+    database only through ``OrderProposalsService``, whose very first act in
+    ``record_fill_evidence_for_rung`` is a ``session.execute``. So an empty
+    ``calls`` list is a direct statement that no DB work was attempted — it does
+    not depend on monkeypatching the service, and it stays true if the write
+    path is later rerouted through ``add``/``flush``/``commit``.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def execute(self, *args: Any, **kwargs: Any) -> _EmptyResult:
+        self.calls.append("execute")
+        return _EmptyResult()
+
+    async def commit(self) -> None:
+        self.calls.append("commit")
+
+    async def flush(self) -> None:
+        self.calls.append("flush")
+
+    async def refresh(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append("refresh")
+
+    def add(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append("add")
+
+
 class _NoCandidates(RestingRungSweepService):
     """Zero candidates, so `apply` exercises the gates and nothing else."""
 
@@ -33,6 +129,49 @@ class _NoCandidates(RestingRungSweepService):
 
     async def plan(self, *, now):  # type: ignore[override]
         return []
+
+
+class _OneTransition(RestingRungSweepService):
+    """One candidate carrying committed terminal evidence.
+
+    Its plan contains a genuine ``TRANSITION``, so the only thing between
+    ``apply`` and a database write is the gate under test.
+    """
+
+    def __init__(self) -> None:
+        self.session = _RecordingSession()
+        super().__init__(session=self.session)  # type: ignore[arg-type]
+
+    async def collect_candidates(self):  # type: ignore[override]
+        return [_candidate()]
+
+    async def fetch_evidence(self, candidate):  # type: ignore[override]
+        return (_terminal_evidence(),)
+
+    async def verify_ownership(self, candidate, evidence):  # type: ignore[override]
+        return evidence, None
+
+
+class _EvidenceReadFails(RestingRungSweepService):
+    """Candidates exist; reading their ledger evidence raises.
+
+    Same candidate shape as ``_OneTransition`` — had the read succeeded these
+    rows would have transitioned — so the only reason no transition appears is
+    that an unreadable ledger is refused as evidence.
+    """
+
+    def __init__(self, n: int = 2) -> None:
+        self.session = _RecordingSession()
+        super().__init__(session=self.session)  # type: ignore[arg-type]
+        self._n = n
+        self.reads = 0
+
+    async def collect_candidates(self):  # type: ignore[override]
+        return [_candidate(rung_id=i, rung_index=i) for i in range(1, self._n + 1)]
+
+    async def fetch_evidence(self, candidate):  # type: ignore[override]
+        self.reads += 1
+        raise TimeoutError("ledger read timed out")
 
 
 @pytest.mark.asyncio
@@ -81,3 +220,217 @@ def test_unknown_open_total_is_reported_as_unknown_not_as_complete():
     """Not knowing the denominator must never be rendered as full coverage."""
     cov = candidate_scan_coverage(scanned=5, open_total=None, limit=100)
     assert cov["truncated"] is None
+
+
+# ------------------------------------------------ B1: unreadable evidence (r2)
+
+
+@pytest.mark.asyncio
+async def test_evidence_read_failure_never_yields_a_transition():
+    """An unreadable ledger is not permission to expire the rung.
+
+    The failure mode this pins: a read timeout gets absorbed as "no terminal
+    evidence found, so it must be dead" and the sweep writes a terminal state
+    off an exception. Candidates are non-empty and would otherwise transition,
+    so `TRANSITION == 0` here is a statement about the branch, not about an
+    empty plan.
+    """
+    svc = _EvidenceReadFails(n=2)
+    decisions = await svc.plan(now=NOW)
+
+    assert len(decisions) == 2  # candidates > 0 — the fixture has teeth
+    assert svc.reads == 2  # ...and the failing branch is the one that ran
+    assert [d for d in decisions if d.verdict is RungVerdict.TRANSITION] == []
+    assert {d.verdict for d in decisions} == {RungVerdict.CONFLICT}
+    assert {d.reason_code for d in decisions} == {"evidence_read_failed"}
+    assert all(d.target_state is None for d in decisions)
+
+
+@pytest.mark.asyncio
+async def test_evidence_read_failure_writes_nothing_even_when_confirmed():
+    """Both gates open, candidates present, ledger unreadable: still zero writes."""
+    svc = _EvidenceReadFails(n=2)
+    result = await svc.apply(now=NOW, dry_run=False, confirm=True)
+
+    assert result["summary"]["candidates"] == 2
+    assert result["summary"]["by_verdict"]["TRANSITION"] == 0
+    assert svc.session.calls == []  # no DB verb was attempted
+    assert result["applied"] == 0
+    assert result["failed"] == 0  # not "tried and failed" — never tried
+
+
+# --------------------------------------------- B2: dry_run with live candidates
+
+
+@pytest.mark.asyncio
+async def test_dry_run_writes_nothing_with_transitionable_candidates():
+    """The dry_run gate, tested where it can actually fail.
+
+    The plan holds a real TRANSITION, so removing the ``if dry_run: return``
+    early exit sends this straight into ``record_fill_evidence_for_rung`` and
+    the recording session sees ``execute``.
+    """
+    svc = _OneTransition()
+    result = await svc.apply(now=NOW)  # dry_run defaults to True
+
+    assert result["dry_run"] is True
+    assert result["summary"]["candidates"] == 1  # candidates > 0
+    assert result["summary"]["by_verdict"]["TRANSITION"] == 1  # ...and writable
+    assert svc.session.calls == []  # DB writes: zero
+    assert result["applied"] == 0
+    assert result["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_confirm_with_dry_run_still_writes_nothing_with_live_candidates():
+    """`confirm=True` is not an override of `dry_run=True`, even with a target."""
+    svc = _OneTransition()
+    result = await svc.apply(now=NOW, dry_run=True, confirm=True)
+
+    assert result["dry_run"] is True
+    assert result["summary"]["by_verdict"]["TRANSITION"] == 1
+    assert svc.session.calls == []
+    assert result["applied"] == 0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_false_alone_is_refused_with_live_candidates():
+    """The refusal must hold when there is something real to write, too."""
+    svc = _OneTransition()
+    with pytest.raises(SweepNotConfirmed):
+        await svc.apply(now=NOW, dry_run=False)
+    assert svc.session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_report_is_read_only_with_transitionable_candidates():
+    """`report` is the operator's read surface; it must never write either."""
+    svc = _OneTransition()
+    payload = await svc.report(now=NOW)
+
+    assert payload["dry_run"] is True
+    assert payload["summary"]["by_verdict"]["TRANSITION"] == 1
+    assert svc.session.calls == []
+
+
+# ------------------------------------------------- S1: dropped-row conflicts
+
+
+class _PartialOwnership(RestingRungSweepService):
+    """Ownership keeps one terminal row and refuses another.
+
+    The refused row is exactly the shape ``verify_ownership`` exists to catch —
+    a ledger row whose keys resolve to some other rung. What is under test is
+    what happens to the *fact of the refusal* once a clean-looking subset
+    survives it.
+    """
+
+    def __init__(self) -> None:
+        self.session = _RecordingSession()
+        super().__init__(session=self.session)  # type: ignore[arg-type]
+
+    async def collect_candidates(self):  # type: ignore[override]
+        return [_candidate()]
+
+    async def fetch_evidence(self, candidate):  # type: ignore[override]
+        return (_terminal_evidence(),)
+
+    async def verify_ownership(self, candidate, evidence):  # type: ignore[override]
+        # One row survives; a second, refused row is reported as a conflict.
+        return evidence, "proposal_evidence_conflict"
+
+
+@pytest.mark.asyncio
+async def test_dropped_row_conflict_is_not_lost_behind_surviving_evidence():
+    """A conflict observed and then dropped is a conflict nobody ever sees.
+
+    Before this, ``plan`` kept the conflict only when *every* row was dropped:
+    if any owned row survived, the surviving subset was classified as though
+    the refusal had never happened — and a TRANSITION written off it.
+    """
+    svc = _PartialOwnership()
+    decisions = await svc.plan(now=NOW)
+
+    assert len(decisions) == 1
+    d = decisions[0]
+    assert d.ownership_conflict == "proposal_evidence_conflict"  # fact survives
+    assert d.verdict is RungVerdict.CONFLICT  # ...and blocks the write
+    assert d.reason_code == "ownership_conflict_with_partial_evidence"
+    assert d.target_state is None
+    assert d.as_row()["ownership_conflict"] == "proposal_evidence_conflict"
+
+
+@pytest.mark.asyncio
+async def test_partially_attributable_evidence_writes_nothing_when_confirmed():
+    svc = _PartialOwnership()
+    result = await svc.apply(now=NOW, dry_run=False, confirm=True)
+
+    assert result["summary"]["candidates"] == 1
+    assert result["summary"]["by_verdict"]["TRANSITION"] == 0
+    assert result["summary"]["ownership_conflicts"] == 1  # visible in the total
+    assert svc.session.calls == []
+    assert result["applied"] == 0
+
+
+@pytest.mark.asyncio
+async def test_clean_ownership_still_transitions():
+    """The conflict guard must not swallow the honest case (no regression)."""
+    svc = _OneTransition()
+    decisions = await svc.plan(now=NOW)
+
+    assert len(decisions) == 1
+    assert decisions[0].verdict is RungVerdict.TRANSITION
+    assert decisions[0].ownership_conflict is None
+    assert decisions[0].target_state == "expired"
+
+
+# ------------------------------------------------------ S2: starvation surfacing
+
+
+def _scan(**over):
+    base = {
+        "scanned": 100,
+        "open_total": 133,
+        "limit": 100,
+        "oldest_scanned_at": datetime.datetime(2026, 7, 17, tzinfo=datetime.UTC),
+        "newest_scanned_at": datetime.datetime(2026, 8, 13, tzinfo=datetime.UTC),
+        "now": NOW,
+    }
+    base.update(over)
+    return candidate_scan_coverage(**base)
+
+
+def test_shortfall_names_the_frontier_nothing_newer_is_ever_reached():
+    """The unreached rows are identifiable, not just countable."""
+    cov = _scan()
+    assert cov["unscanned"] == 33
+    assert cov["unreached_created_after"] == "2026-08-13T00:00:00+00:00"
+    assert cov["scan_order"] == "created_at ASC (oldest-first)"
+
+
+def test_shortfall_reports_how_long_the_slot_holder_has_been_sitting():
+    """A slot holder measured in weeks is what makes the shortfall permanent."""
+    cov = _scan()
+    assert cov["oldest_scanned_age_days"] == 32  # 2026-07-17 -> 2026-08-18
+
+
+def test_shortfall_is_described_as_persistent_not_as_a_backlog():
+    """ "Backlog" implies it drains next pass. Oldest-first means it does not."""
+    cov = _scan()
+    assert "persistent" in cov["note"]
+    assert "not a draining backlog" in cov["note"]
+
+
+def test_starvation_fields_are_omitted_when_the_caller_cannot_supply_them():
+    """Unknown must read as unknown — never as zero days / no frontier."""
+    cov = candidate_scan_coverage(scanned=100, open_total=133, limit=100)
+    assert cov["unscanned"] == 33
+    assert cov["unreached_created_after"] is None
+    assert cov["oldest_scanned_age_days"] is None
+
+
+def test_complete_scan_reports_no_starvation_fields():
+    cov = _scan(scanned=133, open_total=133)
+    assert cov["truncated"] is False
+    assert "unreached_created_after" not in cov
+    assert "note" not in cov

--- a/tests/services/order_proposals/test_rob1284_sweep_gates.py
+++ b/tests/services/order_proposals/test_rob1284_sweep_gates.py
@@ -1,0 +1,83 @@
+"""ROB-1284 — write gates and truncation surfacing.
+
+Two properties:
+  1. Flipping ``dry_run`` alone must not produce a write; ``confirm=True`` is a
+     separate, explicit act.
+  2. A bounded candidate scan must say what it did not look at. "Reconciled N"
+     with M rows never scanned reads as full coverage, and that is how a
+     phantom population stays invisible for weeks.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from app.mcp_server.tooling.proposal_rung_convergence import candidate_scan_coverage
+from app.services.order_proposals.resting_sweep_service import (
+    RestingRungSweepService,
+    SweepNotConfirmed,
+)
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime.datetime(2026, 8, 18, 1, 0, tzinfo=datetime.UTC)
+
+
+class _NoCandidates(RestingRungSweepService):
+    """Zero candidates, so `apply` exercises the gates and nothing else."""
+
+    def __init__(self) -> None:
+        super().__init__(session=None)  # type: ignore[arg-type]
+
+    async def plan(self, *, now):  # type: ignore[override]
+        return []
+
+
+@pytest.mark.asyncio
+async def test_dry_run_is_the_default():
+    result = await _NoCandidates().apply(now=NOW)
+    assert result["dry_run"] is True
+    assert result["applied"] == 0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_false_alone_is_refused():
+    """The dangerous flag is not sufficient on its own."""
+    with pytest.raises(SweepNotConfirmed):
+        await _NoCandidates().apply(now=NOW, dry_run=False)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_false_with_confirm_is_allowed():
+    result = await _NoCandidates().apply(now=NOW, dry_run=False, confirm=True)
+    assert result["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_confirm_alone_still_plans_only():
+    """confirm without dry_run=False must not write either."""
+    result = await _NoCandidates().apply(now=NOW, dry_run=True, confirm=True)
+    assert result["dry_run"] is True
+    assert result["applied"] == 0
+
+
+def test_truncated_scan_reports_the_shortfall():
+    cov = candidate_scan_coverage(scanned=100, open_total=133, limit=100)
+    assert cov["truncated"] is True
+    assert cov["unscanned"] == 33
+    assert "never scanned" in cov["note"]
+
+
+def test_complete_scan_is_marked_untruncated_without_a_note():
+    cov = candidate_scan_coverage(scanned=7, open_total=7, limit=100)
+    assert cov["truncated"] is False
+    assert cov["unscanned"] == 0
+    assert "note" not in cov
+
+
+def test_unknown_open_total_is_reported_as_unknown_not_as_complete():
+    """Not knowing the denominator must never be rendered as full coverage."""
+    cov = candidate_scan_coverage(scanned=5, open_total=None, limit=100)
+    assert cov["truncated"] is None

--- a/tests/services/order_proposals/test_rob1284_sweep_seams.py
+++ b/tests/services/order_proposals/test_rob1284_sweep_seams.py
@@ -1,0 +1,383 @@
+"""ROB-1284 — the two seams the gate suite never entered.
+
+`test_rob1284_sweep_gates` proves the *decision* rules by substituting the
+service's collection points.  That substitution left two production code paths
+with no test at all — not "weakly tested", untested:
+
+**E-A — `RestingRungSweepService.fetch_evidence`.**  Every gate fixture
+overrides it wholesale, so the real multi-ledger, multi-key read loop never ran
+under pytest.  Anything could live inside it.  In particular a per-query
+``try/except: continue`` — absorbing one ledger's read failure and classifying
+off whatever the *other* ledgers happened to return — would have been invisible:
+the suite would stay green while a rung got expired on a partial read.
+
+**E-B — `run_resting_rung_sweep`.**  The reconcile-side wrapper had zero
+matches under ``tests/``.  It is the only thing that turns the reconcile pass's
+``dry_run`` into the sweep's write gates and issues the ``commit``, and it runs
+on the automatic path — the production DML wrapper was the least-tested object
+in the change.
+
+So these tests deliberately do *not* stub the units under test.  E-A drives the
+real ``fetch_evidence`` through a session that answers real ``select()``
+statements; E-B drives the real wrapper and watches what reaches the session.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Any
+
+import pytest
+
+from app.mcp_server.tooling import proposal_rung_convergence as prc
+from app.mcp_server.tooling.proposal_rung_convergence import run_resting_rung_sweep
+from app.services.order_proposals.resting_sweep import RungVerdict
+from app.services.order_proposals.resting_sweep_service import RestingRungSweepService
+from tests.services.order_proposals.test_rob1284_sweep_gates import (
+    NOW,
+    _candidate,
+    _RecordingSession,
+    _terminal_evidence,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ============================================================ E-A: fetch_evidence
+
+
+class _LedgerRow:
+    """The attribute surface `fetch_evidence` reads off a ledger ORM row."""
+
+    def __init__(self) -> None:
+        self.id = 150
+        self.status = "expired"
+        self.order_no = "0023769000"
+        self.idempotency_key = "idem-1"
+        self.correlation_id = "corr-1"
+        self.filled_qty = None
+        self.reconciled_at = None
+        self.updated_at = None
+
+
+class _Rows:
+    def __init__(self, rows: tuple[Any, ...]) -> None:
+        self._rows = list(rows)
+
+    def scalars(self) -> _Rows:
+        return self
+
+    def all(self) -> list[Any]:
+        return list(self._rows)
+
+    def one_or_none(self) -> Any | None:
+        return self._rows[0] if len(self._rows) == 1 else None
+
+    def scalar_one_or_none(self) -> Any | None:
+        return self.one_or_none()
+
+    def first(self) -> Any | None:
+        return self._rows[0] if self._rows else None
+
+
+def _statement_entity(statement: Any) -> str:
+    """Which model a statement selects from — the observation point for E-A.
+
+    ``fetch_evidence`` is the only thing in this test that builds ``select()``
+    statements, so this list *is* the proof the production loop ran: a fixture
+    override could not produce it.
+    """
+    descriptions = getattr(statement, "column_descriptions", None)
+    if not descriptions:
+        return "<non-select>"
+    entity = descriptions[0].get("entity")
+    return getattr(entity, "__name__", None) or "<non-select>"
+
+
+class _LedgerReadSession:
+    """Answers the real ledger SELECTs; fails the ones it is told to fail.
+
+    Reads and writes are recorded separately.  ``entities`` is what
+    ``fetch_evidence`` asked for, in order; ``mutating`` is any write verb.  A
+    read-shaped session cannot use "no execute at all" as its write detector the
+    way ``_RecordingSession`` does, so writes are identified by the statement
+    leaving the three ledger models — which is exactly what a rung transition
+    would do.
+    """
+
+    def __init__(
+        self,
+        *,
+        rows_by_model: dict[str, tuple[Any, ...]],
+        fail_on: tuple[str, ...] = (),
+    ) -> None:
+        self._rows_by_model = rows_by_model
+        self._fail_on = frozenset(fail_on)
+        self.entities: list[str] = []
+        self.mutating: list[str] = []
+
+    async def execute(self, statement: Any, *args: Any, **kwargs: Any) -> _Rows:
+        entity = _statement_entity(statement)
+        self.entities.append(entity)
+        if entity in self._fail_on:
+            raise TimeoutError(f"ledger read timed out: {entity}")
+        return _Rows(self._rows_by_model.get(entity, ()))
+
+    async def commit(self) -> None:
+        self.mutating.append("commit")
+
+    async def flush(self) -> None:
+        self.mutating.append("flush")
+
+    async def refresh(self, *args: Any, **kwargs: Any) -> None:
+        self.mutating.append("refresh")
+
+    def add(self, *args: Any, **kwargs: Any) -> None:
+        self.mutating.append("add")
+
+
+_LEDGER_MODELS = ("KISLiveOrderLedger", "TossLiveOrderLedger", "LiveOrderLedger")
+
+# `_candidate()` carries all three resolving keys, so each ledger is queried
+# three times: broker_order_id, idempotency_key, correlation_id.
+_FULL_SCAN = [name for name in _LEDGER_MODELS for _ in range(3)]
+
+
+class _RealFetchEvidence(RestingRungSweepService):
+    """The service with `fetch_evidence` **left alone**.
+
+    Only the two neighbouring collection points are substituted:
+    ``collect_candidates`` (so no proposals table is needed) and
+    ``verify_ownership`` (a separate seam, already covered in the gate suite).
+    Passing ownership through is what gives this fixture teeth: if
+    ``fetch_evidence`` returns terminal rows, the plan *is* a TRANSITION — so a
+    swallowed read failure produces a write, not a shrug.
+    """
+
+    def __init__(self, *, fail_on: tuple[str, ...] = ()) -> None:
+        self.session = _LedgerReadSession(
+            rows_by_model={"KISLiveOrderLedger": (_LedgerRow(),)},
+            fail_on=fail_on,
+        )
+        super().__init__(session=self.session)  # type: ignore[arg-type]
+
+    async def collect_candidates(self):  # type: ignore[override]
+        return [_candidate()]
+
+    async def verify_ownership(self, candidate, evidence):  # type: ignore[override]
+        return evidence, None
+
+
+@pytest.mark.asyncio
+async def test_production_fetch_evidence_loop_is_the_one_under_test():
+    """Control: the real loop runs, reads every ledger, and yields a TRANSITION.
+
+    This is the fixture's teeth *and* the evidence that no override is standing
+    in for the production function — a stub cannot emit nine ``select()``
+    statements against the three ledger models in key order.
+    """
+    svc = _RealFetchEvidence()
+    decisions = await svc.plan(now=NOW)
+
+    assert svc.session.entities == _FULL_SCAN  # production loop, all three ledgers
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.verdict is RungVerdict.TRANSITION  # would be written
+    assert decision.target_state == "expired"
+    # Three matching queries, one row: the loop's dedup ran too.
+    assert [e.ledger_id for e in decision.evidence] == [150]
+    assert [e.ledger_table for e in decision.evidence] == [
+        "review.kis_live_order_ledger"
+    ]
+    assert svc.session.mutating == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_ledger", ["TossLiveOrderLedger", "LiveOrderLedger"])
+async def test_partial_evidence_read_failure_never_yields_a_transition(failing_ledger):
+    """One ledger unreadable **after** another returned terminal rows.
+
+    This is the dangerous shape: the KIS read already produced a terminal row,
+    so a loop that absorbed the later failure would hand ``classify_rung`` a
+    clean-looking evidence set and expire the rung off an incomplete read.  The
+    read failure must reach ``plan`` and take the whole candidate to CONFLICT.
+    """
+    svc = _RealFetchEvidence(fail_on=(failing_ledger,))
+    decisions = await svc.plan(now=NOW)
+
+    # The loop got as far as the failing ledger, and stopped there.
+    assert svc.session.entities[:3] == ["KISLiveOrderLedger"] * 3
+    assert svc.session.entities[-1] == failing_ledger
+    assert len(svc.session.entities) < len(_FULL_SCAN)
+
+    assert len(decisions) == 1  # candidate > 0 — and the control proves it would write
+    decision = decisions[0]
+    assert [d for d in decisions if d.verdict is RungVerdict.TRANSITION] == []
+    assert decision.verdict is RungVerdict.CONFLICT
+    assert decision.reason_code == "evidence_read_failed"
+    assert decision.target_state is None
+    assert decision.evidence == ()  # the partial set is discarded, not classified
+    assert svc.session.mutating == []
+
+
+@pytest.mark.asyncio
+async def test_partial_read_failure_writes_nothing_even_when_confirmed():
+    """Both gates open, ledger partially unreadable: still zero writes."""
+    svc = _RealFetchEvidence(fail_on=("LiveOrderLedger",))
+    result = await svc.apply(now=NOW, dry_run=False, confirm=True)
+
+    assert result["summary"]["candidates"] == 1
+    assert result["summary"]["by_verdict"]["TRANSITION"] == 0
+    # Nothing was selected outside the evidence read — a rung transition would
+    # have to touch the proposal tables to happen.
+    assert set(svc.session.entities) <= set(_LEDGER_MODELS)
+    assert svc.session.mutating == []
+    assert result["applied"] == 0
+    assert result["failed"] == 0  # not "tried and failed" — never tried
+
+
+# ================================================== E-B: run_resting_rung_sweep
+
+
+class _WiringSession(_RecordingSession):
+    """`_RecordingSession` usable as the wrapper's `async with` session."""
+
+    async def __aenter__(self) -> _WiringSession:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class _WiringProbe(RestingRungSweepService):
+    """The **real** service, with a transitionable plan, recording its call.
+
+    ``apply`` is not replaced — it is wrapped, then delegated to.  So the
+    wrapper's arguments are observed *and* actually executed against the real
+    write gates, which is what makes "no write reached the session" a fact about
+    production behaviour rather than about a stub.
+    """
+
+    def __init__(self, session: Any) -> None:
+        super().__init__(session)
+        self.apply_kwargs: dict[str, Any] | None = None
+
+    async def collect_candidates(self):  # type: ignore[override]
+        return [_candidate()]
+
+    async def fetch_evidence(self, candidate):  # type: ignore[override]
+        return (_terminal_evidence(),)
+
+    async def verify_ownership(self, candidate, evidence):  # type: ignore[override]
+        return evidence, None
+
+    async def apply(self, **kwargs: Any):  # type: ignore[override]
+        self.apply_kwargs = dict(kwargs)
+        return await super().apply(**kwargs)
+
+
+def _install_wiring_probe(monkeypatch) -> tuple[_WiringSession, list[_WiringProbe]]:
+    session = _WiringSession()
+    probes: list[_WiringProbe] = []
+
+    def _factory():
+        return lambda: session
+
+    def _service(db: Any) -> _WiringProbe:
+        probe = _WiringProbe(db)
+        probes.append(probe)
+        return probe
+
+    monkeypatch.setattr(prc, "_session_factory", _factory)
+    monkeypatch.setattr(prc, "RestingRungSweepService", _service)
+    return session, probes
+
+
+@pytest.mark.asyncio
+async def test_wrapper_forwards_the_callers_dry_run_and_writes_nothing(monkeypatch):
+    """A dry-run reconcile pass must stay a dry run all the way to the writes.
+
+    The wrapper is the only translation from the reconcile pass's ``dry_run``
+    into the sweep's two write gates. If it hard-coded a live call, every
+    service-level gate test would still pass while the automatic reconcile path
+    wrote to production.
+    """
+    session, probes = _install_wiring_probe(monkeypatch)
+
+    out = await run_resting_rung_sweep(dry_run=True)
+
+    assert len(probes) == 1
+    assert probes[0].apply_kwargs is not None
+    assert probes[0].apply_kwargs["dry_run"] is True  # forwarded, not re-decided
+    assert probes[0].apply_kwargs["confirm"] is False  # and not confirmed behind it
+    assert session.calls == []  # no execute, no commit — zero DB work
+    assert out["ran"] is True
+    assert out["dry_run"] is True
+    assert out["applied"] == 0
+    # Teeth: there really was a row the sweep would have written.
+    assert out["summary"]["by_verdict"]["TRANSITION"] == 1
+
+
+@pytest.mark.asyncio
+async def test_wrapper_commits_only_on_the_non_dry_run_path(monkeypatch):
+    """The other direction, so "always dry_run" is not a passing implementation."""
+    session, probes = _install_wiring_probe(monkeypatch)
+
+    out = await run_resting_rung_sweep(dry_run=False)
+
+    assert probes[0].apply_kwargs is not None
+    assert probes[0].apply_kwargs["dry_run"] is False
+    assert probes[0].apply_kwargs["confirm"] is True  # confirm is derived, not free
+    assert "commit" in session.calls
+    assert out["ran"] is True
+    assert out["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_wrapper_reports_a_sweep_failure_instead_of_raising(monkeypatch):
+    """A failed sweep must not take down the reconcile that already booked."""
+    session = _WiringSession()
+
+    def _boom(db: Any) -> Any:
+        raise RuntimeError("sweep exploded")
+
+    monkeypatch.setattr(prc, "_session_factory", lambda: lambda: session)
+    monkeypatch.setattr(prc, "RestingRungSweepService", _boom)
+
+    out = await run_resting_rung_sweep(dry_run=True)
+
+    assert out == {"ran": False, "error": "sweep exploded"}
+    assert session.calls == []
+
+
+def test_every_reconcile_kernel_forwards_its_own_dry_run():
+    """Source pin on the three call sites the wrapper is wired into.
+
+    Regression detection, not adversarial defence: the wrapper test above proves
+    the wrapper honours what it is given, and this proves the three reconcile
+    kernels give it their own ``dry_run`` rather than a literal.
+    """
+    from app.mcp_server.tooling import (
+        kis_live_ledger,
+        live_order_ledger,
+        toss_live_ledger,
+    )
+
+    for module in (kis_live_ledger, toss_live_ledger, live_order_ledger):
+        source = pathlib.Path(module.__file__).read_text(encoding="utf-8")
+        calls = [
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "run_resting_rung_sweep"
+        ]
+        assert len(calls) == 1, module.__name__
+        call = calls[0]
+        assert call.args == [], module.__name__  # keyword-only, no positional slip
+        keywords = {kw.arg: kw.value for kw in call.keywords}
+        assert set(keywords) == {"dry_run"}, module.__name__
+        forwarded = keywords["dry_run"]
+        assert isinstance(forwarded, ast.Name), module.__name__
+        assert forwarded.id == "dry_run", module.__name__


### PR DESCRIPTION
## What this is

`sweep_expired` deliberately skips any group holding a rung in a non-voidable state — a local clock is not evidence about a broker order. Correct, but nothing else ever closed those rungs either. `live_order_ledger._converge_proposal_rung:249-253` already names the missing piece verbatim: *"A guaranteed-convergence proposal-rung reconcile sweep is tracked as follow-up."* This is that sweep.

**Dry-run + implementation only. No production DML was executed.**

## The number is 203, not 56

Measured read-only against prod. `order_proposal_list` hard-clamps `limit` to 200 proposals, so it can never show the whole population:

| newest-N-proposals page | visible | hidden |
|---|---|---|
| 50 (the default) | 32 | 171 |
| 200 (the hard clamp) | 109 | 94 |
| 500 / 1000 / 5000 | **203** | 0 |

Window is not the bound either — identical 203 at `since` = 07-11 / 07-01 / 01-01 / 2000-01-01, and the whole table starts 2026-07-11.

**Paged paths that undercount this population** (AC3): `order_proposal_list` (default 50, clamp 200) · `list_recent_groups` (proposal-recency, no rung filter) · the three reconcile candidate scans (`limit=100`, oldest-first).

## Prod dry-run result — the honest answer

203 candidates → **1 TRANSITION · 202 NO_EVIDENCE · 0 CONFLICT · 0 written.**

`ledger_still_open` 183 · `no_ledger_row` 12 · `no_evidence_keys` 7. Buy 49 / sell 154.

Only one rung has committed terminal broker evidence today. The other 202 cannot be closed because **the ledgers are stale too**: `reconciled_at IS NULL` on 100% of open ledger rows (133 Toss, 123 live, 7 KIS), `max(reconciled_at)` is `NULL` on all three. That is an operator/deployment question, not something this PR can fix — flagged, not papered over.

## What the code does

- **`resting_sweep.py`** — pure classifier. Injected clock and evidence, no DB/network. Verdicts are exactly `TRANSITION` / `NO_EVIDENCE` / `CONFLICT`; only the first is ever applied.
- **`resting_sweep_service.py`** — untruncated rung-driven candidate scan + evidence gather + double-gated apply.
- **`proposal_rung_convergence.py`** — shared wiring; called from all three reconcile impls' non-dry-run path. **No new scheduler** — it piggybacks on passes that already run.
- Also surfaces `candidate_scan` coverage: those scans are oldest-first with `limit=100` over populations of 133 and 123, so the oldest rows — already past broker lookback, therefore unresolvable — hold every slot on every pass while newer, resolvable rows are never scanned at all.

## Safety

- Evidence-first: transitions only on committed terminal broker evidence; absent/still-open/contradictory evidence transitions nothing.
- `dry_run=True` is the default; `dry_run=False` additionally requires `confirm=True`.
- No broker call, no broker mutation, no migration, no deps, no scheduler registration.

**A defect this PR's review caught:** the first version matched evidence by *any single key*, which let a ledger row carrying one rung's `order_no` and another rung's `correlation_id` transition the wrong rung — turning a `resting` rung into `filled` off someone else's fill. Two existing ROB-900 conflict tests went red. Ownership is now delegated to `find_unambiguous_evidence_rung_id`, which requires every nonempty key set to intersect on one rung.

## Verification

- 6 evidence-first mutants (no-evidence→transition, still-open→transition, disagreement→transition, drop state-machine guard, `partial` as terminal, drop key guard) → **all RED**, control green both sides.
- `tests/services/order_proposals/` + the three reconcile tooling suites: **892 passed**. Broader reconcile selection: **881 passed**.
- `make lint` (ruff check + format + ty): **green**.

## ROB-1277 is a different defect — not merged here

Zero population overlap, measured:

| | ROB-1284 | ROB-1277 |
|---|---|---|
| rung state | `resting` (184) | `unverified` (19) |
| `broker_order_id` | **100% present** | **100% NULL** |
| `action` | `place` 180 / `replace` 2 | `cancel` 6 / `replace` 1 |
| group lifecycle | `submitted` | `proposed` |

ROB-1284 rungs *have* an order id and their ledger row is stuck open; ROB-1277 rungs never got an id at all. This sweep classifies the ROB-1277 shape as `no_evidence_keys`/`no_ledger_row` → NO_EVIDENCE and correctly refuses to touch it. Merging them would let one sweep mask two different root causes.

## Not done here (deliberately)

- No production backfill. Applying is `--apply --confirm` after operator sign-off.
- The US/crypto reconcile maps ledger `expired` → rung `cancelled` on a stale premise (`resting → expired` *is* a legal edge). Left untouched; the new sweep books expiry as `expired`. Follow-up.

---

## r2 — closing two mutation escapes found by independent verification

An adversarial verifier (grok xhigh, xAI — a different provider family from the
implementer) reproduced every headline number independently: TRUE_N 203, the page
plateau, exactly 1 transitionable rung, dry-run default, and a byte-identical rung
state graph. It also landed **two escaped mutants**, both test-net gaps rather than
code defects, and one real visibility defect. This round fixes the net.

### The two escapes

| escape | why it survived r1 | now |
|---|---|---|
| `evidence_read_failed` → `TRANSITION` | no test referenced that branch at all | `test_evidence_read_failure_never_yields_a_transition` — 2 candidates, evidence read raises, `TRANSITION == 0` asserted. Mutant dies at `test_rob1284_sweep_gates.py:243`. |
| `if dry_run: return` deleted | gate tests ran with **zero candidates**, so `applied == 0` was vacuously true | `test_dry_run_writes_nothing_with_transitionable_candidates` — plan holds a real `TRANSITION`, recording session must see zero DB verbs. Mutant dies at `:279` with `assert ['execute'] == []`. |

The point of both is candidate potency. A gate asserted against an empty plan is
not a gate test; it is a test that a service which writes on every single row
would also pass.

### Dropped-row conflicts are no longer silent

`verify_ownership` refuses ledger rows it cannot attribute to the rung. `plan`
previously kept that conflict **only when every row was dropped** — if any owned
row survived, the surviving subset classified as though the refusal never
happened, and could transition off it.

Now the conflict rides on the decision (`ownership_conflict`, exposed per row and
counted at the top level of the summary) and downgrades a would-be `TRANSITION` to
`CONFLICT`. Partially-attributable evidence is contradictory evidence, and this
module transitions nothing on contradictory evidence.

Production dry-run finds **2 rungs** carrying such a conflict (both `toss_live`
034230 buy, `evidence_owned_by_other_rung`) whose refusal was previously discarded
without a trace. Neither was transitionable, so the applyable count is unchanged.

### Starvation is now a number, not a comment

The verifier confirmed the head-of-line starvation is real *and permanent*: live
has **82 of 123** open rows older than 30 days, and the oldest-first scan
re-selects the same slot holders every pass. `candidate_scan` no longer describes
this as a backlog that drains — it reports the frontier
(`unreached_created_after`: nothing newer is ever reached) and the slot holder's
age (`oldest_scanned_age_days`), both derived from rows already in hand with no
extra query. Fair rotation needs a per-row last-attempt column and a migration, so
it stays out of scope and is named as such in the payload.

The Toss denominator also now uses `list_open`'s own `operation_kind` predicate,
so it cannot count rows as "unreached" that the scan was never going to take.

### Unchanged

TRUE_N 203 · exactly 1 transitionable rung (`c8de3110#1` 086790 `kis_live` sell,
`resting → expired`) · dry-run default · `_ALLOWED` graph byte-identical to
`origin/main` · zero migrations, deps, schedulers, broker clients, or env changes ·
zero production DML, `--apply` never run.

Also corrected in the report: the r1 claim that open ledger rows being 100%
`reconciled_at IS NULL` proves reconcile "never converged" does not hold —
`reconciled_at` is stamped only on an outcome update, so a PENDING/NONE lookup
leaves it NULL whether or not reconcile ran. The real evidence is gate state:
`KIS_LIVE_AUTO_RECONCILE_SAFETY_REVIEW_PASSED` is absent (default false) so the KIS
periodic path is paused, and the Toss/US gates are absent too. No gate was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
