### PR TITLE
docs(ROB-1266): J5A US lane readiness/evidence contract + closed-equality checker

### DIFF
--- a/docs/contracts/rob-1266-us-readiness.md
+++ b/docs/contracts/rob-1266-us-readiness.md
@@ -1,0 +1,400 @@
+# ROB-1266 — US lane readiness and evidence contract
+
+## Scope and authority
+
+This is a contract-only artifact (J5A).  It consumes the signed registry
+without changing it and authorizes no broker, network, database, scheduler,
+deployment, credential, or account operation.  It creates no policy, assigns
+no writer, proposes no cadence, and grants no canary.
+
+The controlling registry is
+`app/services/mock_lane_registry.py::CANONICAL_LANE_REGISTRY`.  The four US
+rows recorded below are a literal consumption of that registry.  Where this
+document and the registry disagree, **the registry is authoritative** and this
+document is the defect.
+
+`role` is a purpose-only registry value.  It is not execution authority, and
+it is independent of `writer`, `auto_order_enabled`, `activation_status`, and
+`scheduler_owner`.  In particular `us.alpaca.paper.default` carries
+`PRIMARY_AUTO` *together with* `AUTO_READY_BLOCKED_BY_POLICY`, `writer=False`,
+`auto_order_enabled=False`, and an absent scheduler owner; those five facts are
+fixed as one unit and may not be quoted apart from each other.
+
+## 1. Document-level fixed tokens
+
+```text
+SIGNED_SOURCE = app/services/mock_lane_registry.py::CANONICAL_LANE_REGISTRY @ e057941425d2ea7d35a36ebf6074a6c70eba3013
+SEPARATION_PROVEN = NO (physical_account_fingerprint missing)
+```
+
+Each token appears exactly once in this document.  `SEPARATION_PROVEN` is the
+machine-checkable form of the standing override: **physical account separation
+is not claimed while every US row carries `physical_account_id` absent.**  See
+§6.
+
+## 2. Record shape
+
+Each US lane is recorded as a `### LANE <lane_id>` heading followed by exactly
+two fenced blocks, in this order:
+
+1. a **REGISTRY** block whose first line is `# REGISTRY`, and
+2. a **DERIVED** block whose first line is `# DERIVED`.
+
+The two are separate because they have different provenance.  REGISTRY holds
+registry dataclass fields only; DERIVED holds values computed from those
+fields.  Mixing them would make neither key set closed.
+
+- The REGISTRY block's key set equals the **full** field-name set of
+  `LaneRegistryEntry` — every field, no extras, no omissions.  It is not a
+  subset.  As of 2026-08-18 that is 34 fields, but the field list itself is the
+  contract, not the count.
+- The DERIVED block's key set is exactly `{CAP_STATUS}` — nothing else.  No
+  optional keys are permitted, because an optional key cannot be held to a
+  closed-equality check.
+
+Each body line is `<key> = <rendered value>`.  Keys do not repeat within a
+block.
+
+## 3. Value rendering rule
+
+A recorded value is `render(v)` of the registry attribute, where `render`
+dispatches on type in exactly this order:
+
+1. `v is None` → `None`
+2. `bool` → `False` / `True` — **before `int`**, because `bool` is a subclass
+   of `int`
+3. `Enum` → `v.value` — **before `str`**, because the registry uses `StrEnum`
+   members (`AUTO_MIRROR`, `NOT_READY`, `BLOCKED`, `mock`, `paper`, `USD`, …)
+4. `str` → the string as-is
+5. `tuple` → `()` when empty, otherwise `"(" + ", ".join(render(x)) + ")"`
+6. dataclass → `ClassName(f1=render(v1), f2=render(v2))`, field names and order
+   taken from `dataclasses.fields(v)`, separator `", "`.  This rule exists for
+   `policy_binding: PolicyBinding | None`; all four US rows currently record it
+   as absent, and no non-absent spelling may be invented here.
+7. `int` / `Decimal` → `str(v)`
+8. anything else → **no fallback**.  The checker raises rather than inventing a
+   representation.
+
+Reordering steps 2 and 3 against steps 4 and 7 silently corrupts the record, so
+the order above is normative.
+
+## 4. Cap status rule
+
+`CAP_STATUS` is derived from the registry alone, from exactly three fields:
+`max_order_notional`, `max_orders_per_session`, `max_open_orders`.
+
+- All three absent → `MISSING`.
+- Any one of them bound → not `MISSING`.
+
+This is an if-and-only-if.  Policy-specific daily, concurrent, or loss caps are
+**not** recorded here: no approved policy exists for any US lane, so no such
+literal exists to quote.  Inventing one is forbidden; the honest record is
+`MISSING`.  All four US rows are `MISSING` today, and each additionally carries
+`cap` inside `missing_bindings`.
+
+## 5. US capability gap evidence
+
+Linear ROB-1266 ① asks what is *impossible* today, with evidence.  The
+following gaps are read from merged code at
+`994b60c90abb7b88fa253acb8b986c532b3967c3`.  Each is a readiness blocker in its
+own right, independent of the policy and cap blockers above.
+
+### 5.1 `us.kis.mock` — no open-order truth in mock mode
+
+`KISOverseasOrders.inquire_overseas_orders`
+(`app/services/brokers/kis/overseas_orders.py:393`) fails closed for the mock
+lane at `app/services/brokers/kis/overseas_orders.py:427-431`:
+
+> `KIS overseas pending-orders inquiry (TTTS3018R) is not available in mock mode.`
+
+The overseas pending-order (미체결) inquiry is the primary source of
+open-order truth for this lane, and it raises before any transport when
+`is_mock=True`.  Any downstream rule of the form "stop unless open order count
+is known" therefore cannot be satisfied from this endpoint at all — it is an
+absent capability, not a transient error.  This is recorded as UNKNOWN; it is
+not evidence that the count is zero.
+
+### 5.2 `us.kis.mock` — USD buying power is not available from integrated margin
+
+`KISAccount.inquire_integrated_margin`
+(`app/services/brokers/kis/account.py:809`) raises for the mock lane at
+`app/services/brokers/kis/account.py:836-840`:
+
+> `KIS integrated margin is not supported in mock mode; use inquire_domestic_cash_balance(is_mock=True) instead.`
+
+That endpoint's documented response is where `usd_ord_psbl_amt` (달러
+주문가능금액) and `usd_balance` come from, so the integrated-margin USD surface
+is unavailable to this lane.  A mock-scoped alternative does exist —
+`KISAccount.inquire_mock_overseas_buyable_amount`
+(`app/services/brokers/kis/account.py:761`) — so the honest statement is
+**"the integrated-margin USD surface is unavailable; a separate mock-only
+buyable-amount endpoint exists"**, not "USD buying power is unobtainable".
+Which of the two a future lane consumes is not decided here.
+
+### 5.3 `us.kiwoom.mock` — US equity is not a declared broker market
+
+`BROKER_CAPABILITIES[Broker.KIWOOM]`
+(`app/services/brokers/capabilities.py:74-79`) declares
+`markets=frozenset({Market.KR_EQUITY})` and `supports_live=False`.
+`Market.US_EQUITY` is **absent** from that set.
+
+A US order/account surface nevertheless exists in the tree
+(`app/services/brokers/kiwoom/us_client.py`, `us_orders.py`, `us_account.py`,
+plus `app/mcp_server/tooling/orders_kiwoom_us_variants.py`).  The gap is
+therefore a *disagreement* between the capability registry and the shipped
+surface, not a simple absence.  This contract records the capability registry
+as it stands and does not reconcile the two; reconciliation would be a
+production change and is out of scope for J5A.
+
+Consistent with the standing decision, `us.kiwoom.mock` is
+`BROKER_REGRESSION` for this epoch.  Promotion to `AUTO_MIRROR` requires a
+separate approved autonomous policy and is not authorized here.
+
+### 5.4 All four US lanes — no executable US-equity paper capability row
+
+`PAPER_BROKER_CAPABILITIES` (`app/services/brokers/capabilities.py:91-136`)
+contains exactly two entries: `Broker.BINANCE` (`market=Market.CRYPTO`) and
+`Broker.ALPACA` (`market=Market.CRYPTO`, `symbols={"BTC/USD", "ETH/USD"}`).
+
+There is **no `Broker.KIS` entry, no `Broker.KIWOOM` entry, and no
+`Market.US_EQUITY` entry at all**.  `get_paper_capabilities(Broker.ALPACA)`
+returns the crypto row, which is not a US equity capability and must not be
+read as one.  Consequently none of the four US lanes has an executable
+capability description covering products, symbols, sides, order types, time in
+force, or sizing modes.  Every such value is UNKNOWN, and the correct
+per-lane conclusion is the registry's own `allowed_order_types = ()` and
+`allowed_time_in_force = ()` — empty, meaning *nothing is authorized*, not
+*anything is allowed*.
+
+### 5.5 Rate-limit fact carried forward, not a readiness claim
+
+The official KIS mock (VTS) host enforces one admitted REST request per second
+across every call for a given account/app-key scope, enforced at the dispatch
+boundary by `app/services/brokers/kis/vts_distributed_gate.py`.  This is
+recorded because it bounds any future evidence-gathering cadence on
+`us.kis.mock`.  It is not a readiness signal in either direction.
+
+## 6. Why separation is not proven
+
+All four US rows record `physical_account_id` as absent,
+`identity_status = UNKNOWN`, `fingerprint_evidence_ref` absent, and carry
+`physical_account_fingerprint` in `missing_bindings`.
+
+What the registry does establish is that the four lanes are declared under
+**distinct credential namespaces** — `KIS_MOCK_*`, `KIWOOM_MOCK_US_*`,
+`ALPACA_PAPER_*`, `ALPACA_PAPER_LAB_*` — and, for the two Alpaca rows, distinct
+`profile_variant` values (`default`, `lab`) over a shared
+`paper-api.alpaca.markets` host allowlist.
+
+Namespace and profile distinctness is a **declaration**, not a measurement.  No
+broker-observed account fingerprint has been recorded for any of the four rows,
+so it remains unproven that two declared namespaces do not resolve to the same
+physical account.  The two Alpaca rows are the sharpest case: they differ only
+by credential namespace and profile variant on the same host.
+
+Therefore the token in §1 is fixed at `NO`, and the strongest supportable claim
+is: *the profiles and credential namespaces are declared separately.*  Any
+stronger claim requires masked physical-account fingerprint evidence that does
+not exist today.  Until then all four rows stay `writer=False`,
+`auto_order_enabled=False`, and activation-blocked.
+
+## 7. What this document does not do
+
+- It does not modify `app/services/mock_lane_registry.py` or any production
+  module.  If a registry row disagrees with the signed values, the fix is a
+  serial J2A follow-up, not an edit from here.
+- It does not create, approve, or imply a policy; `policy` remains in
+  `missing_bindings` for all four rows.
+- It does not assign a scheduler owner.  An absent `scheduler_owner` means
+  **owner absent; mutation-ineligible; no authority to bind one downstream**.
+  It is not an alternative spelling of `DISABLED`, which is a distinct explicit
+  enum member used by other lanes.
+- It does not authorize a canary; `canary` remains in `missing_bindings`.
+- It records no FX rate, parity, or currency conversion.  All four rows are
+  `quote_currency = USD`, and USD is never treated as interchangeable with KRW
+  or USDT.
+
+## 8. Lane records
+
+The four blocks below are the contract surface.  Values are `render()` of the
+signed registry entry as defined in §3.
+
+### LANE us.kis.mock
+
+```text
+# REGISTRY
+lane_id = us.kis.mock
+market = us
+broker = kis
+account_profile = mock
+profile_variant = None
+account_mode = mock
+lane_type = mock
+quote_currency = USD
+role = AUTO_MIRROR
+role_pending_reason = None
+role_on_policy_approval = None
+lane_status = NOT_READY
+activation_status = BLOCKED
+activation_reason = NOT_READY
+policy_binding = None
+execution_mode = None
+scheduler_owner = None
+timing_owner = None
+writer = False
+auto_order_enabled = False
+max_order_notional = None
+max_orders_per_session = None
+max_open_orders = None
+allowed_order_types = ()
+allowed_time_in_force = ()
+endpoint_class = mock
+reconcile_required = None
+credential_namespace = KIS_MOCK_*
+allowed_hosts = (openapivts.koreainvestment.com:29443)
+physical_account_id = None
+identity_status = UNKNOWN
+fingerprint_evidence_ref = None
+canary_binding = None
+missing_bindings = (physical_account_fingerprint, policy, cap, owner, canary)
+```
+
+```text
+# DERIVED
+CAP_STATUS = MISSING
+```
+
+### LANE us.kiwoom.mock
+
+```text
+# REGISTRY
+lane_id = us.kiwoom.mock
+market = us
+broker = kiwoom
+account_profile = mock
+profile_variant = None
+account_mode = mock
+lane_type = mock
+quote_currency = USD
+role = BROKER_REGRESSION
+role_pending_reason = None
+role_on_policy_approval = None
+lane_status = NOT_READY
+activation_status = BLOCKED
+activation_reason = NOT_READY
+policy_binding = None
+execution_mode = None
+scheduler_owner = None
+timing_owner = None
+writer = False
+auto_order_enabled = False
+max_order_notional = None
+max_orders_per_session = None
+max_open_orders = None
+allowed_order_types = ()
+allowed_time_in_force = ()
+endpoint_class = mock
+reconcile_required = None
+credential_namespace = KIWOOM_MOCK_US_*
+allowed_hosts = (mockapi.kiwoom.com)
+physical_account_id = None
+identity_status = UNKNOWN
+fingerprint_evidence_ref = None
+canary_binding = None
+missing_bindings = (physical_account_fingerprint, policy, cap, owner, canary)
+```
+
+```text
+# DERIVED
+CAP_STATUS = MISSING
+```
+
+### LANE us.alpaca.paper.default
+
+```text
+# REGISTRY
+lane_id = us.alpaca.paper.default
+market = us
+broker = alpaca
+account_profile = paper
+profile_variant = default
+account_mode = paper
+lane_type = paper
+quote_currency = USD
+role = PRIMARY_AUTO
+role_pending_reason = None
+role_on_policy_approval = None
+lane_status = AUTO_READY_BLOCKED_BY_POLICY
+activation_status = BLOCKED
+activation_reason = AUTO_READY_BLOCKED_BY_POLICY
+policy_binding = None
+execution_mode = None
+scheduler_owner = None
+timing_owner = None
+writer = False
+auto_order_enabled = False
+max_order_notional = None
+max_orders_per_session = None
+max_open_orders = None
+allowed_order_types = ()
+allowed_time_in_force = ()
+endpoint_class = paper
+reconcile_required = None
+credential_namespace = ALPACA_PAPER_*
+allowed_hosts = (paper-api.alpaca.markets)
+physical_account_id = None
+identity_status = UNKNOWN
+fingerprint_evidence_ref = None
+canary_binding = None
+missing_bindings = (physical_account_fingerprint, policy, cap, owner, canary)
+```
+
+```text
+# DERIVED
+CAP_STATUS = MISSING
+```
+
+### LANE us.alpaca.paper.lab
+
+```text
+# REGISTRY
+lane_id = us.alpaca.paper.lab
+market = us
+broker = alpaca
+account_profile = paper
+profile_variant = lab
+account_mode = paper
+lane_type = paper
+quote_currency = USD
+role = None
+role_pending_reason = policy_absent
+role_on_policy_approval = AUTO_CHALLENGER
+lane_status = AUTO_READY_BLOCKED_BY_LIFECYCLE
+activation_status = BLOCKED
+activation_reason = AUTO_READY_BLOCKED_BY_LIFECYCLE
+policy_binding = None
+execution_mode = None
+scheduler_owner = None
+timing_owner = None
+writer = False
+auto_order_enabled = False
+max_order_notional = None
+max_orders_per_session = None
+max_open_orders = None
+allowed_order_types = ()
+allowed_time_in_force = ()
+endpoint_class = paper
+reconcile_required = None
+credential_namespace = ALPACA_PAPER_LAB_*
+allowed_hosts = (paper-api.alpaca.markets)
+physical_account_id = None
+identity_status = UNKNOWN
+fingerprint_evidence_ref = None
+canary_binding = None
+missing_bindings = (physical_account_fingerprint, policy, cap, owner, canary)
+```
+
+```text
+# DERIVED
+CAP_STATUS = MISSING
+```

