### PR TITLE
test(ROB-1264): pin that the signed kr.kiwoom.mock lane is refused a J3A grant

### DIFF
--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -1202,6 +1202,7 @@ def test_signed_kiwoom_lane_is_not_execution_ready() -> None:
     assert entry.scheduler_owner is None
     assert entry.physical_account_id is None
     assert entry.identity_status == "UNKNOWN"
+    assert entry.fingerprint_evidence_ref is None
     assert entry.missing_bindings
 
     with pytest.raises(LaneGuardError) as refusal:
@@ -1220,6 +1221,7 @@ def test_signed_kiwoom_lane_fails_every_execution_ready_clause() -> None:
     assert entry.activation_status is not ActivationStatus.ENABLED
     assert not (entry.writer and entry.auto)
     assert entry.physical_account_id is None
+    assert entry.fingerprint_evidence_ref is None
     assert entry.missing_bindings != ()
 
 
@@ -1246,15 +1248,98 @@ def test_signed_kiwoom_lane_cannot_construct_the_coordination_adapter() -> None:
 
 
 def test_signed_kiwoom_lane_transport_gate_refuses_even_claiming_a_grant() -> None:
-    """``grant_owned=True`` is not a grant. The signed row still fails closed."""
+    """``grant_owned=True`` is not a grant. The signed row still fails closed.
+
+    The signed row raises ``KiwoomTransportGateRejected`` /
+    ``transport_gate_rejected`` (``physical_account_id is None`` ≠ the
+    caller id). ``LaneGuardError`` is not a path through
+    ``assert_kiwoom_transport_ready`` on this row; that type is raised by
+    ``require_j2a_physical_account_id`` during adapter construction and is
+    pinned by ``test_signed_kiwoom_lane_cannot_construct_the_coordination_adapter``.
+    """
 
     account = FakeKiwoomAccount()
-    with pytest.raises((KiwoomTransportGateRejected, LaneGuardError)):
+    with pytest.raises(KiwoomTransportGateRejected) as refusal:
         assert_kiwoom_transport_ready(
             account=account,
             entry=canonical_kiwoom_entry(),
             physical_account_id=RAW_PHYSICAL_ACCOUNT_ID,
             grant_owned=True,
         )
+    assert refusal.value.reason == "transport_gate_rejected"
     assert account.buy_calls == []
     assert account.sell_calls == []
+
+
+def test_execution_ready_writer_clause_fires_once_activation_passes() -> None:
+    """1182 is independent of 1180: activation ENABLED, writer/auto still off.
+
+    ``kr.kiwoom.mock`` is not on the signed-restriction lists, so 1178
+    stays quiet. Only ``activation_status`` is replaced — this is not
+    ``bound_kiwoom_entry()``.
+    """
+
+    entry = replace(
+        canonical_kiwoom_entry(),
+        activation_status=ActivationStatus.ENABLED,
+    )
+    assert entry.writer is False
+    assert entry.auto is False
+    with pytest.raises(LaneGuardError) as refusal:
+        assert_entry_execution_ready(entry)
+    assert refusal.value.code == "lane_writer_not_enabled"
+
+
+def test_execution_ready_identity_clause_fires_once_prior_clauses_pass() -> None:
+    """1184 is independent of 1180/1182: those two pass, identity stays unknown."""
+
+    entry = replace(
+        canonical_kiwoom_entry(),
+        activation_status=ActivationStatus.ENABLED,
+        writer=True,
+        auto_order_enabled=True,
+    )
+    assert entry.physical_account_id is None
+    assert entry.identity_status == "UNKNOWN"
+    assert entry.fingerprint_evidence_ref is None
+    with pytest.raises(LaneGuardError) as refusal:
+        assert_entry_execution_ready(entry)
+    assert refusal.value.code == "physical_account_identity_unknown"
+
+
+def test_execution_ready_missing_bindings_clause_fires_once_prior_clauses_pass() -> (
+    None
+):
+    """1197 is independent of 1180/1182/1184 *and* of the field-level check.
+
+    Filling policy/caps/canary makes ``required_bindings`` (:1198-1214)
+    pass, so deleting only 1197 cannot hide behind the same
+    ``lane_binding_incomplete`` code. ``missing_bindings`` stays the
+    signed 5-tuple. Still not ``bound_kiwoom_entry()``.
+    """
+
+    signed = canonical_kiwoom_entry()
+    entry = replace(
+        signed,
+        activation_status=ActivationStatus.ENABLED,
+        writer=True,
+        auto_order_enabled=True,
+        physical_account_id=RAW_PHYSICAL_ACCOUNT_ID,
+        identity_status="KNOWN",
+        fingerprint_evidence_ref=FINGERPRINT_REF,
+        policy_binding=PolicyBinding(POLICY_VERSION, POLICY_VERSION_HASH),
+        execution_mode="test-only-clause-independence",
+        scheduler_owner=SchedulerOwner.MANUAL,
+        max_order_notional=Decimal("10000000"),
+        max_orders_per_session=8,
+        max_open_orders=8,
+        allowed_order_types=("limit",),
+        allowed_time_in_force=("day",),
+        reconcile_required=True,
+        canary_binding="test-only-clause-independence",
+    )
+    assert entry.missing_bindings == signed.missing_bindings
+    assert entry.missing_bindings
+    with pytest.raises(LaneGuardError) as refusal:
+        assert_entry_execution_ready(entry)
+    assert refusal.value.code == "lane_binding_incomplete"

