### PR TITLE
fix: linearize Alembic head chain

### DIFF
--- a/alembic/versions/20260819_rob1286_repricing_claims.py
+++ b/alembic/versions/20260819_rob1286_repricing_claims.py
@@ -1,7 +1,7 @@
 """ROB-1286 durable watch-event repricing claims (additive)
 
 Revision ID: 20260819_rob1286_claims
-Revises: 20260815_external_cash
+Revises: 20260815_funding_advisory
 Create Date: 2026-08-19
 
 Additive: creates one new table in the ``review`` schema. No existing table,
@@ -33,7 +33,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260819_rob1286_claims"
-down_revision: str | Sequence[str] | None = "20260815_external_cash"
+down_revision: str | Sequence[str] | None = "20260815_funding_advisory"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary

- Linearize the Alembic chain by making `20260819_rob1286_claims` descend from `20260815_funding_advisory`.
- Update the migration docstring parent reference to match.
- No migration DDL or tests were changed.

## Root cause

Both migrations previously descended directly from `20260815_external_cash`, creating two Alembic heads after merge order differed between the contributing PRs.

## Validation

- Static revision graph: one head, `20260819_rob1286_claims`; chain includes `20260815_external_cash -> 20260815_funding_advisory -> 20260819_rob1286_claims`.
- `git diff --name-status origin/main..HEAD`: one migration file only.
- Negative-parent experiment was reverted and `git status --porcelain` returned empty.
- Required `uv run --frozen --no-sync` Alembic, pytest, and Ruff commands could not start because this worktree's `.venv` has no `alembic`, `pytest`, or `ruff` executables. No install or sync was performed.
