### PR TITLE
Raise KR and US auto-approve caps

### DIFF
--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -5,7 +5,7 @@
 # §104차 (2026-08-19): crash-day 신규진입은 표준 매수 게이트를 통과한
 # strong 지지 후보에 한해 조건부로만 전면 hold를 해제한다. 즉석 판단이나
 # 게이트 면제·완화·대체가 아니며, preplanned ladder도 advisory로만 남긴다.
-version: "2026-08-19.1"
+version: "2026-08-19.2"
 captured_as_of: "2026-08-12"
 source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits)"
 
@@ -47,17 +47,22 @@ posture:
 order_proposals:
   auto_approve:
     min_distance_pct: 3
+    # §106차 (2026-08-19): daily caps are a practical circuit-breaker release;
+    # the daily limit must not constrict the approval lane. Per-order caps are
+    # raised, not removed, and remain the maximum-loss boundary for one
+    # automation error. The 3% distance, tag scan, breakeven band,
+    # resting-only, and round-trip-cost gates remain unchanged.
     per_order_cap:
-      kr: 400000
+      kr: 1000000
       # §65차 (2026-08-14): 450 → 800. The US book holds single-share lots of
       # high-priced ETFs (QQQ/VOO/IVV/BRK.B at $500-750/share), so the band-
       # derived 450 structurally excluded every single-share profit-take from
       # auto-approve (25/25 sell proposals carded on 2026-08-13). 800 admits
       # one-share exits while still capping multi-share notional.
-      us: 800
+      us: 1500
       crypto: 100000
     daily_cap:
-      kr: 400000
+      kr: 5000000
       # §71차 (2026-08-14): 800 -> 5000. The §65차 same-value pairing was wrong
       # for US session scale: a 25-proposal trim day totals $4.4-4.8k per
       # account, so the first auto-approved single share (QQQ $741) consumed
@@ -65,7 +70,7 @@ order_proposals:
       # (measured 2026-08-14 22:35, all rejections daily_cap_exceeded).
       # 5000 covers an observed full trim session (~10% of book/day/account);
       # the $800 per-order cap and per-rung veto cards remain the guardrails.
-      us: 5000
+      us: 20000
       crypto: 300000
     # AUTO-APPROVE-EXPAND (§40차) — inputs to the profit-take classification,
     # consumed only when ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded.

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -198,7 +198,7 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
     }
     # advisory keys are echoed with the same version/content_hash stamp as
     # every other section of the response (ROB-932).
-    assert out["version"] == "2026-08-19.1"
+    assert out["version"] == "2026-08-19.2"
     assert out["content_hash"]
 
 

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -1,4 +1,5 @@
 import re
+from copy import deepcopy
 from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal
 from pathlib import Path
 
@@ -29,9 +30,31 @@ _PLAYBOOK = (
     / "trading-decision-playbook.md"
 )
 
+_ROB1292_ALLOWED_POLICY_DELTAS = (
+    ("order_proposals.auto_approve.per_order_cap.kr", 400000, 1000000),
+    ("order_proposals.auto_approve.per_order_cap.us", 800, 1500),
+    ("order_proposals.auto_approve.daily_cap.kr", 400000, 5000000),
+    ("order_proposals.auto_approve.daily_cap.us", 5000, 20000),
+)
+
 
 def _raw() -> dict:
     return yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
+
+
+def _policy_path_get(payload: dict, path: str):
+    value = payload
+    for key in path.split("."):
+        value = value[key]
+    return value
+
+
+def _policy_path_set(payload: dict, path: str, value) -> None:
+    keys = path.split(".")
+    target = payload
+    for key in keys[:-1]:
+        target = target[key]
+    target[keys[-1]] = value
 
 
 def _breakeven_reserve_trim_tier():