--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -33,8 +33,10 @@ from app.services.mock_integration.lineage import MockLineageFactory
 from app.services.mock_lane_registry import (
     CANONICAL_LANE_REGISTRY,
     ActivationStatus,
+    LaneGuardError,
     LaneRegistryEntry,
     PolicyBinding,
+    assert_entry_execution_ready,
 )
 from scripts.b0x.kr.kiwoom_ordering import (
     ACCOUNT_SUMMARY_FINGERPRINT_IDENTITY_REJECTED,
@@ -1164,3 +1166,95 @@ def test_client_py_unchanged_in_this_job() -> None:
         ).read_bytes()
     ).hexdigest()
     assert digest == _KIWOOM_CLIENT_PY_SHA256
+
+
+# ---------------------------------------------------------------------------
+# §E-9 The signed lane, exactly as shipped
+#
+# Every other test in this module builds ``bound_kiwoom_entry()``, which
+# replaces twenty fields on the canonical row to make the lane execution
+# ready. That fixture answers "does the adapter behave once kr.kiwoom.mock is
+# activated". It cannot answer "is kr.kiwoom.mock activated", and the B-track
+# runner consumes the *signed* row, not the fixture. These tests pin the
+# signed row's real answer so a future reader does not mistake the fixture's
+# green for a grant the port would actually issue.
+# ---------------------------------------------------------------------------
+
+
+def canonical_kiwoom_entry() -> LaneRegistryEntry:
+    """The signed kr.kiwoom.mock row — no overrides, no replace()."""
+
+    return next(
+        entry
+        for entry in CANONICAL_LANE_REGISTRY
+        if entry.lane_id == KIWOOM_CANONICAL_LANE_ID
+    )
+
+
+def test_signed_kiwoom_lane_is_not_execution_ready() -> None:
+    """The port refuses the signed row, and names activation as the reason."""
+
+    entry = canonical_kiwoom_entry()
+    assert entry.activation_status is ActivationStatus.BLOCKED
+    assert entry.lane_status is LaneStatus.NOT_READY
+    assert entry.writer is False
+    assert entry.auto is False
+    assert entry.scheduler_owner is None
+    assert entry.physical_account_id is None
+    assert entry.identity_status == "UNKNOWN"
+    assert entry.missing_bindings
+
+    with pytest.raises(LaneGuardError) as refusal:
+        assert_entry_execution_ready(entry)
+    assert "lane_activation_not_enabled" in str(refusal.value)
+
+
+def test_signed_kiwoom_lane_fails_every_execution_ready_clause() -> None:
+    """Not one stale flag — four independent bindings are absent.
+
+    Recorded so nobody reads the single ``lane_activation_not_enabled`` string
+    above as "flip one boolean and the grant flows".
+    """
+
+    entry = canonical_kiwoom_entry()
+    assert entry.activation_status is not ActivationStatus.ENABLED
+    assert not (entry.writer and entry.auto)
+    assert entry.physical_account_id is None
+    assert entry.missing_bindings != ()
+
+
+def test_signed_kiwoom_lane_cannot_construct_the_coordination_adapter() -> None:
+    """Construction fails on J2A identity, before any port or socket exists."""
+
+    entry = canonical_kiwoom_entry()
+    account = FakeKiwoomAccount()
+    ports = KiwoomCoordinationPorts(
+        persistence=InMemoryLineagePersistence(),
+        dispatch_evidence=InMemoryDispatchEvidence(),
+        uncertainty_gate=InMemoryUncertaintyGate(),
+        claims=DurableSendClaimAdapter(InMemoryReservationPort()),
+        connection_factory=ConnectionFactory(FakeLockSpace(), pid=4242),
+        registry=CANONICAL_LANE_REGISTRY,
+        lineage_factory=MockLineageFactory(),
+        entry=entry,
+    )
+    with pytest.raises(LaneGuardError) as refusal:
+        KiwoomCoordinationAdapter(ports)
+    assert "physical_account_identity_unknown" in str(refusal.value)
+    assert account.buy_calls == []
+    assert account.sell_calls == []
+
+
+def test_signed_kiwoom_lane_transport_gate_refuses_even_claiming_a_grant() -> None:
+    """``grant_owned=True`` is not a grant. The signed row still fails closed."""
+
+    account = FakeKiwoomAccount()
+    with pytest.raises((KiwoomTransportGateRejected, LaneGuardError)):
+        assert_kiwoom_transport_ready(
+            account=account,
+            entry=canonical_kiwoom_entry(),
+            physical_account_id=RAW_PHYSICAL_ACCOUNT_ID,
+            grant_owned=True,
+        )
+    assert account.buy_calls == []
+    assert account.sell_calls == []


