### PR TITLE
ROB-1285: add guarded bootstrap retrospective path

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -39,7 +39,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `artifact`: analysis/stage artifact persistence
   - `proposal`: `order_proposal_create`
   - `fill`: reconcile/fill-evidence tools
-  - `retrospective`: `save_trade_retrospective`
+  - `retrospective`: `save_trade_retrospective`,
+    `save_position_intake_retrospective`
   - Other calls use `other`; join stages with caller/session/run/correlation and report/artifact/proposal identifiers rather than raw symbols.
 
 ## Tools
@@ -882,9 +883,9 @@ order mutation.
     best-effort to remove the old buttons. Submitted/resting/terminal rungs
     are left unchanged because broker cancellation/replacement owns them.
   - It accepts nullable `exit_intent`, `exit_reason`, `retrospective_id`, and
-    `approval_issue_id` fields. For `exit_intent="loss_cut"`, `exit_reason`
-    and `retrospective_id` are required. `approval_issue_id` is optional
-    free-text audit metadata.
+    `approval_issue_id` fields for ordinary proposals. For
+    `exit_intent="loss_cut"`, `exit_reason`, `retrospective_id`, and a
+    non-empty `approval_issue_id` are all required.
   - The referenced retrospective is checked at create time for existence,
     matching symbol, an eligible loss-cut trigger type (`stop_loss` or
     `thesis_change`), and freshness within 72 hours.
@@ -1143,6 +1144,24 @@ secrets into the live `.env.prod.native` file. When any of
 
 The error names variables only — never values.
 
+### Position-intake retrospective (ROB-1285)
+
+`save_position_intake_retrospective` is a DEFAULT-profile-only, narrowly scoped
+write surface for a KIS live KR holding acquired outside the execution ledger
+or before that ledger existed. It is hard-pinned to `kis_live/equity_kr` and writes only
+`review.trade_retrospectives` plus its existing action projection. Before the
+write it locks and scans all same-symbol rows in
+`review.kis_live_order_ledger`; any raw status in `filled`, `rejected`,
+`unknown`, `anomaly`, `cancelled`, or `expired` rejects the intake.
+
+The row stores `evidence_snapshot.retrospective_type="intake"`, the observed
+account/quantity/average/current-price snapshot, acquisition provenance, and
+the zero-match terminal-guard receipt. Ordinary `save_trade_retrospective`
+calls cannot supply that reserved type. Intake rows are excluded by the
+retrospective aggregate and setup-tag learning consumers; forecast Brier
+scoring reads the separate `trade_forecasts` ledger and has no intake write or
+resolution path. This tool never creates a proposal or calls a broker.
+
 ### Toss Live Order MCP Tools
 
 The `default` profile registers eight typed `toss_live` MCP tools:
@@ -1164,7 +1183,7 @@ Operator activation and the one-share live smoke are documented in
 - **Account Mode Routing**: All Toss tools require `account_mode="toss_live"` (or `account_type="toss_live"`) and reject any mismatched account parameters.
 - **Mutation Safety (Dry-Run, Confirm, and Activation Gate)**: All mutation tools (`toss_place_order`, `toss_modify_order`, `toss_cancel_order`) default to `dry_run=True`. They perform actual HTTP requests (POSTs) to Toss Securities only when `dry_run=False`, `confirm=True`, and `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true` are explicitly set. Keep `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false` until the accepted-order ledger and operator live-smoke hold are cleared.
 - **Accepted-only ledger and reconcile**: Real `toss_place_order` writes only an accepted/rejected row to `review.toss_live_order_ledger`. It does not create fills, journals, or realized PnL at send time. `toss_reconcile_orders(dry_run=True)` previews broker evidence from `GET /orders/{orderId}`; `dry_run=False` books only confirmed execution deltas. GET order-detail `403 non-json-response` failures are retried once after token reissue; unresolved failures are persisted as `requires_manual_review=true`. Mutation POSTs are not implicitly retried on that error.
-- **Loss-cut authorization**: Direct `toss_preview_order`/`toss_place_order` loss-cut calls fail closed and point callers to `order_proposal_create`. A loss-cut proposal requires a live limit sell, eligible `exit_reason`, matching <=72h retrospective, allowed submit identity, slip-band compliance, and a valid approval hash. Telegram's first approval click only renders evidence and issues a proposal/rung/revision-bound 90-second `⚠️ 손절 확인` nonce; the second click reruns every guard and may submit. `approval_issue_id` is optional audit text and is never externally queried. Toss ledger rows retain `exit_intent`, `retrospective_id`, and `approval_issue_id` for audit.
+- **Loss-cut authorization**: Direct `toss_preview_order`/`toss_place_order` loss-cut calls fail closed and point callers to `order_proposal_create`. A loss-cut proposal requires a live limit sell, eligible `exit_reason`, matching <=72h retrospective, non-empty `approval_issue_id`, allowed submit identity, slip-band compliance, and a valid approval hash. Telegram's first approval click only renders evidence and issues a proposal/rung/revision-bound 90-second `⚠️ 손절 확인` nonce; the second click reruns every guard and may submit. The issue ID is retained for audit and never externally queried. Toss ledger rows retain `exit_intent`, `retrospective_id`, and `approval_issue_id` for audit.
 - **Loss-cut polling SLA**: Toss has no fill push in this path and both automatic polling paths are default-off. Before enabling Toss loss-cut, either enable and operationally verify `TOSS_FILL_POLL_ENABLED` with an approved `TOSS_FILL_POLL_CRON`, or require a targeted `toss_reconcile_orders(order_id=<broker-order-id>, dry_run=False)` immediately after execution. Non-dry reconcile projects broker evidence to proposal rungs and idempotently repairs terminal-ledger projection misses.
 - **Proposal identity handoff**: Order-proposal flows privately bind a stable client ID derived from `proposal_id + rung` around both `toss_preview_order` and `toss_place_order`, then require preview to return that exact ID. The proposal correlation and rung are carried through the same internal binding into the Toss ledger. These values are not exposed as operator-controlled MCP parameters. Accepted responses expose `approval_hash_digest`, the canonical ledger digest; the raw approval token is used only as the `approval_hash` submit input.
 - **US FX PnL split**: Toss order detail does not provide fill-time FX. For US rows only, `toss_reconcile_orders(dry_run=False)` captures USD/KRW through `exchange_rate_service` at reconcile time. Buy rows persist `buy_fx_rate`; sell rows persist `sell_fx_rate`, FIFO-attributed `fx_pnl_krw`, `security_pnl_usd`, `security_pnl_krw`, and `total_pnl_krw`. Automatic values are labelled `fx_rate_source="reconcile_spot"` and `fx_pnl_accuracy="approximate"`. Legacy lots with no buy FX keep FX PnL fields null until an operator backfills exact values through `modify_journal_entry`.

--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -50,6 +50,7 @@ AVAILABLE_TOOL_NAMES = [
     "screen_stocks",
     # ROB-359: recommend_stocks is registry-hidden (parked); not on the tool surface.
     "get_mock_loop_retrospective",
+    "save_position_intake_retrospective",
     "save_trade_retrospective",
     "get_trade_retrospectives",
     "get_retrospective_aggregate",

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -510,8 +510,9 @@ async def order_proposal_create(
     ``loss_cut`` keeps retrospective/price/hash guards and requires a single-use
     two-click confirmation. Telegram remains the submit-capable channel. The
     authenticated /invest B1 channel shares the nonce but stops at durable
-    validation without submitting an order. ``approval_issue_id`` is an optional
-    free-text audit note; no external issue tracker is queried.
+    validation without submitting an order. ``approval_issue_id`` is required
+    for loss-cut proposals as the operator approval record; no external issue
+    tracker is queried.
 
     Args:
         market: Canonical market in {equity_kr, equity_us, crypto}; aliases
@@ -1011,8 +1012,8 @@ def register_order_proposal_tools(mcp: FastMCP) -> None:
             "Replace/cancel read target-order evidence before persistence, but never "
             "mutate a broker. Approval/submission happens via Telegram (PR 2), not "
             "through this tool. loss_cut requires a two-click confirmation with a "
-            "single-use nonce and full second-click revalidation; approval_issue_id "
-            "is an optional audit note and is never externally queried."
+            "single-use nonce and full second-click revalidation; loss_cut also "
+            "requires a non-empty approval_issue_id (never externally queried)."
         ),
     )(order_proposal_create)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -82,7 +82,7 @@ class LossCutContext:
 
     retrospective_id: int
     exit_reason: str
