### PR TITLE
feat(ROB-1290): wire the watch-fire repricing chain to a real proposal

### DIFF
--- a/alembic/versions/20260820_rob1290_awaiting_reconcile_state.py
+++ b/alembic/versions/20260820_rob1290_awaiting_reconcile_state.py
@@ -1,0 +1,102 @@
+"""ROB-1290 r2 — allow the awaiting_reconcile claim terminal (additive)
+
+Revision ID: 20260820_rob1290_reconcile
+Revises: 20260819_rob1286_claims
+Create Date: 2026-08-20
+
+Widens one CHECK constraint on ``review.watch_event_repricing_claims`` so the
+``state`` column accepts ``'awaiting_reconcile'``. Nothing else changes: no
+column is added, dropped or retyped, no index moves, no data is rewritten, and
+no other table is touched.
+
+Why the state exists
+--------------------
+An ambiguous spawn -- the create call raised and could not be reconciled --
+leaves it unknown whether ``order_proposal_create`` committed. ROB-1286 handled
+that by keeping the claim ``started`` and logging that it would not be retried.
+But ``started`` is exactly the state the lease expires, so the TTL sweep wrote
+``expired_unprocessed`` and the next tick re-claimed at ``generation + 1`` and
+judged the fire again. If the first call had committed and only its
+acknowledgement was lost, that is two proposals from one fire reaching the
+auto-approve lane.
+
+``awaiting_reconcile`` is terminal, so the TTL sweep (which only matches
+``state = 'started'``) cannot reach it and both claim stores refuse to
+re-claim an event holding it. The fire goes to an operator instead.
+
+Ordering note
+-------------
+This must be applied before the flow is armed. That is not a live-deployment
+hazard today: ``WATCH_TRIGGER_REPRICING_ENABLED`` defaults false, no schedule
+registers the tick anywhere in this repo, and the entrypoint's default spawner
+creates nothing -- so no process writes this state until an operator turns the
+feature on, by which time both this migration and ROB-1286's have been applied
+together.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260820_rob1290_reconcile"
+down_revision: str | Sequence[str] | None = "20260819_rob1286_claims"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "watch_event_repricing_claims"
+_SCHEMA = "review"
+# Short name on purpose. Alembic applies ``Base.metadata``'s naming
+# convention (``ck_%(table_name)s_%(constraint_name)s``) to *both*
+# ``drop_constraint`` and ``create_check_constraint``, so passing the full
+# ``ck_watch_event_repricing_claims_state`` produces a double-prefixed,
+# truncated name -- ``ck_watch_event_repricing_claims_ck_watch_event_...``
+# -- and the DROP fails at runtime because no such constraint exists.
+# Verified by rendering this migration offline (``alembic upgrade --sql``).
+_CONSTRAINT = "state"
+_FULL_CONSTRAINT_NAME = "ck_watch_event_repricing_claims_state"
+
+_STATES_AFTER = (
+    "'started', 'proposal_created', 'rejected_with_reason', "
+    "'expired_unprocessed', 'awaiting_reconcile'"
+)
+_STATES_BEFORE = (
+    "'started', 'proposal_created', 'rejected_with_reason', 'expired_unprocessed'"
+)
+
+
+def upgrade() -> None:
+    """Accept the awaiting_reconcile terminal."""
+    op.drop_constraint(_CONSTRAINT, _TABLE, schema=_SCHEMA, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        sa.text(f"state IN ({_STATES_AFTER})"),
+        schema=_SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    """Narrow the constraint back.
+
+    Rows already written as ``awaiting_reconcile`` would violate the narrower
+    constraint, so they are first moved to ``expired_unprocessed`` -- the
+    closest pre-existing "terminal, unresolved" state. That is lossy on
+    purpose: the alternative is a downgrade that fails outright, and this one
+    at least leaves the fire visible as unjudged rather than as done.
+    """
+    op.execute(
+        sa.text(
+            f"UPDATE {_SCHEMA}.{_TABLE} SET state = 'expired_unprocessed' "
+            "WHERE state = 'awaiting_reconcile'"
+        )
+    )
+    op.drop_constraint(_CONSTRAINT, _TABLE, schema=_SCHEMA, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        sa.text(f"state IN ({_STATES_BEFORE})"),
+        schema=_SCHEMA,
+    )

--- a/app/models/watch_event_repricing_claims.py
+++ b/app/models/watch_event_repricing_claims.py
@@ -60,6 +60,9 @@ _LIFECYCLE_STATES = (
     "proposal_created",
     "rejected_with_reason",
     "expired_unprocessed",
+    # ROB-1290 / r2 BLOCKER 2: an ambiguous spawn is terminal so the TTL
+    # cannot walk it back into a re-claim. See ``ClaimLifecycle``.
+    "awaiting_reconcile",
 )
 _STATES_SQL = ", ".join(f"'{state}'" for state in _LIFECYCLE_STATES)
 

--- a/app/services/watch_trigger_repricing/__init__.py
+++ b/app/services/watch_trigger_repricing/__init__.py
@@ -28,8 +28,18 @@ The package is deliberately split so the risky part is pure and testable:
 ``selection``
     Pure dedup + concurrency + per-round cap, with overflow surfaced.
 ``spawn``
-    Session spawner port. The shipped implementation is dry: it records
-    what *would* be spawned and never starts a session.
+    Session spawner port, plus the dry rehearsal implementations: they
+    record what *would* be spawned and never start a session.
+``judgement``
+    The closed union a session may answer with -- propose, or decline with
+    a reason. There is no third member, so an analysis-only outcome is not
+    expressible.
+``proposal_chain``
+    The **write seam** (ROB-1290). The one file allowed to import and call
+    ``order_proposal_create``, mirroring ``event_source`` on the read side.
+``chain_spawner``
+    The live spawner that runs a re-judgement in-process and crosses that
+    seam, so a fire actually becomes a proposal row.
 ``orchestrator``
     The tick: gate -> poll -> claim -> spawn -> resolve the claim against
     what the spawn actually proved.
@@ -44,12 +54,15 @@ from __future__ import annotations
 
 __all__ = [
     "capability",
+    "chain_spawner",
     "claims",
     "consumption",
     "event_source",
     "gate",
+    "judgement",
     "orchestrator",
     "poller",
+    "proposal_chain",
     "selection",
     "spawn",
 ]

--- a/app/services/watch_trigger_repricing/arming.py
+++ b/app/services/watch_trigger_repricing/arming.py
@@ -33,6 +33,13 @@ override went straight past the live contract and the durability rule.
 Comparing ``type(spawner)`` against a closed set of classes this package
 defines closes it -- and the closed set is what makes that safe, since the
 package's own dry spawners are enumerated rather than inherited into.
+
+What arming does not decide (r3)
+--------------------------------
+Everything here is about *which object* runs. None of it constrains what
+that object's judge does once it runs, because the judge is in-process
+Python. :mod:`.chain_spawner` states that limit exactly; do not read a
+passing arming check as an approval boundary.
 """
 
 from __future__ import annotations