### PR DESCRIPTION
## What this is

This branch was opened to wire the B-track kiwoom_mock runner to a J3A coordination grant, reviving the send path that today's deploy fail-closed at `coordination_grant_unavailable`.

**The wiring is not here, on purpose.** The brief made one question a hard stop before any wiring: *does the J3A port issue a grant to a lane in this state?* It does not. Per the brief, that finding is the stopping point — "port 를 고쳐서 통과시키지 마라".

## The answer

`coordinate_mock_order_mutation` calls `_validated_entry` (coordination.py:2364) → `assert_entry_execution_ready` (mock_lane_registry.py:1175). Against the signed `kr.kiwoom.mock` row that raises:

```
LaneGuardError('lane_activation_not_enabled: lane=kr.kiwoom.mock')
```

Four independent clauses fail, not one stale flag:

| registry.py | clause | signed row | result |
|---|---|---|---|
| 1178 | signed lane restriction | writer/auto/activation all falsey | pass |
| 1180 | `activation is ENABLED` | `BLOCKED` | **TRIP — first failure** |
| 1182 | `writer and auto` | `False` / `False` | TRIP |
| 1184 | physical identity known | `physical_account_id=None`, `identity_status="UNKNOWN"` | TRIP |
| 1197 | `missing_bindings` empty | 5 entries | TRIP |

The adapter cannot even be constructed: `KiwoomCoordinationAdapter.__init__` calls `require_j2a_physical_account_id`, which raises `physical_account_identity_unknown`.

Everything that would close the gap — flipping `activation_status`, `writer`, `auto_order_enabled`, binding `physical_account_id` — is exactly what the brief forbids, and is the J5 activation semantics this job must not pre-empt.

## Why the suite was green anyway

Every other test in this module builds `bound_kiwoom_entry()`, which `replace()`s **twenty fields** on the canonical row to make the lane execution-ready. That fixture answers *"does the adapter behave once kr.kiwoom.mock is activated"*. It cannot answer *"is kr.kiwoom.mock activated"* — and the runner consumes the signed row, not the fixture. No test read the signed row. That is the gap these four tests close.

## What is in the diff

One test file, +94 lines. No registry, coordination-port, or runner code is touched.

- `test_signed_kiwoom_lane_is_not_execution_ready` — the port refuses, and names activation
- `test_signed_kiwoom_lane_fails_every_execution_ready_clause` — four clauses, not one
- `test_signed_kiwoom_lane_cannot_construct_the_coordination_adapter` — fails on J2A identity, before any port or socket
- `test_signed_kiwoom_lane_transport_gate_refuses_even_claiming_a_grant` — `grant_owned=True` is not a grant

Broker call count asserted at exactly 0 throughout.

## Mutants (both RED)

| mutant | death |
|---|---|
| drop the activation clause (registry.py:1180-1181) | `test_kiwoom_coordination_adapter.py::test_signed_kiwoom_lane_is_not_execution_ready` — `AssertionError: assert 'lane_activation_not_enabled' in 'lane_writer_not_enabled: lane=kr.kiwoom.mock'` |
| `assert_entry_execution_ready` → no-op | same test, `DID NOT RAISE` |

A third, incidental finding: flipping the signed row to `ENABLED` does not even reach a test — `assert_registry_startup` rejects it at **module import** with `missing_binding_not_blocked[kr.kiwoom.mock]` (registry.py:801-812). Activation and bindings cannot be separated.

## Verification

- `pytest tests/services/mock_integration/ tests/scripts/b0x/kr/kiwoom/` → **633 passed**, exit 0
- with kiwoom smoke + live-readonly guard suites → **708 passed**, exit 0
- `make lint` (ruff check + format + ty) → exit 0
- `git diff --stat origin/main` → 1 file, +94. registry 0 · migration 0 · deps 0 · coordination port 0 · runner 0

## Not done

Zero broker mutation. The CLI was never invoked; `--confirm` was never run. The lane's ordering journal is unchanged (14 lines = 11 prior + the 3 events from the operator's 11:27 cycle), and no artifact was written after 11:27.

**The B-track lane remains blocked.** Reviving it is a contract decision — J5 activation, or a J3A amendment — not a wiring change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming the signed Kiwoom integration lane remains unavailable for execution.
  * Verified that readiness checks reject missing activation, identity, and binding requirements.
  * Confirmed adapter construction and transport access are blocked when execution readiness is not met.
  * Added checks that rejected paths perform no external I/O.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->