-    approval_issue_id: str | None
+    approval_issue_id: str
     requester_agent_id: str
     max_slip: float
     approval_verified_at: datetime.datetime
@@ -537,6 +537,12 @@ async def _validate_loss_cut_preconditions(
                         f"(> {_LOSS_CUT_RETRO_MAX_AGE_HOURS}h old)"
                     )
 
+    resolved_approval_issue_id = (
+        approval_issue_id.strip() if isinstance(approval_issue_id, str) else ""
+    )
+    if not resolved_approval_issue_id:
+        errors.append("loss_cut requires approval_issue_id")
+
     if errors:
         return None, errors
 
@@ -544,7 +550,7 @@ async def _validate_loss_cut_preconditions(
         LossCutContext(
             retrospective_id=retrospective_id,  # type: ignore[arg-type]
             exit_reason=resolved_exit_reason,
-            approval_issue_id=approval_issue_id,
+            approval_issue_id=resolved_approval_issue_id,
             requester_agent_id=caller_agent_id,  # type: ignore[arg-type]
             max_slip=_loss_cut_max_slip_value(),
             approval_verified_at=datetime.datetime.now(datetime.UTC),

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -493,8 +493,8 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "any other account_mode value is rejected."
             ' ROB-864 exit_intent="loss_cut" is disabled on this direct tool. Use '
             "order_proposal_create; Telegram performs two-click confirmation with a "
-            "single-use nonce and second-click full revalidation. approval_issue_id "
-            "is only an optional audit note."
+            "single-use nonce and second-click full revalidation; that proposal "
+            "flow requires approval_issue_id."
         ),
     )
     async def kis_live_place_order(  # NOSONAR - public MCP order schema mirrors legacy tool.

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -218,8 +218,8 @@ def register_order_tools(mcp: FastMCP) -> None:
             "live send; required=mandatory for LIVE sends (mock/is_mock paths exempt)."
             ' ROB-864 exit_intent="loss_cut" is disabled on this direct tool. Use '
             "order_proposal_create; Telegram performs two-click confirmation with a "
-            "single-use nonce and second-click full revalidation. approval_issue_id "
-            "is only an optional audit note."
+            "single-use nonce and second-click full revalidation; that proposal "
+            "flow requires approval_issue_id."
         ),
     )
     async def place_order(

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -2103,7 +2103,7 @@ def register_toss_live_order_tools(mcp: FastMCP) -> None:
             "exit_intent='loss_cut' is disabled for direct MCP calls. Use "
             "order_proposal_create; its Telegram two-click flow revalidates the "
             "<=72h retrospective, current-price slip band, and approval hash before "
-            "submission. approval_issue_id is only an optional audit note."
+            "submission; that proposal flow requires approval_issue_id."
         ),
     )(toss_preview_order)
     mcp.tool(

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -404,7 +404,10 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     # ROB-755 — execution ledger fill event read tool; read-only, always registered.
     register_execution_ledger_event_tools(mcp)
     register_mock_loop_retro_tools(mcp)
-    register_trade_retrospective_tools(mcp)
+    register_trade_retrospective_tools(
+        mcp,
+        include_position_intake=profile is McpProfile.DEFAULT,
+    )
     register_forecast_tools(mcp)
     register_trading_scoreboard_tools(mcp)
     # ROB-1173: this is a direct KIS mock broker mutation despite its report

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -566,6 +566,7 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "research_session_get",
         "research_session_list_recent",
         "research_summary_get",
+        "save_position_intake_retrospective",
         "save_trade_journal",
         "save_trade_retrospective",
         "screen_stocks",

--- a/app/mcp_server/tooling/trade_retrospective_registration.py
+++ b/app/mcp_server/tooling/trade_retrospective_registration.py
@@ -8,19 +8,42 @@ from typing import Any
 from app.mcp_server.tooling.trade_retrospective_tools import (
     get_retrospective_aggregate,
     get_trade_retrospectives,
+    save_position_intake_retrospective,
     save_trade_retrospective,
     trade_retrospective_pending,
 )
 
 TRADE_RETROSPECTIVE_TOOL_NAMES: set[str] = {
     "save_trade_retrospective",
+    "save_position_intake_retrospective",
     "get_trade_retrospectives",
     "get_retrospective_aggregate",
     "trade_retrospective_pending",
 }
 
 
-def register_trade_retrospective_tools(mcp: Any) -> None:
+def register_trade_retrospective_tools(
+    mcp: Any,
+    *,
+    include_position_intake: bool = True,
+) -> None:
+    if include_position_intake:
+        _ = mcp.tool(
+            name="save_position_intake_retrospective",
+            description=(
+                "Create a KIS-live-KR position-intake retrospective for an externally "
+                "acquired or pre-ledger holding. This path is fail-closed: it locks "
+                "and scans the complete review.kis_live_order_ledger history for the "
+                "same symbol and rejects when status is any of {filled, rejected, "
+                "unknown, anomaly, cancelled, expired}. The durable evidence is "
+                "typed retrospective_type=intake and excluded from execution "
+                "learning/scoring. Requires a timezone-aware <=24h position snapshot, "
+                "account/quantity/average/current-price evidence, acquisition "
+                "provenance, an idempotent correlation_id, loss-cut-eligible "
+                "trigger_type, and next_actions. Writes only the retrospective/action "
+                "ledgers; never mutates a broker or creates an order proposal."
+            ),
+        )(save_position_intake_retrospective)
     _ = mcp.tool(
         name="save_trade_retrospective",
         description=(

--- a/app/mcp_server/tooling/trade_retrospective_tools.py
+++ b/app/mcp_server/tooling/trade_retrospective_tools.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -25,6 +25,9 @@ from app.services.trade_journal.trade_retrospective_service import (
     save_retrospective,
     serialize_retrospective,
 )
+from app.services.trade_journal.trade_retrospective_service import (
+    save_position_intake_retrospective as save_position_intake_retrospective_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,69 @@ def _mcp_argument_was_provided(name: str, value: Any) -> bool:
 
 def _session_factory() -> async_sessionmaker[AsyncSession]:
     return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def save_position_intake_retrospective(
+    symbol: str,
+    account_ref: str,
+    quantity: float,
+    average_price: float,
+    current_price: float,
+    observed_at: str,
+    evidence_source: str,
+    acquisition_provenance: str,
+    acquisition_note: str,
+    correlation_id: str,
+    trigger_type: str,
+    next_actions: list,
+    created_by_profile: str,
+    policy_version: str | None = None,
+) -> dict[str, Any]:
+    """Create a guarded KIS-live-KR position-intake retrospective.
+
+    This is only for an externally acquired or pre-ledger position that has no
+    terminal KIS live order event. It writes retrospective evidence only; it
+    cannot create, cancel, modify, approve, or submit an order.
+    """
+    try:
+        observed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+        async with _session_factory()() as db:
+            action, row = await save_position_intake_retrospective_service(
+                db,
+                symbol=symbol,
+                account_ref=account_ref,
+                quantity=quantity,
+                average_price=average_price,
+                current_price=current_price,
+                observed_at=observed,
+                evidence_source=evidence_source,
+                acquisition_provenance=acquisition_provenance,
+                acquisition_note=acquisition_note,
+                correlation_id=correlation_id,
+                trigger_type=trigger_type,
+                next_actions=next_actions,
+                created_by_profile=created_by_profile,
+                policy_version=policy_version,
+                actor=f"mcp:{resolve_mcp_profile(_env('MCP_PROFILE')).value}",
+            )
+            await db.refresh(row)
+            next_actions_data = await RetrospectiveActionRepository(db).read_actions(
+                row.id
+            )
+            data = serialize_retrospective(
+                row,
+                next_actions_override=next_actions_data,
+            )
+            await db.commit()
+            return {"success": True, "action": action, "data": data}
+    except (RetrospectiveValidationError, ValueError) as exc:
+        return {"success": False, "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("save_position_intake_retrospective failed")
+        return {
+            "success": False,
+            "error": f"save_position_intake_retrospective failed: {exc}",
+        }
 
 
 async def save_trade_retrospective(

--- a/app/monitoring/sentry.py
+++ b/app/monitoring/sentry.py
@@ -648,7 +648,9 @@ _FUNNEL_TOOL_STAGES: dict[str, frozenset[str]] = {
             "paper_execution_reconcile",
         }
     ),
-    "retrospective": frozenset({"save_trade_retrospective"}),
+    "retrospective": frozenset(
+        {"save_position_intake_retrospective", "save_trade_retrospective"}
+    ),
 }
 
 

--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -38,6 +38,7 @@ from app.services.trade_journal.forecast_service import (
     _normalize_symbol_for_filter,
     build_forecast_calibration_aggregate,
 )
+from app.services.trade_journal.retrospective_type import sql_is_learning_eligible
 
 MARKET_TO_INSTRUMENT = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
 
@@ -277,6 +278,7 @@ async def _retrospectives(
         select(TradeRetrospective)
         .where(TradeRetrospective.symbol == symbol)
         .where(_visibility_predicate(account_mode))
+        .where(sql_is_learning_eligible())
     )
     rows = (
         (await db.execute(stmt.order_by(TradeRetrospective.created_at.desc())))

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -808,6 +808,8 @@ class OrderProposalsService:
         # support yet) -- so only loss_cut can reach here in practice today.
         if defensive_floor is not None and valid_until < defensive_floor:
             valid_until = defensive_floor
+        if exit_intent == "loss_cut" and isinstance(approval_issue_id, str):
+            approval_issue_id = approval_issue_id.strip()
         await self._validate_exit_binding(
             symbol=symbol,
             market=market,
@@ -953,6 +955,8 @@ class OrderProposalsService:
             )
         if retrospective_id is None:
             errors.append("loss_cut requires retrospective_id")
+        if not isinstance(approval_issue_id, str) or not approval_issue_id.strip():
+            errors.append("loss_cut requires approval_issue_id")
         if (account_mode, market) not in {
             ("kis_live", "equity_kr"),
             ("kis_live", "equity_us"),

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -26,6 +26,7 @@ from app.models.review import (
 from app.models.trading import InstrumentType
 from app.services.market_data import get_ohlcv
 from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
+from app.services.trade_journal.retrospective_type import sql_is_learning_eligible
 
 _EPS = 1e-9
 _SMOKE_TOKENS = ("smoke",)
@@ -512,6 +513,7 @@ async def resolve_setup_tag(
                     TradeRetrospective.correlation_id.in_(corr_ids),
                     TradeRetrospective.strategy_key.isnot(None),
                     TradeRetrospective.account_mode == account_mode,
+                    sql_is_learning_eligible(),
                 )
                 .order_by(TradeRetrospective.created_at.desc())
                 .limit(1)
@@ -523,6 +525,7 @@ async def resolve_setup_tag(
     retro_filters = [
         TradeRetrospective.symbol == norm,
         TradeRetrospective.strategy_key.isnot(None),
+        sql_is_learning_eligible(),
         TradeRetrospective.created_at <= trade.exit_ts,
         TradeRetrospective.created_at >= window_start,
     ]

--- a/app/services/trade_journal/retrospective_type.py
+++ b/app/services/trade_journal/retrospective_type.py
@@ -1,0 +1,55 @@
+"""Stored retrospective-type contract without a schema migration (ROB-1285).
+
+``review.trade_retrospectives.evidence_snapshot`` is the existing durable JSONB
+evidence envelope.  Position-intake retrospectives use its reserved
+``retrospective_type`` key; ordinary execution retrospectives omit the key and
+therefore remain backward-compatible ``execution`` rows.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import or_
+
+from app.models.review import TradeRetrospective
+
+RETROSPECTIVE_TYPE_KEY = "retrospective_type"
+EXECUTION_RETROSPECTIVE_TYPE = "execution"
+INTAKE_RETROSPECTIVE_TYPE = "intake"
+
+
+def retrospective_type_from_snapshot(snapshot: Any) -> str:
+    """Return the typed row kind, treating all legacy rows as execution."""
+    if isinstance(snapshot, dict):
+        value = snapshot.get(RETROSPECTIVE_TYPE_KEY)
+        if value == INTAKE_RETROSPECTIVE_TYPE:
+            return INTAKE_RETROSPECTIVE_TYPE
+    return EXECUTION_RETROSPECTIVE_TYPE
+
+
+def is_intake_retrospective(row: TradeRetrospective) -> bool:
+    return (
+        retrospective_type_from_snapshot(row.evidence_snapshot)
+        == INTAKE_RETROSPECTIVE_TYPE
+    )
+
+
+def sql_is_learning_eligible():
+    """SQL predicate excluding non-execution intake rows from learning reads."""
+    stored_type = TradeRetrospective.evidence_snapshot[RETROSPECTIVE_TYPE_KEY].astext
+    return or_(
+        TradeRetrospective.evidence_snapshot.is_(None),
+        stored_type.is_(None),
+        stored_type != INTAKE_RETROSPECTIVE_TYPE,
+    )
+
+
+__all__ = [
+    "EXECUTION_RETROSPECTIVE_TYPE",
+    "INTAKE_RETROSPECTIVE_TYPE",
+    "RETROSPECTIVE_TYPE_KEY",
+    "is_intake_retrospective",
+    "retrospective_type_from_snapshot",
+    "sql_is_learning_eligible",
+]

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -65,10 +65,20 @@ from app.services.trade_journal.retrospective_query_filters import (
 from app.services.trade_journal.retrospective_query_filters import (
     sql_is_win as _sql_is_win,
 )
+from app.services.trade_journal.retrospective_type import (
+    INTAKE_RETROSPECTIVE_TYPE,
+    RETROSPECTIVE_TYPE_KEY,
+    is_intake_retrospective,
+    retrospective_type_from_snapshot,
+)
 
 # Sentinel: distinguishes "caller did not provide this field" (preserve on
 # upsert) from "caller explicitly set None" (clear the field).
 _UNSET: Any = object()
+# Module-private capability used only after the ROB-1285 terminal-event guard
+# succeeds.  Generic execution-retrospective callers cannot label their own
+# evidence as intake and thereby bypass the dedicated creation path.
+_INTAKE_WRITE_CAPABILITY: Any = object()
 
 _VALID_ACCOUNT_MODES = {
     "kis_mock",
@@ -175,6 +185,7 @@ def serialize_retrospective(
 ) -> dict[str, Any]:
     return {
         "id": r.id,
+        "retrospective_type": retrospective_type_from_snapshot(r.evidence_snapshot),
         "correlation_id": r.correlation_id,
         "journal_id": r.journal_id,
         "report_uuid": r.report_uuid,
@@ -258,7 +269,33 @@ class TradeRetrospectiveRepository:
         payload: dict[str, Any],
         *,
         create_defaults: dict[str, Any] | None = None,
+        _write_capability: Any = None,
     ) -> tuple[str, TradeRetrospective]:
+        intake_write = _write_capability is _INTAKE_WRITE_CAPABILITY
+        if _write_capability is not None and not intake_write:
+            raise RetrospectiveValidationError(
+                "invalid retrospective repository write capability"
+            )
+
+        def _assert_type_boundary(existing: TradeRetrospective | None) -> None:
+            if existing is not None:
+                existing_is_intake = is_intake_retrospective(existing)
+                if existing_is_intake != intake_write:
+                    raise RetrospectiveValidationError(
+                        "retrospective_type boundary violation: intake rows may only "
+                        "be written by save_position_intake_retrospective"
+                    )
+                return
+            snapshot = payload.get("evidence_snapshot")
+            creates_intake = (
+                retrospective_type_from_snapshot(snapshot) == INTAKE_RETROSPECTIVE_TYPE
+            )
+            if creates_intake != intake_write:
+                raise RetrospectiveValidationError(
+                    "retrospective_type boundary violation: intake rows may only "
+                    "be created by save_position_intake_retrospective"
+                )
+
         cid = payload.get("correlation_id")
         account_mode = payload.get("account_mode")
         if cid is not None:
@@ -266,12 +303,14 @@ class TradeRetrospectiveRepository:
                 cid, account_mode, for_update=True
             )
             if existing is not None:
+                _assert_type_boundary(existing)
                 for key, value in payload.items():
                     setattr(existing, key, value)
                 await self.db.flush()
                 return "updated", existing
         create_payload = dict(create_defaults or {})
         create_payload.update(payload)
+        _assert_type_boundary(None)
         row = TradeRetrospective(**create_payload)
         try:
             async with self.db.begin_nested():
@@ -288,6 +327,7 @@ class TradeRetrospectiveRepository:
             )
             if existing is None:
                 raise
+            _assert_type_boundary(existing)
             for key, value in payload.items():
                 setattr(existing, key, value)
             await self.db.flush()
@@ -371,7 +411,28 @@ async def save_retrospective(
     guardrail_fired: Any = _UNSET,
     policy_version: Any = _UNSET,
     actor: str = "internal:save_retrospective",
+    _write_capability: Any = None,
 ) -> tuple[str, TradeRetrospective]:
+    intake_write = _write_capability is _INTAKE_WRITE_CAPABILITY
+    if _write_capability is not None and not intake_write:
+        raise RetrospectiveValidationError("invalid retrospective write capability")
+    has_reserved_type = (
+        isinstance(evidence_snapshot, dict)
+        and RETROSPECTIVE_TYPE_KEY in evidence_snapshot
+    )
+    if has_reserved_type and not intake_write:
+        raise RetrospectiveValidationError(
+            "evidence_snapshot.retrospective_type is reserved; "
+            "use save_position_intake_retrospective"
+        )
+    if intake_write and (
+        not has_reserved_type
+        or retrospective_type_from_snapshot(evidence_snapshot)
+        != INTAKE_RETROSPECTIVE_TYPE
+    ):
+        raise RetrospectiveValidationError(
+            "position intake writes require retrospective_type='intake' evidence"
+        )
     if account_mode not in _VALID_ACCOUNT_MODES:
         raise RetrospectiveValidationError(f"invalid account_mode: {account_mode}")
     if outcome not in _VALID_OUTCOMES:
@@ -426,7 +487,7 @@ async def save_retrospective(
 
     # Note: kiwoom_mock is legacy special case; for US/crypto live, evidence
     # should be available.
-    fill_evidence_available = account_mode != "kiwoom_mock"
+    fill_evidence_available = False if intake_write else account_mode != "kiwoom_mock"
     if not fill_evidence_available and (
         (realized_pnl is not _UNSET and realized_pnl is not None)
         or (fill_price is not _UNSET and fill_price is not None)
@@ -601,7 +662,11 @@ async def save_retrospective(
         payload["policy_version"] = policy_version
 
     repo = TradeRetrospectiveRepository(db)
-    status, retro = await repo.upsert(payload, create_defaults=create_defaults)
+    status, retro = await repo.upsert(
+        payload,
+        create_defaults=create_defaults,
+        _write_capability=_write_capability,
+    )
 
     if _is_canonical and next_actions is not _UNSET and next_actions is not None:
         action_repo = RetrospectiveActionRepository(db)
@@ -977,7 +1042,14 @@ async def build_retrospective_aggregate(
 
     groups: dict[str, list[TradeRetrospective]] = {}
     excluded_no_evidence = 0
+    excluded_intake = 0
     for r in rows:
+        # ROB-1285: intake describes an externally acquired/pre-ledger
+        # position. It is authorization provenance, not an execution outcome,
+        # and must never enter any learning denominator.
+        if is_intake_retrospective(r):
+            excluded_intake += 1
+            continue
         if not r.fill_evidence_available and not include_no_evidence:
             excluded_no_evidence += 1
             continue
@@ -1042,6 +1114,7 @@ async def build_retrospective_aggregate(
         "group_by": group_by,
         "groups": out,
         "excluded_no_fill_evidence": excluded_no_evidence,
+        "excluded_intake": excluded_intake,
     }
 
 
@@ -1056,7 +1129,9 @@ async def build_retrospective_aggregate(
 # expired→cancelled collapse in the ROB-661 spec applies only to lifecycle_state).
 # Without "expired" here the status.in_() scan silently drops those rows from
 # both modes and the excluded count. Treat it as cancel-family.
-_KIS_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
+# ``unknown`` is terminal on this ledger: the send writer maps it to canonical
+# lifecycle_state="anomaly" and the open-row reconciler never revisits it.
+_KIS_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "unknown", "anomaly"})
 _KIS_LIVE_CANCEL_TERMINAL = frozenset({"cancelled", "expired"})
 _GENERIC_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
 _GENERIC_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
@@ -1106,6 +1181,205 @@ _GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_T
 _TOSS_TERMINAL = _TOSS_DEFAULT_TERMINAL | _TOSS_CANCEL_TERMINAL
 _KIS_MOCK_TERMINAL = _KIS_MOCK_DEFAULT_TERMINAL | _KIS_MOCK_CANCEL_TERMINAL
 _ALPACA_PAPER_TERMINAL = _ALPACA_PAPER_DEFAULT_TERMINAL | _ALPACA_PAPER_CANCEL_TERMINAL
+
+# ROB-1285 is deliberately KIS-live-KR-only.  With that scope pinned, this is
+# the exhaustive terminal-event contract for the lot guard: one table, one raw
+# state column, and every terminal status emitted by kis_live_ledger.py.
+KIS_LIVE_INTAKE_TERMINAL_STATUSES = _KIS_LIVE_TERMINAL
+KIS_LIVE_INTAKE_TERMINAL_DEFINITION = {
+    "table": "review.kis_live_order_ledger",
+    "state_column": "status",
+    "statuses": tuple(sorted(KIS_LIVE_INTAKE_TERMINAL_STATUSES)),
+}
+_INTAKE_ACQUISITION_PROVENANCE = frozenset(
+    {"external_acquisition", "pre_ledger_migration", "unknown_external"}
+)
+_INTAKE_SNAPSHOT_MAX_AGE = timedelta(hours=24)
+_INTAKE_SNAPSHOT_FUTURE_SKEW = timedelta(minutes=5)
+
+
+def _positive_intake_decimal(field: str, value: Any) -> Decimal:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise RetrospectiveValidationError(f"{field} must be a finite number") from exc
+    if not parsed.is_finite() or parsed <= 0:
+        raise RetrospectiveValidationError(f"{field} must be positive and finite")
+    return parsed
+
+
+async def assert_no_kis_live_terminal_event_for_intake(
+    db: AsyncSession,
+    *,
+    symbol: str,
+    checked_at: datetime,
+) -> dict[str, Any]:
+    """Fail closed when any terminal KIS-live-KR event exists for ``symbol``.
+
+    The KIS live ledger does not store a broker-account discriminator, so the
+    narrowest durable lot identity is ``account_mode='kis_live' + symbol``.
+    Deliberately checking the full history makes an uncertain account/lot match
+    reject rather than turn intake into a normal-retrospective bypass.
+    """
+    bind = db.get_bind()
+    if bind.dialect.name != "postgresql":
+        raise RetrospectiveValidationError(
+            "position intake terminal guard requires PostgreSQL table locking"
+        )
+    # Serialize the absence check with live-ledger INSERT/UPDATE transactions.
+    # Intake is an exceptional one-shot path; holding this lock only through
+    # the retrospective INSERT closes the check-then-create race.
+    await db.execute(text("LOCK TABLE review.kis_live_order_ledger IN SHARE MODE"))
+    terminal = (
+        await db.execute(
+            select(
+                KISLiveOrderLedger.id,
+                KISLiveOrderLedger.status,
+                KISLiveOrderLedger.trade_date,
+            )
+            .where(
+                KISLiveOrderLedger.account_mode == "kis_live",
+                KISLiveOrderLedger.symbol == symbol,
+                KISLiveOrderLedger.status.in_(KIS_LIVE_INTAKE_TERMINAL_STATUSES),
+            )
+            .order_by(KISLiveOrderLedger.id.asc())
+            .limit(1)
+        )
+    ).first()
+    if terminal is not None:
+        raise RetrospectiveValidationError(
+            "position_intake_terminal_event_exists: "
+            f"table=review.kis_live_order_ledger ledger_id={terminal.id} "
+            f"status={terminal.status}"
+        )
+    return {
+        **KIS_LIVE_INTAKE_TERMINAL_DEFINITION,
+        "scope": {"account_mode": "kis_live", "symbol": symbol},
+        "matched_terminal_events": 0,
+        "checked_at": checked_at.isoformat(),
+        "lock_mode": "SHARE",
+    }
+
+
+async def save_position_intake_retrospective(
+    db: AsyncSession,
+    *,
+    symbol: str,
+    account_ref: str,
+    quantity: Any,
+    average_price: Any,
+    current_price: Any,
+    observed_at: datetime,
+    evidence_source: str,
+    acquisition_provenance: str,
+    acquisition_note: str,
+    correlation_id: str,
+    trigger_type: str,
+    next_actions: list[dict[str, Any]],
+    created_by_profile: str,
+    policy_version: str | None = None,
+    actor: str = "internal:save_position_intake_retrospective",
+    now: datetime | None = None,
+) -> tuple[str, TradeRetrospective]:
+    """Create a non-execution intake retrospective after the terminal guard."""
+    normalized_symbol = _normalize_symbol(symbol, "equity_kr")
+    if not normalized_symbol:
+        raise RetrospectiveValidationError("symbol is required")
+    normalized_account_ref = (account_ref or "").strip()
+    if not normalized_account_ref:
+        raise RetrospectiveValidationError("account_ref is required")
+    normalized_source = (evidence_source or "").strip()
+    if not normalized_source:
+        raise RetrospectiveValidationError("evidence_source is required")
+    normalized_note = (acquisition_note or "").strip()
+    if not normalized_note:
+        raise RetrospectiveValidationError("acquisition_note is required")
+    normalized_correlation = (correlation_id or "").strip()
+    if not normalized_correlation:
+        raise RetrospectiveValidationError("correlation_id is required")
+    normalized_profile = (created_by_profile or "").strip()
+    if not normalized_profile:
+        raise RetrospectiveValidationError("created_by_profile is required")
+    if acquisition_provenance not in _INTAKE_ACQUISITION_PROVENANCE:
+        raise RetrospectiveValidationError(
+            "invalid acquisition_provenance "
+            f"(allowed: {sorted(_INTAKE_ACQUISITION_PROVENANCE)})"
+        )
+    if trigger_type not in {"stop_loss", "thesis_change"}:
+        raise RetrospectiveValidationError(
+            "position intake trigger_type must be stop_loss or thesis_change"
+        )
+    if not isinstance(observed_at, datetime) or observed_at.tzinfo is None:
+        raise RetrospectiveValidationError("observed_at must be timezone-aware")
+
+    checked_at = now or now_kst()
+    if checked_at.tzinfo is None:
+        raise RetrospectiveValidationError("intake clock must be timezone-aware")
+    if observed_at > checked_at + _INTAKE_SNAPSHOT_FUTURE_SKEW:
+        raise RetrospectiveValidationError("position intake snapshot is in the future")
+    if checked_at - observed_at > _INTAKE_SNAPSHOT_MAX_AGE:
+        raise RetrospectiveValidationError("position intake snapshot is stale (>24h)")
+
+    qty = _positive_intake_decimal("quantity", quantity)
+    avg = _positive_intake_decimal("average_price", average_price)
+    current = _positive_intake_decimal("current_price", current_price)
+    pnl_pct = (current - avg) / avg * Decimal("100")
+
+    terminal_guard = await assert_no_kis_live_terminal_event_for_intake(
+        db,
+        symbol=normalized_symbol,
+        checked_at=checked_at,
+    )
+    evidence_snapshot = {
+        RETROSPECTIVE_TYPE_KEY: INTAKE_RETROSPECTIVE_TYPE,
+        "learning_eligibility": {
+            "execution_scoring": False,
+            "reason": "non_execution_position_intake",
+        },
+        "position_intake": {
+            "account_mode": "kis_live",
+            "account_ref": normalized_account_ref,
+            "market": "equity_kr",
+            "symbol": normalized_symbol,
+            "quantity": str(qty),
+            "average_price": str(avg),
+            "current_price": str(current),
+            "pnl_pct": str(pnl_pct),
+            "observed_at": observed_at.isoformat(),
+            "evidence_source": normalized_source,
+            "acquisition_provenance": acquisition_provenance,
+            "acquisition_note": normalized_note,
+            "terminal_guard": terminal_guard,
+        },
+    }
+    return await save_retrospective(
+        db,
+        symbol=normalized_symbol,
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="unfilled",
+        side="sell",
+        market="kr",
+        correlation_id=normalized_correlation,
+        pnl_pct=pnl_pct,
+        rationale=(
+            "Position intake for an externally acquired/pre-ledger lot; "
+            "no execution outcome is asserted."
+        ),
+        result_summary=(
+            f"Current position snapshot {qty} shares at average {avg}; "
+            f"observed {current} ({pnl_pct:.4f}%)."
+        ),
+        evidence_snapshot=evidence_snapshot,
+        created_by_profile=normalized_profile,
+        trigger_type=trigger_type,
+        next_actions=next_actions,
+        guardrail_fired="position_intake_terminal_absence_guard",
+        policy_version=policy_version,
+        actor=actor,
+        _write_capability=_INTAKE_WRITE_CAPABILITY,
+    )
+
 
 # Representative selection is independent of mutable metadata timestamps.
 # A completed closing leg is the most informative roundtrip summary; then prefer

--- a/tests/mcp_server/tooling/test_loss_cut_position_scope.py
+++ b/tests/mcp_server/tooling/test_loss_cut_position_scope.py
@@ -98,7 +98,7 @@ async def test_loss_cut_preview_requires_fresh_orderable_quantity(monkeypatch):
     context = LossCutContext(
         retrospective_id=42,
         exit_reason="stop_loss",
-        approval_issue_id=None,
+        approval_issue_id="ROB-1285",
         requester_agent_id="fixture-agent",
         max_slip=0.02,
         approval_verified_at=datetime.now(UTC),

--- a/tests/mcp_server/tooling/test_loss_cut_preconditions.py
+++ b/tests/mcp_server/tooling/test_loss_cut_preconditions.py
@@ -173,7 +173,7 @@ async def test_loss_cut_preconditions_pass_builds_context():
             exit_intent="loss_cut",
             retrospective_id=42,
             exit_reason="stop_loss",
-            approval_issue_id=None,
+            approval_issue_id="ROB-1285",
             side="sell",
             order_type="limit",
             is_mock=False,
@@ -182,7 +182,49 @@ async def test_loss_cut_preconditions_pass_builds_context():
         )
     assert errors == []
     assert ctx is not None and ctx.retrospective_id == 42 and ctx.max_slip > 0
-    assert ctx.approval_issue_id is None
+    assert ctx.approval_issue_id == "ROB-1285"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_loss_cut_preconditions_require_approval_issue():
+    fake_retro = type(
+        "R",
+        (),
+        {
+            "id": 42,
+            "symbol": "KRW-DOT",
+            "trigger_type": "stop_loss",
+            "created_at": __import__("datetime").datetime.now(
+                __import__("datetime").timezone.utc
+            ),
+        },
+    )()
+    with (
+        patch.object(
+            ov,
+            "get_caller_agent_id",
+            return_value="6b2192cc-14fa-4335-b572-2fe1e0cb54a7",
+        ),
+        patch.object(
+            ov,
+            "_get_retrospective_by_id_for_loss_cut",
+            new=AsyncMock(return_value=fake_retro),
+        ),
+    ):
+        ctx, errors = await ov._validate_loss_cut_preconditions(
+            exit_intent="loss_cut",
+            retrospective_id=42,
+            exit_reason="stop_loss",
+            approval_issue_id=None,
+            side="sell",
+            order_type="limit",
+            is_mock=False,
+            symbol="KRW-DOT",
+            proposal_flow=True,
+        )
+    assert ctx is None
+    assert errors == ["loss_cut requires approval_issue_id"]
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -785,7 +785,7 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
-        approval_issue_id=None,
+        approval_issue_id="ROB-1285",
         now=now,
     )
     nonce = unique[:11]
@@ -1021,7 +1021,7 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
     assert (row.exit_intent, row.retrospective_id, row.approval_issue_id) == (
         "loss_cut",
         42,
-        None,
+        "ROB-1285",
     )
 
     partial = _toss_evidence(

--- a/tests/mcp_server/tooling/test_toss_loss_cut.py
+++ b/tests/mcp_server/tooling/test_toss_loss_cut.py
@@ -125,7 +125,7 @@ def _configure_loss_cut_preconditions(
 
 
 @pytest.mark.asyncio
-async def test_toss_proposal_loss_cut_allows_missing_issue_without_paperclip(
+async def test_toss_proposal_loss_cut_requires_approval_issue(
     monkeypatch,
 ):
     _configure_toss(monkeypatch)
@@ -133,8 +133,9 @@ async def test_toss_proposal_loss_cut_allows_missing_issue_without_paperclip(
 
     result = await _preview_loss_cut(approval_issue_id=None)
 
-    assert result["success"] is True
-    assert result["retrospective_id"] == 42
+    assert result["success"] is False
+    assert result["error"] == "loss_cut_preconditions_failed"
+    assert result["violations"] == ["loss_cut requires approval_issue_id"]
 
 
 @pytest.mark.asyncio
@@ -459,13 +460,13 @@ async def test_toss_loss_cut_submit_does_not_query_paperclip(monkeypatch):
             exit_intent="loss_cut",
             exit_reason="stop_loss",
             retrospective_id=42,
-            approval_issue_id=None,
+            approval_issue_id="ROB-858",
         )
 
     assert result["success"] is True
     assert len(client.placed_payloads) == 1
     record_send.assert_awaited_once()
-    assert record_send.await_args.kwargs["approval_issue_id"] is None
+    assert record_send.await_args.kwargs["approval_issue_id"] == "ROB-858"
 
 
 @pytest.mark.asyncio
@@ -512,7 +513,7 @@ async def test_toss_loss_cut_submit_requires_supplied_valid_hash_in_off_mode(
             exit_intent="loss_cut",
             exit_reason="stop_loss",
             retrospective_id=42,
-            approval_issue_id=None,
+            approval_issue_id="ROB-858",
         )
 
     assert result["success"] is False

--- a/tests/services/order_proposals/test_loss_cut_approval.py
+++ b/tests/services/order_proposals/test_loss_cut_approval.py
@@ -95,6 +95,7 @@ async def _seed_loss_cut_proposal(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=retro.id,
+        approval_issue_id="ROB-1285",
         now=now,
         valid_until=now + timedelta(minutes=15),
     )

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -501,6 +501,7 @@ async def test_loss_cut_confirmation_preview_is_read_only_and_builds_evidence(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
+        approval_issue_id="ROB-1285",
     )
     calls = []
 
@@ -594,6 +595,7 @@ async def test_loss_cut_confirmation_preview_rejects_quantity_above_sellable(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=43,
+        approval_issue_id="ROB-1285",
     )
 
     async def fake_preview(**kwargs):

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -467,7 +467,7 @@ def _loss_cut_create_kwargs(*, now: datetime):
         "exit_intent": "loss_cut",
         "exit_reason": "stop_loss",
         "retrospective_id": 42,
-        "approval_issue_id": None,
+        "approval_issue_id": "ROB-1285",
         "now": now,
     }
 
@@ -515,6 +515,7 @@ async def test_loss_cut_requires_all_group_fields_without_paperclip_lookup(
     ("overrides", "message"),
     [
         ({"retrospective_id": None}, "retrospective_id"),
+        ({"approval_issue_id": None}, "approval_issue_id"),
         ({"exit_reason": None}, "exit_reason"),
         ({"exit_intent": "emergency"}, "unknown exit_intent"),
         # ROB-929 code review: every submit path still only recognizes
@@ -574,11 +575,11 @@ async def test_valid_loss_cut_persists_exact_group_binding(db_session, monkeypat
         group.exit_reason,
         group.retrospective_id,
         group.approval_issue_id,
-    ) == ("loss_cut", "stop_loss", 42, None)
+    ) == ("loss_cut", "stop_loss", 42, "ROB-1285")
 
 
 @pytest.mark.asyncio
-async def test_loss_cut_preserves_optional_approval_issue_as_audit_note(
+async def test_loss_cut_preserves_required_approval_issue_as_audit_note(
     db_session, monkeypatch
 ):
     async def fake_lookup(session, retrospective_id):
@@ -3123,6 +3124,7 @@ async def _create_defensive_rung(
             exit_intent="loss_cut",
             exit_reason="stop_loss",
             retrospective_id=42,
+            approval_issue_id="ROB-1285",
             valid_until=datetime(2026, 7, 20, 0, 0, tzinfo=UTC),
             now=_HANDOFF_CREATED,
         )
@@ -3196,6 +3198,7 @@ async def test_expired_defensive_handoff_includes_voided_loss_cut(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
+        approval_issue_id="ROB-1285",
         now=_HANDOFF_RECENT,
         creator_agent_id=_TEST_OWNER_AGENT,
     )

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -337,6 +337,7 @@ async def _seed_loss_cut_proposal(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
+        approval_issue_id="ROB-1285",
     )
     dispatched_at = datetime.now(UTC)
     window = await allow_known_session(group, now=dispatched_at)

--- a/tests/services/test_position_intake_retrospective.py
+++ b/tests/services/test_position_intake_retrospective.py
@@ -1,0 +1,345 @@
+"""ROB-1285 — guarded position-intake retrospective path."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp_server.tooling.kis_live_ledger import _STATUS_TO_LIFECYCLE
+from app.mcp_server.tooling.trade_retrospective_tools import (
+    save_position_intake_retrospective as save_position_intake_retrospective_tool,
+)
+from app.models.review import KISLiveOrderLedger, TradeForecast, TradeRetrospective
+from app.services import decision_history
+from app.services.trade_journal import trade_retrospective_service as svc
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+_TERMINAL_STATUSES = (
+    "filled",
+    "rejected",
+    "unknown",
+    "anomaly",
+    "cancelled",
+    "expired",
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
+    await db_session.execute(delete(TradeRetrospective))
+    await db_session.execute(delete(KISLiveOrderLedger))
+    await db_session.execute(delete(TradeForecast))
+    await db_session.commit()
+
+
+def _ledger_row(*, status: str, symbol: str = "012030") -> KISLiveOrderLedger:
+    return KISLiveOrderLedger(
+        trade_date=datetime.now(UTC),
+        symbol=symbol,
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=Decimal("150"),
+        price=Decimal("2150"),
+        account_mode="kis_live",
+        broker="kis",
+        status=status,
+        lifecycle_state=_STATUS_TO_LIFECYCLE.get(status, status),
+        order_no=f"ROB1285-{status}-{symbol}",
+    )
+
+
+def _intake_kwargs(**overrides):
+    observed_at = datetime.now(UTC)
+    values = {
+        "symbol": "012030",
+        "account_ref": "kis-live-primary",
+        "quantity": Decimal("150"),
+        "average_price": Decimal("2150"),
+        "current_price": Decimal("1524"),
+        "observed_at": observed_at,
+        "evidence_source": "operator_holdings_snapshot",
+        "acquisition_provenance": "pre_ledger_migration",
+        "acquisition_note": "Position predates the canonical live order ledger.",
+        "correlation_id": "position-intake:kis_live:012030:ROB-1285",
+        "trigger_type": "stop_loss",
+        "next_actions": [
+            {
+                "action": "Review the bound loss-cut proposal under ROB-1285",
+                "owner": "operator",
+                "issue_id": "ROB-1285",
+                "status": "open",
+            }
+        ],
+        "created_by_profile": "rob1285-test",
+        "policy_version": "test-policy",
+        "now": observed_at,
+    }
+    values.update(overrides)
+    return values
+
+
+def test_terminal_definition_covers_every_terminal_kis_live_writer_status():
+    terminal_lifecycle_states = {"filled", "failed", "cancelled", "anomaly"}
+    statuses_emitted_as_terminal = {
+        raw
+        for raw, lifecycle in _STATUS_TO_LIFECYCLE.items()
+        if lifecycle in terminal_lifecycle_states
+    }
+    assert statuses_emitted_as_terminal == set(_TERMINAL_STATUSES)
+    assert svc.KIS_LIVE_INTAKE_TERMINAL_STATUSES == set(_TERMINAL_STATUSES)
+    assert svc.KIS_LIVE_INTAKE_TERMINAL_DEFINITION == {
+        "table": "review.kis_live_order_ledger",
+        "state_column": "status",
+        "statuses": tuple(sorted(_TERMINAL_STATUSES)),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", _TERMINAL_STATUSES)
+async def test_every_terminal_status_rejects_intake(
+    db_session: AsyncSession, terminal_status: str
+):
+    db_session.add(_ledger_row(status=terminal_status))
+    await db_session.commit()
+
+    with pytest.raises(
+        svc.RetrospectiveValidationError,
+        match=rf"position_intake_terminal_event_exists: .*status={terminal_status}",
+    ):
+        await svc.save_position_intake_retrospective(db_session, **_intake_kwargs())
+
+    persisted = (
+        await db_session.execute(select(func.count()).select_from(TradeRetrospective))
+    ).scalar_one()
+    assert persisted == 0
+
+
+@pytest.mark.asyncio
+async def test_intake_creation_path_calls_terminal_guard(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    async def _guard_must_run(*_args, **_kwargs):
+        raise svc.RetrospectiveValidationError("terminal-guard-wiring-sentinel")
+
+    monkeypatch.setattr(
+        svc,
+        "assert_no_kis_live_terminal_event_for_intake",
+        _guard_must_run,
+    )
+    with pytest.raises(
+        svc.RetrospectiveValidationError,
+        match="terminal-guard-wiring-sentinel",
+    ):
+        await svc.save_position_intake_retrospective(db_session, **_intake_kwargs())
+    persisted = (
+        await db_session.execute(select(func.count()).select_from(TradeRetrospective))
+    ).scalar_one()
+    assert persisted == 0
+
+
+@pytest.mark.asyncio
+async def test_nonterminal_rows_do_not_false_positive_for_012030(
+    db_session: AsyncSession,
+):
+    db_session.add_all(
+        [_ledger_row(status=status) for status in ("accepted", "pending", "partial")]
+    )
+    await db_session.commit()
+
+    action, row = await svc.save_position_intake_retrospective(
+        db_session, **_intake_kwargs()
+    )
+    await db_session.commit()
+
+    assert action == "created"
+    assert row.symbol == "012030"
+    assert row.fill_evidence_available is False
+    assert svc.serialize_retrospective(row)["retrospective_type"] == "intake"
+    assert (
+        row.evidence_snapshot["position_intake"]["terminal_guard"][
+            "matched_terminal_events"
+        ]
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_for_other_symbol_does_not_false_positive(
+    db_session: AsyncSession,
+):
+    db_session.add(_ledger_row(status="filled", symbol="005930"))
+    await db_session.commit()
+
+    action, row = await svc.save_position_intake_retrospective(
+        db_session, **_intake_kwargs()
+    )
+    await db_session.commit()
+
+    assert action == "created"
+    assert row.symbol == "012030"
+
+
+@pytest.mark.asyncio
+async def test_generic_retrospective_cannot_spoof_intake_type(
+    db_session: AsyncSession,
+):
+    with pytest.raises(
+        svc.RetrospectiveValidationError,
+        match="retrospective_type is reserved",
+    ):
+        await svc.save_retrospective(
+            db_session,
+            symbol="012030",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="unfilled",
+            evidence_snapshot={"retrospective_type": "intake"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_generic_upsert_cannot_retype_or_mutate_existing_intake(
+    db_session: AsyncSession,
+):
+    _action, intake = await svc.save_position_intake_retrospective(
+        db_session, **_intake_kwargs()
+    )
+    await db_session.commit()
+
+    with pytest.raises(
+        svc.RetrospectiveValidationError,
+        match="retrospective_type boundary violation",
+    ):
+        await svc.save_retrospective(
+            db_session,
+            symbol="012030",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            correlation_id=intake.correlation_id,
+            evidence_snapshot={},
+        )
+
+    await db_session.refresh(intake)
+    assert svc.serialize_retrospective(intake)["retrospective_type"] == "intake"
+    assert intake.outcome == "unfilled"
+
+
+@pytest.mark.asyncio
+async def test_intake_is_excluded_by_actual_learning_aggregate_consumer(
+    db_session: AsyncSession,
+):
+    await svc.save_position_intake_retrospective(db_session, **_intake_kwargs())
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        strategy_key="execution-strategy",
+        realized_pnl=1000,
+        realized_pnl_currency="KRW",
+        pnl_pct=1.5,
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_aggregate(
+        db_session,
+        group_by="trigger_type",
+    )
+
+    assert result["excluded_intake"] == 1
+    assert sum(group["sample_size"] for group in result["groups"]) == 1
+    assert result["groups"][0]["by_outcome"] == {"filled": 1}
+    forecasts = (
+        await db_session.execute(select(func.count()).select_from(TradeForecast))
+    ).scalar_one()
+    assert forecasts == 0
+
+
+@pytest.mark.asyncio
+async def test_intake_is_excluded_from_decision_history_learning_context(
+    db_session: AsyncSession,
+):
+    await svc.save_position_intake_retrospective(db_session, **_intake_kwargs())
+    await svc.save_retrospective(
+        db_session,
+        symbol="012030",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        pnl_pct=Decimal("1.25"),
+        lesson="execution lesson remains eligible",
+    )
+    await db_session.commit()
+
+    lessons, outcomes = await decision_history._retrospectives(
+        db_session,
+        "012030",
+        "kis_live",
+    )
+
+    assert lessons == ["execution lesson remains eligible"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["outcome"] == "filled"
+    assert outcomes[0]["pnl_pct"] == 1.25
+
+
+@pytest.mark.asyncio
+async def test_existing_execution_retrospective_path_regresses_zero(
+    db_session: AsyncSession,
+):
+    action, row = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        evidence_snapshot={"broker_evidence": "fixture"},
+    )
+    await db_session.commit()
+
+    assert action == "created"
+    assert row.fill_evidence_available is True
+    assert svc.serialize_retrospective(row)["retrospective_type"] == "execution"
+
+
+@pytest.mark.asyncio
+async def test_mcp_intake_tool_wires_guarded_service(db_session: AsyncSession):
+    observed_at = datetime.now(UTC)
+    result = await save_position_intake_retrospective_tool(
+        symbol="012030",
+        account_ref="kis-live-primary",
+        quantity=150,
+        average_price=2150,
+        current_price=1524,
+        observed_at=observed_at.isoformat(),
+        evidence_source="operator_holdings_snapshot",
+        acquisition_provenance="pre_ledger_migration",
+        acquisition_note="Position predates the canonical live order ledger.",
+        correlation_id="position-intake:kis_live:012030:mcp-test",
+        trigger_type="stop_loss",
+        next_actions=[
+            {
+                "action": "Review the bound loss-cut proposal under ROB-1285",
+                "status": "open",
+            }
+        ],
+        created_by_profile="rob1285-test",
+    )
+
+    assert result["success"] is True
+    assert result["data"]["retrospective_type"] == "intake"
+    assert result["data"]["fill_evidence_available"] is False

--- a/tests/services/test_trade_journal_aggregates_tag.py
+++ b/tests/services/test_trade_journal_aggregates_tag.py
@@ -68,6 +68,41 @@ async def test_untagged_when_no_signal(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_position_intake_is_excluded_from_exact_and_window_setup_tag_reads(
+    db_session: AsyncSession,
+) -> None:
+    sym = _digit_symbol()
+    norm = _normalize_symbol_for_filter(sym, "equity_kr")
+    corr = f"rob1285-intake-{uuid.uuid4()}"
+    db_session.add(
+        TradeRetrospective(
+            symbol=norm,
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="unfilled",
+            strategy_key="must_not_seed_learning",
+            correlation_id=corr,
+            evidence_snapshot={"retrospective_type": "intake"},
+            created_at=datetime(2026, 6, 4, tzinfo=UTC),
+        )
+    )
+    await db_session.flush()
+
+    info = await resolve_setup_tag(
+        db_session,
+        _trade(
+            symbol=sym,
+            account="kis",
+            entry_correlation_ids=(corr,),
+        ),
+    )
+
+    assert info.tag == "untagged"
+    assert info.tag_source == "untagged"
+    assert info.link_quality == "symbol_window"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("trade_account", "retro_account_mode"),
     [("kis", "kis_live"), ("toss", "toss_live")],

--- a/tests/test_kis_mock_loss_sell_guard.py
+++ b/tests/test_kis_mock_loss_sell_guard.py
@@ -396,7 +396,7 @@ def test_rob_912_sell_marketable_band_guards() -> None:
     loss_ctx = LossCutContext(
         retrospective_id=1,
         exit_reason="loss_cut",
-        approval_issue_id=None,
+        approval_issue_id="ROB-1285",
         requester_agent_id="test",
         max_slip=0.05,
         approval_verified_at=datetime.datetime.now(datetime.UTC),

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1571,6 +1571,7 @@ async def test_list_expired_defensive_returns_expired_loss_cut_proposal(
             exit_intent="loss_cut",
             exit_reason="stop_loss",
             retrospective_id=42,
+            approval_issue_id="ROB-1285",
             rungs=[
                 {
                     "rung_index": 0,
@@ -1648,6 +1649,7 @@ async def test_list_expired_defensive_filters_by_market(monkeypatch):
             exit_intent="loss_cut",
             exit_reason="stop_loss",
             retrospective_id=42,
+            approval_issue_id="ROB-1285",
             rungs=[
                 {
                     "rung_index": 0,

--- a/tests/test_trade_retrospective_pending.py
+++ b/tests/test_trade_retrospective_pending.py
@@ -404,11 +404,14 @@ async def test_kis_expired_restored_by_include_cancelled(db_session: AsyncSessio
 
 
 @pytest.mark.asyncio
-async def test_anomaly_and_rejected_kept_by_default(db_session: AsyncSession):
+async def test_anomaly_rejected_and_unknown_kept_by_default(
+    db_session: AsyncSession,
+):
     db_session.add_all(
         [
             _kis_row(order_no="K-ANOM", status="anomaly"),
             _kis_row(order_no="K-REJ", status="rejected"),
+            _kis_row(order_no="K-UNKNOWN", status="unknown"),
         ]
     )
     await db_session.commit()
@@ -417,7 +420,11 @@ async def test_anomaly_and_rejected_kept_by_default(db_session: AsyncSession):
         db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
     )
     refs = {p["suggested_correlation_id"] for p in result["pending"]}
-    assert refs == {"kis_live:K-ANOM", "kis_live:K-REJ"}
+    assert refs == {
+        "kis_live:K-ANOM",
+        "kis_live:K-REJ",
+        "kis_live:K-UNKNOWN",
+    }
     assert result["excluded_by_filter"] == {"cancelled": 0}
 
 

--- a/tests/test_trade_retrospective_tools.py
+++ b/tests/test_trade_retrospective_tools.py
@@ -273,6 +273,7 @@ def test_tool_names_set_complete():
     )
 
     assert TRADE_RETROSPECTIVE_TOOL_NAMES == {
+        "save_position_intake_retrospective",
         "save_trade_retrospective",
         "get_trade_retrospectives",
         "get_retrospective_aggregate",
@@ -284,6 +285,7 @@ def test_tools_in_available_surface():
     from app.mcp_server import AVAILABLE_TOOL_NAMES
 
     for name in (
+        "save_position_intake_retrospective",
         "save_trade_retrospective",
         "get_trade_retrospectives",
         "get_retrospective_aggregate",
@@ -292,7 +294,7 @@ def test_tools_in_available_surface():
         assert name in AVAILABLE_TOOL_NAMES
 
 
-def test_register_wires_three_tools():
+def test_register_wires_all_retrospective_tools():
     from app.mcp_server.tooling.trade_retrospective_registration import (
         register_trade_retrospective_tools,
     )
@@ -310,6 +312,7 @@ def test_register_wires_three_tools():
 
     register_trade_retrospective_tools(_FakeMCP())
     assert set(registered) == {
+        "save_position_intake_retrospective",
         "save_trade_retrospective",
         "get_trade_retrospectives",
         "get_retrospective_aggregate",


### PR DESCRIPTION
## What changed

- Add a DEFAULT-profile-only KIS-live-KR position-intake retrospective path for externally acquired or pre-ledger holdings.
- Fail closed when any same-symbol KIS live terminal event exists, covering `filled`, `rejected`, `unknown`, `anomaly`, `cancelled`, and `expired`, with the guard wired directly into creation.
- Persist `retrospective_type=intake` in the existing evidence envelope and exclude intake rows from retrospective aggregates, setup-tag attribution, and decision-history learning context.
- Keep loss-cut proposal controls intact and strengthen both proposal creation and direct revalidation to require a non-empty `approval_issue_id`.
- Preserve the Telegram two-click loss-cut ceremony and required loss-rate/second-window card disclosures.

## Why

A pre-ledger 012030 holding had no system terminal event, so the existing retrospective prerequisite made a loss-cut proposal impossible to create. The new intake path supplies non-execution provenance without pretending a broker fill occurred or weakening approval/execution controls.

## Safety and impact

- No migration, dependency, scheduler, broker gateway, or broker ledger implementation changes.
- The intake path writes only the existing retrospective/action records; it never creates or submits an order.
- Operational acceptance emitted the initial Telegram approval card only. No approval click, broker order, fill, deployment, merge, or ready-for-review transition was performed.

## Validation

- Guard mutants independently proved RED for: one omitted terminal status, removed two-click routing, and removed intake learning exclusion.
- `1239 passed, 1 warning` across retrospective, learning-consumer, order-proposal, two-step approval, MCP profile, KIS, and Toss related suites.
- Existing LLM-boundary guard: `3 passed`.
- `make lint`: Ruff check, Ruff format check, and ty all passed.
- Existing assertion counts did not decrease; no skip/xfail references were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added position-intake retrospectives for recording externally acquired position evidence.
  * Added validation for freshness, provenance, pricing, timestamps, and terminal position status.
  * Intake retrospectives are excluded from learning, scoring, and aggregate insights.
* **Bug Fixes**
  * Loss-cut proposals now require a non-empty approval issue ID, which is retained through authorization and execution.
  * Unknown KIS order statuses are handled as terminal for intake safeguards.
* **Documentation**
  * Updated tool guidance and retrospective workflow documentation for the new requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->