### PR TITLE
Preserve Futures Demo open-order positionSide

### DIFF
--- a/app/services/brokers/binance/futures_demo/dto.py
+++ b/app/services/brokers/binance/futures_demo/dto.py
@@ -83,6 +83,9 @@ class FuturesDemoOpenOrder:
     qty: Decimal
     status: str
     reduce_only: bool
+    # ROB-1289: broker-echoed ``positionSide``, preserved verbatim.  Absence
+    # remains ``None``; callers must not infer it from any other field.
+    position_side: str | None = None
 
 
 @dataclass(frozen=True)

--- a/app/services/brokers/binance/futures_demo/execution_client.py
+++ b/app/services/brokers/binance/futures_demo/execution_client.py
@@ -689,6 +689,7 @@ class BinanceFuturesDemoExecutionClient:
                 qty=Decimal(str(entry.get("origQty", "0"))),
                 status=str(entry.get("status", "")),
                 reduce_only=bool(entry.get("reduceOnly", False)),
+                position_side=_extract_position_side(entry),
             )
             for entry in body
         ]
@@ -718,6 +719,7 @@ class BinanceFuturesDemoExecutionClient:
                 qty=Decimal(str(entry.get("origQty", "0"))),
                 status=str(entry.get("status", "")),
                 reduce_only=bool(entry.get("reduceOnly", False)),
+                position_side=_extract_position_side(entry),
             )
             for entry in body
         ]

--- a/tests/services/brokers/binance/futures_demo/test_execution_client_position_side.py
+++ b/tests/services/brokers/binance/futures_demo/test_execution_client_position_side.py
@@ -50,6 +50,9 @@ _ORDER_TEST_URL = re.compile(
 _POSITION_RISK_URL = re.compile(
     r"^https://demo-fapi\.binance\.com/fapi/v2/positionRisk\?.*$"
 )
+_OPEN_ORDERS_URL = re.compile(
+    r"^https://demo-fapi\.binance\.com/fapi/v1/openOrders\?.*$"
+)
 
 
 @pytest.fixture
@@ -216,6 +219,95 @@ async def test_get_order_preserves_position_side(
     )
     result = await client.get_order(symbol="XRPUSDT", client_order_id="rob1288-cid")
     assert result.position_side == "BOTH"
+
+
+@pytest.mark.asyncio
+async def test_get_open_orders_preserves_position_side(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    """A symbol-scoped open-order row carries Binance's exact positionSide."""
+    httpx_mock.add_response(
+        method="GET",
+        url=_OPEN_ORDERS_URL,
+        status_code=200,
+        json=[
+            {
+                "symbol": "XRPUSDT",
+                "orderId": 1289,
+                "clientOrderId": "rob1289-open-cid",
+                "side": "SELL",
+                "origQty": "7.4",
+                "status": "NEW",
+                "reduceOnly": True,
+                "positionSide": "BOTH",
+            }
+        ],
+    )
+
+    result = await client.get_open_orders(symbol="XRPUSDT")
+
+    assert result.orders[0].position_side == "BOTH"
+    assert result.orders[0].qty == Decimal("7.4")
+    assert result.orders[0].side == "SELL"
+    assert result.orders[0].reduce_only is True
+
+
+@pytest.mark.asyncio
+async def test_open_order_without_position_side_stays_none(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    """Missing positionSide is not inferred from qty, side, or reduceOnly."""
+    httpx_mock.add_response(
+        method="GET",
+        url=_OPEN_ORDERS_URL,
+        status_code=200,
+        json=[
+            {
+                "symbol": "XRPUSDT",
+                "orderId": 1290,
+                "clientOrderId": "rob1290-open-cid",
+                "side": "SELL",
+                "origQty": "7.4",
+                "status": "NEW",
+                "reduceOnly": True,
+            }
+        ],
+    )
+
+    result = await client.get_open_orders(symbol="XRPUSDT")
+
+    assert result.orders[0].position_side is None
+
+
+@pytest.mark.asyncio
+async def test_get_all_open_orders_preserves_position_side_without_symbol(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    """The account-wide path preserves positionSide and omits symbol scope."""
+    httpx_mock.add_response(
+        method="GET",
+        url=_OPEN_ORDERS_URL,
+        status_code=200,
+        json=[
+            {
+                "symbol": "DOGEUSDT",
+                "orderId": 1291,
+                "clientOrderId": "rob1291-open-cid",
+                "side": "BUY",
+                "origQty": "5",
+                "status": "NEW",
+                "reduceOnly": False,
+                "positionSide": "SHORT",
+            }
+        ],
+    )
+
+    result = await client.get_all_open_orders()
+
+    request = httpx_mock.get_requests()[0]
+    assert "symbol=" not in str(request.url)
+    assert result.orders[0].symbol == "DOGEUSDT"
+    assert result.orders[0].position_side == "SHORT"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Add terminal-default `position_side: str | None = None` to `FuturesDemoOpenOrder`.
- Preserve Binance's raw `positionSide` through both `get_open_orders(symbol=...)` and `get_all_open_orders()` parsers.
- Add offline httpx-mocked positive, no-inference, and account-wide regression tests.

## Scope and safety

- Additive DTO-only surface; existing fields and public mutation signatures are unchanged.
- No position-side inference from quantity, side, or reduceOnly.
- No open-order serialization/ledger recording path exists in the searched Futures Demo surface; consumers only inspect emptiness and client order IDs.
- No broker/live account mutation, migration, dependency, scheduler, env, Spot Demo, or registry changes.

## Validation

- `uv run --frozen --no-sync pytest -q tests/services/brokers/binance/futures_demo/` — 175 passed.
- `uv run --frozen --no-sync pytest -q tests/services/test_upbit_futures_boundary.py tests/services/execution_outcomes/test_static_boundaries.py` — 61 passed.
- `uv run --frozen --no-sync ruff check ...` — All checks passed.
- `uv run --frozen --no-sync ruff format --check ...` — 3 files already formatted.
- Socket guard: `active=True blocked_attempts=0 workers=0`.
- Three clean-commit mutation tests each went RED at the intended assertion and were restored with clean `git status --porcelain`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Open-order details now accurately preserve the broker-provided position side for both symbol-specific and account-wide queries.
  * Orders without a position side continue to display it as unavailable rather than inferring a value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->