@@ -119,7 +142,7 @@ def _breakeven_reserve_trim_triggered(
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
-    assert doc.version == "2026-08-19.1"
+    assert doc.version == "2026-08-19.2"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -942,7 +965,16 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
     del baseline_dump["decision_rules"]["buy.preplanned_support_ladder"]
     del baseline_dump["crash_day"]["actions"]["new_entry_hold_exception"]
 
-    assert current_dump == baseline_dump
+    normalized_current_dump = deepcopy(current_dump)
+    for path, baseline_value, current_value in _ROB1292_ALLOWED_POLICY_DELTAS:
+        assert _policy_path_get(baseline_dump, path) == baseline_value
+        assert _policy_path_get(current_dump, path) == current_value
+        _policy_path_set(normalized_current_dump, path, baseline_value)
+
+    # Only the four explicitly enumerated §106차 cap deltas are accepted;
+    # every other pre-existing key/value, including both crypto caps, must
+    # still match the ROB-1289 baseline exactly.
+    assert normalized_current_dump == baseline_dump
 
 
 def test_crash_day_missing_block_rejected():

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -899,20 +899,24 @@ def test_auto_veto_card_raises_when_thesis_is_missing():
         )
 
 
-def test_policy_caps_follow_the_declared_upper_bands_and_one_new_entry_limit():
+def test_policy_caps_match_the_operator_declared_limits():
     kr = limits_for_market("equity_kr")
     us = limits_for_market("equity_us")
+    crypto = limits_for_market("crypto")
 
     assert kr is not None
     assert us is not None
-    # policy buy.per_symbol_notional_krw_range=[200000,400000],
-    # buy.per_symbol_notional_usd_range=[150,450], and one concurrent new
-    # entry; see the ownership-minimal derivation comment in the cap block.
-    assert (kr.per_order_cap, kr.daily_cap) == (Decimal("400000"), Decimal("400000"))
-    # §65차/§71차 (2026-08-14): per-order 800 admits single-share exits of
-    # $500-750 ETFs; daily 5000 covers a full observed trim session instead of
-    # being consumed by its first rung. The sizing band above is unchanged.
-    assert (us.per_order_cap, us.daily_cap) == (Decimal("800"), Decimal("5000"))
+    assert crypto is not None
+    # The buy sizing bands remain unchanged; §106차 intentionally lifts the
+    # approval caps independently of those bands.
+    # §106차 (2026-08-19): daily caps no longer constrict the approval lane;
+    # per-order caps remain the maximum-loss boundary for one automation error.
+    assert (kr.per_order_cap, kr.daily_cap) == (Decimal("1000000"), Decimal("5000000"))
+    assert (us.per_order_cap, us.daily_cap) == (Decimal("1500"), Decimal("20000"))
+    assert (crypto.per_order_cap, crypto.daily_cap) == (
+        Decimal("100000"),
+        Decimal("300000"),
+    )
 
 
 def test_policy_cost_rate_cannot_be_edited_below_the_code_floor(monkeypatch):


### PR DESCRIPTION
## What changed

- Bumped the trading policy version to `2026-08-19.2`.
- Raised only the KR/US auto-approval caps: KR `1,000,000` per order / `5,000,000` daily; US `1,500` per order / `20,000` daily.
- Preserved both crypto caps and the §65차/§71차 historical comments.
- Added the §106차 rationale and updated policy cap assertions, including explicit crypto invariants.

## Safety scope

- No changes to auto-approval gate code under `app/services/order_proposals/**`.
- No changes to distance, tag, breakeven, resting-only, or round-trip-cost gates.
- No migrations, dependencies, scheduler, environment, or broker changes.

## Validation

- `uv run --frozen --no-sync pytest -q tests/services/order_proposals/test_auto_approve.py` — 58 passed.
- `uv run --frozen --no-sync pytest -q tests/services/order_proposals/test_auto_approve.py -k "trading_policy or policy"` — 3 passed, 55 deselected.
- `ruff check .` — passed.
- `ruff format --check .` — 4012 files already formatted.
- Cap mutation (`kr per_order_cap=1000001`) made the cap assertion test fail; restored state is clean.

Draft only; merge and deployment remain operator-owned.