@@ -49,6 +56,7 @@ from app.services.watch_trigger_repricing.spawn import (
 
 __all__ = [
     "DRY_SPAWNER_TYPES",
+    "live_spawner_types",
     "ArmingRefused",
     "assert_arming_contract",
     "is_dry_spawner",
@@ -57,6 +65,25 @@ __all__ = [
 # Closed set. Membership is decided here, by exact type, never by the
 # object and never by inheritance.
 DRY_SPAWNER_TYPES: tuple[type, ...] = (DrySessionSpawner, ScriptedDrySessionSpawner)
+
+
+def live_spawner_types() -> tuple[type, ...]:
+    """The concrete live spawners this package will arm. Closed, by type.
+
+    r3: satisfying :class:`~.live_contract.LiveSessionSpawner` was not enough.
+    An external subclass could take a callable in *its own* constructor,
+    override ``spawn``, declare a clean grant, and arm -- the base class no
+    longer has a ``tool=`` argument, but a subclass can add one back. So
+    arming names the exact classes it will run, the same way dryness does,
+    and a subclass of an allowed type is *not* an allowed type.
+
+    Imported lazily: ``chain_spawner`` imports the MCP registration surface,
+    and importing that at module scope here would drag it into every
+    consumer of :mod:`.arming`.
+    """
+    from app.services.watch_trigger_repricing.chain_spawner import ProposalChainSpawner
+
+    return (ProposalChainSpawner,)
 
 
 class ArmingRefused(RuntimeError):
@@ -78,10 +105,16 @@ def is_dry_spawner(spawner: object) -> bool:
 
 
 def assert_arming_contract(*, spawner: object, store: object) -> None:
-    """Refuse to run unless the live path has proven what it must."""
+    """Refuse to run unless the live path has proven what it must.
+
+    Read the module docstring for what this does **not** buy: the judge a
+    live spawner runs is in-process code, and no check here constrains it.
+    """
     if is_dry_spawner(spawner):
         return
 
+    # Contract first, so a duck-typed or grant-less object still gets the
+    # specific diagnostic that names what it is missing.
     try:
         assert_live_spawner_contract(spawner)
     except LiveSpawnerContractViolation as exc:
@@ -94,6 +127,18 @@ def assert_arming_contract(*, spawner: object, store: object) -> None:
         raise ArmingRefused(
             "live_spawner_contract_unmet",
             f"{type(spawner).__name__} is not a LiveSessionSpawner",
+        )
+
+    # Then the closed set. Satisfying the contract is not the same as being
+    # a spawner this package wrote: a well-formed external subclass passes
+    # every check above and can still put anything it likes in ``spawn``.
+    if type(spawner) not in live_spawner_types():
+        raise ArmingRefused(
+            "unlisted_live_spawner",
+            f"refusing to run {type(spawner).__name__}: arming accepts only the "
+            "concrete live spawners this package defines, by exact type. A "
+            "subclass is not one of them -- it can reintroduce in its own "
+            "constructor the injected callable the base class removed",
         )
 
     if not getattr(store, "is_durable", False):

--- a/app/services/watch_trigger_repricing/arming.py
+++ b/app/services/watch_trigger_repricing/arming.py
@@ -23,11 +23,16 @@ so. Everything else is live and must satisfy the full contract:
   permanently unjudged fire;
 * the claim store is durable, so dedup survives the flow run.
 
-A stand-in can still *claim* to be a ``DrySessionSpawner`` by subclassing
-it -- and that is fine, because subclassing it means inheriting a ``spawn``
-that starts nothing unless the subclass overrides it, at which point the
-subclass is a live spawner that failed to inherit the live base and is
-refused. There is no shape that both starts sessions and passes.
+Membership is by **exact type**, not ``isinstance`` (ROB-1290)
+-------------------------------------------------------------
+r2's fix said a ``DrySessionSpawner`` subclass was harmless because it
+inherits a ``spawn`` that starts nothing "unless the subclass overrides
+it, at which point the subclass is a live spawner ... and is refused". The
+second half was not true: ``isinstance`` accepted the subclass, so an
+override went straight past the live contract and the durability rule.
+Comparing ``type(spawner)`` against a closed set of classes this package
+defines closes it -- and the closed set is what makes that safe, since the
+package's own dry spawners are enumerated rather than inherited into.
 """
 
 from __future__ import annotations
@@ -37,7 +42,10 @@ from app.services.watch_trigger_repricing.live_contract import (
     LiveSpawnerContractViolation,
     assert_live_spawner_contract,
 )
-from app.services.watch_trigger_repricing.spawn import DrySessionSpawner
+from app.services.watch_trigger_repricing.spawn import (
+    DrySessionSpawner,
+    ScriptedDrySessionSpawner,
+)
 
 __all__ = [
     "DRY_SPAWNER_TYPES",
@@ -46,8 +54,9 @@ __all__ = [
     "is_dry_spawner",
 ]
 
-# Closed set. Membership is decided here, by type, never by the object.
-DRY_SPAWNER_TYPES: tuple[type, ...] = (DrySessionSpawner,)
+# Closed set. Membership is decided here, by exact type, never by the
+# object and never by inheritance.
+DRY_SPAWNER_TYPES: tuple[type, ...] = (DrySessionSpawner, ScriptedDrySessionSpawner)
 
 
 class ArmingRefused(RuntimeError):
@@ -59,8 +68,13 @@ class ArmingRefused(RuntimeError):
 
 
 def is_dry_spawner(spawner: object) -> bool:
-    """Dryness by type. ``is_dry`` self-reporting is deliberately ignored."""
-    return isinstance(spawner, DRY_SPAWNER_TYPES)
+    """Dryness by exact type. Self-reporting and inheritance are both ignored.
+
+    A subclass of a dry spawner is not dry: overriding ``spawn`` is all it
+    takes to start doing real work, and inheriting a name must not buy an
+    exemption from the live contract.
+    """
+    return type(spawner) in DRY_SPAWNER_TYPES
 
 
 def assert_arming_contract(*, spawner: object, store: object) -> None:

--- a/app/services/watch_trigger_repricing/arming.py
+++ b/app/services/watch_trigger_repricing/arming.py
@@ -34,6 +34,22 @@ Comparing ``type(spawner)`` against a closed set of classes this package
 defines closes it -- and the closed set is what makes that safe, since the
 package's own dry spawners are enumerated rather than inherited into.
 
+The live side is a closed set too (ROB-1290 r3)
+-----------------------------------------------
+Satisfying the live contract turned out not to be the same as being a
+spawner this package wrote. A subclass of :class:`ProposalChainSpawner`
+can take a callable in *its own* constructor -- the base no longer has a
+``tool=`` argument, but nothing stopped a subclass adding one back -- call
+``super().__init__()`` for a clean grant, override ``spawn``, and arm. A
+direct subclass of :class:`~.live_contract.LiveSessionSpawner` needs even
+less. Both were measured running a name-spoofed callable after passing
+every structural check.
+
+So :func:`live_spawner_types` names the concrete classes arming will run,
+and a subclass of an allowed type is **not** an allowed type. The contract
+check still runs first, so a duck-typed or grant-less object keeps the
+specific diagnostic that names what it is missing.
+
 What arming does not decide (r3)
 --------------------------------
 Everything here is about *which object* runs. None of it constrains what

--- a/app/services/watch_trigger_repricing/chain_spawner.py
+++ b/app/services/watch_trigger_repricing/chain_spawner.py
@@ -36,12 +36,40 @@ compared with closed equality **on every spawn**, before the judge is
 asked, so widening the profile stops the flow rather than widening the
 session.
 
-No substitutable boundary (r2 / BLOCKER 1)
-------------------------------------------
-This class takes a judge and a proposer. It does **not** take the tool it
-calls, so there is no wiring in which something other than the shipping
-``order_proposal_create`` runs. See :mod:`.proposal_chain` for why the
-previous ``__name__`` check was worthless.
+What this class guarantees, exactly (r3)
+----------------------------------------
+Stated precisely, because two earlier rounds stated it too strongly and a
+verifier had to measure the difference each time.
+
+**It guarantees**: given a judgement, the only write performed is
+``order_proposal_create``, with arguments bound to the fire that was
+claimed (symbol checked, event id carried), and the terminal recorded
+matches what the tool actually returned. No parameter of this class, or
+of the write seam, accepts a callable -- the ``tool=`` argument r1 had is
+gone, and passing one is a ``TypeError``. Arming additionally accepts
+only the concrete types in :func:`~.arming.live_spawner_types`, by exact
+type, so an external subclass cannot reintroduce that argument in its own
+constructor and arm.
+
+**It does not guarantee** that a judge stays inside those rails. The
+judge runs in this interpreter with this process's full privileges. It
+can rebind the seam's module global, mint a capability grant from the
+module-private sentinel, or ignore this package entirely and import a
+broker order tool -- all measured in r3, none of them closable from
+inside the process. CPython offers no way to revoke import, attribute
+assignment, or subclassing from code already running in it.
+
+So the honest summary is: **accident prevention and static detectability,
+not a security boundary.** Every route above is a deliberate act that
+shows up in review as an import or an assignment somebody had to write.
+
+The boundary this feature actually needs is the **process** boundary the
+``watch_repricing`` MCP profile already describes: a session in a separate
+process, reaching only the tools that profile registers, unable to import
+anything else because it is not in this interpreter. This class runs the
+judge in-process and therefore stands *inside* that boundary rather than
+providing it -- which is why it is a rehearsal harness and why nothing in
+this repo arms it (see ``RUNS_JUDGE_IN_PROCESS``).
 
 Retry safety
 ------------
@@ -118,7 +146,19 @@ def provisioned_repricing_tools() -> frozenset[str]:
 
 
 class ProposalChainSpawner(LiveSessionSpawner):
-    """Judge one fire, create the proposal it earns, record the terminal."""
+    """Judge one fire, create the proposal it earns, record the terminal.
+
+    Read the module docstring for the exact guarantee this carries, and
+    for the one it does not.
+    """
+
+    # r3: declared, not inferred. True means the judgement runs in this
+    # interpreter, so this spawner cannot bound what the judge does and is
+    # a rehearsal harness rather than a production approval boundary. An
+    # out-of-process spawner would set this False and would be the first
+    # thing in this package that could honestly claim otherwise; the
+    # arming tests pin the current value so that flip cannot be silent.
+    RUNS_JUDGE_IN_PROCESS = True
 
     def __init__(
         self,

--- a/app/services/watch_trigger_repricing/chain_spawner.py
+++ b/app/services/watch_trigger_repricing/chain_spawner.py
@@ -36,6 +36,13 @@ compared with closed equality **on every spawn**, before the judge is
 asked, so widening the profile stops the flow rather than widening the
 session.
 
+No substitutable boundary (r2 / BLOCKER 1)
+------------------------------------------
+This class takes a judge and a proposer. It does **not** take the tool it
+calls, so there is no wiring in which something other than the shipping
+``order_proposal_create`` runs. See :mod:`.proposal_chain` for why the
+previous ``__name__`` check was worthless.
+
 Retry safety
 ------------
 The three failure shapes get the three different answers their evidence
@@ -68,7 +75,6 @@ from app.services.watch_trigger_repricing.live_contract import (
 )
 from app.services.watch_trigger_repricing.proposal_chain import (
     DEFAULT_PROPOSER,
-    BoundaryTool,
     ProposalChainFailure,
     run_judgement_session,
 )
@@ -118,16 +124,20 @@ class ProposalChainSpawner(LiveSessionSpawner):
         self,
         *,
         judge: object,
-        tool: BoundaryTool | None = None,
         proposer: str = DEFAULT_PROPOSER,
     ) -> None:
+        # r2 / BLOCKER 1: there is deliberately no ``tool`` parameter. r1
+        # accepted one and checked its ``__name__``, so a callable renamed
+        # ``order_proposal_create`` -- a broker submit, say -- constructed
+        # cleanly, armed cleanly, and then ran. Passing one is now a
+        # TypeError, which is what §101차 ③ means by enforcing the boundary
+        # at the constructor rather than validating it at use.
         if not hasattr(judge, "judge"):
             raise TypeError(
                 "ProposalChainSpawner requires a RepricingJudge; this package "
                 "ships none, because the judgement is out-of-process work"
             )
         self._judge = judge
-        self._tool = tool
         self._proposer = proposer
         # event_uuid -> terminal, read by the entrypoint's fenced finalise.
         self.session_outcomes: dict[str, SessionOutcome] = {}
@@ -154,7 +164,6 @@ class ProposalChainSpawner(LiveSessionSpawner):
                 request=request,
                 judge=self._judge,
                 grant=self.proposal_chain_grant,
-                tool=self._tool,
                 proposer=self._proposer,
             )
         except JudgementRefused as exc:

--- a/app/services/watch_trigger_repricing/chain_spawner.py
+++ b/app/services/watch_trigger_repricing/chain_spawner.py
@@ -1,0 +1,178 @@
+"""ROB-1290 — the spawner that actually reaches the boundary.
+
+What this is, precisely
+-----------------------
+:class:`ProposalChainSpawner` runs the re-judgement session **in this
+process**: it asks an injected :class:`~.judgement.RepricingJudge` for a
+decision and hands a draft straight to :mod:`.proposal_chain`, which calls
+``order_proposal_create``. So the chain a tick executes is
+poll -> claim -> spawn -> create -> terminal, with no scripted id and no
+row planted ahead of time.
+
+The part that is still outside the repo is the *judgement*, and it has to
+be: deciding whether a fired watch level still deserves an order is LLM
+work, and this runtime owns no in-process LLM provider. That seam was
+always going to be injected. What was missing -- and what this closes --
+is everything downstream of the decision.
+
+Why it is a live spawner, not a dry one
+---------------------------------------
+Because it creates proposals. :mod:`.arming` therefore requires it to
+satisfy the full live contract before a tick may run it: the base
+constructor checks its grant is exactly
+:data:`~.capability.PROPOSAL_ONLY_TOOLS`, it must be able to reconcile, and
+the claim store must be durable. There is no configuration in which a
+proposal-creating spawner runs against a store that forgets, which is what
+would let one fire become two proposals across flow runs.
+
+Attestation is a readback, not an echo
+--------------------------------------
+r2's escape was a spawner that passed a clean profile in the *request* and
+provisioned something else. :meth:`attest_granted_tools` does not repeat
+the request: it builds the shipping ``watch_repricing`` MCP profile through
+:func:`~app.mcp_server.tooling.watch_repricing_registration.register_watch_repricing_tools`
+and returns the names that registration actually produced. That set is
+compared with closed equality **on every spawn**, before the judge is
+asked, so widening the profile stops the flow rather than widening the
+session.
+
+Retry safety
+------------
+The three failure shapes get the three different answers their evidence
+supports (see :mod:`.proposal_chain` for why the middle one exists):
+
+``JudgementRefused``   nothing was written -> ``SpawnNotStarted``, retried next tick.
+``ProposalChainFailure`` the tool refused pre-commit -> ``SpawnNotStarted``, retried.
+``ProposalChainAmbiguous`` unknown -> propagated, so the tick quarantines it.
+
+:meth:`reconcile` answers ``STARTED`` only for a fire this spawner holds a
+recorded outcome for. Otherwise it stays ``AMBIGUOUS`` -- guessing
+``NOT_STARTED`` after an unknown create is the double-proposal direction.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from app.mcp_server.tooling.watch_repricing_registration import (
+    register_watch_repricing_tools,
+    watch_repricing_tool_names,
+)
+from app.services.watch_trigger_repricing.capability import PROPOSAL_ONLY_TOOLS
+from app.services.watch_trigger_repricing.judgement import JudgementRefused
+from app.services.watch_trigger_repricing.lifecycle import SessionOutcome
+from app.services.watch_trigger_repricing.live_contract import (
+    LiveSessionSpawner,
+    assert_exact_grant,
+)
+from app.services.watch_trigger_repricing.proposal_chain import (
+    DEFAULT_PROPOSER,
+    BoundaryTool,
+    ProposalChainFailure,
+    run_judgement_session,
+)
+from app.services.watch_trigger_repricing.spawn import (
+    SpawnDisposition,
+    SpawnNotStarted,
+    SpawnOutcome,
+    SpawnRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ProposalChainSpawner", "provisioned_repricing_tools"]
+
+
+class _ProbeRegistry:
+    """Collects the names a registration pass actually registers."""
+
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, *args: Any, **kwargs: Any) -> Any:
+        name = kwargs.get("name") or (args[0] if args else None)
+
+        def decorator(func: Any) -> Any:
+            self.tools[str(name)] = func
+            return func
+
+        return decorator
+
+
+def provisioned_repricing_tools() -> frozenset[str]:
+    """Names the shipping watch-repricing profile registration produces.
+
+    A readback of the provisioning path rather than a restatement of the
+    allowlist: if the two ever drift, this is the side that changes.
+    """
+    probe = _ProbeRegistry()
+    register_watch_repricing_tools(cast("Any", probe))
+    return watch_repricing_tool_names(probe)
+
+
+class ProposalChainSpawner(LiveSessionSpawner):
+    """Judge one fire, create the proposal it earns, record the terminal."""
+
+    def __init__(
+        self,
+        *,
+        judge: object,
+        tool: BoundaryTool | None = None,
+        proposer: str = DEFAULT_PROPOSER,
+    ) -> None:
+        if not hasattr(judge, "judge"):
+            raise TypeError(
+                "ProposalChainSpawner requires a RepricingJudge; this package "
+                "ships none, because the judgement is out-of-process work"
+            )
+        self._judge = judge
+        self._tool = tool
+        self._proposer = proposer
+        # event_uuid -> terminal, read by the entrypoint's fenced finalise.
+        self.session_outcomes: dict[str, SessionOutcome] = {}
+        self.requests: list[SpawnRequest] = []
+        # Last, so the grant is minted over a fully built object.
+        super().__init__()
+
+    # -- live contract -------------------------------------------------
+    def declared_grant(self) -> frozenset[str]:
+        return PROPOSAL_ONLY_TOOLS
+
+    def attest_granted_tools(self, request: SpawnRequest) -> frozenset[str]:
+        return provisioned_repricing_tools()
+
+    # -- the chain -----------------------------------------------------
+    async def spawn(self, request: SpawnRequest) -> SpawnOutcome:
+        assert_exact_grant(
+            self.attest_granted_tools(request),
+            who=f"{type(self).__name__}.attest_granted_tools()",
+        )
+        self.requests.append(request)
+        try:
+            outcome = await run_judgement_session(
+                request=request,
+                judge=self._judge,
+                grant=self.proposal_chain_grant,
+                tool=self._tool,
+                proposer=self._proposer,
+            )
+        except JudgementRefused as exc:
+            raise SpawnNotStarted(f"no_judgement: {exc}") from exc
+        except ProposalChainFailure as exc:
+            raise SpawnNotStarted(f"proposal_create_refused: {exc}") from exc
+
+        self.session_outcomes[request.event_uuid] = outcome
+        return SpawnOutcome(
+            request=request,
+            disposition=SpawnDisposition.STARTED,
+            detail=f"judged:{outcome.state}",
+        )
+
+    def reconcile(self, request: SpawnRequest) -> SpawnDisposition:
+        if request.event_uuid in self.session_outcomes:
+            return SpawnDisposition.STARTED
+        # The session ran but left no terminal, which is exactly the case
+        # where "did a row get written?" is the open question. Saying
+        # NOT_STARTED here would release the claim and re-judge the fire.
+        return SpawnDisposition.AMBIGUOUS

--- a/app/services/watch_trigger_repricing/claims.py
+++ b/app/services/watch_trigger_repricing/claims.py
@@ -49,6 +49,8 @@ from app.services.watch_trigger_repricing.consumption import (
     project_claim_state,
 )
 from app.services.watch_trigger_repricing.lifecycle import (
+    NON_RECLAIMABLE_STATES,
+    RESOLVED_LIFECYCLE_STATES,
     ClaimLifecycle,
     SessionOutcome,
 )
@@ -171,11 +173,12 @@ class InMemoryClaimStore:
             latest = self._latest(event_uuid)
             if latest is None:
                 return project_claim_state(claim_found=False, store_available=True)
-            if latest.state in (
-                ClaimLifecycle.PROPOSAL_CREATED,
-                ClaimLifecycle.REJECTED_WITH_REASON,
-            ):
+            if latest.state in RESOLVED_LIFECYCLE_STATES:
                 return ConsumptionState.CONSUMED
+            if latest.state is ClaimLifecycle.AWAITING_RECONCILE:
+                # Terminal and a fault: nobody knows whether a proposal
+                # exists, so no consumer may take it (r2 / BLOCKER 2).
+                return ConsumptionState.QUARANTINED
             return project_claim_state(
                 claim_found=latest.is_live(now=now), store_available=True
             )
@@ -209,12 +212,13 @@ class InMemoryClaimStore:
             if latest is not None:
                 if latest.is_live(now=now):
                     return None
-                if latest.state in (
-                    ClaimLifecycle.PROPOSAL_CREATED,
-                    ClaimLifecycle.REJECTED_WITH_REASON,
-                ):
-                    # Already resolved. Re-judging is the double-proposal
-                    # direction.
+                if latest.state in NON_RECLAIMABLE_STATES:
+                    # Already resolved, or terminally ambiguous. Re-judging
+                    # either is the double-proposal direction: the first
+                    # produced a proposal, or *may* have and nobody knows.
+                    # Note this is checked after ``is_live``, which is a
+                    # lease question -- a terminal outlives its lease by
+                    # design, so no clock can walk this refusal back.
                     return None
             # Stands in for UNIQUE (symbol) WHERE state = 'started'. r2
             # NEW BLOCKER 2: without this, two ticks holding the same empty

--- a/app/services/watch_trigger_repricing/db_claim_store.py
+++ b/app/services/watch_trigger_repricing/db_claim_store.py
@@ -251,6 +251,47 @@ class DatabaseClaimStore:
                 )
             await session.commit()
 
+    async def release(self, handle: ClaimHandle, *, reason: str) -> None:
+        """Hand a claim back after a *proven* clean failure to start.
+
+        ROB-1290: this method was on the :class:`~.claims.ClaimStore`
+        protocol and implemented only by the in-memory rehearsal store. No
+        shipped spawner could return ``NOT_STARTED`` -- the dry one always
+        answers ``DRY`` -- so the orchestrator's release branch had never
+        run against the durable store, and the first spawner that could
+        prove a clean failure would have hit ``AttributeError`` mid-tick
+        and left the claim held until its lease expired.
+
+        Deletes the row rather than writing a terminal, exactly as the
+        in-memory store does: nothing was judged, so the fire must look
+        untouched to the next tick, and the row must stop occupying the
+        per-symbol partial-unique slot. The release is not silent -- the
+        orchestrator logs it and reports the event with its reason -- and
+        the evidence that matters (that no proposal exists) is the absence
+        of a proposal row, not the absence of this one.
+
+        Fenced like :meth:`finalise`: a rolled-over owner matches no row
+        and raises rather than deleting the current claimant's work, or an
+        already-written ``expired_unprocessed`` terminal.
+        """
+        async with self.session_factory() as session:  # type: ignore[operator]
+            result = await session.execute(
+                sa.delete(_TABLE).where(
+                    _TABLE.event_uuid == uuid.UUID(handle.event_uuid),
+                    _TABLE.generation == handle.generation,
+                    _TABLE.owner_token == uuid.UUID(handle.owner_token),
+                    _TABLE.state == ClaimLifecycle.STARTED.value,
+                )
+            )
+            if result.rowcount == 0:
+                await session.rollback()
+                raise ClaimNotHeld(
+                    f"claim {handle.event_uuid}#{handle.generation} is not held by "
+                    f"this owner (lease rolled over, or already terminal); "
+                    f"refusing to release it (reason={reason!r})"
+                )
+            await session.commit()
+
     async def outcomes_for(self, event_uuids: list[str]) -> dict[str, SessionOutcome]:
         """Read back terminals so the completion mapping is a stored fact."""
         if not event_uuids:

--- a/app/services/watch_trigger_repricing/db_claim_store.py
+++ b/app/services/watch_trigger_repricing/db_claim_store.py
@@ -52,10 +52,14 @@ from app.services.watch_trigger_repricing.consumption import (
     project_claim_state,
 )
 from app.services.watch_trigger_repricing.lifecycle import (
+    NON_RECLAIMABLE_STATES,
     TERMINAL_LIFECYCLE_STATES,
     ClaimLifecycle,
     SessionOutcome,
 )
+
+# Spelled as raw values once, for the SQL-facing comparisons below.
+_NON_RECLAIMABLE_VALUES = tuple(state.value for state in NON_RECLAIMABLE_STATES)
 
 __all__ = ["DatabaseClaimStore"]
 
@@ -88,6 +92,10 @@ class DatabaseClaimStore:
             # the TTL terminal, which explicitly means "nobody judged it".
             if row.state == ClaimLifecycle.EXPIRED_UNPROCESSED:
                 return project_claim_state(claim_found=False, store_available=True)
+            if row.state == ClaimLifecycle.AWAITING_RECONCILE:
+                # Unknown, not done. Blocks every consumer and is reported
+                # for operator reconciliation (r2 / BLOCKER 2).
+                return ConsumptionState.QUARANTINED
             return ConsumptionState.CONSUMED
         return project_claim_state(
             claim_found=row.lease_expires_at > now, store_available=True
@@ -181,12 +189,13 @@ class DatabaseClaimStore:
                         finalised_at=now,
                     )
                 )
-            if latest is not None and latest.state in (
-                ClaimLifecycle.PROPOSAL_CREATED.value,
-                ClaimLifecycle.REJECTED_WITH_REASON.value,
-            ):
-                # Already resolved. Never re-judge a fire that produced an
-                # outcome -- that is the double-proposal direction.
+            if latest is not None and latest.state in _NON_RECLAIMABLE_VALUES:
+                # Already resolved, or terminally ambiguous. Never re-judge
+                # a fire that produced an outcome, or one that *may* have
+                # produced a proposal nobody could confirm -- both are the
+                # double-proposal direction. r2 / BLOCKER 2: this branch is
+                # reached before any lease arithmetic, so TTL expiry cannot
+                # undo it.
                 return None
 
             generation = (latest.generation + 1) if latest is not None else 1

--- a/app/services/watch_trigger_repricing/entrypoint.py
+++ b/app/services/watch_trigger_repricing/entrypoint.py
@@ -59,6 +59,7 @@ DISABLED_RESULT: dict[str, Any] = {
     "skipped": [],
     "needsReconcile": [],
     "completion": [],
+    "completionQuarantined": [],
 }
 
 
@@ -166,12 +167,21 @@ async def run_watch_repricing_tick(
                 handle.generation,
             )
     # Everything the tick knowingly set aside, with the reason it gave.
+    # Quarantined fires are split out: they are terminal and no later tick
+    # will pick them up, so reporting them as "deferred" would promise a
+    # retry that is deliberately never coming (r2 / BLOCKER 2).
+    quarantined = {
+        skipped.event_uuid: skipped.reason for skipped in result.needs_reconcile
+    }
     deferrals = {
         skipped.event_uuid: skipped.reason
-        for skipped in result.overflow + result.skipped + result.needs_reconcile
+        for skipped in result.overflow + result.skipped
     }
     completion = build_completion_mapping(
-        polled_event_uuids=polled, outcomes=outcomes, deferrals=deferrals
+        polled_event_uuids=polled,
+        outcomes=outcomes,
+        deferrals=deferrals,
+        quarantined=quarantined,
     )
     for row in completion.unaccounted:
         logger.warning(
@@ -189,6 +199,18 @@ async def run_watch_repricing_tick(
     payload["completionComplete"] = completion.is_complete
     payload["completionAccounted"] = completion.is_accounted
     payload["completionDeferred"] = [row.event_uuid for row in completion.deferred]
+    payload["completionQuarantined"] = [
+        row.event_uuid for row in completion.quarantined
+    ]
+    for row in completion.quarantined:
+        logger.error(
+            "watch_trigger_repricing: event %s (symbol=%s) is quarantined (%s) -- "
+            "whether a proposal was created is unknown, it will NOT be re-judged, "
+            "and an operator must reconcile it",
+            row.event_uuid,
+            row.symbol,
+            row.deferral_reason,
+        )
     for row in completion.deferred:
         logger.info(
             "watch_trigger_repricing: event %s (symbol=%s) deferred to a later tick "

--- a/app/services/watch_trigger_repricing/judgement.py
+++ b/app/services/watch_trigger_repricing/judgement.py
@@ -1,0 +1,187 @@
+"""ROB-1290 — what a re-judgement session may hand back, and nothing else.
+
+The closed union
+----------------
+A session spawned for one watch fire produces exactly one of two things:
+
+:class:`ProposalDraft`
+    "Propose this." Carries everything ``order_proposal_create`` needs, and
+    is turned into a real proposal row by :mod:`.proposal_chain`.
+:class:`Decline`
+    "Do not propose, and here is why -- for *this* event." The reason is
+    required and non-blank.
+
+There is no third member, and that is the point. §101차 ⑤ forbids an
+analysis-only outcome, so the type that models a session's answer must not
+be able to express one. :func:`interpret_judgement` is the funnel every
+answer passes through: anything that is not one of these two -- ``None``, a
+report, a bare string, a future variant somebody adds without thinking --
+is :class:`JudgementRefused`, which the spawner turns into "this fire is
+not finished" rather than into a comfortable success.
+
+Why the judge lives outside this repo
+-------------------------------------
+The judgement itself is LLM work, and this runtime owns no in-process LLM
+provider (the ROB-501 boundary). So :class:`RepricingJudge` is a port, the
+package ships no implementation of it, and the spawner refuses to be built
+without one. What ships here is the part that must be deterministic: the
+shape of the answer, and the wiring from that answer to a durable row.
+
+The judge decides; it never writes
+----------------------------------
+A judge is handed a :class:`~.spawn.SpawnRequest` and returns a value. It
+is given no capability object, and :mod:`.proposal_chain` is the sole
+writer -- which is what lets a judge failure be classified as "provably
+nothing was written", and therefore as safely retryable rather than as an
+ambiguity needing an operator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "Decline",
+    "Judgement",
+    "JudgementRefused",
+    "ProposalDraft",
+    "ProposalRung",
+    "RepricingJudge",
+    "interpret_judgement",
+]
+
+_SIDES = frozenset({"buy", "sell"})
+
+
+class JudgementRefused(ValueError):
+    """A session handed back something that is not a judgement.
+
+    Deliberately an error rather than a state: the completion criterion
+    counts fires that produced neither a proposal nor an attributed reason
+    as failures, so the type system must not offer a way to record one.
+    """
+
+
+@dataclass(frozen=True)
+class ProposalRung:
+    """One ladder step of a draft, in the shape the boundary tool takes."""
+
+    rung_index: int
+    side: str
+    quantity: str
+    limit_price: str | None = None
+    notional: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.rung_index < 0:
+            raise JudgementRefused(f"rung_index must be >= 0, got {self.rung_index}")
+        if self.side not in _SIDES:
+            raise JudgementRefused(f"rung side must be one of {sorted(_SIDES)}")
+        if not str(self.quantity).strip():
+            raise JudgementRefused("rung quantity must be non-blank")
+
+    def as_tool_argument(self) -> dict[str, object]:
+        return {
+            "rung_index": self.rung_index,
+            "side": self.side,
+            "quantity": self.quantity,
+            "limit_price": self.limit_price,
+            "notional": self.notional,
+        }
+
+
+@dataclass(frozen=True)
+class ProposalDraft:
+    """A session's decision to propose, validated before it reaches the tool.
+
+    ``event_uuid`` is carried so the draft is bound to the fire it answers.
+    A judge that returns a draft for a different event is refused in
+    :func:`interpret_judgement` rather than silently proposing against
+    whatever fire happened to be in flight.
+    """
+
+    event_uuid: str
+    symbol: str
+    market: str
+    account_mode: str
+    side: str
+    order_type: str
+    rungs: tuple[ProposalRung, ...]
+    thesis: str
+    strategy: str = "watch-trigger-repricing"
+    valid_until: str | None = None
+
+    def __post_init__(self) -> None:
+        for name in (
+            "event_uuid",
+            "symbol",
+            "market",
+            "account_mode",
+            "order_type",
+            "thesis",
+            "strategy",
+        ):
+            if not str(getattr(self, name) or "").strip():
+                raise JudgementRefused(f"ProposalDraft.{name} must be non-blank")
+        if self.side not in _SIDES:
+            raise JudgementRefused(f"side must be one of {sorted(_SIDES)}")
+        if not self.rungs:
+            raise JudgementRefused(
+                "a draft with no rungs proposes nothing; return a Decline instead"
+            )
+        mismatched = [r.rung_index for r in self.rungs if r.side != self.side]
+        if mismatched:
+            raise JudgementRefused(
+                f"rungs {mismatched} disagree with the draft side {self.side!r}"
+            )
+
+
+@dataclass(frozen=True)
+class Decline:
+    """A session's decision not to propose, with the reason for this fire."""
+
+    event_uuid: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not str(self.event_uuid or "").strip():
+            raise JudgementRefused("Decline.event_uuid must be non-blank")
+        if not str(self.reason or "").strip():
+            raise JudgementRefused(
+                "a Decline without a reason is an analysis-only outcome by "
+                "another name; §101차 ⑤ forbids one"
+            )
+
+
+Judgement = ProposalDraft | Decline
+
+
+@runtime_checkable
+class RepricingJudge(Protocol):
+    """The out-of-process judgement seam. May be sync or async."""
+
+    def judge(self, request: object) -> object: ...
+
+
+def interpret_judgement(value: object, *, event_uuid: str) -> Judgement:
+    """Funnel a session's answer into the closed union, or refuse it.
+
+    Every path from a spawned session to a terminal passes through here, so
+    a new "outcome" cannot be introduced by returning a novel object: it
+    would land in the final ``raise`` instead of quietly becoming a third
+    kind of success.
+    """
+    if isinstance(value, ProposalDraft | Decline):
+        if value.event_uuid != event_uuid:
+            raise JudgementRefused(
+                f"judgement is bound to event {value.event_uuid!r} but the "
+                f"session was spawned for {event_uuid!r}"
+            )
+        return value
+    raise JudgementRefused(
+        f"a re-judgement session must return a ProposalDraft or a Decline for "
+        f"event {event_uuid}; got {type(value).__name__}. There is no "
+        "analysis-only judgement -- a session that looked and said nothing "
+        "has not finished."
+    )

--- a/app/services/watch_trigger_repricing/lifecycle.py
+++ b/app/services/watch_trigger_repricing/lifecycle.py
@@ -17,6 +17,30 @@ of three terminals:
     The lease ran out with no terminal. Only the TTL path may write it.
     The flow then re-spawns at ``generation + 1``, and fencing stops the
     stale owner from writing over the new one.
+``AWAITING_RECONCILE``
+    r2 / BLOCKER 2. The spawn was ambiguous and could not be reconciled,
+    so whether ``order_proposal_create`` committed is **unknown**. r1
+    handled this by logging "will NOT be retried automatically" and
+    leaving the claim ``STARTED`` -- but a ``STARTED`` claim is exactly
+    what the lease expires, so thirty minutes later the TTL wrote
+    ``EXPIRED_UNPROCESSED``, the flow re-claimed at ``generation + 1``,
+    and the fire was judged again. If the first call had committed and
+    only its acknowledgement was lost, that is **two proposals from one
+    fire**, in front of the auto-approve lane.
+
+    So "no blind retry" is a state, not a log line. This is a terminal;
+    the TTL sweep only touches ``STARTED`` and therefore cannot walk it
+    back, and both claim stores refuse to re-claim an event that holds it.
+    It goes to an operator instead.
+
+Terminal is not the same as resolved
+------------------------------------
+Four terminals, but only **two** of them are outcomes.
+:data:`RESOLVED_LIFECYCLE_STATES` is the pair that satisfies the
+completion criterion; ``EXPIRED_UNPROCESSED`` and ``AWAITING_RECONCILE``
+are terminal *faults*, and counting either as done would relabel the
+original accident as success. Keeping the two sets separate is what stops
+"we stopped touching it" from drifting into "we finished it".
 
 There is deliberately **no analysis-only terminal**
 ---------------------------------------------------
@@ -38,11 +62,14 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 __all__ = [
+    "NON_RECLAIMABLE_STATES",
+    "RESOLVED_LIFECYCLE_STATES",
     "TERMINAL_LIFECYCLE_STATES",
     "ClaimLifecycle",
     "CompletionRow",
     "IncompleteOutcome",
     "SessionOutcome",
+    "awaiting_reconcile",
     "build_completion_mapping",
     "rejected",
     "proposal_created",
@@ -56,13 +83,35 @@ class ClaimLifecycle(StrEnum):
     PROPOSAL_CREATED = "proposal_created"
     REJECTED_WITH_REASON = "rejected_with_reason"
     EXPIRED_UNPROCESSED = "expired_unprocessed"
+    AWAITING_RECONCILE = "awaiting_reconcile"
 
 
-TERMINAL_LIFECYCLE_STATES = frozenset(
+# The only two states that answer the completion criterion. Everything
+# else is either in flight or a fault.
+RESOLVED_LIFECYCLE_STATES = frozenset(
     {
         ClaimLifecycle.PROPOSAL_CREATED,
         ClaimLifecycle.REJECTED_WITH_REASON,
+    }
+)
+
+# States a claim may end in. A terminal is never re-claimed except
+# ``EXPIRED_UNPROCESSED``, which exists precisely so a crashed tick's fire
+# is picked up again.
+TERMINAL_LIFECYCLE_STATES = frozenset(
+    {
+        *RESOLVED_LIFECYCLE_STATES,
         ClaimLifecycle.EXPIRED_UNPROCESSED,
+        ClaimLifecycle.AWAITING_RECONCILE,
+    }
+)
+
+# Terminals that must survive the TTL and block a re-claim. r2 / BLOCKER 2:
+# the whole point of ``AWAITING_RECONCILE`` is that no clock walks it back.
+NON_RECLAIMABLE_STATES = frozenset(
+    {
+        *RESOLVED_LIFECYCLE_STATES,
+        ClaimLifecycle.AWAITING_RECONCILE,
     }
 )
 
@@ -113,6 +162,13 @@ class SessionOutcome:
                     "EXPIRED_UNPROCESSED is the TTL terminal and carries neither "
                     "a proposal nor a reason"
                 )
+        elif self.state is ClaimLifecycle.AWAITING_RECONCILE:
+            if self.proposal_id or self.rejection_reason:
+                raise IncompleteOutcome(
+                    "AWAITING_RECONCILE means nobody knows what the session did; "
+                    "carrying a proposal id or a reason would claim knowledge "
+                    "this terminal exists to say we lack"
+                )
         else:
             raise IncompleteOutcome(
                 f"{self.state} is not a terminal outcome; a session may not "
@@ -132,6 +188,15 @@ def rejected(reason: str) -> SessionOutcome:
     )
 
 
+def awaiting_reconcile() -> SessionOutcome:
+    """The terminal for an ambiguous spawn. Carries no claim of knowledge.
+
+    Written by the tick, not by a session -- the session is exactly what we
+    could not get an answer from.
+    """
+    return SessionOutcome(state=ClaimLifecycle.AWAITING_RECONCILE)
+
+
 @dataclass(frozen=True)
 class CompletionRow:
     """One row of the event -> outcome mapping table."""
@@ -142,6 +207,19 @@ class CompletionRow:
     proposal_id: str | None
     rejection_reason: str | None
     deferral_reason: str | None = None
+
+    @property
+    def is_quarantined(self) -> bool:
+        """The tick does not know what happened, and a human must look.
+
+        Kept distinct from :attr:`is_deferred` because the two make
+        opposite promises. A deferred fire will be judged by a later tick.
+        A quarantined one will not be -- it is terminal by design (r2 /
+        BLOCKER 2), because the alternative is re-judging a fire that may
+        already have produced a proposal. Reporting it as "deferred" would
+        say a retry is coming when none is.
+        """
+        return self.state == ClaimLifecycle.AWAITING_RECONCILE
 
     @property
     def is_deferred(self) -> bool:
@@ -156,6 +234,8 @@ class CompletionRow:
         later tick resolves it, which is what
         :attr:`CompletionReport.is_complete` refuses to assume.
         """
+        if self.is_quarantined:
+            return False
         return bool((self.deferral_reason or "").strip()) and not self.is_resolved
 
     @property
@@ -170,6 +250,7 @@ class CompletionRow:
             return bool((self.proposal_id or "").strip())
         if self.state == ClaimLifecycle.REJECTED_WITH_REASON:
             return bool((self.rejection_reason or "").strip())
+        # EXPIRED_UNPROCESSED and AWAITING_RECONCILE are terminal faults.
         return False
 
 
@@ -188,13 +269,20 @@ class CompletionReport:
         return tuple(row for row in self.rows if row.is_deferred)
 
     @property
+    def quarantined(self) -> tuple[CompletionRow, ...]:
+        """Fires whose outcome is unknown and which need an operator."""
+        return tuple(row for row in self.rows if row.is_quarantined)
+
+    @property
     def unaccounted(self) -> tuple[CompletionRow, ...]:
         """Fires with neither an outcome nor even a stated reason for waiting.
 
         These are the ones that vanished, which is the accident.
         """
         return tuple(
-            row for row in self.rows if not row.is_resolved and not row.is_deferred
+            row
+            for row in self.rows
+            if not row.is_resolved and not row.is_deferred and not row.is_quarantined
         )
 
     @property
@@ -232,6 +320,7 @@ def build_completion_mapping(
     polled_event_uuids: list[tuple[str, str]],
     outcomes: dict[str, SessionOutcome],
     deferrals: dict[str, str] | None = None,
+    quarantined: dict[str, str] | None = None,
 ) -> CompletionReport:
     """Map every polled fire to its outcome, or to nothing.
 
@@ -242,9 +331,23 @@ def build_completion_mapping(
     completeness.
     """
     deferrals = deferrals or {}
+    quarantined = quarantined or {}
     rows: list[CompletionRow] = []
     for event_uuid, symbol in polled_event_uuids:
         outcome = outcomes.get(event_uuid)
+        if outcome is None and event_uuid in quarantined:
+            # Terminal, unresolved, and not coming back on a later tick.
+            rows.append(
+                CompletionRow(
+                    event_uuid=event_uuid,
+                    symbol=symbol,
+                    state=str(ClaimLifecycle.AWAITING_RECONCILE),
+                    proposal_id=None,
+                    rejection_reason=None,
+                    deferral_reason=quarantined[event_uuid],
+                )
+            )
+            continue
         if outcome is None:
             deferral = deferrals.get(event_uuid)
             rows.append(

--- a/app/services/watch_trigger_repricing/live_contract.py
+++ b/app/services/watch_trigger_repricing/live_contract.py
@@ -41,7 +41,7 @@ r2 escape. Only closed equality rules out both.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Protocol, runtime_checkable
+from typing import Final, Protocol, final, runtime_checkable
 
 from app.services.watch_trigger_repricing.capability import (
     PROPOSAL_ONLY_TOOLS,
@@ -56,6 +56,7 @@ from app.services.watch_trigger_repricing.spawn import (
 __all__ = [
     "LiveSessionSpawner",
     "LiveSpawnerContractViolation",
+    "ProposalChainGrant",
     "assert_exact_grant",
     "assert_live_spawner_contract",
 ]
@@ -83,6 +84,61 @@ def assert_exact_grant(granted: frozenset[str] | set[str], *, who: str) -> None:
     )
 
 
+# Minted nowhere but :meth:`LiveSessionSpawner.__init__`. A module-private
+# sentinel is what makes :class:`ProposalChainGrant` unforgeable *by
+# accident*: writing ``ProposalChainGrant(object())`` raises, so a spawner
+# that skipped the base class cannot hand one to the write seam. It is not
+# a defence against deliberate private access, and does not claim to be --
+# what it buys is that the bypass cannot be written without reaching into
+# another module's underscore name, which is a reviewable act rather than
+# an oversight.
+_GRANT_ISSUER: Final[object] = object()
+
+
+@final
+class ProposalChainGrant:
+    """Proof that a spawner's tool grant was checked at construction.
+
+    §101차 ③ asked for the attestation to be enforced "in the protocol or
+    the constructor" rather than in a runbook. This is the value that makes
+    that enforcement reach further than the spawner object itself: the
+    execution boundary (:mod:`.proposal_chain`) requires one, and the only
+    way to obtain one is to construct a :class:`LiveSessionSpawner`
+    subclass, whose ``__init__`` refuses any grant that is not exactly
+    :data:`~.capability.PROPOSAL_ONLY_TOOLS`.
+
+    So "wire a spawner that creates proposals while skipping the grant
+    check" is not a runtime risk to be tested for -- it is code that cannot
+    be written without failing at the constructor.
+    """
+
+    __slots__ = ("_tools", "_who")
+
+    def __init__(
+        self, issuer: object, *, who: str, tools: frozenset[str] | set[str]
+    ) -> None:
+        if issuer is not _GRANT_ISSUER:
+            raise LiveSpawnerContractViolation(
+                "ProposalChainGrant is minted only by LiveSessionSpawner.__init__; "
+                "constructing one directly is exactly the bypass that check exists "
+                "to prevent"
+            )
+        assert_exact_grant(tools, who=who)
+        self._who = who
+        self._tools = frozenset(tools)
+
+    @property
+    def who(self) -> str:
+        return self._who
+
+    @property
+    def tools(self) -> frozenset[str]:
+        return self._tools
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"ProposalChainGrant(who={self._who!r}, tools={len(self._tools)})"
+
+
 @runtime_checkable
 class ReconcilingLiveSpawner(Protocol):
     """The shape the arming gate insists on for anything not dry."""
@@ -108,9 +164,30 @@ class LiveSessionSpawner(ABC):
     """
 
     def __init__(self) -> None:
-        assert_exact_grant(
-            self.declared_grant(), who=f"{type(self).__name__}.declared_grant()"
+        who = f"{type(self).__name__}.declared_grant()"
+        declared = frozenset(self.declared_grant())
+        assert_exact_grant(declared, who=who)
+        self._proposal_chain_grant = ProposalChainGrant(
+            _GRANT_ISSUER, who=who, tools=declared
         )
+
+    @property
+    def proposal_chain_grant(self) -> ProposalChainGrant:
+        """The capability token :mod:`.proposal_chain` demands.
+
+        Raises rather than returning ``None`` when a subclass skipped
+        ``super().__init__()``: a spawner whose grant was never checked must
+        not be able to reach the execution boundary by being falsy in the
+        right place.
+        """
+        grant = getattr(self, "_proposal_chain_grant", None)
+        if grant is None:
+            raise LiveSpawnerContractViolation(
+                f"{type(self).__name__} never ran LiveSessionSpawner.__init__, so "
+                "its tool grant was never checked and it holds no proposal-chain "
+                "grant"
+            )
+        return grant
 
     @property
     def is_dry(self) -> bool:

--- a/app/services/watch_trigger_repricing/live_contract.py
+++ b/app/services/watch_trigger_repricing/live_contract.py
@@ -223,9 +223,11 @@ class LiveSessionSpawner(ABC):
 def assert_live_spawner_contract(spawner: object) -> None:
     """Gate check for a non-dry spawner.
 
-    Structural *and* nominal: the protocol check catches a duck-typed object
-    that implements the methods, and the base-class check catches one that
-    implements them without ever running the constructor's grant check.
+    Three layers, because each catches something the others miss: the
+    protocol check catches a duck-typed object that implements the methods,
+    the base-class check catches one that implements them without
+    inheriting the constructor's grant check, and the grant check catches a
+    subclass that inherited it and then skipped ``super().__init__()``.
     """
     if not isinstance(spawner, ReconcilingLiveSpawner):
         missing = [
@@ -244,3 +246,17 @@ def assert_live_spawner_contract(spawner: object) -> None:
             "tool grant is checked at construction; implementing the methods "
             "without the base class skips that check"
         )
+    # r2 SHOULD 1: inheriting the base is not the same as having *run* it. A
+    # subclass whose ``__init__`` skips ``super().__init__()`` never had its
+    # grant checked and holds no token, and arming used to accept it -- the
+    # failure only arrived later, when the write seam asked for the grant.
+    # Fail-closed either way, but "rejected at the boundary" is what the
+    # contract claims, so check it at the boundary.
+    grant = getattr(spawner, "_proposal_chain_grant", None)
+    if not isinstance(grant, ProposalChainGrant):
+        raise LiveSpawnerContractViolation(
+            f"{type(spawner).__name__} holds no proposal-chain grant, so "
+            "LiveSessionSpawner.__init__ never ran and its tool grant was "
+            "never checked"
+        )
+    assert_exact_grant(grant.tools, who=f"{type(spawner).__name__} (armed)")

--- a/app/services/watch_trigger_repricing/orchestrator.py
+++ b/app/services/watch_trigger_repricing/orchestrator.py
@@ -48,10 +48,16 @@ implements :class:`~.spawn.ReconcilableSpawner`, the tick asks it whether a
 session with this event's deterministic ``spawn_key`` exists, and a
 definite answer resolves to CONSUMED or released exactly as above. Only an
 undecidable result is quarantined, and quarantine is chosen with its cost
-stated: **one event's latency, in exchange for never double-spawning into
-the approval lane**. It is not silent -- a quarantined event is logged at
-ERROR and returned in ``TickResult.needs_reconcile``, so it surfaces as an
-operator task rather than as an event that quietly stopped existing.
+stated: **this fire is not judged at all until a human looks, in exchange
+for never double-proposing into the approval lane**. It is not silent -- a
+quarantined event is written to the ``awaiting_reconcile`` terminal, logged
+at ERROR, and returned in ``TickResult.needs_reconcile``, so it surfaces as
+an operator task rather than as an event that quietly stopped existing.
+
+r2 / BLOCKER 2 corrected the cost statement above. r1 said "one event's
+latency" while leaving the claim ``STARTED``, which is the state the lease
+expires -- so the fire *was* retried, thirty minutes later, automatically.
+The terminal is what makes the sentence true.
 
 r3 (§101차 ③) closes that last sentence: a live spawner without
 ``reconcile`` is no longer "under pressure" to implement it -- it cannot be
@@ -75,11 +81,13 @@ from typing import Any
 
 from app.services.watch_trigger_repricing.claims import (
     DEFAULT_LEASE,
+    ClaimNotHeld,
     ClaimStore,
     ClaimStoreUnavailable,
     InMemoryClaimStore,
 )
 from app.services.watch_trigger_repricing.gate import GateDecision, evaluate_gate
+from app.services.watch_trigger_repricing.lifecycle import awaiting_reconcile
 from app.services.watch_trigger_repricing.selection import (
     DEFAULT_ROUND_CAP,
     CandidateEvent,
@@ -364,10 +372,32 @@ async def run_repricing_tick(
             )
             continue
 
-        # AMBIGUOUS and undecidable. Hold the claim so it cannot double
-        # spawn, and shout so it cannot silently vanish. The lease still
-        # runs, so if nothing reconciles it the TTL sweep records
-        # EXPIRED_UNPROCESSED -- an unjudged fire, named as such.
+        # AMBIGUOUS and undecidable. r2 / BLOCKER 2: r1 held the claim in
+        # STARTED and said in a log line that it would not be retried --
+        # but STARTED is the state the lease expires, so thirty minutes
+        # later the TTL wrote EXPIRED_UNPROCESSED and the next tick
+        # re-claimed and re-judged the fire. If the first create had
+        # committed and only its acknowledgement was lost, that is two
+        # proposals from one fire. Writing the terminal makes the refusal
+        # a property of the row rather than a promise in a log.
+        try:
+            await store.finalise(handle, awaiting_reconcile())
+        except ClaimNotHeld:
+            # The lease already rolled over to another claimant. Do not
+            # fight it: the current owner's row is authoritative, and the
+            # event is still reported below.
+            logger.exception(
+                "watch_trigger_repricing: could not quarantine event %s; the "
+                "claim is no longer held by this owner",
+                event.event_uuid,
+            )
+        except ClaimStoreUnavailable:
+            logger.exception(
+                "watch_trigger_repricing: could not quarantine event %s; the "
+                "claim store is unavailable, so the lease may still expire and "
+                "the fire may be re-judged",
+                event.event_uuid,
+            )
         logger.error(
             "watch_trigger_repricing: AMBIGUOUS spawn for event %s (symbol=%s, "
             "spawn_key=%s): %s -- claim quarantined, needs operator "

--- a/app/services/watch_trigger_repricing/orchestrator.py
+++ b/app/services/watch_trigger_repricing/orchestrator.py
@@ -66,6 +66,7 @@ judged nothing and gave no reason has not finished.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import threading
 from dataclasses import dataclass, field
@@ -193,7 +194,7 @@ class TickResult:
         }
 
 
-def _resolve_ambiguity(
+async def _resolve_ambiguity(
     *,
     spawner: SessionSpawner,
     request: SpawnRequest,
@@ -210,6 +211,8 @@ def _resolve_ambiguity(
         return SpawnDisposition.AMBIGUOUS, f"{detail}; spawner cannot reconcile"
     try:
         verdict = spawner.reconcile(request)
+        if inspect.isawaitable(verdict):
+            verdict = await verdict
     except Exception as exc:  # noqa: BLE001 - a failed readback stays ambiguous
         logger.exception(
             "watch_trigger_repricing: reconcile failed for spawn_key=%s",
@@ -221,14 +224,23 @@ def _resolve_ambiguity(
     return SpawnDisposition.AMBIGUOUS, f"{detail}; reconcile inconclusive"
 
 
-def _attempt_spawn(
+async def _attempt_spawn(
     *,
     spawner: SessionSpawner,
     request: SpawnRequest,
 ) -> tuple[SpawnDisposition, str]:
-    """Call the spawner and classify what it actually proved."""
+    """Call the spawner and classify what it actually proved.
+
+    ``spawn`` may be sync or async. The dry rehearsal spawners are sync
+    because they do nothing; a spawner that actually reaches
+    ``order_proposal_create`` is necessarily async, and awaiting here is
+    what lets the *same* orchestrator drive both rather than growing a
+    second, less-tested tick for the live path.
+    """
     try:
         outcome = spawner.spawn(request)
+        if inspect.isawaitable(outcome):
+            outcome = await outcome
     except SpawnNotStarted as exc:
         # The only exception that proves a clean failure.
         return SpawnDisposition.NOT_STARTED, f"spawn_not_started: {exc}"
@@ -325,9 +337,9 @@ async def run_repricing_tick(
             label=session_label(event.symbol, now=now),
         )
 
-        disposition, detail = _attempt_spawn(spawner=spawner, request=request)
+        disposition, detail = await _attempt_spawn(spawner=spawner, request=request)
         if disposition is SpawnDisposition.AMBIGUOUS:
-            disposition, detail = _resolve_ambiguity(
+            disposition, detail = await _resolve_ambiguity(
                 spawner=spawner, request=request, detail=detail
             )
 

--- a/app/services/watch_trigger_repricing/proposal_chain.py
+++ b/app/services/watch_trigger_repricing/proposal_chain.py
@@ -26,21 +26,16 @@ What it refuses
     ``LiveSessionSpawner.__init__`` can mint and only after checking the
     spawner's grant equals :data:`~.capability.PROPOSAL_ONLY_TOOLS`. A
     spawner that skipped the base class has nothing to pass.
-``a substitute callable`` (r2 / BLOCKER 1)
-    There is no substitute to refuse, because there is nowhere to pass
-    one. r1 took the boundary as an optional argument and validated it by
+``a substitute callable passed as an argument`` (r2 / BLOCKER 1)
+    r1 took the boundary as an optional argument and validated it by
     ``__name__``, which is the "이름 매칭 ≠ 의미 강제" mistake in its purest
     form: any callable renamed ``order_proposal_create`` -- including one
     that submits to a broker -- passed the check and then ran. A name is a
     label the untrusted side chooses.
 
     So the argument is gone. This module calls the module-global it
-    imported at the top of the file, and no parameter, attribute or
-    setter anywhere in the package accepts a callable. Wiring a substitute
-    is not a runtime risk to be validated; it is a ``TypeError`` at the
-    constructor. (A test may still ``monkeypatch`` the module global --
-    that is true of every Python module, and it is deliberately *not* a
-    configuration path: nothing a caller can construct reaches it.)
+    imported at the top of the file, and no parameter anywhere in the
+    package accepts a callable.
 ``a different symbol``
     A session spawned for one fire may not propose on another symbol. The
     per-symbol concurrency rule is meaningless if the session can wander.
@@ -61,6 +56,32 @@ boundary and runs every later step behind a never-raise boundary, so:
 
 Reading "unknown" as "no" is the double-proposal direction, which is the
 one failure this whole feature must not create.
+
+What this seam does **not** buy (r3, measured)
+----------------------------------------------
+It would be comfortable to write that the boundary is now unreachable by
+anything but the real tool. That is false, and the false version was in
+this docstring until r3 measured it.
+
+The seam is sound *given that it is used*: with a judgement in hand, only
+``order_proposal_create`` is called, with arguments validated against the
+fire. What the seam cannot do is compel anyone to go through it. The
+judge :mod:`.chain_spawner` runs is ordinary Python in this interpreter,
+and an in-process caller can:
+
+* rebind ``proposal_chain.order_proposal_create`` -- and rebind any
+  module-private capture of it just as easily, so "hide the name" is not
+  a fix (measured: ``H1_PRIVATE_CAPTURE=DEFEATED``);
+* import :data:`~.live_contract._GRANT_ISSUER` and mint a grant
+  (measured: ``H2_GRANT_SENTINEL=MINTED``);
+* skip this module altogether and import a broker order tool directly
+  (measured: ``H3_SEAM_IS_OPTIONAL`` -- ``toss_place_order`` is two lines
+  of ``importlib`` away from any judge).
+
+The third is decisive and no amount of hardening here answers it. **The
+approval boundary this feature needs is a process boundary, not a
+function call.** See :mod:`.chain_spawner` for the guarantee this package
+actually provides today, stated exactly.
 """
 
 from __future__ import annotations

--- a/app/services/watch_trigger_repricing/proposal_chain.py
+++ b/app/services/watch_trigger_repricing/proposal_chain.py
@@ -1,0 +1,271 @@
+"""ROB-1290 — the execution boundary, actually crossed.
+
+The gap this closes
+-------------------
+ROB-1286 shipped poll, gate, claim, fencing, lifecycle and the capability
+allowlist as real code, and then stopped one step short: the spawn path
+*named* ``order_proposal_create`` in a string, a docstring and an
+allowlist, and never called it. The only test that reached a proposal row
+created that row itself, before the tick, and handed the id to a scripted
+spawner. So the operator's completion criterion -- every fire ends as a
+proposal or an attributed reason -- could not be satisfied by the shipping
+chain, only narrated about.
+
+This module is the missing mile. It is the **write seam**: the one file in
+the package allowed to import the boundary tool, exactly as
+:mod:`.event_source` is the one file allowed to import the read side. The
+package invariants enforce both halves, so widening the write surface is a
+diff in a file that has a test watching it rather than an import somebody
+adds in passing.
+
+What it refuses
+---------------
+``a grant it cannot verify``
+    :func:`create_proposal_for_fire` takes a
+    :class:`~.live_contract.ProposalChainGrant`, which only
+    ``LiveSessionSpawner.__init__`` can mint and only after checking the
+    spawner's grant equals :data:`~.capability.PROPOSAL_ONLY_TOOLS`. A
+    spawner that skipped the base class has nothing to pass.
+``a different tool``
+    An injected callable is accepted only if it is *named*
+    :data:`~.capability.EXECUTION_BOUNDARY`. Tests may substitute a fake
+    boundary; nobody may substitute a submit path.
+``a different symbol``
+    A session spawned for one fire may not propose on another symbol. The
+    per-symbol concurrency rule is meaningless if the session can wander.
+
+Three answers, not two
+----------------------
+The tool's own contract makes the distinction that matters for retry
+safety. ``order_proposal_create`` freezes its success at the commit
+boundary and runs every later step behind a never-raise boundary, so:
+
+* ``success: False`` is returned only from the pre-commit validation
+  handlers -- **no row exists**, and the fire is safe to re-judge. That is
+  :class:`ProposalChainFailure`.
+* an exception escaping the tool means the commit may or may not have
+  happened -- **unknown**, and re-judging could put a second proposal in
+  front of the approval lane. That is :class:`ProposalChainAmbiguous`, and
+  the orchestrator quarantines it for an operator instead of guessing.
+
+Reading "unknown" as "no" is the double-proposal direction, which is the
+one failure this whole feature must not create.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.mcp_server.caller_identity import caller_agent_id_var
+from app.mcp_server.tooling.order_proposal_tools import order_proposal_create
+from app.services.watch_trigger_repricing.capability import (
+    EXECUTION_BOUNDARY,
+    CapabilityBoundaryViolation,
+)
+from app.services.watch_trigger_repricing.judgement import (
+    Decline,
+    JudgementRefused,
+    ProposalDraft,
+    interpret_judgement,
+)
+from app.services.watch_trigger_repricing.lifecycle import (
+    SessionOutcome,
+    proposal_created,
+    rejected,
+)
+from app.services.watch_trigger_repricing.live_contract import (
+    ProposalChainGrant,
+    assert_exact_grant,
+)
+from app.services.watch_trigger_repricing.spawn import SpawnRequest
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_PROPOSER",
+    "ProposalChainAmbiguous",
+    "ProposalChainFailure",
+    "create_proposal_for_fire",
+    "run_judgement_session",
+]
+
+# The ``proposer`` text carried on every proposal this lane creates, so an
+# operator reading the approval queue can see which lane produced it.
+DEFAULT_PROPOSER = "watch-trigger-repricing"
+
+# Server-recorded caller identity prefix. Ownership checks elsewhere use
+# this rather than the free-text ``proposer``.
+_AGENT_PREFIX = "watch-trigger-repricing"
+
+BoundaryTool = Callable[..., Awaitable[dict[str, Any]]]
+
+
+class ProposalChainFailure(RuntimeError):
+    """The create provably did not happen. Safe to hand the fire back."""
+
+
+class ProposalChainAmbiguous(RuntimeError):
+    """Unknown whether a proposal row was committed. Never retry blindly."""
+
+
+def _resolve_boundary_tool(tool: BoundaryTool | None) -> BoundaryTool:
+    """Return the boundary callable, refusing anything that is not it."""
+    if tool is None:
+        return order_proposal_create
+    name = getattr(tool, "__name__", "")
+    if name != EXECUTION_BOUNDARY:
+        raise CapabilityBoundaryViolation(
+            f"the repricing write seam may only invoke {EXECUTION_BOUNDARY!r}; "
+            f"refusing an injected callable named {name!r}"
+        )
+    return tool
+
+
+def _check_grant(grant: object, *, request: SpawnRequest) -> ProposalChainGrant:
+    if not isinstance(grant, ProposalChainGrant):
+        raise CapabilityBoundaryViolation(
+            "reaching the execution boundary requires a ProposalChainGrant minted "
+            "by LiveSessionSpawner.__init__; got "
+            f"{type(grant).__name__} for event {request.event_uuid}"
+        )
+    # Re-checked here, not merely at mint time, so a grant object that was
+    # somehow mutated between construction and use still fails closed.
+    assert_exact_grant(grant.tools, who=f"proposal chain for {grant.who}")
+    return grant
+
+
+async def create_proposal_for_fire(
+    *,
+    request: SpawnRequest,
+    draft: ProposalDraft,
+    grant: object,
+    tool: BoundaryTool | None = None,
+    proposer: str = DEFAULT_PROPOSER,
+) -> SessionOutcome:
+    """Cross the boundary for one fire and return the terminal it earned.
+
+    Returns :data:`~.lifecycle.ClaimLifecycle.PROPOSAL_CREATED` carrying the
+    real ``review.order_proposals`` id, or raises. It never returns a
+    "created nothing" success -- that shape is what the completion criterion
+    exists to catch.
+    """
+    _check_grant(grant, request=request)
+    if draft.symbol != request.symbol:
+        raise CapabilityBoundaryViolation(
+            f"a session spawned for {request.symbol!r} may not propose on "
+            f"{draft.symbol!r}"
+        )
+    boundary = _resolve_boundary_tool(tool)
+
+    identity = caller_agent_id_var.set(f"{_AGENT_PREFIX}:{request.event_uuid}")
+    try:
+        response = await boundary(
+            symbol=draft.symbol,
+            market=draft.market,
+            account_mode=draft.account_mode,
+            side=draft.side,
+            order_type=draft.order_type,
+            proposer=proposer,
+            rungs=[rung.as_tool_argument() for rung in draft.rungs],
+            thesis=draft.thesis,
+            strategy=draft.strategy,
+            valid_until=draft.valid_until,
+            rationale={
+                "source": "watch_trigger_repricing",
+                "event_uuid": request.event_uuid,
+                "spawn_key": request.spawn_key,
+                "kst_date": request.kst_date,
+                "session_label": request.label,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 - unknown is not "no"
+        logger.exception(
+            "watch_trigger_repricing: %s raised for event %s (symbol=%s); whether "
+            "a proposal row was committed is UNKNOWN",
+            EXECUTION_BOUNDARY,
+            request.event_uuid,
+            request.symbol,
+        )
+        raise ProposalChainAmbiguous(
+            f"{EXECUTION_BOUNDARY} raised for event {request.event_uuid}: {exc!r}"
+        ) from exc
+    finally:
+        caller_agent_id_var.reset(identity)
+
+    if not isinstance(response, dict):
+        raise ProposalChainAmbiguous(
+            f"{EXECUTION_BOUNDARY} returned {type(response).__name__}, not a "
+            "result mapping; the commit state cannot be read from it"
+        )
+    if response.get("success") is not True:
+        # Pre-commit refusal. The tool's success snapshot is frozen at the
+        # commit boundary and every later step is never-raise, so this is
+        # positive evidence that no row exists.
+        raise ProposalChainFailure(
+            f"{EXECUTION_BOUNDARY} refused event {request.event_uuid}: "
+            f"{response.get('error')!r}"
+        )
+    proposal_id = str(response.get("proposal_id") or "").strip()
+    if not proposal_id:
+        raise ProposalChainAmbiguous(
+            f"{EXECUTION_BOUNDARY} reported success without a proposal_id for "
+            f"event {request.event_uuid}"
+        )
+    logger.info(
+        "watch_trigger_repricing: event %s (symbol=%s) produced proposal %s",
+        request.event_uuid,
+        request.symbol,
+        proposal_id,
+    )
+    return proposal_created(proposal_id)
+
+
+async def run_judgement_session(
+    *,
+    request: SpawnRequest,
+    judge: object,
+    grant: object,
+    tool: BoundaryTool | None = None,
+    proposer: str = DEFAULT_PROPOSER,
+) -> SessionOutcome:
+    """Ask the judge, then act on its answer. Exactly one terminal, or raise.
+
+    Judge-side failures are collapsed into :class:`~.judgement.JudgementRefused`
+    on purpose. The judge holds no grant and this module is the sole writer,
+    so "the judge blew up" is positive evidence that nothing was written --
+    which lets the caller hand the fire straight back instead of parking it
+    in a quarantine that needs an operator.
+    """
+    try:
+        answer = judge.judge(request)  # type: ignore[attr-defined]
+        if inspect.isawaitable(answer):
+            answer = await answer
+        judgement = interpret_judgement(answer, event_uuid=request.event_uuid)
+    except JudgementRefused:
+        raise
+    except Exception as exc:  # noqa: BLE001 - nothing was written; say so plainly
+        raise JudgementRefused(
+            f"the judge raised before producing a judgement for event "
+            f"{request.event_uuid}: {exc!r}"
+        ) from exc
+
+    if isinstance(judgement, ProposalDraft):
+        return await create_proposal_for_fire(
+            request=request,
+            draft=judgement,
+            grant=grant,
+            tool=tool,
+            proposer=proposer,
+        )
+    if isinstance(judgement, Decline):
+        return rejected(judgement.reason)
+    # Unreachable while ``Judgement`` stays closed. Kept so that adding a
+    # third variant fails loudly here instead of silently returning None --
+    # a None terminal is precisely the analysis-only outcome §101차 ⑤ bans.
+    raise JudgementRefused(
+        f"unhandled judgement variant {type(judgement).__name__} for event "
+        f"{request.event_uuid}"
+    )

--- a/app/services/watch_trigger_repricing/proposal_chain.py
+++ b/app/services/watch_trigger_repricing/proposal_chain.py
@@ -26,10 +26,21 @@ What it refuses
     ``LiveSessionSpawner.__init__`` can mint and only after checking the
     spawner's grant equals :data:`~.capability.PROPOSAL_ONLY_TOOLS`. A
     spawner that skipped the base class has nothing to pass.
-``a different tool``
-    An injected callable is accepted only if it is *named*
-    :data:`~.capability.EXECUTION_BOUNDARY`. Tests may substitute a fake
-    boundary; nobody may substitute a submit path.
+``a substitute callable`` (r2 / BLOCKER 1)
+    There is no substitute to refuse, because there is nowhere to pass
+    one. r1 took the boundary as an optional argument and validated it by
+    ``__name__``, which is the "이름 매칭 ≠ 의미 강제" mistake in its purest
+    form: any callable renamed ``order_proposal_create`` -- including one
+    that submits to a broker -- passed the check and then ran. A name is a
+    label the untrusted side chooses.
+
+    So the argument is gone. This module calls the module-global it
+    imported at the top of the file, and no parameter, attribute or
+    setter anywhere in the package accepts a callable. Wiring a substitute
+    is not a runtime risk to be validated; it is a ``TypeError`` at the
+    constructor. (A test may still ``monkeypatch`` the module global --
+    that is true of every Python module, and it is deliberately *not* a
+    configuration path: nothing a caller can construct reaches it.)
 ``a different symbol``
     A session spawned for one fire may not propose on another symbol. The
     per-symbol concurrency rule is meaningless if the session can wander.
@@ -56,8 +67,6 @@ from __future__ import annotations
 
 import inspect
 import logging
-from collections.abc import Awaitable, Callable
-from typing import Any
 
 from app.mcp_server.caller_identity import caller_agent_id_var
 from app.mcp_server.tooling.order_proposal_tools import order_proposal_create
@@ -89,6 +98,7 @@ __all__ = [
     "ProposalChainAmbiguous",
     "ProposalChainFailure",
     "create_proposal_for_fire",
+    "interpret_create_response",
     "run_judgement_session",
 ]
 
@@ -100,8 +110,6 @@ DEFAULT_PROPOSER = "watch-trigger-repricing"
 # this rather than the free-text ``proposer``.
 _AGENT_PREFIX = "watch-trigger-repricing"
 
-BoundaryTool = Callable[..., Awaitable[dict[str, Any]]]
-
 
 class ProposalChainFailure(RuntimeError):
     """The create provably did not happen. Safe to hand the fire back."""
@@ -111,17 +119,34 @@ class ProposalChainAmbiguous(RuntimeError):
     """Unknown whether a proposal row was committed. Never retry blindly."""
 
 
-def _resolve_boundary_tool(tool: BoundaryTool | None) -> BoundaryTool:
-    """Return the boundary callable, refusing anything that is not it."""
-    if tool is None:
-        return order_proposal_create
-    name = getattr(tool, "__name__", "")
-    if name != EXECUTION_BOUNDARY:
-        raise CapabilityBoundaryViolation(
-            f"the repricing write seam may only invoke {EXECUTION_BOUNDARY!r}; "
-            f"refusing an injected callable named {name!r}"
+def interpret_create_response(response: object, *, event_uuid: str) -> SessionOutcome:
+    """Classify what the boundary said, by evidence.
+
+    Split out as a pure function so the three classifications can be
+    tested without anything resembling a substitutable tool. r1 tested
+    them by injecting fake callables, which is exactly the seam r2 found
+    was a bypass -- the tests were paying for a hole in the design.
+    """
+    if not isinstance(response, dict):
+        raise ProposalChainAmbiguous(
+            f"{EXECUTION_BOUNDARY} returned {type(response).__name__}, not a "
+            "result mapping; the commit state cannot be read from it"
         )
-    return tool
+    if response.get("success") is not True:
+        # Pre-commit refusal. The tool's success snapshot is frozen at the
+        # commit boundary and every later step is never-raise, so this is
+        # positive evidence that no row exists.
+        raise ProposalChainFailure(
+            f"{EXECUTION_BOUNDARY} refused event {event_uuid}: "
+            f"{response.get('error')!r}"
+        )
+    proposal_id = str(response.get("proposal_id") or "").strip()
+    if not proposal_id:
+        raise ProposalChainAmbiguous(
+            f"{EXECUTION_BOUNDARY} reported success without a proposal_id for "
+            f"event {event_uuid}"
+        )
+    return proposal_created(proposal_id)
 
 
 def _check_grant(grant: object, *, request: SpawnRequest) -> ProposalChainGrant:
@@ -142,7 +167,6 @@ async def create_proposal_for_fire(
     request: SpawnRequest,
     draft: ProposalDraft,
     grant: object,
-    tool: BoundaryTool | None = None,
     proposer: str = DEFAULT_PROPOSER,
 ) -> SessionOutcome:
     """Cross the boundary for one fire and return the terminal it earned.
@@ -158,11 +182,10 @@ async def create_proposal_for_fire(
             f"a session spawned for {request.symbol!r} may not propose on "
             f"{draft.symbol!r}"
         )
-    boundary = _resolve_boundary_tool(tool)
 
     identity = caller_agent_id_var.set(f"{_AGENT_PREFIX}:{request.event_uuid}")
     try:
-        response = await boundary(
+        response = await order_proposal_create(
             symbol=draft.symbol,
             market=draft.market,
             account_mode=draft.account_mode,
@@ -195,32 +218,14 @@ async def create_proposal_for_fire(
     finally:
         caller_agent_id_var.reset(identity)
 
-    if not isinstance(response, dict):
-        raise ProposalChainAmbiguous(
-            f"{EXECUTION_BOUNDARY} returned {type(response).__name__}, not a "
-            "result mapping; the commit state cannot be read from it"
-        )
-    if response.get("success") is not True:
-        # Pre-commit refusal. The tool's success snapshot is frozen at the
-        # commit boundary and every later step is never-raise, so this is
-        # positive evidence that no row exists.
-        raise ProposalChainFailure(
-            f"{EXECUTION_BOUNDARY} refused event {request.event_uuid}: "
-            f"{response.get('error')!r}"
-        )
-    proposal_id = str(response.get("proposal_id") or "").strip()
-    if not proposal_id:
-        raise ProposalChainAmbiguous(
-            f"{EXECUTION_BOUNDARY} reported success without a proposal_id for "
-            f"event {request.event_uuid}"
-        )
+    outcome = interpret_create_response(response, event_uuid=request.event_uuid)
     logger.info(
         "watch_trigger_repricing: event %s (symbol=%s) produced proposal %s",
         request.event_uuid,
         request.symbol,
-        proposal_id,
+        outcome.proposal_id,
     )
-    return proposal_created(proposal_id)
+    return outcome
 
 
 async def run_judgement_session(
@@ -228,7 +233,6 @@ async def run_judgement_session(
     request: SpawnRequest,
     judge: object,
     grant: object,
-    tool: BoundaryTool | None = None,
     proposer: str = DEFAULT_PROPOSER,
 ) -> SessionOutcome:
     """Ask the judge, then act on its answer. Exactly one terminal, or raise.
@@ -257,7 +261,6 @@ async def run_judgement_session(
             request=request,
             draft=judgement,
             grant=grant,
-            tool=tool,
             proposer=proposer,
         )
     if isinstance(judgement, Decline):

--- a/app/services/watch_trigger_repricing/spawn.py
+++ b/app/services/watch_trigger_repricing/spawn.py
@@ -48,6 +48,7 @@ a decidable answer via :meth:`ReconcilableSpawner.reconcile`.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -173,11 +174,15 @@ class SessionSpawner(Protocol):
         """True only if this spawner structurally cannot start a session.
 
         Read fail-closed by the orchestrator: an implementation that does
-        not answer is assumed live.
+        not answer is assumed live. Note that :mod:`.arming` decides
+        dryness by *type* and ignores this answer entirely -- it is kept as
+        documentation of intent, not as a gate.
         """
         ...
 
-    def spawn(self, request: SpawnRequest) -> SpawnOutcome: ...
+    def spawn(
+        self, request: SpawnRequest
+    ) -> SpawnOutcome | Awaitable[SpawnOutcome]: ...
 
 
 @runtime_checkable
@@ -189,7 +194,9 @@ class ReconcilableSpawner(Protocol):
     STARTED/NOT_STARTED on the same tick.
     """
 
-    def reconcile(self, request: SpawnRequest) -> SpawnDisposition: ...
+    def reconcile(
+        self, request: SpawnRequest
+    ) -> SpawnDisposition | Awaitable[SpawnDisposition]: ...
 
 
 @dataclass

--- a/tests/services/watch_trigger_repricing/test_db_claim_store.py
+++ b/tests/services/watch_trigger_repricing/test_db_claim_store.py
@@ -231,3 +231,54 @@ async def test_database_rejects_proposal_terminal_without_proposal_id(store) -> 
         with pytest.raises(IntegrityError):
             await session.commit()
         await session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# ROB-1290 — release, which the durable store never implemented
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_release_hands_the_fire_back_and_the_next_tick_can_reclaim(
+    store,
+) -> None:
+    """The branch no shipped spawner could reach until the chain existed.
+
+    ``release`` was on the ClaimStore protocol and only the in-memory
+    rehearsal store implemented it, so the first spawner able to prove a
+    clean failure would have raised ``AttributeError`` mid-tick.
+    """
+    event = _uuid(20)
+    handle = await store.try_claim(
+        event_uuid=event, symbol="005930", market="kr", claimed_by="t", now=NOW
+    )
+    assert handle is not None
+
+    await store.release(handle, reason="spawn_not_started")
+
+    # The fire looks untouched ...
+    assert await store.state_for(event, now=NOW) is ConsumptionState.UNCLAIMED
+    # ... the symbol slot is free ...
+    assert await store.active_symbols(now=NOW) == frozenset()
+    # ... and a later tick can take it for real.
+    again = await store.try_claim(
+        event_uuid=event, symbol="005930", market="kr", claimed_by="t2", now=NOW
+    )
+    assert again is not None
+    await store.finalise(again, proposal_created("pid-20"))
+    outcomes = await store.outcomes_for([event])
+    assert outcomes[event].state is ClaimLifecycle.PROPOSAL_CREATED
+
+
+@pytest.mark.asyncio
+async def test_release_is_fenced_against_a_stale_owner(store) -> None:
+    event = _uuid(21)
+    handle = await store.try_claim(
+        event_uuid=event, symbol="000660", market="kr", claimed_by="t", now=NOW
+    )
+    assert handle is not None
+    await store.finalise(handle, rejected("judged and declined"))
+
+    # The same handle must not be able to delete its own terminal.
+    with pytest.raises(ClaimNotHeld):
+        await store.release(handle, reason="spawn_not_started")
+    outcomes = await store.outcomes_for([event])
+    assert outcomes[event].state is ClaimLifecycle.REJECTED_WITH_REASON

--- a/tests/services/watch_trigger_repricing/test_e2e_chain_creates_proposals.py
+++ b/tests/services/watch_trigger_repricing/test_e2e_chain_creates_proposals.py
@@ -1,0 +1,447 @@
+"""ROB-1290 — poll -> claim -> spawn -> ``order_proposal_create``, for real.
+
+What ROB-1286's e2e could not show
+----------------------------------
+Its ``test_full_chain_reaches_a_real_proposal_row`` created the proposal
+row *itself*, before the tick, and handed the id to a scripted spawner. So
+the row existed whether or not the tick worked, and the assertion "the id
+in the mapping is a real row" was true by construction.
+
+These tests invert that. Every one of them asserts the proposal table is
+**empty for this lane before the tick runs**, and the rows that exist
+afterwards were created by the spawn path calling the real
+``order_proposal_create`` against the run-owned test database. Delete the
+call and there is no row to assert on.
+
+The one thing still injected is the *judgement* -- whether a fired level
+still deserves an order. That is LLM work and this runtime owns no
+in-process LLM provider, so it was always going to be a port. Everything
+downstream of the decision is the shipping chain.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, func, select
+
+from app.models.investment_reports import InvestmentWatchEvent
+from app.models.order_proposals import (
+    OrderProposal,
+    OrderProposalApprovalDispatchAttempt,
+    OrderProposalRung,
+)
+from app.models.watch_event_repricing_claims import WatchEventRepricingClaim
+from app.services.watch_trigger_repricing.chain_spawner import ProposalChainSpawner
+from app.services.watch_trigger_repricing.db_claim_store import DatabaseClaimStore
+from app.services.watch_trigger_repricing.entrypoint import run_watch_repricing_tick
+from app.services.watch_trigger_repricing.judgement import (
+    Decline,
+    ProposalDraft,
+    ProposalRung,
+)
+from app.services.watch_trigger_repricing.lifecycle import ClaimLifecycle
+from app.services.watch_trigger_repricing.spawn import SpawnRequest
+
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("enabled")]
+
+KST = dt.timezone(dt.timedelta(hours=9))
+FIRE = dt.datetime(2026, 8, 18, 9, 5, tzinfo=KST)
+TICK = dt.datetime(2026, 8, 18, 9, 6, tzinfo=KST)
+
+PROPOSER = "rob1290-chain"
+CORRELATION_PREFIX = "rob1290-chain"
+
+# Three distinct symbols, so one tick can judge all three: the per-symbol
+# concurrency rule is a real constraint and this test is about the chain,
+# not about deferral (which ROB-1286's suite already covers).
+FIRES: tuple[tuple[str, str, int], ...] = (
+    (str(uuid.UUID(int=101290001)), "005930", 276000),
+    (str(uuid.UUID(int=101290002)), "000660", 198000),
+    (str(uuid.UUID(int=101290003)), "035420", 214000),
+)
+BY_SYMBOL = {symbol: event_uuid for event_uuid, symbol, _ in FIRES}
+
+
+class ScriptedJudge:
+    """Answers with a pre-decided judgement. Decide-only: it never writes.
+
+    Stands in for the out-of-process re-judgement session, and *only* for
+    it -- the draft it returns is turned into a real proposal row by the
+    shipping write seam, not by this class.
+    """
+
+    def __init__(self, answers: dict[str, object]) -> None:
+        self.answers = answers
+        self.asked: list[str] = []
+
+    async def judge(self, request: SpawnRequest) -> object:
+        self.asked.append(request.event_uuid)
+        return self.answers.get(request.event_uuid)
+
+
+def sell_draft(event_uuid: str, symbol: str, *, limit_price: str) -> ProposalDraft:
+    return ProposalDraft(
+        event_uuid=event_uuid,
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="kis_live",
+        side="sell",
+        order_type="limit",
+        rungs=(
+            ProposalRung(
+                rung_index=0, side="sell", quantity="10", limit_price=limit_price
+            ),
+        ),
+        thesis=f"watch level crossed on {symbol}; trim into resistance",
+    )
+
+
+async def _clean(session_factory) -> None:
+    async with session_factory() as session:
+        await session.execute(delete(WatchEventRepricingClaim))
+        await session.execute(
+            delete(InvestmentWatchEvent).where(
+                InvestmentWatchEvent.correlation_id.like(f"{CORRELATION_PREFIX}%")
+            )
+        )
+        mine = select(OrderProposal.id).where(OrderProposal.proposer == PROPOSER)
+        await session.execute(
+            delete(OrderProposalApprovalDispatchAttempt).where(
+                OrderProposalApprovalDispatchAttempt.proposal_pk.in_(mine)
+            )
+        )
+        await session.execute(
+            delete(OrderProposalRung).where(OrderProposalRung.proposal_pk.in_(mine))
+        )
+        await session.execute(
+            delete(OrderProposal).where(OrderProposal.proposer == PROPOSER)
+        )
+        await session.commit()
+
+
+@pytest_asyncio.fixture
+async def seeded(_bootstrap_test_schema):
+    from app.core.db import AsyncSessionLocal
+
+    await _clean(AsyncSessionLocal)
+    async with AsyncSessionLocal() as session:
+        for index, (event_uuid, symbol, threshold) in enumerate(FIRES, start=1):
+            session.add(
+                InvestmentWatchEvent(
+                    event_uuid=uuid.UUID(event_uuid),
+                    idempotency_key=f"{CORRELATION_PREFIX}:{event_uuid}",
+                    market="kr",
+                    target_kind="asset",
+                    symbol=symbol,
+                    metric="price",
+                    operator="above",
+                    threshold=threshold,
+                    threshold_key=f"price_above_{threshold}",
+                    intent="sell_review",
+                    action_mode="approval_required",
+                    outcome="review_required",
+                    correlation_id=f"{CORRELATION_PREFIX}-{index}",
+                    kst_date="2026-08-18",
+                    delivery_status="delivered",
+                    delivered_at=FIRE,
+                )
+            )
+        await session.commit()
+    yield AsyncSessionLocal
+    await _clean(AsyncSessionLocal)
+
+
+async def proposal_ids(session_factory) -> set[str]:
+    async with session_factory() as session:
+        rows = await session.scalars(
+            select(OrderProposal.proposal_id).where(OrderProposal.proposer == PROPOSER)
+        )
+        return {str(row) for row in rows}
+
+
+async def proposal_count(session_factory) -> int:
+    async with session_factory() as session:
+        return int(
+            await session.scalar(
+                select(func.count())
+                .select_from(OrderProposal)
+                .where(OrderProposal.proposer == PROPOSER)
+            )
+            or 0
+        )
+
+
+def spawner_for(answers: dict[str, object]) -> ProposalChainSpawner:
+    return ProposalChainSpawner(judge=ScriptedJudge(answers), proposer=PROPOSER)
+
+
+# ---------------------------------------------------------------------------
+# GAP_CLOSED / REAL_CHAIN — the tick creates the row, nothing else does
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_the_tick_itself_creates_the_proposal_row(seeded) -> None:
+    """No row is planted first. If the spawn path does not call the tool,
+    there is nothing here to find."""
+    assert await proposal_count(seeded) == 0, "precondition: this lane owns no rows"
+
+    event_uuid, symbol, _ = FIRES[0]
+    spawner = spawner_for(
+        {
+            event_uuid: sell_draft(event_uuid, symbol, limit_price="286000"),
+            BY_SYMBOL["000660"]: Decline(
+                event_uuid=BY_SYMBOL["000660"], reason="level reclaimed before judging"
+            ),
+            BY_SYMBOL["035420"]: Decline(
+                event_uuid=BY_SYMBOL["035420"], reason="no sellable quantity"
+            ),
+        }
+    )
+
+    result = await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded), spawner=spawner, now=TICK
+    )
+
+    assert result["status"] == "ok"
+    created = await proposal_ids(seeded)
+    assert len(created) == 1, "exactly the one draft became a row"
+
+    mapping = {row["eventUuid"]: row for row in result["completion"]}
+    assert mapping[event_uuid]["state"] == ClaimLifecycle.PROPOSAL_CREATED
+    # The id in the mapping is the id of the row the tick wrote.
+    assert mapping[event_uuid]["proposalId"] in created
+
+
+@pytest.mark.asyncio
+async def test_the_created_row_carries_the_draft_and_lane_provenance(seeded) -> None:
+    event_uuid, symbol, _ = FIRES[0]
+    spawner = spawner_for(
+        {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
+    )
+    await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded), spawner=spawner, now=TICK
+    )
+
+    created = await proposal_ids(seeded)
+    assert len(created) == 1
+    async with seeded() as session:
+        row = await session.scalar(
+            select(OrderProposal).where(
+                OrderProposal.proposal_id == uuid.UUID(created.pop())
+            )
+        )
+    assert row is not None
+    assert row.symbol == symbol
+    assert row.side == "sell"
+    assert row.proposer == PROPOSER
+    assert row.rationale["event_uuid"] == event_uuid
+    assert row.rationale["source"] == "watch_trigger_repricing"
+
+
+# ---------------------------------------------------------------------------
+# COMPLETION — N fires in, N outcomes out, one each
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_every_fire_maps_to_exactly_one_proposal_or_one_reason(seeded) -> None:
+    assert await proposal_count(seeded) == 0
+
+    answers: dict[str, object] = {
+        BY_SYMBOL["005930"]: sell_draft(
+            BY_SYMBOL["005930"], "005930", limit_price="286000"
+        ),
+        BY_SYMBOL["000660"]: sell_draft(
+            BY_SYMBOL["000660"], "000660", limit_price="205000"
+        ),
+        BY_SYMBOL["035420"]: Decline(
+            event_uuid=BY_SYMBOL["035420"],
+            reason="level reclaimed within the bar; no trim warranted",
+        ),
+    }
+    result = await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded),
+        spawner=spawner_for(answers),
+        now=TICK,
+    )
+
+    polled = {row["eventUuid"] for row in result["polled"]}
+    assert polled == {event_uuid for event_uuid, _, _ in FIRES}
+
+    rows = {row["eventUuid"]: row for row in result["completion"]}
+    assert set(rows) == polled, "the mapping covers the polled set exactly"
+
+    # The 1:1 assertion: exactly one of the two, for every fire, no blanks.
+    for event_uuid, row in rows.items():
+        has_proposal = bool((row["proposalId"] or "").strip())
+        has_reason = bool((row["rejectionReason"] or "").strip())
+        assert has_proposal != has_reason, (
+            f"event {event_uuid} resolved to {row} -- every fire must end as a "
+            "proposal or as an attributed reason, and never as both or neither"
+        )
+
+    assert result["completionComplete"] is True
+    assert result["completionAccounted"] is True
+
+    # And the two proposal ids are two distinct rows the tick actually wrote.
+    created = await proposal_ids(seeded)
+    assert len(created) == 2
+    assert {rows[u]["proposalId"] for u in rows if rows[u]["proposalId"]} == created
+
+
+@pytest.mark.asyncio
+async def test_the_terminals_are_persisted_against_the_real_ids(seeded) -> None:
+    answers: dict[str, object] = {
+        BY_SYMBOL["005930"]: sell_draft(
+            BY_SYMBOL["005930"], "005930", limit_price="286000"
+        ),
+        BY_SYMBOL["000660"]: Decline(
+            event_uuid=BY_SYMBOL["000660"], reason="already trimmed this session"
+        ),
+    }
+    store = DatabaseClaimStore(session_factory=seeded)
+    await run_watch_repricing_tick(store=store, spawner=spawner_for(answers), now=TICK)
+
+    created = await proposal_ids(seeded)
+    outcomes = await store.outcomes_for([BY_SYMBOL["005930"], BY_SYMBOL["000660"]])
+
+    assert outcomes[BY_SYMBOL["005930"]].state is ClaimLifecycle.PROPOSAL_CREATED
+    assert outcomes[BY_SYMBOL["005930"]].proposal_id in created
+    assert outcomes[BY_SYMBOL["000660"]].state is ClaimLifecycle.REJECTED_WITH_REASON
+    assert (
+        outcomes[BY_SYMBOL["000660"]].rejection_reason == "already trimmed this session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_analysis_only_session_leaves_the_fire_unresolved(seeded) -> None:
+    """The mutant AC3 asks about: a judge that produces nothing must go RED.
+
+    Nothing is written, the run is not complete, and the fire is handed
+    back rather than being marked done -- so a later tick can still judge
+    it. What must never happen is a blank row that reads as success.
+    """
+    result = await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded),
+        spawner=spawner_for({}),  # every judge answer is None
+        now=TICK,
+    )
+
+    assert await proposal_count(seeded) == 0
+    assert result["completionComplete"] is False
+
+    rows = {row["eventUuid"]: row for row in result["completion"]}
+    assert set(rows) == {event_uuid for event_uuid, _, _ in FIRES}
+    for row in rows.values():
+        assert not row["proposalId"]
+        assert not row["rejectionReason"]
+        # Not silently omitted: each carries the reason it was set aside.
+        assert row["deferralReason"], row
+    assert result["completionAccounted"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_refused_create_hands_the_fire_back_for_the_next_tick(seeded) -> None:
+    """Provably-no-row is retryable, and the retry actually resolves it."""
+    event_uuid, symbol, _ = FIRES[0]
+
+    async def order_proposal_create(**kwargs):
+        return {"success": False, "error": "unsupported account_mode"}
+
+    store = DatabaseClaimStore(session_factory=seeded)
+    refusing = ProposalChainSpawner(
+        judge=ScriptedJudge(
+            {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
+        ),
+        tool=order_proposal_create,
+        proposer=PROPOSER,
+    )
+    first = await run_watch_repricing_tick(store=store, spawner=refusing, now=TICK)
+
+    assert await proposal_count(seeded) == 0
+    assert first["completionComplete"] is False
+    first_rows = {row["eventUuid"]: row for row in first["completion"]}
+    assert first_rows[event_uuid]["deferralReason"] == "spawn_not_started"
+
+    # Next tick, with the real tool: the same fire resolves.
+    second = await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded),
+        spawner=spawner_for(
+            {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
+        ),
+        now=TICK + dt.timedelta(minutes=1),
+    )
+    second_rows = {row["eventUuid"]: row for row in second["completion"]}
+    assert second_rows[event_uuid]["state"] == ClaimLifecycle.PROPOSAL_CREATED
+    assert second_rows[event_uuid]["proposalId"] in await proposal_ids(seeded)
+
+
+@pytest.mark.asyncio
+async def test_an_ambiguous_create_is_quarantined_and_never_double_proposes(
+    seeded,
+) -> None:
+    event_uuid, symbol, _ = FIRES[0]
+
+    async def order_proposal_create(**kwargs):
+        raise TimeoutError("acknowledgement lost")
+
+    store = DatabaseClaimStore(session_factory=seeded)
+    first = await run_watch_repricing_tick(
+        store=store,
+        spawner=ProposalChainSpawner(
+            judge=ScriptedJudge(
+                {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
+            ),
+            tool=order_proposal_create,
+            proposer=PROPOSER,
+        ),
+        now=TICK,
+    )
+    assert [row["eventUuid"] for row in first["needsReconcile"]] == [event_uuid]
+
+    # A later tick must not re-judge a fire whose create outcome is unknown.
+    second = await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded),
+        spawner=spawner_for(
+            {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
+        ),
+        now=TICK + dt.timedelta(minutes=1),
+    )
+    assert event_uuid not in {row["eventUuid"] for row in second["spawned"]}
+    assert await proposal_count(seeded) == 0
+
+
+# ---------------------------------------------------------------------------
+# NO_BYPASS / NOT_ARMED, against the shipping entrypoint
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_a_proposal_creating_spawner_is_blocked_on_a_volatile_store(
+    seeded,
+) -> None:
+    from app.services.watch_trigger_repricing.claims import InMemoryClaimStore
+
+    event_uuid, symbol, _ = FIRES[0]
+    result = await run_watch_repricing_tick(
+        store=InMemoryClaimStore(),
+        spawner=spawner_for(
+            {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
+        ),
+        now=TICK,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["reason"] == "non_durable_claim_store"
+    assert await proposal_count(seeded) == 0
+
+
+@pytest.mark.asyncio
+async def test_the_default_entrypoint_still_creates_nothing(seeded) -> None:
+    """NOT_ARMED: with no spawner injected the tick is the dry rehearsal."""
+    result = await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded), now=TICK
+    )
+
+    assert result["status"] == "ok"
+    assert await proposal_count(seeded) == 0
+    assert result["completionComplete"] is False

--- a/tests/services/watch_trigger_repricing/test_e2e_chain_creates_proposals.py
+++ b/tests/services/watch_trigger_repricing/test_e2e_chain_creates_proposals.py
@@ -21,6 +21,7 @@ downstream of the decision is the shipping chain.
 
 from __future__ import annotations
 
+import contextlib
 import datetime as dt
 import uuid
 
@@ -36,6 +37,8 @@ from app.models.order_proposals import (
 )
 from app.models.watch_event_repricing_claims import WatchEventRepricingClaim
 from app.services.watch_trigger_repricing.chain_spawner import ProposalChainSpawner
+from app.services.watch_trigger_repricing.claims import DEFAULT_LEASE
+from app.services.watch_trigger_repricing.consumption import ConsumptionState
 from app.services.watch_trigger_repricing.db_claim_store import DatabaseClaimStore
 from app.services.watch_trigger_repricing.entrypoint import run_watch_repricing_tick
 from app.services.watch_trigger_repricing.judgement import (
@@ -177,6 +180,31 @@ async def proposal_count(session_factory) -> int:
 
 def spawner_for(answers: dict[str, object]) -> ProposalChainSpawner:
     return ProposalChainSpawner(judge=ScriptedJudge(answers), proposer=PROPOSER)
+
+
+def unsupported_draft(event_uuid: str, symbol: str) -> ProposalDraft:
+    """A draft the real boundary refuses *before* it commits anything.
+
+    ``upbit`` cannot trade ``equity_kr``, and ``order_proposal_create``
+    rejects the combination in its pre-commit validation, returning
+    ``success: False``. No fake tool is involved: this is the real
+    refusal, which is what makes "provably no row" evidence rather than
+    an assumption.
+    """
+    return ProposalDraft(
+        event_uuid=event_uuid,
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="upbit",
+        side="sell",
+        order_type="limit",
+        rungs=(
+            ProposalRung(
+                rung_index=0, side="sell", quantity="10", limit_price="286000"
+            ),
+        ),
+        thesis="deliberately unsupported account_mode/market pair",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -343,20 +371,15 @@ async def test_an_analysis_only_session_leaves_the_fire_unresolved(seeded) -> No
 
 @pytest.mark.asyncio
 async def test_a_refused_create_hands_the_fire_back_for_the_next_tick(seeded) -> None:
-    """Provably-no-row is retryable, and the retry actually resolves it."""
+    """Provably-no-row is retryable, and the retry actually resolves it.
+
+    The refusal comes from the real boundary tool rejecting a real
+    unsupported combination -- nothing is substituted.
+    """
     event_uuid, symbol, _ = FIRES[0]
 
-    async def order_proposal_create(**kwargs):
-        return {"success": False, "error": "unsupported account_mode"}
-
     store = DatabaseClaimStore(session_factory=seeded)
-    refusing = ProposalChainSpawner(
-        judge=ScriptedJudge(
-            {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
-        ),
-        tool=order_proposal_create,
-        proposer=PROPOSER,
-    )
+    refusing = spawner_for({event_uuid: unsupported_draft(event_uuid, symbol)})
     first = await run_watch_repricing_tick(store=store, spawner=refusing, now=TICK)
 
     assert await proposal_count(seeded) == 0
@@ -377,39 +400,165 @@ async def test_a_refused_create_hands_the_fire_back_for_the_next_tick(seeded) ->
     assert second_rows[event_uuid]["proposalId"] in await proposal_ids(seeded)
 
 
+@contextlib.contextmanager
+def lost_acknowledgement():
+    """Make the boundary raise, as a lost acknowledgement would.
+
+    Patches the module global rather than passing a substitute, because
+    there is no parameter to pass one to (r2 / BLOCKER 1). This is a
+    test-runtime patch, not a configuration path.
+
+    Deliberately its own :meth:`pytest.MonkeyPatch.context` rather than the
+    test's ``monkeypatch`` fixture: ``monkeypatch.undo()`` reverts *every*
+    patch made through that fixture, including the ``enabled`` fixture's,
+    which silently turned the tick off and made the assertions afterwards
+    vacuous.
+    """
+    from app.services.watch_trigger_repricing import proposal_chain
+
+    async def boom(**kwargs):
+        raise TimeoutError("acknowledgement lost after commit")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(proposal_chain, "order_proposal_create", boom)
+        yield
+
+
 @pytest.mark.asyncio
 async def test_an_ambiguous_create_is_quarantined_and_never_double_proposes(
     seeded,
 ) -> None:
     event_uuid, symbol, _ = FIRES[0]
-
-    async def order_proposal_create(**kwargs):
-        raise TimeoutError("acknowledgement lost")
+    draft = sell_draft(event_uuid, symbol, limit_price="286000")
 
     store = DatabaseClaimStore(session_factory=seeded)
-    first = await run_watch_repricing_tick(
-        store=store,
-        spawner=ProposalChainSpawner(
-            judge=ScriptedJudge(
-                {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
-            ),
-            tool=order_proposal_create,
-            proposer=PROPOSER,
-        ),
-        now=TICK,
-    )
+    with lost_acknowledgement():
+        first = await run_watch_repricing_tick(
+            store=store, spawner=spawner_for({event_uuid: draft}), now=TICK
+        )
     assert [row["eventUuid"] for row in first["needsReconcile"]] == [event_uuid]
+    assert first["completionQuarantined"] == [event_uuid]
 
-    # A later tick must not re-judge a fire whose create outcome is unknown.
+    rows = {row["eventUuid"]: row for row in first["completion"]}
+    # Reported as terminal-unknown, not as "deferred to a later tick".
+    assert rows[event_uuid]["state"] == ClaimLifecycle.AWAITING_RECONCILE
+    assert not rows[event_uuid]["proposalId"]
+    assert not rows[event_uuid]["rejectionReason"]
+    assert first["completionComplete"] is False
+    assert first["completionAccounted"] is True
+    assert event_uuid not in first["completionDeferred"]
+
+    # The refusal is a row, not a log line.
+    async with seeded() as session:
+        state = await session.scalar(
+            select(WatchEventRepricingClaim.state).where(
+                WatchEventRepricingClaim.event_uuid == uuid.UUID(event_uuid)
+            )
+        )
+    assert state == ClaimLifecycle.AWAITING_RECONCILE
+
+    # A later tick, with the real boundary, must not re-judge it.
     second = await run_watch_repricing_tick(
         store=DatabaseClaimStore(session_factory=seeded),
-        spawner=spawner_for(
-            {event_uuid: sell_draft(event_uuid, symbol, limit_price="286000")}
-        ),
+        spawner=spawner_for({event_uuid: draft}),
         now=TICK + dt.timedelta(minutes=1),
     )
     assert event_uuid not in {row["eventUuid"] for row in second["spawned"]}
     assert await proposal_count(seeded) == 0
+
+
+@pytest.mark.asyncio
+async def test_the_ttl_cannot_walk_a_quarantine_back_into_a_second_proposal(
+    seeded,
+) -> None:
+    """r2 / BLOCKER 2, end to end.
+
+    r1 left an ambiguous fire's claim in ``started`` and said in a log
+    line that it would not be retried. ``started`` is the state the lease
+    expires, so once the 30-minute lease ran out the TTL wrote
+    ``expired_unprocessed``, the next tick re-claimed at generation + 1,
+    and the fire was judged again -- creating a second proposal if the
+    first call had committed and only its acknowledgement was lost.
+
+    This drives the clock well past the lease and asserts the fire is
+    still not re-judged and still produces no proposal.
+    """
+    event_uuid, symbol, _ = FIRES[0]
+    draft = sell_draft(event_uuid, symbol, limit_price="286000")
+
+    with lost_acknowledgement():
+        await run_watch_repricing_tick(
+            store=DatabaseClaimStore(session_factory=seeded),
+            spawner=spawner_for({event_uuid: draft}),
+            now=TICK,
+        )
+
+    store = DatabaseClaimStore(session_factory=seeded)
+    # Past the lease, by a wide margin, and sweep as the TTL path would.
+    long_after = TICK + DEFAULT_LEASE + dt.timedelta(hours=2)
+    assert await store.sweep_expired(now=long_after) == [], (
+        "a terminal claim must not be swept; only 'started' leases expire"
+    )
+
+    # The claim store still refuses to hand it out ...
+    assert await store.state_for(event_uuid, now=long_after) is (
+        ConsumptionState.QUARANTINED
+    )
+    assert (
+        await store.try_claim(
+            event_uuid=event_uuid,
+            symbol=symbol,
+            market="kr",
+            claimed_by="later-tick",
+            now=long_after,
+        )
+        is None
+    )
+
+    # ... and a full tick long after the lease creates no second proposal.
+    later = await run_watch_repricing_tick(
+        store=DatabaseClaimStore(session_factory=seeded),
+        spawner=spawner_for({event_uuid: draft}),
+        now=dt.datetime(2026, 8, 18, 14, 30, tzinfo=KST),
+    )
+    assert event_uuid not in {row["eventUuid"] for row in later["spawned"]}
+    assert await proposal_count(seeded) == 0
+
+    skipped = {row["eventUuid"]: row["reason"] for row in later["skipped"]}
+    assert skipped[event_uuid] == "awaiting_spawn_reconcile"
+
+
+@pytest.mark.asyncio
+async def test_a_quarantine_does_not_block_other_fires_on_the_same_symbol(
+    seeded,
+) -> None:
+    """Quarantine is per-event. The symbol slot is freed, not held forever."""
+    quarantined_uuid, symbol, _ = FIRES[0]
+    with lost_acknowledgement():
+        await run_watch_repricing_tick(
+            store=DatabaseClaimStore(session_factory=seeded),
+            spawner=spawner_for(
+                {
+                    quarantined_uuid: sell_draft(
+                        quarantined_uuid, symbol, limit_price="286000"
+                    )
+                }
+            ),
+            now=TICK,
+        )
+
+    store = DatabaseClaimStore(session_factory=seeded)
+    assert await store.active_symbols(now=TICK + dt.timedelta(minutes=1)) == frozenset()
+
+    other = BY_SYMBOL["000660"]
+    result = await run_watch_repricing_tick(
+        store=store,
+        spawner=spawner_for({other: sell_draft(other, "000660", limit_price="205000")}),
+        now=TICK + dt.timedelta(minutes=1),
+    )
+    rows = {row["eventUuid"]: row for row in result["completion"]}
+    assert rows[other]["state"] == ClaimLifecycle.PROPOSAL_CREATED
+    assert await proposal_count(seeded) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/watch_trigger_repricing/test_invariants.py
+++ b/tests/services/watch_trigger_repricing/test_invariants.py
@@ -367,19 +367,82 @@ def test_settings_gate_defaults_off() -> None:
     assert Settings.model_fields["WATCH_TRIGGER_REPRICING_ENABLED"].default is False
 
 
-def test_exactly_one_migration_is_added_and_it_is_additive() -> None:
-    """§101차 ①: the claims table, and nothing else."""
+def test_this_feature_migrates_only_its_own_table() -> None:
+    """§101차 ①: the claims table, and nothing else.
+
+    ROB-1290 r2 adds a second migration (the ``awaiting_reconcile`` state,
+    which is what stops an ambiguous fire being re-judged after the TTL).
+    Counting files was always a proxy for the property that matters, so
+    this asserts the property directly and for *every* migration this
+    feature owns: exactly one table is ever created, no other table is
+    named, and ``review.investment_watch_events`` is never touched.
+    """
     versions = REPO_ROOT / "alembic" / "versions"
-    mine = [
+    mine = sorted(
         p
         for p in versions.glob("*.py")
         if "watch_event_repricing_claims" in p.read_text()
+    )
+    assert [p.name for p in mine] == [
+        "20260819_rob1286_repricing_claims.py",
+        "20260820_rob1290_awaiting_reconcile_state.py",
     ]
-    assert len(mine) == 1, [p.name for p in mine]
 
-    source = mine[0].read_text()
-    # Additive: creates its own table, alters nobody else's.
-    assert source.count("op.create_table(") == 1
-    for destructive in ("op.drop_column", "op.alter_column", "op.drop_constraint"):
-        assert destructive not in source.split("def downgrade")[0]
-    assert "investment_watch_events" not in _code_tokens(mine[0])
+    # Across the whole set, the table is created exactly once.
+    assert sum(p.read_text().count("op.create_table(") for p in mine) == 1
+
+    for path in mine:
+        # The feature never reads or writes the fire table.
+        assert "investment_watch_events" not in _code_tokens(path), path.name
+        # No other table is named anywhere in the migration.
+        tree = ast.parse(path.read_text())
+        table_like = {
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and ("watch_event" in node.value or "review." in node.value)
+        }
+        for literal in table_like:
+            assert "watch_event_repricing_claims" in literal, (
+                f"{path.name} names another table: {literal!r}"
+            )
+
+    # Which statements each migration actually emits is asserted against the
+    # rendered DDL in ``test_migration_render.py`` -- reading the source
+    # cannot catch a name mangled by alembic's naming convention.
+
+
+def test_the_second_migration_alters_nothing_but_one_check_constraint() -> None:
+    """Additive in the sense that matters: it widens, it does not remove."""
+    source = (
+        REPO_ROOT
+        / "alembic"
+        / "versions"
+        / "20260820_rob1290_awaiting_reconcile_state.py"
+    ).read_text()
+    upgrade = source.split("def downgrade")[0]
+
+    for destructive in ("op.drop_column", "op.alter_column", "op.drop_table"):
+        assert destructive not in upgrade
+    # It replaces the state CHECK, and only that one.
+    assert upgrade.count("op.drop_constraint(") == 1
+    assert upgrade.count("op.create_check_constraint(") == 1
+    assert "ck_watch_event_repricing_claims_state" in source
+    # The widened set is a strict superset of the old one.
+    assert "awaiting_reconcile" in source
+    for kept in (
+        "started",
+        "proposal_created",
+        "rejected_with_reason",
+        "expired_unprocessed",
+    ):
+        assert kept in source
+
+
+def test_the_model_check_matches_the_lifecycle_enum() -> None:
+    """The DB's spelling of the states and the code's cannot drift."""
+    from app.models.watch_event_repricing_claims import _LIFECYCLE_STATES
+    from app.services.watch_trigger_repricing.lifecycle import ClaimLifecycle
+
+    assert set(_LIFECYCLE_STATES) == {m.value for m in ClaimLifecycle}

--- a/tests/services/watch_trigger_repricing/test_invariants.py
+++ b/tests/services/watch_trigger_repricing/test_invariants.py
@@ -24,12 +24,17 @@ PACKAGE_FILES = sorted(PACKAGE.glob("*.py"))
 # and the claim store the one allowed to write -- to its own table only.
 READ_SEAM = PACKAGE / "event_source.py"
 CLAIM_WRITER = PACKAGE / "db_claim_store.py"
+# ROB-1290: the boundary is crossed for real now, so exactly one file may
+# import the tool that crosses it. Same shape as READ_SEAM, and it is a
+# *narrow* exemption -- every other forbidden fragment still applies here.
+WRITE_SEAM = PACKAGE / "proposal_chain.py"
+BOUNDARY_MODULE = "app.mcp_server.tooling.order_proposal_tools"
 
 FORBIDDEN_IMPORT_FRAGMENTS = (
     "app.services.brokers",
     "app.services.order_proposals",
     "app.mcp_server.tooling.orders",
-    "app.mcp_server.tooling.order_proposal_tools",
+    BOUNDARY_MODULE,
     "app.services.kis_trading_service",
     "app.services.trade_journal",
 )
@@ -88,16 +93,19 @@ def test_package_files_are_the_expected_set() -> None:
         "__init__.py",
         "arming.py",
         "capability.py",
+        "chain_spawner.py",
         "claims.py",
         "consumption.py",
         "db_claim_store.py",
         "entrypoint.py",
         "event_source.py",
         "gate.py",
+        "judgement.py",
         "lifecycle.py",
         "live_contract.py",
         "orchestrator.py",
         "poller.py",
+        "proposal_chain.py",
         "selection.py",
         "spawn.py",
     }
@@ -107,6 +115,8 @@ def test_package_files_are_the_expected_set() -> None:
 # The approval machinery cannot be reached, relaxed, or read from here
 # ---------------------------------------------------------------------------
 def test_no_broker_or_approval_imports() -> None:
+    """The write seam may import the boundary tool. Nothing else may, and it
+    may import nothing else from the forbidden list either."""
     offenders: list[str] = []
     for path, tree in _trees():
         for node in ast.walk(tree):
@@ -117,9 +127,71 @@ def test_no_broker_or_approval_imports() -> None:
             else:
                 continue
             for name in names:
+                if path == WRITE_SEAM and name == BOUNDARY_MODULE:
+                    continue
                 if any(f in name for f in FORBIDDEN_IMPORT_FRAGMENTS):
                     offenders.append(f"{path.name}:{node.lineno} {name}")
     assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# ROB-1290 — the boundary is crossed, exactly once, from exactly one file
+# ---------------------------------------------------------------------------
+def _boundary_importers() -> dict[str, list[str]]:
+    """path name -> names imported from the boundary tool module."""
+    found: dict[str, list[str]] = {}
+    for path, tree in _trees():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == BOUNDARY_MODULE:
+                found.setdefault(path.name, []).extend(a.name for a in node.names)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == BOUNDARY_MODULE:
+                        found.setdefault(path.name, []).append("<module>")
+    return found
+
+
+def test_exactly_one_file_imports_the_boundary_tool() -> None:
+    assert _boundary_importers() == {WRITE_SEAM.name: ["order_proposal_create"]}
+
+
+def test_the_write_seam_actually_calls_the_boundary() -> None:
+    """The ROB-1286 gap, asserted structurally.
+
+    r3 named ``order_proposal_create`` in a string, a docstring and an
+    allowlist, and never called it, so "the chain reaches a proposal" was a
+    sentence. This walks the seam's AST for a call whose callee resolves to
+    the imported boundary name -- prose and allowlist entries cannot
+    satisfy it.
+    """
+    from app.services.watch_trigger_repricing.capability import EXECUTION_BOUNDARY
+
+    tree = ast.parse(WRITE_SEAM.read_text())
+    # The seam resolves the callable through one helper, so accept either a
+    # direct call or a return of the bare name from that resolver.
+    referenced = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and node.id == EXECUTION_BOUNDARY
+    ]
+    assert referenced, f"{WRITE_SEAM.name} never references {EXECUTION_BOUNDARY}"
+
+    awaited_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call)
+    ]
+    assert awaited_calls, "the seam must await the boundary call"
+
+
+def test_the_boundary_name_is_not_reachable_from_any_other_package_file() -> None:
+    """A second importer would make the seam a convention, not a control."""
+    other = [
+        p.name
+        for p in PACKAGE_FILES
+        if p != WRITE_SEAM and "order_proposal_tools" in _code_tokens(p)
+    ]
+    assert other == []
 
 
 def test_approval_gate_settings_are_never_referenced() -> None:

--- a/tests/services/watch_trigger_repricing/test_lifecycle_completion.py
+++ b/tests/services/watch_trigger_repricing/test_lifecycle_completion.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 import pytest
 
 from app.services.watch_trigger_repricing.lifecycle import (
+    NON_RECLAIMABLE_STATES,
+    RESOLVED_LIFECYCLE_STATES,
     TERMINAL_LIFECYCLE_STATES,
     ClaimLifecycle,
+    CompletionRow,
     IncompleteOutcome,
     SessionOutcome,
+    awaiting_reconcile,
     build_completion_mapping,
     proposal_created,
     rejected,
@@ -23,14 +27,41 @@ pytestmark = pytest.mark.unit
 
 
 # ---------------------------------------------------------------------------
-# The enum has exactly three terminals, and none of them is "analysed"
+# Exactly two states are *outcomes*, and neither of them is "analysed"
 # ---------------------------------------------------------------------------
-def test_terminals_are_exactly_the_three_operator_named_states() -> None:
+def test_only_two_states_satisfy_the_completion_criterion() -> None:
+    """The load-bearing half: what counts as *done*.
+
+    ROB-1290 r2 added a fourth terminal (``awaiting_reconcile``) so an
+    ambiguous spawn survives the TTL instead of being re-judged. That must
+    not become a third way to look finished, so the resolved set is
+    asserted separately from the terminal set, and it is still the same
+    two states the operator named.
+    """
+    assert {str(s) for s in RESOLVED_LIFECYCLE_STATES} == {
+        "proposal_created",
+        "rejected_with_reason",
+    }
+
+
+def test_the_extra_terminals_are_faults_and_are_never_resolved() -> None:
     assert {str(s) for s in TERMINAL_LIFECYCLE_STATES} == {
         "proposal_created",
         "rejected_with_reason",
         "expired_unprocessed",
+        "awaiting_reconcile",
     }
+    faults = TERMINAL_LIFECYCLE_STATES - RESOLVED_LIFECYCLE_STATES
+    assert {str(s) for s in faults} == {"expired_unprocessed", "awaiting_reconcile"}
+    for fault in faults:
+        row = CompletionRow(
+            event_uuid="e",
+            symbol="005930",
+            state=str(fault),
+            proposal_id=None,
+            rejection_reason=None,
+        )
+        assert row.is_resolved is False
 
 
 def test_no_analysis_only_terminal_exists() -> None:
@@ -45,6 +76,7 @@ def test_no_analysis_only_terminal_exists() -> None:
         "proposal_created",
         "rejected_with_reason",
         "expired_unprocessed",
+        "awaiting_reconcile",
     }
     for forbidden in (
         "analysed",
@@ -56,6 +88,33 @@ def test_no_analysis_only_terminal_exists() -> None:
         "acknowledged",
     ):
         assert forbidden not in members
+
+
+def test_the_quarantine_terminal_claims_no_knowledge() -> None:
+    """It means "nobody knows", so it may not carry evidence either way."""
+    assert awaiting_reconcile().state is ClaimLifecycle.AWAITING_RECONCILE
+    assert awaiting_reconcile().proposal_id is None
+    assert awaiting_reconcile().rejection_reason is None
+    with pytest.raises(IncompleteOutcome):
+        SessionOutcome(state=ClaimLifecycle.AWAITING_RECONCILE, proposal_id="prop-1")
+    with pytest.raises(IncompleteOutcome):
+        SessionOutcome(
+            state=ClaimLifecycle.AWAITING_RECONCILE, rejection_reason="unknown"
+        )
+
+
+def test_the_ttl_terminal_is_the_only_reclaimable_one() -> None:
+    """r2 / BLOCKER 2, stated as a set.
+
+    ``expired_unprocessed`` exists so a crashed tick's fire is picked up
+    again. ``awaiting_reconcile`` exists so an ambiguous one is *not*.
+    """
+    assert {str(s) for s in NON_RECLAIMABLE_STATES} == {
+        "proposal_created",
+        "rejected_with_reason",
+        "awaiting_reconcile",
+    }
+    assert ClaimLifecycle.EXPIRED_UNPROCESSED not in NON_RECLAIMABLE_STATES
 
 
 def test_started_is_not_a_terminal() -> None:

--- a/tests/services/watch_trigger_repricing/test_live_spawner_contract.py
+++ b/tests/services/watch_trigger_repricing/test_live_spawner_contract.py
@@ -293,7 +293,21 @@ def test_self_attested_dryness_no_longer_bypasses_the_durability_rule() -> None:
 
 
 def test_a_correct_live_spawner_still_needs_a_durable_store() -> None:
-    spawner = _good_live_spawner()()
+    """Uses the real shipping spawner.
+
+    ROB-1290 r3: arming accepts only the concrete live spawners this
+    package defines, so a locally-defined ``Good(LiveSessionSpawner)`` is
+    refused as unlisted before the durability rule is ever reached. Testing
+    the durability rule therefore has to use the spawner that actually
+    ships, which is a closer test than the stand-in was.
+    """
+    from app.services.watch_trigger_repricing.chain_spawner import ProposalChainSpawner
+
+    class _Judge:
+        async def judge(self, request):  # pragma: no cover - never invoked
+            raise AssertionError("arming must fail before any judging")
+
+    spawner = ProposalChainSpawner(judge=_Judge())
 
     with pytest.raises(ArmingRefused) as exc:
         assert_arming_contract(spawner=spawner, store=InMemoryClaimStore())
@@ -303,6 +317,23 @@ def test_a_correct_live_spawner_still_needs_a_durable_store() -> None:
     assert_arming_contract(
         spawner=spawner, store=DatabaseClaimStore(session_factory=None)
     )
+
+
+def test_a_well_formed_external_subclass_is_refused_as_unlisted() -> None:
+    """r3 / remaining bypass 1: the contract is not the whole gate.
+
+    ``Good`` satisfies every structural check -- it inherits the live base,
+    ran its constructor, declares and attests exactly the proposal-only
+    set, and can reconcile. It is still refused, because a subclass can put
+    anything at all in ``spawn`` and arming has no way to look.
+    """
+    spawner = _good_live_spawner()()
+
+    with pytest.raises(ArmingRefused) as exc:
+        assert_arming_contract(
+            spawner=spawner, store=DatabaseClaimStore(session_factory=None)
+        )
+    assert exc.value.reason == "unlisted_live_spawner"
 
 
 def test_the_dry_spawner_is_dry_by_type() -> None:

--- a/tests/services/watch_trigger_repricing/test_migration_render.py
+++ b/tests/services/watch_trigger_repricing/test_migration_render.py
@@ -1,0 +1,145 @@
+"""ROB-1290 r2 — the claim-state migration, rendered rather than assumed.
+
+Alembic applies ``Base.metadata``'s naming convention
+(``ck_%(table_name)s_%(constraint_name)s``) to ``drop_constraint`` as well
+as to ``create_check_constraint``. Passing the *full* constraint name
+therefore produces a double-prefixed, truncated identifier and the DROP
+fails at runtime against a constraint that does not exist -- which a
+source-level test reading the file would never notice, because the file
+looks perfectly reasonable.
+
+So this renders the real DDL with ``alembic upgrade --sql`` (offline mode:
+no database is contacted) and asserts the statements that actually reach
+Postgres. It deliberately does not shell out to a ``.venv/bin/alembic``
+path the way the repo's older migration tests do -- that hard-coding is
+why they cannot run outside one particular interpreter layout.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import pathlib
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from alembic import command
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _contain_alembic_logging_config():
+    """Undo ``fileConfig``'s global logger sabotage.
+
+    ``alembic/env.py`` calls ``logging.config.fileConfig(alembic.ini)``,
+    which defaults to ``disable_existing_loggers=True`` and therefore
+    silences every logger created before it -- for the rest of the pytest
+    session. Without this, loading alembic here made an unrelated test
+    elsewhere in the suite fail on an empty ``caplog``, and only when the
+    two happened to run in the same process.
+    """
+    loggers = logging.Logger.manager.loggerDict
+    before = {
+        name: (obj.disabled, obj.level)
+        for name, obj in loggers.items()
+        if isinstance(obj, logging.Logger)
+    }
+    root = logging.getLogger()
+    root_level, root_handlers = root.level, list(root.handlers)
+    try:
+        yield
+    finally:
+        for name, obj in loggers.items():
+            if not isinstance(obj, logging.Logger):
+                continue
+            if name in before:
+                obj.disabled, obj.level = before[name]
+            else:
+                # Created during the render; must not stay disabled either.
+                obj.disabled = False
+        root.setLevel(root_level)
+        root.handlers[:] = root_handlers
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+BEFORE = "20260819_rob1286_claims"
+AFTER = "20260820_rob1290_reconcile"
+CONSTRAINT = "ck_watch_event_repricing_claims_state"
+TABLE = "review.watch_event_repricing_claims"
+
+
+def _config(buffer: io.StringIO | None = None) -> Config:
+    config = Config(str(REPO_ROOT / "alembic.ini"), output_buffer=buffer)
+    config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    return config
+
+
+def _render(*, upgrade: bool) -> str:
+    buffer = io.StringIO()
+    config = _config(buffer)
+    if upgrade:
+        command.upgrade(config, f"{BEFORE}:{AFTER}", sql=True)
+    else:
+        command.downgrade(config, f"{AFTER}:{BEFORE}", sql=True)
+    return buffer.getvalue()
+
+
+def test_the_chain_still_has_exactly_one_head() -> None:
+    script = ScriptDirectory.from_config(_config())
+    assert list(script.get_heads()) == [AFTER]
+
+
+def test_upgrade_drops_and_recreates_the_state_check_by_its_real_name() -> None:
+    sql = _render(upgrade=True)
+
+    assert f"ALTER TABLE {TABLE} DROP CONSTRAINT {CONSTRAINT};" in sql
+    # The bug this test exists for: a double-prefixed identifier.
+    assert "ck_watch_event_repricing_claims_ck_" not in sql
+
+    add = next(line for line in sql.splitlines() if "ADD CONSTRAINT" in line)
+    assert CONSTRAINT in add
+    for state in (
+        "started",
+        "proposal_created",
+        "rejected_with_reason",
+        "expired_unprocessed",
+        "awaiting_reconcile",
+    ):
+        assert f"'{state}'" in add
+
+
+def test_upgrade_touches_nothing_but_that_constraint() -> None:
+    sql = _render(upgrade=True)
+    statements = [
+        line.strip()
+        for line in sql.splitlines()
+        if line.strip().startswith(("ALTER", "CREATE", "DROP", "UPDATE", "INSERT"))
+    ]
+    # Two ALTERs on our table, plus alembic's own version bookkeeping.
+    assert [s for s in statements if TABLE in s] == [
+        f"ALTER TABLE {TABLE} DROP CONSTRAINT {CONSTRAINT};",
+        next(s for s in statements if "ADD CONSTRAINT" in s),
+    ]
+    assert not [s for s in statements if "investment_watch_events" in s]
+    assert not [s for s in statements if s.startswith("CREATE TABLE")]
+    assert not [s for s in statements if s.startswith("DROP TABLE")]
+
+
+def test_downgrade_rescues_quarantined_rows_before_narrowing() -> None:
+    """The narrower CHECK would reject them, so they move first."""
+    sql = _render(upgrade=False)
+    lines = [line.strip() for line in sql.splitlines() if line.strip()]
+
+    update_at = next(
+        i for i, line in enumerate(lines) if line.startswith("UPDATE " + TABLE)
+    )
+    drop_at = next(i for i, line in enumerate(lines) if "DROP CONSTRAINT" in line)
+    assert update_at < drop_at, "rows must be moved before the constraint narrows"
+    assert "SET state = 'expired_unprocessed'" in lines[update_at]
+    assert "WHERE state = 'awaiting_reconcile'" in lines[update_at]
+
+    add = next(line for line in lines if "ADD CONSTRAINT" in line)
+    assert "'awaiting_reconcile'" not in add

--- a/tests/services/watch_trigger_repricing/test_migration_roundtrip.py
+++ b/tests/services/watch_trigger_repricing/test_migration_roundtrip.py
@@ -1,0 +1,147 @@
+"""ROB-1290 r2 SHOULD 2 — the migration, run against a real database.
+
+Two gaps this closes.
+
+``the package's schema never went through alembic``
+    ``_bootstrap_test_schema`` builds the test database from
+    ``Base.metadata``, not by running the migration chain. So every other
+    test in this package proves the *model* is right and proves nothing
+    about the migration that has to produce it in production.
+``the repo's existing roundtrip tests cannot run here``
+    They shell out to a hard-coded ``REPO / ".venv/bin/alembic"``, which
+    does not exist when the interpreter lives elsewhere -- and creating one
+    in the worktree is exactly what the run conditions forbid. This drives
+    ``alembic.operations`` in-process instead, so it runs wherever pytest
+    runs.
+
+What it actually does: takes the run-owned test database, runs the real
+``downgrade()`` and ``upgrade()`` functions from the migration module
+against a live connection, and checks the constraint's *behaviour* flips
+both ways -- a row the widened CHECK accepts must be rejected once the
+narrow one is back. Everything happens inside a transaction that is rolled
+back, so the shared test schema is unchanged when the test finishes.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import pathlib
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy.exc import IntegrityError
+
+from app.models.base import Base
+
+pytestmark = pytest.mark.integration
+
+MIGRATION_PATH = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "alembic"
+    / "versions"
+    / "20260820_rob1290_awaiting_reconcile_state.py"
+)
+TABLE = sa.text("review.watch_event_repricing_claims")
+NOW = dt.datetime(2026, 8, 18, 0, 6, tzinfo=dt.UTC)
+
+_INSERT = sa.text(
+    """
+    INSERT INTO review.watch_event_repricing_claims
+        (event_uuid, symbol, market, generation, owner_token, claimed_by,
+         state, claimed_at, lease_expires_at)
+    VALUES
+        (:event_uuid, :symbol, 'kr', 1, :owner_token, 'rob1290-roundtrip',
+         :state, :now, :lease)
+    """
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("rob1290_migration", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _insert_awaiting_reconcile(connection: sa.Connection) -> None:
+    connection.execute(
+        _INSERT,
+        {
+            "event_uuid": uuid.uuid4(),
+            "symbol": f"RT{uuid.uuid4().hex[:4]}",
+            "owner_token": uuid.uuid4(),
+            "state": "awaiting_reconcile",
+            "now": NOW,
+            "lease": NOW + dt.timedelta(minutes=30),
+        },
+    )
+
+
+def _accepts_awaiting_reconcile(connection: sa.Connection) -> bool:
+    """Try the write in a savepoint so a rejection does not poison the tx."""
+    savepoint = connection.begin_nested()
+    try:
+        _insert_awaiting_reconcile(connection)
+    except IntegrityError:
+        savepoint.rollback()
+        return False
+    savepoint.rollback()
+    return True
+
+
+def _roundtrip(connection: sa.Connection) -> list[str]:
+    migration = _load_migration()
+    context = MigrationContext.configure(
+        connection=connection, opts={"target_metadata": Base.metadata}
+    )
+    trace: list[str] = []
+    with Operations.context(context):
+        trace.append(f"initial_accepts={_accepts_awaiting_reconcile(connection)}")
+        migration.downgrade()
+        trace.append(
+            f"after_downgrade_accepts={_accepts_awaiting_reconcile(connection)}"
+        )
+        migration.upgrade()
+        trace.append(f"after_upgrade_accepts={_accepts_awaiting_reconcile(connection)}")
+    return trace
+
+
+@pytest.mark.asyncio
+async def test_upgrade_downgrade_upgrade_against_the_real_database(
+    _bootstrap_test_schema,
+) -> None:
+    from app.core.db import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as session:
+        connection = await session.connection()
+        trace = await connection.run_sync(_roundtrip)
+        # Nothing this test did survives it.
+        await session.rollback()
+
+    assert trace == [
+        # The shipped model already carries the widened CHECK ...
+        "initial_accepts=True",
+        # ... the real downgrade() narrows it, and the row is refused ...
+        "after_downgrade_accepts=False",
+        # ... and the real upgrade() widens it again.
+        "after_upgrade_accepts=True",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_shared_schema_is_unchanged_afterwards(
+    _bootstrap_test_schema,
+) -> None:
+    """The roundtrip rolls back, so the next test sees the widened CHECK."""
+    from app.core.db import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as session:
+        connection = await session.connection()
+        accepts = await connection.run_sync(_accepts_awaiting_reconcile)
+        await session.rollback()
+    assert accepts is True

--- a/tests/services/watch_trigger_repricing/test_proposal_chain.py
+++ b/tests/services/watch_trigger_repricing/test_proposal_chain.py
@@ -39,6 +39,7 @@ from app.services.watch_trigger_repricing.live_contract import (
     LiveSessionSpawner,
     LiveSpawnerContractViolation,
     ProposalChainGrant,
+    assert_live_spawner_contract,
 )
 from app.services.watch_trigger_repricing.proposal_chain import (
     ProposalChainAmbiguous,
@@ -57,6 +58,10 @@ from app.services.watch_trigger_repricing.spawn import (
 pytestmark = pytest.mark.unit
 
 EVENT = "00001290-0000-4000-8000-000000000000"
+
+
+class _DurableStore:
+    is_durable = True
 
 
 def _request(symbol: str = "005930", event_uuid: str = EVENT) -> SpawnRequest:
@@ -195,6 +200,14 @@ def test_a_spawner_that_skips_the_base_constructor_holds_no_grant() -> None:
     with pytest.raises(LiveSpawnerContractViolation) as exc:
         _ = SkipsInit().proposal_chain_grant
     assert "never ran LiveSessionSpawner.__init__" in str(exc.value)
+
+    # r2 SHOULD 1: and arming refuses it at the boundary, not only later
+    # when the write seam happens to ask for the grant.
+    with pytest.raises(LiveSpawnerContractViolation):
+        assert_live_spawner_contract(SkipsInit())
+    with pytest.raises(ArmingRefused) as refused:
+        assert_arming_contract(spawner=SkipsInit(), store=_DurableStore())
+    assert refused.value.reason == "live_spawner_contract_unmet"
 
 
 def test_a_chain_spawner_with_a_widened_grant_cannot_be_constructed() -> None:

--- a/tests/services/watch_trigger_repricing/test_proposal_chain.py
+++ b/tests/services/watch_trigger_repricing/test_proposal_chain.py
@@ -16,6 +16,7 @@ from app.services.watch_trigger_repricing.arming import (
     ArmingRefused,
     assert_arming_contract,
     is_dry_spawner,
+    live_spawner_types,
 )
 from app.services.watch_trigger_repricing.capability import (
     EXECUTION_BOUNDARY,
@@ -51,6 +52,7 @@ from app.services.watch_trigger_repricing.proposal_chain import (
 from app.services.watch_trigger_repricing.spawn import (
     DrySessionSpawner,
     ScriptedDrySessionSpawner,
+    SpawnDisposition,
     SpawnNotStarted,
     SpawnRequest,
 )
@@ -314,6 +316,148 @@ async def test_a_widened_attestation_stops_the_spawn_before_the_judge_runs() -> 
     with pytest.raises(CapabilityBoundaryViolation):
         await spawner.spawn(_request())
     assert judge.seen == [], "the judge must not run on a widened grant"
+
+
+# ---------------------------------------------------------------------------
+# r3 — the two bypasses a verifier measured, and the one that stays open
+# ---------------------------------------------------------------------------
+async def _forged_boundary(**kwargs):
+    """Stands in for a direct broker submit. Harmless: records and returns."""
+    _FORGED_CALLS.append(kwargs)
+    return {"success": True, "proposal_id": "forged"}
+
+
+_forged_boundary.__name__ = EXECUTION_BOUNDARY  # the r1 spoof, verbatim
+_FORGED_CALLS: list[dict] = []
+
+
+@pytest.fixture(autouse=True)
+def _reset_forged_calls():
+    _FORGED_CALLS.clear()
+    yield
+    _FORGED_CALLS.clear()
+
+
+def test_the_armable_live_spawners_are_a_closed_set() -> None:
+    assert live_spawner_types() == (ProposalChainSpawner,)
+
+
+def test_a_subclass_reintroducing_the_tool_argument_is_refused_at_arming() -> None:
+    """r3 bypass 1, measured.
+
+    r2 removed ``tool=`` from the base constructor. A subclass can add it
+    back in its own, call ``super().__init__()`` for a clean grant, and
+    override ``spawn``. Every structural check passed and the forged
+    callable ran. Arming now decides by exact type, so it does not.
+    """
+
+    class ToolInjectingSubclass(ProposalChainSpawner):
+        def __init__(self, *, judge, tool, proposer="probe"):
+            self._forged = tool
+            super().__init__(judge=judge, proposer=proposer)
+
+        async def spawn(self, request):
+            return await self._forged(symbol=request.symbol)
+
+    spawner = ToolInjectingSubclass(judge=_Judge(_draft()), tool=_forged_boundary)
+
+    with pytest.raises(ArmingRefused) as exc:
+        assert_arming_contract(spawner=spawner, store=_DurableStore())
+    assert exc.value.reason == "unlisted_live_spawner"
+    assert _FORGED_CALLS == [], "refused before anything could run"
+
+
+def test_a_rogue_subclass_of_the_live_base_is_refused_at_arming() -> None:
+    """Same hole, reached without going through ProposalChainSpawner at all."""
+
+    class RogueLiveSpawner(LiveSessionSpawner):
+        def declared_grant(self):
+            return PROPOSAL_ONLY_TOOLS
+
+        def attest_granted_tools(self, request):
+            return PROPOSAL_ONLY_TOOLS
+
+        async def spawn(self, request):  # pragma: no cover - never reached
+            await _forged_boundary(symbol=request.symbol)
+
+        def reconcile(self, request):
+            return SpawnDisposition.STARTED
+
+    with pytest.raises(ArmingRefused) as exc:
+        assert_arming_contract(spawner=RogueLiveSpawner(), store=_DurableStore())
+    assert exc.value.reason == "unlisted_live_spawner"
+    assert _FORGED_CALLS == []
+
+
+def test_the_in_process_trust_boundary_is_declared_not_inferred() -> None:
+    """Pins the flag so flipping it has to be deliberate.
+
+    An out-of-process spawner would set this ``False`` and would be the
+    first thing here that could honestly claim to bound its judge.
+    """
+    assert ProposalChainSpawner.RUNS_JUDGE_IN_PROCESS is True
+    for spawner_type in live_spawner_types():
+        assert isinstance(spawner_type.RUNS_JUDGE_IN_PROCESS, bool)
+
+
+@pytest.mark.asyncio
+async def test_KNOWN_LIMITATION_an_in_process_judge_is_not_bounded_here() -> None:
+    """r3 bypass 2 — recorded as open, deliberately.
+
+    This asserts a limitation rather than a guarantee, which is unusual and
+    is the point: two rounds of documentation claimed the boundary was
+    closed and a verifier had to measure that it was not. The judge runs in
+    this interpreter, so it can rebind the write seam's module global --
+    and could equally mint a grant from the module-private sentinel, or
+    skip this package and import a broker tool directly. None of that is
+    closable from inside the process; it needs the ``watch_repricing`` MCP
+    profile's *process* boundary.
+
+    If a future change closes this, **this test will fail**, and whoever
+    closes it must update the guarantee statement in ``chain_spawner``
+    rather than leaving a stale claim behind.
+    """
+    from app.services.watch_trigger_repricing import proposal_chain
+
+    original = proposal_chain.order_proposal_create
+
+    class SwappingJudge:
+        async def judge(self, request):
+            proposal_chain.order_proposal_create = _forged_boundary
+            return _draft(event_uuid=request.event_uuid)
+
+    spawner = ProposalChainSpawner(judge=SwappingJudge(), proposer="probe")
+    assert_arming_contract(spawner=spawner, store=_DurableStore())
+    try:
+        await spawner.spawn(_request())
+    finally:
+        proposal_chain.order_proposal_create = original
+
+    assert _FORGED_CALLS, (
+        "expected the in-process judge to reach the swapped global; if this "
+        "now fails the limitation was closed -- update chain_spawner's "
+        "guarantee statement and delete this test"
+    )
+    assert proposal_chain.order_proposal_create is original
+
+
+def test_KNOWN_LIMITATION_a_judge_can_reach_order_tools_without_this_package() -> None:
+    """The decisive one. Import-and-inspect only; nothing is called.
+
+    No hardening of the write seam answers this: the judge never has to use
+    the seam. That is why the honest answer is a process boundary.
+    """
+    import importlib
+
+    reachable = [
+        f"{module}.{symbol}"
+        for module, symbol in (
+            ("app.mcp_server.tooling.orders_toss_variants", "toss_place_order"),
+            ("app.mcp_server.tooling.order_proposal_tools", EXECUTION_BOUNDARY),
+        )
+        if hasattr(importlib.import_module(module), symbol)
+    ]
+    assert len(reachable) == 2, reachable
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/watch_trigger_repricing/test_proposal_chain.py
+++ b/tests/services/watch_trigger_repricing/test_proposal_chain.py
@@ -1,0 +1,430 @@
+"""ROB-1290 — the write seam, and the ways it must refuse to be used.
+
+ROB-1286 left the last mile open: the spawn path named
+``order_proposal_create`` and never called it, and the one test that
+reached a proposal row created that row itself before the tick. These
+tests cover the code that closes it, at the level where the guarantees
+live -- the closed judgement union, the unforgeable grant, and the three
+different answers a create attempt can produce.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.watch_trigger_repricing.arming import (
+    ArmingRefused,
+    assert_arming_contract,
+    is_dry_spawner,
+)
+from app.services.watch_trigger_repricing.capability import (
+    EXECUTION_BOUNDARY,
+    PROPOSAL_ONLY_TOOLS,
+    CapabilityBoundaryViolation,
+)
+from app.services.watch_trigger_repricing.chain_spawner import (
+    ProposalChainSpawner,
+    provisioned_repricing_tools,
+)
+from app.services.watch_trigger_repricing.claims import InMemoryClaimStore
+from app.services.watch_trigger_repricing.judgement import (
+    Decline,
+    JudgementRefused,
+    ProposalDraft,
+    ProposalRung,
+    interpret_judgement,
+)
+from app.services.watch_trigger_repricing.lifecycle import ClaimLifecycle
+from app.services.watch_trigger_repricing.live_contract import (
+    LiveSessionSpawner,
+    LiveSpawnerContractViolation,
+    ProposalChainGrant,
+)
+from app.services.watch_trigger_repricing.proposal_chain import (
+    ProposalChainAmbiguous,
+    ProposalChainFailure,
+    create_proposal_for_fire,
+    run_judgement_session,
+)
+from app.services.watch_trigger_repricing.spawn import (
+    DrySessionSpawner,
+    ScriptedDrySessionSpawner,
+    SpawnNotStarted,
+    SpawnRequest,
+)
+
+pytestmark = pytest.mark.unit
+
+EVENT = "00001290-0000-4000-8000-000000000000"
+
+
+def _request(symbol: str = "005930", event_uuid: str = EVENT) -> SpawnRequest:
+    return SpawnRequest(
+        event_uuid=event_uuid,
+        symbol=symbol,
+        market="kr",
+        kst_date="2026-08-18",
+        label=f"opa-watch-{symbol}-0906",
+    )
+
+
+def _draft(symbol: str = "005930", event_uuid: str = EVENT) -> ProposalDraft:
+    return ProposalDraft(
+        event_uuid=event_uuid,
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="kis_live",
+        side="sell",
+        order_type="limit",
+        rungs=(
+            ProposalRung(
+                rung_index=0, side="sell", quantity="10", limit_price="286000"
+            ),
+        ),
+        thesis="rung crossed; trim into resistance",
+    )
+
+
+class _Judge:
+    """Decide-only stand-in for the out-of-process session."""
+
+    def __init__(self, answer: object) -> None:
+        self._answer = answer
+        self.seen: list[SpawnRequest] = []
+
+    async def judge(self, request: SpawnRequest) -> object:
+        self.seen.append(request)
+        if isinstance(self._answer, BaseException):
+            raise self._answer
+        return self._answer
+
+
+def _grant_for(spawner: LiveSessionSpawner) -> ProposalChainGrant:
+    return spawner.proposal_chain_grant
+
+
+def _spawner(answer: object, tool=None) -> ProposalChainSpawner:
+    return ProposalChainSpawner(judge=_Judge(answer), tool=tool, proposer="rob1290")
+
+
+# ---------------------------------------------------------------------------
+# The judgement union is closed: no analysis-only member, none reachable
+# ---------------------------------------------------------------------------
+def test_a_session_that_analysed_and_said_nothing_is_refused() -> None:
+    with pytest.raises(JudgementRefused) as exc:
+        interpret_judgement(None, event_uuid=EVENT)
+    assert "analysis-only" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        None,
+        "analysed, no action",
+        {"state": "analysed"},
+        ["reviewed"],
+        object(),
+    ],
+)
+def test_no_shape_other_than_the_two_variants_is_a_judgement(answer: object) -> None:
+    with pytest.raises(JudgementRefused):
+        interpret_judgement(answer, event_uuid=EVENT)
+
+
+def test_a_decline_without_a_reason_cannot_be_constructed() -> None:
+    for blank in ("", "   ", None):
+        with pytest.raises(JudgementRefused):
+            Decline(event_uuid=EVENT, reason=blank)  # type: ignore[arg-type]
+
+
+def test_a_draft_with_no_rungs_cannot_be_constructed() -> None:
+    with pytest.raises(JudgementRefused):
+        ProposalDraft(
+            event_uuid=EVENT,
+            symbol="005930",
+            market="equity_kr",
+            account_mode="kis_live",
+            side="sell",
+            order_type="limit",
+            rungs=(),
+            thesis="t",
+        )
+
+
+def test_a_judgement_for_another_event_is_refused() -> None:
+    with pytest.raises(JudgementRefused) as exc:
+        interpret_judgement(_draft(event_uuid="other"), event_uuid=EVENT)
+    assert "spawned for" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# NO_BYPASS — the grant cannot be forged, and the boundary demands one
+# ---------------------------------------------------------------------------
+def test_a_grant_cannot_be_minted_directly() -> None:
+    with pytest.raises(LiveSpawnerContractViolation):
+        ProposalChainGrant(object(), who="x", tools=PROPOSAL_ONLY_TOOLS)
+
+
+@pytest.mark.asyncio
+async def test_the_boundary_refuses_a_caller_with_no_grant() -> None:
+    for fake in (None, object(), PROPOSAL_ONLY_TOOLS):
+        with pytest.raises(CapabilityBoundaryViolation):
+            await create_proposal_for_fire(
+                request=_request(), draft=_draft(), grant=fake
+            )
+
+
+def test_a_spawner_that_skips_the_base_constructor_holds_no_grant() -> None:
+    class SkipsInit(LiveSessionSpawner):
+        def __init__(self) -> None:  # deliberately does not call super()
+            pass
+
+        def declared_grant(self):
+            return PROPOSAL_ONLY_TOOLS
+
+        def attest_granted_tools(self, request):
+            return PROPOSAL_ONLY_TOOLS
+
+        async def spawn(self, request):
+            raise AssertionError("unreachable")
+
+        def reconcile(self, request):
+            raise AssertionError("unreachable")
+
+    with pytest.raises(LiveSpawnerContractViolation) as exc:
+        _ = SkipsInit().proposal_chain_grant
+    assert "never ran LiveSessionSpawner.__init__" in str(exc.value)
+
+
+def test_a_chain_spawner_with_a_widened_grant_cannot_be_constructed() -> None:
+    """§101차 ③: the mutant fails at the constructor, not at first spawn."""
+
+    class Widened(ProposalChainSpawner):
+        def declared_grant(self):
+            return PROPOSAL_ONLY_TOOLS | {"toss_place_order"}
+
+    with pytest.raises(CapabilityBoundaryViolation) as exc:
+        Widened(judge=_Judge(_draft()))
+    assert "toss_place_order" in str(exc.value)
+
+
+def test_a_chain_spawner_that_drops_the_boundary_cannot_be_constructed() -> None:
+    class Narrowed(ProposalChainSpawner):
+        def declared_grant(self):
+            return PROPOSAL_ONLY_TOOLS - {EXECUTION_BOUNDARY}
+
+    with pytest.raises(CapabilityBoundaryViolation):
+        Narrowed(judge=_Judge(_draft()))
+
+
+@pytest.mark.asyncio
+async def test_the_seam_refuses_any_callable_that_is_not_the_boundary() -> None:
+    async def toss_submit(**kwargs):  # a stand-in for "something else"
+        raise AssertionError("must never be called")
+
+    spawner = _spawner(_draft(), tool=toss_submit)
+    with pytest.raises(CapabilityBoundaryViolation) as exc:
+        await run_judgement_session(
+            request=_request(),
+            judge=_Judge(_draft()),
+            grant=_grant_for(spawner),
+            tool=toss_submit,
+        )
+    assert EXECUTION_BOUNDARY in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_a_session_may_not_propose_on_a_different_symbol() -> None:
+    spawner = _spawner(_draft())
+    with pytest.raises(CapabilityBoundaryViolation) as exc:
+        await create_proposal_for_fire(
+            request=_request(symbol="005930"),
+            draft=_draft(symbol="000660"),
+            grant=_grant_for(spawner),
+        )
+    assert "000660" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# ALLOWLIST — closed equality, attested from the provisioning path
+# ---------------------------------------------------------------------------
+def test_the_attested_registry_equals_the_allowlist_exactly() -> None:
+    provisioned = provisioned_repricing_tools()
+    assert provisioned == PROPOSAL_ONLY_TOOLS
+    assert EXECUTION_BOUNDARY in provisioned
+    spawner = _spawner(_draft())
+    assert spawner.attest_granted_tools(_request()) == PROPOSAL_ONLY_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_a_widened_attestation_stops_the_spawn_before_the_judge_runs() -> None:
+    judge = _Judge(_draft())
+
+    class LiesAtAttest(ProposalChainSpawner):
+        def attest_granted_tools(self, request):
+            return PROPOSAL_ONLY_TOOLS | {"toss_place_order"}
+
+    spawner = LiesAtAttest(judge=judge)
+    with pytest.raises(CapabilityBoundaryViolation):
+        await spawner.spawn(_request())
+    assert judge.seen == [], "the judge must not run on a widened grant"
+
+
+# ---------------------------------------------------------------------------
+# ARMING — a proposal-creating spawner is never dry, and needs a durable store
+# ---------------------------------------------------------------------------
+def test_the_chain_spawner_is_not_dry() -> None:
+    assert is_dry_spawner(_spawner(_draft())) is False
+
+
+def test_the_chain_spawner_needs_a_durable_claim_store() -> None:
+    with pytest.raises(ArmingRefused) as exc:
+        assert_arming_contract(spawner=_spawner(_draft()), store=InMemoryClaimStore())
+    assert exc.value.reason == "non_durable_claim_store"
+
+
+def test_subclassing_a_dry_spawner_no_longer_buys_a_dry_exemption() -> None:
+    """The r2 hole: isinstance let an override keep the dry label."""
+
+    class SneakyLive(DrySessionSpawner):
+        def spawn(self, request):
+            raise AssertionError("would have started something")
+
+    assert is_dry_spawner(SneakyLive()) is False
+    with pytest.raises(ArmingRefused):
+        assert_arming_contract(spawner=SneakyLive(), store=InMemoryClaimStore())
+
+    # The package's own rehearsal spawners stay dry, by exact type.
+    assert is_dry_spawner(DrySessionSpawner()) is True
+    assert is_dry_spawner(ScriptedDrySessionSpawner()) is True
+
+
+# ---------------------------------------------------------------------------
+# The three answers a create attempt can produce
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_a_successful_create_becomes_the_proposal_created_terminal() -> None:
+    calls: list[dict] = []
+
+    async def order_proposal_create(**kwargs):
+        calls.append(kwargs)
+        return {"success": True, "proposal_id": "pid-1"}
+
+    spawner = _spawner(_draft(), tool=order_proposal_create)
+    outcome = await spawner.spawn(_request())
+
+    assert outcome.disposition.value == "started"
+    recorded = spawner.session_outcomes[EVENT]
+    assert recorded.state is ClaimLifecycle.PROPOSAL_CREATED
+    assert recorded.proposal_id == "pid-1"
+    assert calls[0]["symbol"] == "005930"
+    assert calls[0]["proposer"] == "rob1290"
+    assert calls[0]["rungs"] == [
+        {
+            "rung_index": 0,
+            "side": "sell",
+            "quantity": "10",
+            "limit_price": "286000",
+            "notional": None,
+        }
+    ]
+    assert calls[0]["rationale"]["event_uuid"] == EVENT
+
+
+@pytest.mark.asyncio
+async def test_a_decline_becomes_the_rejected_terminal_with_its_reason() -> None:
+    spawner = _spawner(Decline(event_uuid=EVENT, reason="rung already covered"))
+    await spawner.spawn(_request())
+
+    recorded = spawner.session_outcomes[EVENT]
+    assert recorded.state is ClaimLifecycle.REJECTED_WITH_REASON
+    assert recorded.rejection_reason == "rung already covered"
+    assert recorded.proposal_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_pre_commit_refusal_is_retryable_not_ambiguous() -> None:
+    async def order_proposal_create(**kwargs):
+        return {"success": False, "error": "unsupported account_mode"}
+
+    spawner = _spawner(_draft(), tool=order_proposal_create)
+    with pytest.raises(SpawnNotStarted) as exc:
+        await spawner.spawn(_request())
+    assert "proposal_create_refused" in str(exc.value)
+    assert EVENT not in spawner.session_outcomes
+
+
+@pytest.mark.asyncio
+async def test_a_raising_create_is_ambiguous_and_is_never_retried() -> None:
+    async def order_proposal_create(**kwargs):
+        raise TimeoutError("acknowledgement lost")
+
+    spawner = _spawner(_draft(), tool=order_proposal_create)
+    with pytest.raises(ProposalChainAmbiguous):
+        await spawner.spawn(_request())
+    # And the spawner refuses to resolve it either way.
+    assert spawner.reconcile(_request()).value == "ambiguous"
+
+
+@pytest.mark.asyncio
+async def test_success_without_a_proposal_id_is_ambiguous_not_success() -> None:
+    async def order_proposal_create(**kwargs):
+        return {"success": True, "proposal_id": ""}
+
+    with pytest.raises(ProposalChainAmbiguous):
+        await _spawner(_draft(), tool=order_proposal_create).spawn(_request())
+
+
+@pytest.mark.asyncio
+async def test_a_failed_create_is_classified_by_evidence_not_by_hope() -> None:
+    """The two failure classes must not collapse into one another."""
+    assert not issubclass(ProposalChainFailure, ProposalChainAmbiguous)
+    assert not issubclass(ProposalChainAmbiguous, ProposalChainFailure)
+
+
+@pytest.mark.asyncio
+async def test_a_judge_that_returns_nothing_leaves_no_terminal() -> None:
+    spawner = _spawner(None)
+    with pytest.raises(SpawnNotStarted) as exc:
+        await spawner.spawn(_request())
+    assert "no_judgement" in str(exc.value)
+    assert spawner.session_outcomes == {}
+
+
+@pytest.mark.asyncio
+async def test_a_judge_that_raises_is_treated_as_having_written_nothing() -> None:
+    spawner = _spawner(RuntimeError("session died"))
+    with pytest.raises(SpawnNotStarted):
+        await spawner.spawn(_request())
+    assert spawner.session_outcomes == {}
+
+
+def test_a_spawner_without_a_judge_cannot_be_constructed() -> None:
+    with pytest.raises(TypeError):
+        ProposalChainSpawner(judge=object())
+
+
+def test_the_default_boundary_is_the_real_tool_object() -> None:
+    """Identity, not a name match.
+
+    ROB-1286's boundary was a string that happened to spell the tool's
+    name. This asserts the seam's default callable *is* the function the
+    MCP surface exposes, so the chain cannot be satisfied by anything that
+    merely looks like it.
+    """
+    from app.mcp_server.tooling import order_proposal_tools as opt
+    from app.services.watch_trigger_repricing import proposal_chain
+
+    assert proposal_chain._resolve_boundary_tool(None) is opt.order_proposal_create
+
+
+def test_the_package_ships_no_judge_implementation() -> None:
+    """The judgement is out-of-process work; a default judge would arm it."""
+    import app.services.watch_trigger_repricing.judgement as judgement
+
+    concrete = [
+        name
+        for name in dir(judgement)
+        if name.endswith("Judge") and name != "RepricingJudge"
+    ]
+    assert concrete == []

--- a/tests/services/watch_trigger_repricing/test_proposal_chain.py
+++ b/tests/services/watch_trigger_repricing/test_proposal_chain.py
@@ -44,6 +44,7 @@ from app.services.watch_trigger_repricing.proposal_chain import (
     ProposalChainAmbiguous,
     ProposalChainFailure,
     create_proposal_for_fire,
+    interpret_create_response,
     run_judgement_session,
 )
 from app.services.watch_trigger_repricing.spawn import (
@@ -103,8 +104,8 @@ def _grant_for(spawner: LiveSessionSpawner) -> ProposalChainGrant:
     return spawner.proposal_chain_grant
 
 
-def _spawner(answer: object, tool=None) -> ProposalChainSpawner:
-    return ProposalChainSpawner(judge=_Judge(answer), tool=tool, proposer="rob1290")
+def _spawner(answer: object) -> ProposalChainSpawner:
+    return ProposalChainSpawner(judge=_Judge(answer), proposer="rob1290")
 
 
 # ---------------------------------------------------------------------------
@@ -217,20 +218,52 @@ def test_a_chain_spawner_that_drops_the_boundary_cannot_be_constructed() -> None
         Narrowed(judge=_Judge(_draft()))
 
 
-@pytest.mark.asyncio
-async def test_the_seam_refuses_any_callable_that_is_not_the_boundary() -> None:
-    async def toss_submit(**kwargs):  # a stand-in for "something else"
-        raise AssertionError("must never be called")
+def test_no_seam_anywhere_accepts_a_substitute_callable() -> None:
+    """r2 / BLOCKER 1: the injection point is gone, not merely validated.
 
-    spawner = _spawner(_draft(), tool=toss_submit)
-    with pytest.raises(CapabilityBoundaryViolation) as exc:
-        await run_judgement_session(
+    r1 took the boundary as an argument and checked its ``__name__``, so a
+    broker submit renamed ``order_proposal_create`` constructed cleanly,
+    armed cleanly, and ran. A name is a label the untrusted side picks.
+    """
+    import inspect
+
+    from app.services.watch_trigger_repricing import proposal_chain
+
+    assert set(
+        inspect.signature(proposal_chain.create_proposal_for_fire).parameters
+    ) == {"request", "draft", "grant", "proposer"}
+    assert set(inspect.signature(proposal_chain.run_judgement_session).parameters) == {
+        "request",
+        "judge",
+        "grant",
+        "proposer",
+    }
+    assert set(inspect.signature(ProposalChainSpawner.__init__).parameters) == {
+        "self",
+        "judge",
+        "proposer",
+    }
+
+
+def test_a_name_spoofed_callable_cannot_even_be_wired() -> None:
+    """The mutant: fail at the constructor, not after it has run."""
+
+    async def order_proposal_create(**kwargs):  # the spoof, verbatim name
+        raise AssertionError("must never be reachable")
+
+    assert order_proposal_create.__name__ == EXECUTION_BOUNDARY  # r1 passed on this
+
+    with pytest.raises(TypeError):
+        ProposalChainSpawner(  # type: ignore[call-arg]
+            judge=_Judge(_draft()), tool=order_proposal_create
+        )
+    with pytest.raises(TypeError):
+        run_judgement_session(  # type: ignore[call-arg]
             request=_request(),
             judge=_Judge(_draft()),
-            grant=_grant_for(spawner),
-            tool=toss_submit,
+            grant=None,
+            tool=order_proposal_create,
         )
-    assert EXECUTION_BOUNDARY in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -302,24 +335,17 @@ def test_subclassing_a_dry_spawner_no_longer_buys_a_dry_exemption() -> None:
 # ---------------------------------------------------------------------------
 # The three answers a create attempt can produce
 # ---------------------------------------------------------------------------
-@pytest.mark.asyncio
-async def test_a_successful_create_becomes_the_proposal_created_terminal() -> None:
-    calls: list[dict] = []
+def test_a_successful_response_becomes_the_proposal_created_terminal() -> None:
+    outcome = interpret_create_response(
+        {"success": True, "proposal_id": "pid-1"}, event_uuid=EVENT
+    )
+    assert outcome.state is ClaimLifecycle.PROPOSAL_CREATED
+    assert outcome.proposal_id == "pid-1"
 
-    async def order_proposal_create(**kwargs):
-        calls.append(kwargs)
-        return {"success": True, "proposal_id": "pid-1"}
 
-    spawner = _spawner(_draft(), tool=order_proposal_create)
-    outcome = await spawner.spawn(_request())
-
-    assert outcome.disposition.value == "started"
-    recorded = spawner.session_outcomes[EVENT]
-    assert recorded.state is ClaimLifecycle.PROPOSAL_CREATED
-    assert recorded.proposal_id == "pid-1"
-    assert calls[0]["symbol"] == "005930"
-    assert calls[0]["proposer"] == "rob1290"
-    assert calls[0]["rungs"] == [
+def test_the_draft_is_translated_into_the_tool_arguments() -> None:
+    """The rung shape the boundary takes, without calling anything."""
+    assert [r.as_tool_argument() for r in _draft().rungs] == [
         {
             "rung_index": 0,
             "side": "sell",
@@ -328,7 +354,6 @@ async def test_a_successful_create_becomes_the_proposal_created_terminal() -> No
             "notional": None,
         }
     ]
-    assert calls[0]["rationale"]["event_uuid"] == EVENT
 
 
 @pytest.mark.asyncio
@@ -342,41 +367,50 @@ async def test_a_decline_becomes_the_rejected_terminal_with_its_reason() -> None
     assert recorded.proposal_id is None
 
 
+def test_a_pre_commit_refusal_is_retryable_not_ambiguous() -> None:
+    with pytest.raises(ProposalChainFailure):
+        interpret_create_response(
+            {"success": False, "error": "unsupported account_mode"},
+            event_uuid=EVENT,
+        )
+
+
+def test_success_without_a_proposal_id_is_ambiguous_not_success() -> None:
+    for response in ({"success": True, "proposal_id": ""}, {"success": True}):
+        with pytest.raises(ProposalChainAmbiguous):
+            interpret_create_response(response, event_uuid=EVENT)
+
+
+def test_a_non_mapping_response_is_ambiguous() -> None:
+    for response in (None, "ok", 1, ["success"]):
+        with pytest.raises(ProposalChainAmbiguous):
+            interpret_create_response(response, event_uuid=EVENT)
+
+
 @pytest.mark.asyncio
-async def test_a_pre_commit_refusal_is_retryable_not_ambiguous() -> None:
-    async def order_proposal_create(**kwargs):
-        return {"success": False, "error": "unsupported account_mode"}
+async def test_a_raising_boundary_is_ambiguous_and_is_never_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Module-global patch: there is no argument to pass a substitute to.
 
-    spawner = _spawner(_draft(), tool=order_proposal_create)
-    with pytest.raises(SpawnNotStarted) as exc:
-        await spawner.spawn(_request())
-    assert "proposal_create_refused" in str(exc.value)
-    assert EVENT not in spawner.session_outcomes
+    This is a test-runtime patch of a module attribute, which is available
+    for any module in Python. It is emphatically not a wiring path -- see
+    ``test_no_seam_anywhere_accepts_a_substitute_callable``.
+    """
+    from app.services.watch_trigger_repricing import proposal_chain
 
-
-@pytest.mark.asyncio
-async def test_a_raising_create_is_ambiguous_and_is_never_retried() -> None:
-    async def order_proposal_create(**kwargs):
+    async def boom(**kwargs):
         raise TimeoutError("acknowledgement lost")
 
-    spawner = _spawner(_draft(), tool=order_proposal_create)
+    monkeypatch.setattr(proposal_chain, "order_proposal_create", boom)
+    spawner = _spawner(_draft())
     with pytest.raises(ProposalChainAmbiguous):
         await spawner.spawn(_request())
-    # And the spawner refuses to resolve it either way.
+    # The spawner refuses to resolve it either way.
     assert spawner.reconcile(_request()).value == "ambiguous"
 
 
-@pytest.mark.asyncio
-async def test_success_without_a_proposal_id_is_ambiguous_not_success() -> None:
-    async def order_proposal_create(**kwargs):
-        return {"success": True, "proposal_id": ""}
-
-    with pytest.raises(ProposalChainAmbiguous):
-        await _spawner(_draft(), tool=order_proposal_create).spawn(_request())
-
-
-@pytest.mark.asyncio
-async def test_a_failed_create_is_classified_by_evidence_not_by_hope() -> None:
+def test_a_failed_create_is_classified_by_evidence_not_by_hope() -> None:
     """The two failure classes must not collapse into one another."""
     assert not issubclass(ProposalChainFailure, ProposalChainAmbiguous)
     assert not issubclass(ProposalChainAmbiguous, ProposalChainFailure)
@@ -415,7 +449,7 @@ def test_the_default_boundary_is_the_real_tool_object() -> None:
     from app.mcp_server.tooling import order_proposal_tools as opt
     from app.services.watch_trigger_repricing import proposal_chain
 
-    assert proposal_chain._resolve_boundary_tool(None) is opt.order_proposal_create
+    assert proposal_chain.order_proposal_create is opt.order_proposal_create
 
 
 def test_the_package_ships_no_judge_implementation() -> None:


### PR DESCRIPTION
> [!IMPORTANT]
> **r3 결론 — 이 PR 은 승인 경계를 in-process 로 제공하지 못한다. 설계 판단이 필요하다.**
> 서브클래스 우회 2경로는 닫았다(arming exact-type allowlist, raw 증거 있음). 그러나 주입된 `judge` 는
> 이 인터프리터에서 프로세스 전권으로 돌기 때문에 **닫을 수 없다** — 실측: judge 는 write seam 을 쓸
> 필요조차 없고 `importlib` 두 줄로 `toss_place_order` 에 닿는다.
> **진짜 승인 경계는 아웃오브프로세스 MCP 세션(= `watch_repricing` 프로파일이 이미 절반 만들어 둔 것)이며,
> 그 스포너는 아직 없다.** 그 작업 없이 이 기능을 arm 하는 것은 권고하지 않는다.
> 현재 실질적 안전장치는 **arm 되지 않았다는 사실**이다(env 기본 false · 스케줄 0 · 런처 미편입).
> 상세 = `herdr-inbox/jobs/rob1290-.../events/impl-r3.md`

ROB-1286 후속 (§102차 ③). ROB-1286 은 poll·gate·claim·fencing·lifecycle·capability allowlist 를 실코드로 냈지만 **마지막 한 마일**에서 멈췄다: spawn 경로는 `order_proposal_create` 를 문자열·docstring·allowlist 로 *이름만* 부르고 **호출하지 않았다**. 유일하게 proposal 행에 닿는 테스트는 tick **전에** 그 행을 직접 만들고 id 를 scripted spawner 에 넘긴 스탠드인이었다.

## 무엇을 배선했나

`watch 발화 → claim(STARTED) → spawn → order_proposal_create 실호출 → terminal`

- **`judgement.py`** — 세션이 답할 수 있는 **닫힌 합집합**: 제안(`ProposalDraft`) 또는 사유 있는 거절(`Decline`). 제3의 멤버가 없어 §101차 ⑤ 가 금지한 분석-온리 결과는 **표현 자체가 불가능**하다.
- **`proposal_chain.py`** — **write seam**. boundary tool 을 import·호출하는 것이 허용된 유일한 파일이며, read 쪽 `event_source` 와 정확히 같은 모양이다(양쪽 다 패키지 인바리언트가 강제).
- **`chain_spawner.py`** — 그 seam 을 건너는 live spawner. attestation 은 request echo 가 아니라 **shipping `watch_repricing` 프로파일 등록의 readback** 이고, judge 호출 **전에** 매 spawn 마다 닫힌 등가(`==`)로 대조한다.
- **`live_contract.ProposalChainGrant`** — `LiveSessionSpawner.__init__` 만 발행하는 위조 불가 토큰. write seam 이 요구하므로 grant 검사를 건너뛴 배선은 **생성자에서 실패**한다.

---

# r2 — 적대검증 BLOCKER 2건 대응

## 🔴 BLOCKER 1 — 이름은 능력이 아니다

r1 의 `ProposalChainSpawner(tool=...)` 는 callable 의 **`__name__`** 만 봤다. `order_proposal_create` 로 개명한 브로커 submit 이 생성자와 arming 을 통과해 **실행됐다** — 승인 기계 통째 우회. 「이름 매칭 ≠ 의미 강제」 그 자체.

**주입 지점을 조인 게 아니라 없앴다.** `create_proposal_for_fire` · `run_judgement_session` · `ProposalChainSpawner.__init__` 어디에도 callable 파라미터가 없고, seam 은 상단에서 import 한 모듈 전역을 직접 호출한다(`await order_proposal_create(...)`). 이름 위장 callable 을 넘기면 **생성자에서 `TypeError`** — §101차 ③ 의 "배선 자체가 불가능".

응답 분류는 순수 함수 `interpret_create_response` 로 분리했다. 세 분류를 **substitutable tool 비슷한 것 없이** 테스트한다 — r1 은 테스트가 설계의 구멍에 값을 치르고 있었다.

## 🔴 BLOCKER 2 — "재시도 안 함"이 로그 문구였다

ambiguous create 는 claim 을 `started` 로 붙들고 "자동 재시도하지 않는다"고 **로그만** 찍었다. 그런데 `started` 야말로 lease 가 만료시키는 상태다: 30분 뒤 TTL 이 `expired_unprocessed` 를 쓰고, 다음 tick 이 generation+1 로 재claim 해 **다시 판단했다**. 첫 호출이 commit 후 ack 유실이었다면 **한 발화에서 제안 2건**이 승인 레인으로 간다.

**`awaiting_reconcile` terminal 추가.** TTL 스윕은 `started` 만 매칭하므로 어떤 시계도 되돌리지 못하고, 두 claim store 모두 이 상태를 가진 이벤트의 재claim 을 거부한다(`NON_RECLAIMABLE_STATES`). `QUARANTINED` 로 보고되고, `deferred`(나중 tick 이 판단한다는 약속)에서 **제외**되며, 결코 resolved 로 세지 않는다.

🔴 **NO_ANALYSIS_ONLY 를 깨지 않기 위해** `RESOLVED_LIFECYCLE_STATES`(2개)를 `TERMINAL_LIFECYCLE_STATES`(4개)에서 분리했다 — 네 번째 terminal 이 "세 번째로 완료처럼 보이는 상태"로 흘러가지 못하게. 두 terminal fault(`expired_unprocessed`·`awaiting_reconcile`)는 `is_resolved` False 가 테스트로 고정된다.

증명: `test_the_ttl_cannot_walk_a_quarantine_back_into_a_second_proposal` — ambiguous 발생 → lease+2h 경과 → `sweep_expired()` 무반응 → `state_for` = QUARANTINED → `try_claim` = None → 14:30 전체 tick 에서도 재spawn 0 · proposal 0.

## 그 과정에서 함께 발견한 것

- 🔴 **migration 의 `drop_constraint` 가 전체 제약명을 넘겼다.** alembic 은 naming convention 을 drop 에도 적용하므로 `ck_watch_event_repricing_claims_ck_watch_event_repricin_8805` 가 생성됐다 — 존재하지 않는 제약에 대한 DROP. **오프라인 DDL 렌더로 발견**했고, `test_migration_render.py` 가 이제 실제 방출 SQL 을 단언한다(DB 불필요, `.venv/bin/alembic` 하드코딩 없음).
- 🔴 **`alembic/env.py` 의 `fileConfig` 가 `disable_existing_loggers=True`.** 테스트에서 alembic 을 로드하면 세션 내내 모든 로거가 죽어 무관한 `caplog` 단언이 깨졌다. 새 테스트 모듈의 fixture 로 봉쇄.
- 🔴 **r1 테스트 1건이 공허하게 통과했다.** `monkeypatch.undo()` 가 `enabled` fixture 의 패치까지 되돌려 tick 이 disabled 상태로 단언되고 있었다. scoped `pytest.MonkeyPatch.context()` 로 교체.

## 🟡 SHOULD 2건 (검증자 지적) — 둘 다 처리

**SHOULD 1 — arming 이 grant 부재를 안 봤다.** `LiveSessionSpawner` 서브클래스가 `super().__init__()` 를 생략하면 grant 가 없는데도 arming 이 통과시켰다. fail-closed 이긴 했지만(나중에 write seam 이 raise), r1 이 주장한 "생성자/타입 단계에서 실패"는 그 경로에 대해 **틀렸다**. `assert_live_spawner_contract` 가 이제 3층 — protocol → base class → **grant 보유 + tool set 재검증**.

**SHOULD 2 — migration 이 DB 대상으로 한 번도 안 돌았다.** `_bootstrap_test_schema` 는 `Base.metadata` bootstrap 이라 migration chain 을 검증하지 않는다. `test_migration_roundtrip.py` 가 **실제 `upgrade()`/`downgrade()` 함수**를 run-owned DB 라이브 커넥션에 돌려 CHECK 동작이 양방향으로 뒤집히는지 확인한다(`initial=True → downgrade=False → upgrade=True`), 전부 롤백되는 트랜잭션 안에서.
기존 roundtrip 테스트들이 쓰는 `.venv/bin/alembic` 하드코딩은 **쓰지 않았다** — `alembic.operations` in-process 구동이라 인터프리터 위치와 무관하다. alembic head 단일성도 테스트로 고정했다(rebase 로 2 heads → 1 head 해소).

🔵 **후속 이슈 권고**: 기존 roundtrip 테스트 3종(`invalid_sample_eligibility`·`paper_cohort`·`paper_evaluation`)의 `.venv/bin/alembic` 하드코딩. 이번에 쓴 in-process 패턴이 그대로 적용된다. 이 PR 범위 밖.

---

# r3 — B1: 부분 Ⓐ + **Ⓑ(설계 답변)**

## 닫은 것 — 서브클래스 2경로, arming 단계 거부

r2 는 base 생성자에서 `tool=` 만 없앴다. 서브클래스가 **자기 생성자에 다시 넣고** `super().__init__()` 로
깨끗한 grant 를 받은 뒤 `spawn` 을 오버라이드하면 전부 통과했다. `LiveSessionSpawner` 를 직접 상속하면
더 쉽다(검증자가 짚지 않은 3번째 경로 — 내가 추가로 찾았다).

`assert_arming_contract` 가 이제 **닫힌 집합에 대한 정확한 타입** 검사를 한다(`live_spawner_types()`).
dryness 가 이미 쓰던 패턴이고, **어떤 타입의 서브클래스도 그 타입이 아니다**. contract 검사를 먼저 두어
duck-typed·grant 없는 객체의 구체적 진단은 그대로 유지했다.

```
수정 전: SUBCLASS_TOOL_SPOOF=ARMED_AND_CALLED   DIRECT_LIVE_SUBCLASS=ARMED_AND_CALLED
수정 후: 둘 다 ArmingRefused(unlisted_live_spawner) — forged callable 호출 0회
```

## 닫을 수 없는 것 — injected judge (실측)

| 후보 방어 | 실측 |
|---|---|
| boundary 를 module-private 이름에 숨김 | `H1_PRIVATE_CAPTURE=DEFEATED` — private 은 관례일 뿐 |
| 위조 불가 capability 토큰 | `H2_GRANT_SENTINEL=MINTED` — `_GRANT_ISSUER` import 하면 발행 |
| **seam 을 아무리 굳혀도?** | `H3_SEAM_IS_OPTIONAL` — `toss_place_order` 가 `importlib` 두 줄 거리 |
| arming allowlist 가 judge 도 막나 | `H4_JUDGE_AFTER_ARMING_FIX=STILL_REACHED` |

🔴 **H3 가 결정적**이다. judge 는 seam 을 쓸 필요가 없으므로 **seam 하드닝은 답이 되지 않는다.**
CPython 은 이미 돌고 있는 코드로부터 import·속성 대입·상속을 회수할 수 없다. 게다가 judge 는
**설계상 외부 코드**다(ROB-501 상 판단은 이 런타임 밖) — 막아야 할 대상이 곧 확장점이다.

## 정확한 보장 문장 (r2 의 거짓 주장 삭제)

r2 docstring 의 ~~"deliberately not a configuration path: nothing a caller can construct reaches it"~~ 는
**거짓이었다**(생성된 judge 가 도달한다). 삭제하고 실측으로 대체했다. 지금 `chain_spawner` 는:

> **보장**: 판단이 주어졌을 때 유일한 쓰기는 `order_proposal_create` 이며 인자는 claim 된 발화에 결속된다.
> 어떤 파라미터도 callable 을 받지 않고, arming 은 정확한 타입만 수락한다.
> **비보장**: judge 가 레일 안에 머무는 것.
> **정직한 요약: 우발 방지 + 정적 검출 가능성이지 보안 경계가 아니다.**

한계를 **테스트로 박제**했다 — `test_KNOWN_LIMITATION_*` 2건은 보장이 아니라 **한계를 단언**한다.
누가 이걸 닫으면 테스트가 RED 가 되어 보장 문장 갱신을 강제한다.
`ProposalChainSpawner.RUNS_JUDGE_IN_PROCESS = True` 로 트러스트 경계를 추론이 아닌 **선언**으로 만들었다.

## 권고

승인 경계 = **① 아웃오브프로세스 MCP 세션**. `McpProfile.WATCH_REPRICING` 은 실제 프로파일이고 닫힌
분기·닫힌 등가 테스트까지 이미 있다 — 없는 건 **스포너(런처)** 뿐이다. 세션이 이 인터프리터에 없으면
`toss_place_order` 는 import 할 대상 자체가 없다. (② OS 권한 분리는 배포 복잡도, ③ in-process 샌드박스는
**권고하지 않음** — 착각만 만든다, ④ 브로커측 2인 승인은 별도 에픽.)

## Arm 하지 않음

`WATCH_TRIGGER_REPRICING_ENABLED` 기본 false · entrypoint 기본 spawner 는 여전히 dry · 런처 allowlist(`SAFE_MOCK_PROFILES`) 미편입 · **스케줄/deployment 등록 0** · 의존성 변경 0 · MCP 서버·트랜스포트 기동 0 · 승인 게이트 완화 0.

migration 은 arm 전에 적용돼야 하지만 **라이브 순서 위험은 없다** — 기본 off 이고 스케줄이 없어 운영자가 켜기 전까지 이 코드를 도는 프로세스가 없다.

## 남은 스탠드인 (명시)

**판단 자체**뿐이다. LLM 작업이고 이 런타임은 in-process LLM provider 를 소유하지 않는다(ROB-501). `RepricingJudge` 는 포트이고 패키지는 구현을 **출고하지 않는다**. 판단 하류는 전부 shipping 코드다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

