### PR TITLE
feat(ROB-1291): bind Binance Demo physical identity

### DIFF
--- a/app/services/mock_lane_registry.py
+++ b/app/services/mock_lane_registry.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from decimal import Decimal
 from enum import StrEnum
 from types import MappingProxyType
@@ -369,7 +369,7 @@ def _canonical_entry(
     )
 
 
-CANONICAL_LANE_REGISTRY: Final[tuple[LaneRegistryEntry, ...]] = (
+_BASE_CANONICAL_LANE_REGISTRY: Final[tuple[LaneRegistryEntry, ...]] = (
     _canonical_entry(
         "kr.kis.mock",
         market="kr",
@@ -507,6 +507,68 @@ CANONICAL_LANE_REGISTRY: Final[tuple[LaneRegistryEntry, ...]] = (
         activation_status=ActivationStatus.DISABLED,
         scheduler_owner=SchedulerOwner.DISABLED,
     ),
+)
+
+
+_BINANCE_DEMO_IDENTITY_LANE_IDS: Final[tuple[str, ...]] = (
+    "crypto.binance.spot_demo.canonical",
+    "crypto.binance.spot_demo.b0x_sidecar",
+    "crypto.binance.futures_demo",
+)
+_BINANCE_DEMO_SHARED_PHYSICAL_ACCOUNT_ID: Final[str] = (
+    "binance_demo:spot_plus_futures:credential_fingerprint="
+    "sha256:e33925948f2cb6e03842cca9967b70f11f9242bc5c8f99c69ce0ca5cbc4d73df:"
+    "one_shared_domain"
+)
+_BINANCE_DEMO_FINGERPRINT_EVIDENCE_REF: Final[str] = (
+    "d2-phasea-20260817:impl="
+    "sha256:44a9a5b4059c176eb8300d23048cd396daa77d6400faa3be8bbaf7c465d6ee82;"
+    "verify=sha256:03cfae4c8a9193ce0aa8ef4803d7e4ff3190eca1b6de777862b44d410a498e21"
+)
+
+
+def _apply_binance_demo_identity_amendment(
+    entries: tuple[LaneRegistryEntry, ...],
+) -> tuple[LaneRegistryEntry, ...]:
+    """Apply the signed three-field J2A identity binding to its effective view."""
+
+    if tuple(entry.lane_id for entry in entries) != CANONICAL_LANE_IDS:
+        raise RuntimeError("binance_demo_identity_base_registry_mismatch")
+
+    base_by_id = {entry.lane_id: entry for entry in entries}
+    if set(_BINANCE_DEMO_IDENTITY_LANE_IDS) - set(base_by_id):
+        raise RuntimeError("binance_demo_identity_lane_missing")
+
+    for lane_id in _BINANCE_DEMO_IDENTITY_LANE_IDS:
+        entry = base_by_id[lane_id]
+        if (
+            entry.physical_account_id is not None
+            or entry.identity_status != "UNKNOWN"
+            or entry.fingerprint_evidence_ref is not None
+            or MissingBinding.PHYSICAL_ACCOUNT_FINGERPRINT not in entry.missing_bindings
+        ):
+            raise RuntimeError("binance_demo_identity_base_binding_mismatch")
+
+    return tuple(
+        replace(
+            entry,
+            physical_account_id=_BINANCE_DEMO_SHARED_PHYSICAL_ACCOUNT_ID,
+            identity_status="KNOWN",
+            fingerprint_evidence_ref=_BINANCE_DEMO_FINGERPRINT_EVIDENCE_REF,
+            missing_bindings=tuple(
+                binding
+                for binding in entry.missing_bindings
+                if binding is not MissingBinding.PHYSICAL_ACCOUNT_FINGERPRINT
+            ),
+        )
+        if entry.lane_id in _BINANCE_DEMO_IDENTITY_LANE_IDS
+        else entry
+        for entry in entries
+    )
+
+
+CANONICAL_LANE_REGISTRY: Final[tuple[LaneRegistryEntry, ...]] = (
+    _apply_binance_demo_identity_amendment(_BASE_CANONICAL_LANE_REGISTRY)
 )
 
 _CANONICAL_BY_ID: Final[Mapping[str, LaneRegistryEntry]] = MappingProxyType(

--- a/tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py
+++ b/tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py
@@ -765,15 +765,13 @@ def test_mutant_01_two_binance_writers_in_one_domain_fail() -> None:
     mal.assert_binance_single_writer_domain(CANONICAL_LANE_REGISTRY)
 
 
-def test_mutant_01b_conservative_domain_ignores_unknown_physical_ids() -> None:
-    """§F-1 — the registry's own guard cannot fire while identity is UNKNOWN.
+def test_mutant_01b_shared_physical_identity_reaches_registry_writer_guard() -> None:
+    """§F-1 — the bound shared identity makes the generic writer guard fire."""
 
-    This is exactly why J6B carries a stricter conservative guard: proving the
-    weaker one silent is what makes the stronger one necessary rather than
-    decorative.
-    """
-
-    from app.services.mock_lane_registry import assert_single_writer
+    from app.services.mock_lane_registry import (
+        RegistryStartupError,
+        assert_single_writer,
+    )
 
     mutated = tuple(
         dataclasses.replace(entry, writer=True)
@@ -781,14 +779,18 @@ def test_mutant_01b_conservative_domain_ignores_unknown_physical_ids() -> None:
         else entry
         for entry in CANONICAL_LANE_REGISTRY
     )
-    assert all(
-        entry.physical_account_id is None
-        for entry in mutated
-        if entry.broker == "binance"
+    assert (
+        len(
+            {
+                entry.physical_account_id
+                for entry in mutated
+                if entry.broker == "binance"
+            }
+        )
+        == 1
     )
-    # Silent: no known physical account to collide on.
-    assert_single_writer(mutated)
-    # Not silent:
+    with pytest.raises(RegistryStartupError):
+        assert_single_writer(mutated)
     with pytest.raises(mal.SpotDemoLimitError):
         mal.assert_binance_single_writer_domain(mutated)
 
@@ -1284,8 +1286,12 @@ def test_registry_row_is_consumed_unchanged() -> None:
     assert entry.lane_status is LaneStatus.NOT_READY
     assert entry.activation_status is ActivationStatus.BLOCKED
     assert entry.scheduler_owner is SchedulerOwner.DISABLED
-    assert entry.physical_account_id is None
-    assert entry.identity_status == "UNKNOWN"
+    assert entry.physical_account_id == (
+        "binance_demo:spot_plus_futures:credential_fingerprint="
+        "sha256:e33925948f2cb6e03842cca9967b70f11f9242bc5c8f99c69ce0ca5cbc4d73df:"
+        "one_shared_domain"
+    )
+    assert entry.identity_status == "KNOWN"
     assert entry.allowed_hosts == ("demo-api.binance.com",)
 
 
@@ -1528,24 +1534,16 @@ async def test_restart_trigger_without_a_claim_source_fails_closed(
 
 
 @pytest.mark.asyncio
-async def test_restart_trigger_cannot_enumerate_while_identity_is_unknown(
+async def test_restart_trigger_enumerates_with_canonical_identity_binding(
     client: BinanceSpotDemoExecutionClient, httpx_mock: Any
 ) -> None:
-    """The signed row has no physical identity, so no scope can be enumerated.
-
-    This is the honest state of the lane today and the reason C3-2 counts as a
-    computed gap: the scope is derived from J2A identity and is never accepted
-    from a caller.
-    """
+    """The canonical J2A identity, not a caller scope, drives enumeration."""
 
     reservations = _RecordedReservations([])
     composition = _composition(client, reservations=reservations)
-    with pytest.raises(LaneGuardError) as error:
-        await composition.rediscover_restart_claims(
-            entry=get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID), symbols={}
-        )
-    assert "physical_account_identity_unknown" in str(error.value)
-    assert reservations.scopes == []
+    entry = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
+    assert await composition.rediscover_restart_claims(entry=entry, symbols={}) == ()
+    assert reservations.scopes == [_lane_scope(entry)]
     assert httpx_mock.get_requests() == []
 
 
@@ -2133,15 +2131,13 @@ def test_c3_7_each_missing_recovery_item_is_reported_on_its_own(
     wired = _composition(client, reservations=_RecordedReservations([]))
     unwired = _composition(client)
 
-    # Identity unknown alone blocks the restart trigger, even fully wired.
+    # The signed identity plus a wired read-side port makes this one item ready.
     signed = get_lane_registry_entry(mal.SPOT_DEMO_CANONICAL_LANE_ID)
-    assert mal.spot_demo_recovery_contract_gaps(signed, composition=wired) == (
+    assert mal.spot_demo_recovery_contract_gaps(signed, composition=wired) == ()
+    # An unbound reservation port alone still blocks the same trigger.
+    assert mal.spot_demo_recovery_contract_gaps(signed, composition=unwired) == (
         "restart_trigger",
     )
-    # An unbound reservation port alone blocks it too, even with a known identity.
-    assert mal.spot_demo_recovery_contract_gaps(
-        _identity_known_entry(), composition=unwired
-    ) == ("restart_trigger",)
 
 
 def test_c3_7_the_runbook_states_the_computed_status_not_a_wish() -> None:

--- a/tests/test_mock_lane_registry.py
+++ b/tests/test_mock_lane_registry.py
@@ -547,18 +547,54 @@ def test_bounded_canary_does_not_authorize_recurring() -> None:
 
 
 def test_unknown_fingerprint_rows_are_safe_and_preserved() -> None:
-    binance_identity_lane_ids = {
-        "crypto.binance.spot_demo.canonical",
-        "crypto.binance.spot_demo.b0x_sidecar",
-        "crypto.binance.futures_demo",
+    binance_demo_physical_account_id = (
+        "binance_demo:spot_plus_futures:credential_fingerprint="
+        "sha256:e33925948f2cb6e03842cca9967b70f11f9242bc5c8f99c69ce0ca5cbc4d73df:"
+        "one_shared_domain"
+    )
+    binance_demo_fingerprint_evidence_ref = (
+        "d2-phasea-20260817:impl="
+        "sha256:44a9a5b4059c176eb8300d23048cd396daa77d6400faa3be8bbaf7c465d6ee82;"
+        "verify=sha256:03cfae4c8a9193ce0aa8ef4803d7e4ff3190eca1b6de777862b44d410a498e21"
+    )
+    expected_identity_by_lane = {
+        "kr.kis.mock": (None, None, "UNKNOWN"),
+        "kr.kiwoom.mock": (None, None, "UNKNOWN"),
+        "us.kis.mock": (None, None, "UNKNOWN"),
+        "us.kiwoom.mock": (None, None, "UNKNOWN"),
+        "us.alpaca.paper.default": (None, None, "UNKNOWN"),
+        "us.alpaca.paper.lab": (None, None, "UNKNOWN"),
+        "crypto.binance.spot_demo.canonical": (
+            binance_demo_physical_account_id,
+            binance_demo_fingerprint_evidence_ref,
+            "KNOWN",
+        ),
+        "crypto.binance.spot_demo.b0x_sidecar": (
+            binance_demo_physical_account_id,
+            binance_demo_fingerprint_evidence_ref,
+            "KNOWN",
+        ),
+        "crypto.alpaca.paper.default": (None, None, "UNKNOWN"),
+        "crypto.alpaca.paper.clean": (None, None, "UNKNOWN"),
+        "crypto.upbit.shadow": (None, None, "UNKNOWN"),
+        "crypto.binance.futures_demo": (
+            binance_demo_physical_account_id,
+            binance_demo_fingerprint_evidence_ref,
+            "KNOWN",
+        ),
     }
+
     assert len(registry.CANONICAL_LANE_REGISTRY) == 12
+    assert tuple(expected_identity_by_lane) == registry.CANONICAL_LANE_IDS
     for entry in registry.CANONICAL_LANE_REGISTRY:
-        if entry.lane_id in binance_identity_lane_ids:
-            continue
-        assert entry.physical_account_id is None
-        assert entry.fingerprint_evidence_ref is None
-        assert entry.identity_status == "UNKNOWN"
+        (
+            expected_physical_account_id,
+            expected_fingerprint_evidence_ref,
+            expected_identity_status,
+        ) = expected_identity_by_lane[entry.lane_id]
+        assert entry.physical_account_id == expected_physical_account_id
+        assert entry.fingerprint_evidence_ref == expected_fingerprint_evidence_ref
+        assert entry.identity_status == expected_identity_status
         assert entry.writer is False
         assert entry.auto is False
         assert registry.get_lane_registry_entry(entry.lane_id) is entry

--- a/tests/test_mock_lane_registry.py
+++ b/tests/test_mock_lane_registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from dataclasses import replace
+from dataclasses import fields, replace
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -547,14 +547,114 @@ def test_bounded_canary_does_not_authorize_recurring() -> None:
 
 
 def test_unknown_fingerprint_rows_are_safe_and_preserved() -> None:
+    binance_identity_lane_ids = {
+        "crypto.binance.spot_demo.canonical",
+        "crypto.binance.spot_demo.b0x_sidecar",
+        "crypto.binance.futures_demo",
+    }
     assert len(registry.CANONICAL_LANE_REGISTRY) == 12
     for entry in registry.CANONICAL_LANE_REGISTRY:
+        if entry.lane_id in binance_identity_lane_ids:
+            continue
         assert entry.physical_account_id is None
         assert entry.fingerprint_evidence_ref is None
         assert entry.identity_status == "UNKNOWN"
         assert entry.writer is False
         assert entry.auto is False
         assert registry.get_lane_registry_entry(entry.lane_id) is entry
+
+
+def test_j2a_binance_demo_identity_amendment_is_verbatim_and_additive() -> None:
+    """§3 values are exact; §4 changes no base-row field beyond the binding."""
+
+    lane_ids = (
+        "crypto.binance.spot_demo.canonical",
+        "crypto.binance.spot_demo.b0x_sidecar",
+        "crypto.binance.futures_demo",
+    )
+    physical_account_id = (
+        "binance_demo:spot_plus_futures:credential_fingerprint="
+        "sha256:e33925948f2cb6e03842cca9967b70f11f9242bc5c8f99c69ce0ca5cbc4d73df:"
+        "one_shared_domain"
+    )
+    fingerprint_evidence_ref = (
+        "d2-phasea-20260817:impl="
+        "sha256:44a9a5b4059c176eb8300d23048cd396daa77d6400faa3be8bbaf7c465d6ee82;"
+        "verify=sha256:03cfae4c8a9193ce0aa8ef4803d7e4ff3190eca1b6de777862b44d410a498e21"
+    )
+    base_by_id = {
+        entry.lane_id: entry for entry in registry._BASE_CANONICAL_LANE_REGISTRY
+    }
+    effective_by_id = _by_id()
+    binding_fields = {
+        "physical_account_id",
+        "identity_status",
+        "fingerprint_evidence_ref",
+        "missing_bindings",
+    }
+    expected_activation_statuses = {
+        "crypto.binance.spot_demo.canonical": registry.ActivationStatus.BLOCKED,
+        "crypto.binance.spot_demo.b0x_sidecar": registry.ActivationStatus.DISABLED,
+        "crypto.binance.futures_demo": registry.ActivationStatus.DISABLED,
+    }
+
+    assert len(fields(registry.LaneRegistryEntry)) == 34
+    assert (
+        tuple(lane_id for lane_id in lane_ids if lane_id in effective_by_id) == lane_ids
+    )
+    for lane_id, base in base_by_id.items():
+        effective = effective_by_id[lane_id]
+        changed_fields = {
+            field.name
+            for field in fields(registry.LaneRegistryEntry)
+            if getattr(base, field.name) != getattr(effective, field.name)
+        }
+        if lane_id not in lane_ids:
+            assert changed_fields == set()
+            continue
+
+        assert changed_fields == binding_fields
+        assert effective.physical_account_id == physical_account_id
+        assert effective.identity_status == "KNOWN"
+        assert effective.fingerprint_evidence_ref == fingerprint_evidence_ref
+        assert effective.missing_bindings == (
+            registry.MissingBinding.POLICY,
+            registry.MissingBinding.CAP,
+            registry.MissingBinding.OWNER,
+            registry.MissingBinding.CANARY,
+        )
+        assert effective.activation_status is expected_activation_statuses[lane_id]
+        assert effective.activation_status is base.activation_status
+        assert effective.writer is base.writer is False
+        assert effective.auto_order_enabled is base.auto_order_enabled is False
+
+
+def test_binance_demo_identity_unblocks_only_j3a_scope_not_execution_grant() -> None:
+    """Known identity permits the lease key; activation/writer gates still deny use."""
+
+    from app.services.mock_integration import coordination
+
+    lane_ids = (
+        "crypto.binance.spot_demo.canonical",
+        "crypto.binance.spot_demo.b0x_sidecar",
+        "crypto.binance.futures_demo",
+    )
+    entries = [registry.get_lane_registry_entry(lane_id) for lane_id in lane_ids]
+    scopes = [coordination.physical_account_scope_for_entry(entry) for entry in entries]
+
+    assert scopes[0] == scopes[1] == scopes[2]
+    assert tuple(coordination.physical_account_scope_for_entry.__annotations__) == (
+        "entry",
+        "return",
+    )
+    scope_deriver = coordination.physical_account_scope_for_entry
+    with pytest.raises(TypeError):
+        scope_deriver(entries[0], "caller")  # type: ignore[call-arg]
+
+    for entry in entries:
+        with pytest.raises(registry.LaneGuardError) as refusal:
+            registry.assert_entry_execution_ready(entry)
+        assert refusal.value.code == "lane_activation_not_enabled"
 
 
 @pytest.mark.parametrize(
@@ -588,7 +688,16 @@ def test_missing_bindings_keep_rows_blocked_or_disabled_with_reasons() -> None:
         == registry.CANONICAL_LANE_IDS
     )
     for entry in registry.CANONICAL_LANE_REGISTRY:
-        assert set(entry.missing_bindings) == required_missing
+        expected_missing = required_missing
+        if entry.lane_id in {
+            "crypto.binance.spot_demo.canonical",
+            "crypto.binance.spot_demo.b0x_sidecar",
+            "crypto.binance.futures_demo",
+        }:
+            expected_missing = required_missing - {
+                registry.MissingBinding.PHYSICAL_ACCOUNT_FINGERPRINT
+            }
+        assert set(entry.missing_bindings) == expected_missing
         assert entry.activation_status in {
             registry.ActivationStatus.BLOCKED,
             registry.ActivationStatus.DISABLED,


### PR DESCRIPTION
## What changed

- Applied the J2A signed Binance Demo shared physical-account identity as an additive runtime registry view for Spot canonical, Spot B0-X sidecar, and Futures Demo.
- Removed only the resolved `physical_account_fingerprint` missing-binding marker; activation, writer, scheduler, policy, cap, owner, and canary state remain unchanged.
- Added exact-payload, 34-field preservation, J3A scope, caller-scope rejection, activation/writer blocking, and mutation regression coverage.

## Why

D2 needs the canonical J2A physical identity to derive one shared J3A lease key across the three Binance Demo lanes. Identity knowledge must not grant execution authority.

## Validation

- `uv run --frozen --no-sync pytest -q tests/test_mock_lane_registry.py tests/services/mock_integration/` — 573 passed
- `uv run --frozen --no-sync pytest -q tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py` — 126 passed
- `ruff check` and `ruff format --check` for changed files — passed
- Three temporary mutations were red and reverted: `KNOWN → UNKNOWN`, one-character physical ID change, and canonical activation relaxation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Binance Spot Demo lanes now correctly recognize their shared physical account identity and fingerprint.
  - Restart recovery and account discovery use the canonical shared account scope.
  - Recovery checks now distinguish between signed identity evidence and unbound ports.

- **Tests**
  - Expanded validation for shared identity bindings, coordination scope, and restricted execution states.
  - Updated collision, activation, writer, and auto-order safeguards for the Binance demo lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->