--- a/tests/services/mock_integration/test_rob1266_us_readiness_contract.py
+++ b/tests/services/mock_integration/test_rob1266_us_readiness_contract.py
@@ -1,0 +1,364 @@
+"""ROB-1266 J5A — US readiness/evidence contract checker.
+
+Offline only: this module reads two artifacts — the contract document and the
+signed lane registry — and compares them.  It opens no socket, no database
+connection, and no file outside the repository, and it modifies nothing.
+
+Expectation provenance is deliberately split:
+
+* Structural expectations (G1-G3, G5) are **derived** from the registry.  The
+  document is the artifact under test and the registry is the expectation
+  source, so this is a cross-artifact comparison, not a circular one.
+* The safety invariant (G6) is **literal**.  If the registry itself is flipped,
+  these assertions must go red rather than quietly follow it.
+* G7 proves that G6 really is literal, so nobody can later convert it to a
+  derived value unnoticed.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import pathlib
+import re
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+import pytest
+
+from app.services.mock_lane_registry import (
+    CANONICAL_LANE_REGISTRY,
+    LaneRegistryEntry,
+)
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_DOC_PATH = _REPO_ROOT / "docs/contracts/rob-1266-us-readiness.md"
+
+_SIGNED_SOURCE_TOKEN = (
+    "SIGNED_SOURCE = app/services/mock_lane_registry.py::CANONICAL_LANE_REGISTRY"
+    " @ e057941425d2ea7d35a36ebf6074a6c70eba3013"
+)
+_SEPARATION_TOKEN = "SEPARATION_PROVEN = NO (physical_account_fingerprint missing)"
+
+_CAP_FIELDS = (
+    "max_order_notional",
+    "max_orders_per_session",
+    "max_open_orders",
+)
+
+# ---------------------------------------------------------------------------
+# G6 expectation — LITERAL BY CONTRACT.  Do not derive any part of the two
+# constants below from ``app.services.mock_lane_registry``; ``test_g7_*``
+# enforces that mechanically.
+# ---------------------------------------------------------------------------
+
+_SAFETY_AXES = (
+    "role",
+    "role_pending_reason",
+    "lane_status",
+    "activation_status",
+    "scheduler_owner",
+    "writer",
+    "auto_order_enabled",
+    "physical_account_id",
+    "identity_status",
+)
+
+_SAFETY_AXES_EXPECTED = {
+    "us.kis.mock": (
+        "AUTO_MIRROR",
+        None,
+        "NOT_READY",
+        "BLOCKED",
+        None,
+        False,
+        False,
+        None,
+        "UNKNOWN",
+    ),
+    "us.kiwoom.mock": (
+        "BROKER_REGRESSION",
+        None,
+        "NOT_READY",
+        "BLOCKED",
+        None,
+        False,
+        False,
+        None,
+        "UNKNOWN",
+    ),
+    "us.alpaca.paper.default": (
+        "PRIMARY_AUTO",
+        None,
+        "AUTO_READY_BLOCKED_BY_POLICY",
+        "BLOCKED",
+        None,
+        False,
+        False,
+        None,
+        "UNKNOWN",
+    ),
+    "us.alpaca.paper.lab": (
+        None,
+        "policy_absent",
+        "AUTO_READY_BLOCKED_BY_LIFECYCLE",
+        "BLOCKED",
+        None,
+        False,
+        False,
+        None,
+        "UNKNOWN",
+    ),
+}
+
+# The lane set is likewise literal: G1 is a closed-equality check against the
+# four lanes this contract owns, not against whatever the document happens to
+# contain.
+_US_LANE_IDS = (
+    "us.kis.mock",
+    "us.kiwoom.mock",
+    "us.alpaca.paper.default",
+    "us.alpaca.paper.lab",
+)
+
+
+class RenderUnsupportedType(TypeError):
+    """Raised instead of inventing a textual form for an unforeseen type."""
+
+
+def render(value: Any) -> str:
+    """Render a registry value exactly as the contract document records it.
+
+    The dispatch order is normative: ``bool`` precedes ``int`` because ``bool``
+    subclasses ``int``, and ``Enum`` precedes ``str`` because the registry uses
+    ``StrEnum`` members.
+    """
+
+    if value is None:
+        return "None"
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, Enum):
+        return str(value.value)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, tuple):
+        if not value:
+            return "()"
+        return "(" + ", ".join(render(item) for item in value) + ")"
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        inner = ", ".join(
+            f"{f.name}={render(getattr(value, f.name))}"
+            for f in dataclasses.fields(value)
+        )
+        return f"{type(value).__name__}({inner})"
+    if isinstance(value, (int, Decimal)):
+        return str(value)
+    raise RenderUnsupportedType(type(value).__name__)
+
+
+# ---------------------------------------------------------------------------
+# Document parsing
+# ---------------------------------------------------------------------------
+
+_LANE_HEADER_RE = re.compile(r"^### LANE (?P<lane>\S+)[ \t]*$", re.M)
+_FENCE_RE = re.compile(r"^```[a-zA-Z]*\n(?P<body>.*?)^```[ \t]*$", re.M | re.S)
+
+
+def _doc_text() -> str:
+    return _DOC_PATH.read_text(encoding="utf-8")
+
+
+def _lane_sections(text: str) -> dict[str, str]:
+    """Split the document into ``lane_id -> section text`` (header included)."""
+
+    matches = list(_LANE_HEADER_RE.finditer(text))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        lane = match.group("lane")
+        assert lane not in sections, f"duplicate lane heading: {lane}"
+        sections[lane] = text[match.start() : end]
+    return sections
+
+
+def _parse_block(body: str, kind: str) -> dict[str, str]:
+    lines = body.splitlines()
+    assert lines, f"empty {kind} block"
+    assert lines[0] == f"# {kind}", f"expected first line '# {kind}', got {lines[0]!r}"
+    parsed: dict[str, str] = {}
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        key, separator, value = line.partition(" = ")
+        assert separator, f"{kind} line is not '<key> = <value>': {line!r}"
+        assert key not in parsed, f"duplicate {kind} key: {key}"
+        parsed[key] = value
+    return parsed
+
+
+def _lane_blocks(section: str, lane: str) -> tuple[dict[str, str], dict[str, str]]:
+    """Return the ``(REGISTRY, DERIVED)`` key/value maps for one lane."""
+
+    fences = _FENCE_RE.findall(section)
+    assert len(fences) == 2, (
+        f"lane {lane}: expected exactly 2 fenced blocks, found {len(fences)}"
+    )
+    return _parse_block(fences[0], "REGISTRY"), _parse_block(fences[1], "DERIVED")
+
+
+def _entry(lane: str) -> LaneRegistryEntry:
+    for candidate in CANONICAL_LANE_REGISTRY:
+        if candidate.lane_id == lane:
+            return candidate
+    raise AssertionError(f"lane absent from signed registry: {lane}")
+
+
+def _require_section(lane: str) -> str:
+    sections = _lane_sections(_doc_text())
+    assert lane in sections, f"lane block missing from contract document: {lane}"
+    return sections[lane]
+
+
+def _registry_field_names() -> tuple[str, ...]:
+    return tuple(f.name for f in dataclasses.fields(LaneRegistryEntry))
+
+
+# ---------------------------------------------------------------------------
+# G1 — lane set is closed
+# ---------------------------------------------------------------------------
+
+
+def test_g1_lane_set_is_closed() -> None:
+    assert set(_lane_sections(_doc_text())) == set(_US_LANE_IDS)
+
+
+# ---------------------------------------------------------------------------
+# G2 — REGISTRY key set equals the full dataclass field set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lane", _US_LANE_IDS)
+def test_g2_registry_key_set_is_closed(lane: str) -> None:
+    registry_block, _ = _lane_blocks(_require_section(lane), lane)
+    assert set(registry_block) == set(_registry_field_names())
+
+
+# ---------------------------------------------------------------------------
+# G3 — every recorded value equals render(registry value)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lane", _US_LANE_IDS)
+def test_g3_registry_values_match(lane: str) -> None:
+    registry_block, _ = _lane_blocks(_require_section(lane), lane)
+    entry = _entry(lane)
+    mismatches = {
+        field: (registry_block[field], render(getattr(entry, field)))
+        for field in _registry_field_names()
+        if field in registry_block
+        and registry_block[field] != render(getattr(entry, field))
+    }
+    assert not mismatches, f"lane {lane}: documented != registry: {mismatches}"
+
+
+# ---------------------------------------------------------------------------
+# G4 — document-level fixed tokens, verbatim, exactly once each
+# ---------------------------------------------------------------------------
+
+
+def test_g4_document_level_tokens() -> None:
+    text = _doc_text()
+    assert text.count(_SEPARATION_TOKEN) == 1
+    assert text.count(_SIGNED_SOURCE_TOKEN) == 1
+
+
+# ---------------------------------------------------------------------------
+# G5 — DERIVED key set is exactly {CAP_STATUS}, and MISSING is an iff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lane", _US_LANE_IDS)
+def test_g5_cap_status(lane: str) -> None:
+    _, derived_block = _lane_blocks(_require_section(lane), lane)
+    assert set(derived_block) == {"CAP_STATUS"}
+
+    entry = _entry(lane)
+    caps_absent = all(getattr(entry, field) is None for field in _CAP_FIELDS)
+    assert (derived_block["CAP_STATUS"] == "MISSING") is caps_absent
+
+
+# ---------------------------------------------------------------------------
+# G6 — literal safety invariant asserted against the registry itself
+# ---------------------------------------------------------------------------
+
+
+def _axis_value(entry: LaneRegistryEntry, axis: str) -> Any:
+    value = getattr(entry, axis)
+    return value.value if isinstance(value, Enum) else value
+
+
+@pytest.mark.parametrize("lane", _US_LANE_IDS)
+def test_g6_frozen_safety_axes(lane: str) -> None:
+    entry = _entry(lane)
+    expected = _SAFETY_AXES_EXPECTED[lane]
+    assert len(expected) == len(_SAFETY_AXES)
+    for axis, want in zip(_SAFETY_AXES, expected, strict=True):
+        got = _axis_value(entry, axis)
+        assert type(got) is type(want), f"{lane}.{axis}: type {type(got)!r}"
+        assert got == want, f"{lane}.{axis}: {got!r} != {want!r}"
+
+
+# ---------------------------------------------------------------------------
+# G7 — prove G6's expectation really is a literal
+# ---------------------------------------------------------------------------
+
+_PURE_LITERAL_NODES = (ast.Dict, ast.Tuple, ast.Constant, ast.Load)
+_REGISTRY_MODULE = "app.services.mock_lane_registry"
+
+
+def _self_source() -> str:
+    return pathlib.Path(__file__).read_text(encoding="utf-8")
+
+
+def _module_constant(name: str) -> tuple[ast.AST, str]:
+    source = _self_source()
+    for node in ast.parse(source).body:
+        targets = getattr(node, "targets", [])
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in targets
+        ):
+            segment = ast.get_source_segment(source, node.value)
+            assert segment is not None, f"no source segment for {name}"
+            return node.value, segment
+    raise AssertionError(f"module-level constant not found: {name}")
+
+
+def _registry_import_symbols() -> set[str]:
+    symbols: set[str] = set()
+    for node in ast.walk(ast.parse(_self_source())):
+        if isinstance(node, ast.ImportFrom) and node.module == _REGISTRY_MODULE:
+            for alias in node.names:
+                symbols.add(alias.name)
+                if alias.asname:
+                    symbols.add(alias.asname)
+    return symbols
+
+
+@pytest.mark.parametrize("name", ["_SAFETY_AXES", "_SAFETY_AXES_EXPECTED"])
+def test_g7_safety_expectation_is_literal(name: str) -> None:
+    value_node, segment = _module_constant(name)
+
+    impure = [
+        type(node).__name__
+        for node in ast.walk(value_node)
+        if not isinstance(node, _PURE_LITERAL_NODES)
+    ]
+    assert not impure, f"{name} is not a pure literal; found nodes: {impure}"
+
+    symbols = _registry_import_symbols()
+    assert symbols, "expected this module to import from the signed registry"
+    leaked = sorted(symbol for symbol in symbols if symbol in segment)
+    assert not leaked, f"{name} references registry symbols: {leaked}"
+    assert _REGISTRY_MODULE not in segment


### PR DESCRIPTION
## J5A / ROB-1266 — US readiness & evidence contract

Records the four US lanes as a literal consumption of the signed registry, plus a
checker that holds the document to it. **No production code, registry, migration,
scheduler, broker, or network surface is touched.**

### Files (exactly two, both new)

| file | role |
| --- | --- |
| `docs/contracts/rob-1266-us-readiness.md` | the contract artifact |
| `tests/services/mock_integration/test_rob1266_us_readiness_contract.py` | the checker |

### Contract shape

- Document tokens: `SIGNED_SOURCE` (registry @ `e057941425d2ea7d35a36ebf6074a6c70eba3013`) and `SEPARATION_PROVEN = NO (physical_account_fingerprint missing)`, each exactly once.
- Per lane: a **REGISTRY** block whose key set equals the *full* `LaneRegistryEntry` field set (34 today), and a separate **DERIVED** block whose key set is exactly `{CAP_STATUS}`. Split so both key sets can be closed-equality checked.
- `CAP_STATUS = MISSING` on all four rows. No policy-specific daily/concurrent/loss cap is invented — none exists to quote.
- `scheduler_owner` absent is recorded as absent, **not** rewritten to `disabled`. `role` is recorded as purpose-only and never merged with `role_pending_reason`.

### Assertions

| id | check |
| --- | --- |
| G1 | doc lane set `==` the four US lanes |
| G2 | REGISTRY key set `==` `dataclasses.fields(LaneRegistryEntry)` |
| G3 | per-field value equality vs `render(registry value)` |
| G4 | both document-level tokens verbatim, exactly once |
| G5 | DERIVED key set `==` `{CAP_STATUS}`; `MISSING` iff all three cap fields absent |
| G6 | nine frozen safety axes per lane, **literal** — a registry flip must go red |
| G7 | AST self-proof that G6's expectation stays a pure literal |

G3 derives expectations from the registry (cross-artifact, not circular); G6 is
deliberately literal so the registry cannot silently drag the test along.

### Evidence

- Mutants M1–M9 (document-level and lane-scoped): **9/9 killed**, each restored to the exact pre-mutation SHA with a clean `git status --porcelain`.
- `pytest tests/services/mock_integration/test_rob1266_us_readiness_contract.py` — 20 passed.
- `pytest tests/test_mock_lane_registry.py` — 86 passed.
- `pytest tests/services/mock_integration/` — 485 passed.
- `ruff check` / `ruff format --check` on the new test — clean.
- The checker imports only stdlib + `pytest` + the registry; the repo socket guard reports `blocked_attempts=0`.

### US capability gaps recorded (with code citations)

- `us.kis.mock`: overseas pending-order inquiry (TTTS3018R) raises in mock mode (`app/services/brokers/kis/overseas_orders.py:427-431`) — no open-order truth.
- `us.kis.mock`: integrated margin unsupported in mock mode (`app/services/brokers/kis/account.py:836-840`); a mock-only buyable-amount endpoint exists as a separate surface.
- `us.kiwoom.mock`: `Market.US_EQUITY` absent from `BROKER_CAPABILITIES[Broker.KIWOOM]` while a US surface ships in-tree — recorded as a disagreement, not reconciled here.
- All four: `PAPER_BROKER_CAPABILITIES` has no US-equity row at all.

🔴 Draft. Independent verification and merge are orch-mock's; do not mark ready or merge from here.