### PR TITLE
feat(ROB-1295): call-phase-only duration telemetry + freshness validation

### DIFF
--- a/.github/workflows/test-durations-refresh.yml
+++ b/.github/workflows/test-durations-refresh.yml
@@ -5,6 +5,13 @@ name: Refresh test durations
 # isolated by tests/conftest.py. Shards emit clean JSON maps and identical
 # collection manifests. The merge job drops stale entries and refuses partial,
 # duplicate, or collection-inconsistent results.
+#
+# ROB-1295: the same "Measure shard" step also captures call-phase-only
+# duration telemetry (tests/_call_duration_plugin.py) into a second,
+# additive sidecar artifact (.call_durations.json). This never touches
+# .test_durations or pytest-split's shard-balancing consumer — it is a
+# separate, stricter-validated freshness record (scripts/call_durations.py)
+# built and self-validated in the merge job below.
 
 on:
   schedule:
@@ -127,6 +134,8 @@ jobs:
           --splits 4 --group "${{ matrix.group }}" \
           --durations-path "durations-shard-${{ matrix.group }}.json" \
           --store-durations --clean-durations \
+          -p tests._call_duration_plugin \
+          --call-durations-out "call-durations-shard-${{ matrix.group }}.json" \
           -n 4 --dist=loadfile \
           -o faulthandler_timeout=120
 
@@ -136,6 +145,7 @@ jobs:
         name: durations-shard-${{ matrix.group }}
         path: |
           durations-shard-${{ matrix.group }}.json
+          call-durations-shard-${{ matrix.group }}.json
           collected-shard-${{ matrix.group }}.txt
         if-no-files-found: error
 
@@ -150,6 +160,7 @@ jobs:
       changed: ${{ steps.diff.outputs.changed }}
       before_entries: ${{ steps.diff.outputs.before_entries }}
       after_entries: ${{ steps.diff.outputs.after_entries }}
+      call_durations_changed: ${{ steps.call-durations-diff.outputs.changed }}
     env:
       PYTHON_VERSION: "3.13"
 
@@ -211,10 +222,64 @@ jobs:
         path: refreshed-test-durations.json
         if-no-files-found: error
 
+    - name: Build call-phase duration artifact
+      run: |
+        python scripts/call_durations.py build \
+          --shard duration-artifacts/call-durations-shard-1.json \
+          --shard duration-artifacts/call-durations-shard-2.json \
+          --shard duration-artifacts/call-durations-shard-3.json \
+          --shard duration-artifacts/call-durations-shard-4.json \
+          --collected duration-artifacts/collected-shard-1.txt \
+          --collected duration-artifacts/collected-shard-2.txt \
+          --collected duration-artifacts/collected-shard-3.txt \
+          --collected duration-artifacts/collected-shard-4.txt \
+          --source-commit-sha "${{ github.sha }}" \
+          --output .call_durations.json
+
+    - name: Validate call-phase duration freshness
+      # Self-check: the artifact this job just built must itself pass the
+      # same fail-closed freshness contract a future PR/consumer would run
+      # (ROB-1295). A validate failure here means build_artifact and
+      # validate_freshness disagree — treat that as a bug, not driftable.
+      run: |
+        python scripts/call_durations.py validate \
+          --artifact .call_durations.json \
+          --collected duration-artifacts/collected-shard-1.txt \
+          --collected duration-artifacts/collected-shard-2.txt \
+          --collected duration-artifacts/collected-shard-3.txt \
+          --collected duration-artifacts/collected-shard-4.txt \
+          --expected-source-sha "${{ github.sha }}"
+
+    - name: Detect .call_durations.json changes
+      id: call-durations-diff
+      # git status --porcelain (not git diff --quiet) because this file does
+      # not exist in the repo yet on its first run: git diff never reports
+      # an untracked path as changed, which would silently never open the
+      # seeding PR.
+      run: |
+        if [ -z "$(git status --porcelain -- .call_durations.json)" ]; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "No .call_durations.json changes — nothing to PR."
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Stage call-phase duration artifact
+      if: steps.call-durations-diff.outputs.changed == 'true'
+      run: cp .call_durations.json refreshed-call-durations.json
+
+    - name: Upload call-phase duration artifact
+      if: steps.call-durations-diff.outputs.changed == 'true'
+      uses: actions/upload-artifact@v6
+      with:
+        name: merged-call-durations
+        path: refreshed-call-durations.json
+        if-no-files-found: error
+
   pull-request:
     name: Open duration refresh PR
     needs: merge
-    if: needs.merge.outputs.changed == 'true'
+    if: needs.merge.outputs.changed == 'true' || needs.merge.outputs.call_durations_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -227,32 +292,54 @@ jobs:
         persist-credentials: false
 
     - name: Download merged duration artifact
+      if: needs.merge.outputs.changed == 'true'
       uses: actions/download-artifact@v6
       with:
         name: merged-test-durations
         path: duration-refresh-output
 
     - name: Install merged duration set
+      if: needs.merge.outputs.changed == 'true'
       run: cp duration-refresh-output/refreshed-test-durations.json .test_durations
+
+    - name: Download call-phase duration artifact
+      if: needs.merge.outputs.call_durations_changed == 'true'
+      uses: actions/download-artifact@v6
+      with:
+        name: merged-call-durations
+        path: call-durations-refresh-output
+
+    - name: Install call-phase duration set
+      if: needs.merge.outputs.call_durations_changed == 'true'
+      run: cp call-durations-refresh-output/refreshed-call-durations.json .call_durations.json
 
     - name: Open auto-PR with refreshed durations
       uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.DURATIONS_REFRESH_TOKEN }}
-        commit-message: "chore(ci): refresh .test_durations (pytest-split shard balance)"
-        add-paths: .test_durations
+        commit-message: "chore(ci): refresh .test_durations and .call_durations.json"
+        add-paths: |
+          .test_durations
+          .call_durations.json
         branch: ci/test-durations-refresh
         delete-branch: true
         base: main
         title: "chore(ci): refresh .test_durations"
         body: |
-          Automated weekly refresh of `.test_durations` (ROB-963 / ROB-1051).
+          Automated weekly refresh of `.test_durations` (ROB-963 / ROB-1051)
+          and `.call_durations.json` (ROB-1295).
 
           Four CI-equivalent shards measured the full non-live suite using
           independent PostgreSQL services and worker-isolated databases. The
-          merge rejected missing/duplicate measurements, dropped stale entries,
-          and wrote a deterministic node-id-sorted map.
+          `.test_durations` merge rejected missing/duplicate measurements,
+          dropped stale entries, and wrote a deterministic node-id-sorted map
+          — this still drives pytest-split shard balancing, unchanged.
 
-          - recorded duration entries: `${{ needs.merge.outputs.before_entries }}` → `${{ needs.merge.outputs.after_entries }}`
+          `.call_durations.json` is a separate, additive call-phase-only
+          duration record (excludes setup/teardown/fixture cost) with
+          source-commit and collection-hash provenance, built and
+          self-validated by `scripts/call_durations.py`.
+
+          - recorded `.test_durations` entries: `${{ needs.merge.outputs.before_entries }}` → `${{ needs.merge.outputs.after_entries }}`
 
           Generated by `.github/workflows/test-durations-refresh.yml`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
     - name: Run duration merge unit tests
       run: uv run pytest scripts/merge_test_durations_test.py -q
 
+    - name: Run call-duration freshness unit tests
+      run: uv run pytest scripts/call_durations_test.py -q
+
   # Exact-head source-ownership fence for the fencefix PR itself (ROB-1262
   # follow-up). Evaluates only this PR's actual base/head change set from
   # the GitHub event — never a fixed historical SHA vs. an advancing branch

--- a/scripts/call_durations.py
+++ b/scripts/call_durations.py
@@ -18,12 +18,23 @@ Two operations, deliberately asymmetric:
   duplicate/missing/malformed input — there is no "stale" concept when
   building fresh from the current shard measurements).
 * ``validate`` checks an already-serialized artifact against the *current*
-  repository state (collected node ids, HEAD commit sha) and fails closed on
-  any drift: duplicate node ids, missing node ids, stale/removed node ids,
-  a source-commit mismatch, a collection-hash mismatch, or a malformed
-  duration value. Unlike pytest-split's tolerant shard-balancing hint, this
-  artifact is meant to be trustworthy provenance data, so drift is a hard
-  failure rather than something to silently drop and continue past.
+  repository state (collected node ids, expected source-commit sha) and
+  fails closed on any drift: duplicate node ids, missing node ids,
+  stale/removed node ids, a source-commit mismatch, a collection-hash
+  mismatch, an unsupported schema version, or a malformed duration value.
+  Unlike pytest-split's tolerant shard-balancing hint, this artifact is
+  meant to be trustworthy provenance data, so drift is a hard failure
+  rather than something to silently drop and continue past.
+
+``source_commit_sha`` is the sha of the commit the four shards *measured*
+(the run's ``github.sha``), not necessarily the commit that ends up
+containing the resulting ``.call_durations.json`` file — the weekly refresh
+workflow's own self-validate step compares against that same measured sha
+(consistent by construction), but ``peter-evans/create-pull-request`` then
+commits the file as a new commit on ``ci/test-durations-refresh``, so
+``HEAD`` moves past ``source_commit_sha`` the moment that auto-PR merges.
+A future consumer must compare against the measured-tree sha it expects,
+not assume it equals the artifact's own containing commit.
 
 ROB-1295 R1 — collected-but-never-called nodes: a node whose ``setup`` phase
 itself skips (``@pytest.mark.skip``, ``skipif``, a skip-raising fixture, ...)
@@ -39,6 +50,14 @@ exactly one of ``durations`` or ``not_called`` — never both, never neither.
 A node that skips *inside* its call phase (e.g. ``pytest.skip()`` called
 from the test body) is unaffected: pytest still emits a real ``call`` report
 with a real duration, so it is captured in ``durations`` as usual.
+
+ROB-1295 R2 (post-verify hardening): shard files and artifact files are both
+parsed with duplicate-JSON-key rejection (a corrupt/hand-edited file cannot
+silently drop data via Python's last-key-wins ``dict`` construction);
+``schema_version`` is checked, not just required-present; duplicate entries
+inside ``not_called`` are rejected instead of silently deduplicated by
+``set()``; and ``node_count`` is cross-checked against the actual
+``durations``/``not_called`` sizes rather than trusted as a free-form label.
 """
 
 from __future__ import annotations
@@ -58,6 +77,7 @@ _REQUIRED_ARTIFACT_FIELDS = (
     "schema_version",
     "source_commit_sha",
     "collection_hash",
+    "node_count",
     "durations",
     "not_called",
 )
@@ -66,6 +86,29 @@ _REQUIRED_ARTIFACT_FIELDS = (
 def compute_collection_hash(collected_nodes: set[str] | frozenset[str]) -> str:
     joined = "\n".join(sorted(collected_nodes))
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+class DuplicateJsonKeyError(ValueError):
+    """Raised when a JSON object (top-level or nested) has a duplicate key."""
+
+
+def _no_duplicate_pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise DuplicateJsonKeyError(f"duplicate key in JSON object: {key!r}")
+        seen[key] = value
+    return seen
+
+
+def _load_json_no_duplicates(path: Path) -> Any:
+    """Parse JSON, fail-closed on any duplicate key at any nesting level."""
+    try:
+        return json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=_no_duplicate_pairs_hook
+        )
+    except DuplicateJsonKeyError as error:
+        raise ValueError(f"{path}: {error}") from error
 
 
 def _validate_duration_values(
@@ -91,12 +134,25 @@ def _validate_not_called_list(raw: Any, *, source: str) -> set[str]:
         isinstance(node_id, str) for node_id in raw
     ):
         raise ValueError(f"{source}: 'not_called' must be a JSON array of strings")
+    if len(raw) != len(set(raw)):
+        duplicates = sorted({node_id for node_id in raw if raw.count(node_id) > 1})
+        raise ValueError(
+            f"{source}: 'not_called' contains duplicate entries: {duplicates[:10]!r}"
+        )
     return set(raw)
+
+
+def _validate_schema_version(raw: Any, *, source: str) -> int:
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw != SCHEMA_VERSION:
+        raise ValueError(
+            f"{source}: unsupported schema_version {raw!r}; expected {SCHEMA_VERSION!r}"
+        )
+    return raw
 
 
 def _load_call_duration_shard(path: Path) -> tuple[dict[str, float], set[str]]:
     """Load one shard's ``{"durations": {...}, "not_called": [...]}`` output."""
-    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    raw: Any = _load_json_no_duplicates(path)
     if not isinstance(raw, dict) or "durations" not in raw or "not_called" not in raw:
         raise ValueError(
             f"{path}: expected an object with 'durations' and 'not_called' keys"
@@ -191,25 +247,8 @@ def serialize_artifact(artifact: dict[str, Any]) -> str:
     return json.dumps(artifact, sort_keys=True, indent=2) + "\n"
 
 
-class DuplicateArtifactKeyError(ValueError):
-    """Raised when the artifact JSON itself contains a duplicate key."""
-
-
-def _no_duplicate_pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    seen: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in seen:
-            raise DuplicateArtifactKeyError(f"duplicate key in artifact JSON: {key!r}")
-        seen[key] = value
-    return seen
-
-
 def load_artifact(path: Path) -> dict[str, Any]:
-    text = path.read_text(encoding="utf-8")
-    try:
-        raw = json.loads(text, object_pairs_hook=_no_duplicate_pairs_hook)
-    except DuplicateArtifactKeyError as error:
-        raise ValueError(f"{path}: {error}") from error
+    raw = _load_json_no_duplicates(path)
 
     if not isinstance(raw, dict):
         raise ValueError(f"{path}: expected a JSON object")
@@ -218,6 +257,7 @@ def load_artifact(path: Path) -> dict[str, Any]:
             raise ValueError(f"{path}: missing required field {field!r}")
     if not isinstance(raw["durations"], dict):
         raise ValueError(f"{path}: 'durations' must be a JSON object")
+    _validate_schema_version(raw["schema_version"], source=str(path))
     _validate_not_called_list(raw["not_called"], source=str(path))
     return raw
 
@@ -230,6 +270,7 @@ def validate_freshness(
 ) -> None:
     """Fail closed unless ``artifact`` is trustworthy telemetry for today's tree."""
     source = "call-duration artifact"
+    _validate_schema_version(artifact.get("schema_version"), source=source)
     durations = _validate_duration_values(artifact["durations"], source=source)
     not_called = _validate_not_called_list(
         artifact.get("not_called", []), source=source
@@ -240,6 +281,14 @@ def validate_freshness(
         raise ValueError(
             f"{source}: node id(s) present in both 'durations' and "
             f"'not_called': {overlap[:10]!r}"
+        )
+
+    expected_node_count = len(durations) + len(not_called)
+    if artifact.get("node_count") != expected_node_count:
+        raise ValueError(
+            f"{source}: node_count mismatch: artifact={artifact.get('node_count')!r} "
+            f"expected={expected_node_count!r} (len(durations) + len(not_called)) "
+            "— refresh the call-duration artifact"
         )
 
     if artifact["source_commit_sha"] != expected_source_commit_sha:

--- a/scripts/call_durations.py
+++ b/scripts/call_durations.py
@@ -1,0 +1,263 @@
+"""Deterministic call-phase-only duration telemetry with freshness validation.
+
+ROB-1295. This is strictly additive to ``.test_durations``:
+
+* ``.test_durations`` keeps being produced exactly as before by pytest-split's
+  own ``--store-durations``/``--durations-path`` mechanism, and keeps driving
+  shard balancing exactly as before (``scripts/merge_test_durations.py`` is
+  unchanged). No consumer of that file requires any change.
+* This module instead builds a new sidecar artifact (conventionally
+  ``.call_durations.json``) from call-phase-only measurements captured by
+  ``tests/_call_duration_plugin.py``, and validates that a candidate/
+  committed artifact is still trustworthy for the current tree.
+
+Two operations, deliberately asymmetric:
+
+* ``build`` merges per-shard call-phase measurements into a single artifact
+  scoped to exactly the currently collected test set (fail-closed on
+  duplicate/missing/malformed input — there is no "stale" concept when
+  building fresh from the current shard measurements).
+* ``validate`` checks an already-serialized artifact against the *current*
+  repository state (collected node ids, HEAD commit sha) and fails closed on
+  any drift: duplicate node ids, missing node ids, stale/removed node ids,
+  a source-commit mismatch, a collection-hash mismatch, or a malformed
+  duration value. Unlike pytest-split's tolerant shard-balancing hint, this
+  artifact is meant to be trustworthy provenance data, so drift is a hard
+  failure rather than something to silently drop and continue past.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from scripts.merge_test_durations import _load_collected_nodes, _load_durations
+
+SCHEMA_VERSION = 1
+
+_REQUIRED_ARTIFACT_FIELDS = (
+    "schema_version",
+    "source_commit_sha",
+    "collection_hash",
+    "durations",
+)
+
+
+def compute_collection_hash(collected_nodes: set[str] | frozenset[str]) -> str:
+    joined = "\n".join(sorted(collected_nodes))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def merge_call_duration_shards(
+    *, shard_paths: list[Path], collected_paths: list[Path]
+) -> tuple[dict[str, float], set[str]]:
+    """Merge call-phase shard measurements into one fresh, complete map."""
+    collected = _load_collected_nodes(collected_paths)
+    measured: dict[str, float] = {}
+
+    for shard_path in shard_paths:
+        shard = _load_durations(shard_path)
+        unexpected = sorted(set(shard) - collected)
+        if unexpected:
+            raise ValueError(
+                f"{shard_path}: call durations contain uncollected tests: "
+                f"{unexpected[:10]!r}"
+            )
+        duplicates = sorted(set(shard) & set(measured))
+        if duplicates:
+            raise ValueError(
+                f"{shard_path}: duplicate node id(s) across call-duration "
+                f"shards: {duplicates[:10]!r}"
+            )
+        measured.update(shard)
+
+    missing = sorted(collected - set(measured))
+    if missing:
+        raise ValueError(
+            "call-duration shards are incomplete; "
+            f"{len(missing)} collected tests have no call-phase measurement: "
+            f"{missing[:20]!r}"
+        )
+
+    return measured, collected
+
+
+def build_artifact(
+    *,
+    shard_paths: list[Path],
+    collected_paths: list[Path],
+    source_commit_sha: str,
+) -> dict[str, Any]:
+    if not source_commit_sha or not source_commit_sha.strip():
+        raise ValueError("source_commit_sha must not be empty")
+
+    measured, collected = merge_call_duration_shards(
+        shard_paths=shard_paths, collected_paths=collected_paths
+    )
+    durations = {node_id: measured[node_id] for node_id in sorted(collected)}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_commit_sha": source_commit_sha,
+        "collection_hash": compute_collection_hash(collected),
+        "node_count": len(durations),
+        "durations": durations,
+    }
+
+
+def serialize_artifact(artifact: dict[str, Any]) -> str:
+    return json.dumps(artifact, sort_keys=True, indent=2) + "\n"
+
+
+class DuplicateArtifactKeyError(ValueError):
+    """Raised when the artifact JSON itself contains a duplicate key."""
+
+
+def _no_duplicate_pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise DuplicateArtifactKeyError(f"duplicate key in artifact JSON: {key!r}")
+        seen[key] = value
+    return seen
+
+
+def load_artifact(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        raw = json.loads(text, object_pairs_hook=_no_duplicate_pairs_hook)
+    except DuplicateArtifactKeyError as error:
+        raise ValueError(f"{path}: {error}") from error
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    for field in _REQUIRED_ARTIFACT_FIELDS:
+        if field not in raw:
+            raise ValueError(f"{path}: missing required field {field!r}")
+    if not isinstance(raw["durations"], dict):
+        raise ValueError(f"{path}: 'durations' must be a JSON object")
+    return raw
+
+
+def _validate_duration_values(
+    durations: dict[str, Any], *, source: str
+) -> dict[str, float]:
+    validated: dict[str, float] = {}
+    for node_id, duration in durations.items():
+        if (
+            not isinstance(node_id, str)
+            or isinstance(duration, bool)
+            or not isinstance(duration, int | float)
+        ):
+            raise ValueError(f"{source}: invalid duration entry {node_id!r}")
+        value = float(duration)
+        if value < 0 or not math.isfinite(value):
+            raise ValueError(f"{source}: invalid duration for {node_id}: {duration!r}")
+        validated[node_id] = value
+    return validated
+
+
+def validate_freshness(
+    artifact: dict[str, Any],
+    *,
+    collected_nodes: set[str],
+    expected_source_commit_sha: str,
+) -> None:
+    """Fail closed unless ``artifact`` is trustworthy telemetry for today's tree."""
+    source = "call-duration artifact"
+    durations = _validate_duration_values(artifact["durations"], source=source)
+
+    if artifact["source_commit_sha"] != expected_source_commit_sha:
+        raise ValueError(
+            f"{source}: source commit sha mismatch: "
+            f"artifact={artifact['source_commit_sha']!r} "
+            f"expected={expected_source_commit_sha!r} "
+            "— refresh the call-duration artifact"
+        )
+
+    expected_hash = compute_collection_hash(collected_nodes)
+    if artifact["collection_hash"] != expected_hash:
+        raise ValueError(
+            f"{source}: collection hash mismatch: "
+            f"artifact={artifact['collection_hash']!r} expected={expected_hash!r} "
+            "— refresh the call-duration artifact"
+        )
+
+    missing = sorted(collected_nodes - set(durations))
+    if missing:
+        raise ValueError(
+            f"{source}: missing measurement(s) for {len(missing)} currently "
+            f"collected test(s): {missing[:20]!r} "
+            "— refresh the call-duration artifact"
+        )
+
+    stale = sorted(set(durations) - collected_nodes)
+    if stale:
+        raise ValueError(
+            f"{source}: {len(stale)} stale/removed node id(s) present: "
+            f"{stale[:20]!r} — refresh the call-duration artifact"
+        )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser(
+        "build", help="merge shard measurements into a fresh call-duration artifact"
+    )
+    build_parser.add_argument("--shard", type=Path, action="append", required=True)
+    build_parser.add_argument("--collected", type=Path, action="append", required=True)
+    build_parser.add_argument("--source-commit-sha", type=str, required=True)
+    build_parser.add_argument("--output", type=Path, required=True)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="validate a call-duration artifact against the current tree"
+    )
+    validate_parser.add_argument("--artifact", type=Path, required=True)
+    validate_parser.add_argument(
+        "--collected", type=Path, action="append", required=True
+    )
+    validate_parser.add_argument("--expected-source-sha", type=str, required=True)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if args.command == "build":
+        artifact = build_artifact(
+            shard_paths=args.shard,
+            collected_paths=args.collected,
+            source_commit_sha=args.source_commit_sha,
+        )
+        args.output.write_text(serialize_artifact(artifact), encoding="utf-8")
+        print(
+            f"built call-duration artifact: {artifact['node_count']} entries, "
+            f"source_commit_sha={artifact['source_commit_sha']}, "
+            f"collection_hash={artifact['collection_hash']}"
+        )
+        return
+
+    if args.command == "validate":
+        artifact = load_artifact(args.artifact)
+        collected = _load_collected_nodes(args.collected)
+        validate_freshness(
+            artifact,
+            collected_nodes=collected,
+            expected_source_commit_sha=args.expected_source_sha,
+        )
+        print(
+            f"call-duration artifact is fresh: {len(collected)} entries match "
+            f"collection_hash={artifact['collection_hash']} at "
+            f"source_commit_sha={artifact['source_commit_sha']}"
+        )
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/call_durations.py
+++ b/scripts/call_durations.py
@@ -24,6 +24,21 @@ Two operations, deliberately asymmetric:
   duration value. Unlike pytest-split's tolerant shard-balancing hint, this
   artifact is meant to be trustworthy provenance data, so drift is a hard
   failure rather than something to silently drop and continue past.
+
+ROB-1295 R1 — collected-but-never-called nodes: a node whose ``setup`` phase
+itself skips (``@pytest.mark.skip``, ``skipif``, a skip-raising fixture, ...)
+is collected but never reaches the ``call`` phase at all — pytest's own
+runtest protocol only invokes ``call`` after ``setup`` passes. Such nodes
+have no call-phase cost to measure, so ``tests/_call_duration_plugin.py``
+records them separately in ``not_called`` rather than either (a) silently
+omitting them, which this module would otherwise fail closed on as a missing
+measurement, or (b) coercing them to a ``0.0`` duration, which would be
+indistinguishable from a real, very-fast call and would corrupt any later
+statistics over ``durations``. Every currently collected node must land in
+exactly one of ``durations`` or ``not_called`` — never both, never neither.
+A node that skips *inside* its call phase (e.g. ``pytest.skip()`` called
+from the test body) is unaffected: pytest still emits a real ``call`` report
+with a real duration, so it is captured in ``durations`` as usual.
 """
 
 from __future__ import annotations
@@ -35,15 +50,16 @@ import math
 from pathlib import Path
 from typing import Any
 
-from scripts.merge_test_durations import _load_collected_nodes, _load_durations
+from scripts.merge_test_durations import _load_collected_nodes
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 _REQUIRED_ARTIFACT_FIELDS = (
     "schema_version",
     "source_commit_sha",
     "collection_hash",
     "durations",
+    "not_called",
 )
 
 
@@ -52,38 +68,99 @@ def compute_collection_hash(collected_nodes: set[str] | frozenset[str]) -> str:
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
 
+def _validate_duration_values(
+    durations: dict[str, Any], *, source: str
+) -> dict[str, float]:
+    validated: dict[str, float] = {}
+    for node_id, duration in durations.items():
+        if (
+            not isinstance(node_id, str)
+            or isinstance(duration, bool)
+            or not isinstance(duration, int | float)
+        ):
+            raise ValueError(f"{source}: invalid duration entry {node_id!r}")
+        value = float(duration)
+        if value < 0 or not math.isfinite(value):
+            raise ValueError(f"{source}: invalid duration for {node_id}: {duration!r}")
+        validated[node_id] = value
+    return validated
+
+
+def _validate_not_called_list(raw: Any, *, source: str) -> set[str]:
+    if not isinstance(raw, list) or not all(
+        isinstance(node_id, str) for node_id in raw
+    ):
+        raise ValueError(f"{source}: 'not_called' must be a JSON array of strings")
+    return set(raw)
+
+
+def _load_call_duration_shard(path: Path) -> tuple[dict[str, float], set[str]]:
+    """Load one shard's ``{"durations": {...}, "not_called": [...]}`` output."""
+    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or "durations" not in raw or "not_called" not in raw:
+        raise ValueError(
+            f"{path}: expected an object with 'durations' and 'not_called' keys"
+        )
+    if not isinstance(raw["durations"], dict):
+        raise ValueError(f"{path}: 'durations' must be a JSON object")
+
+    durations = _validate_duration_values(raw["durations"], source=str(path))
+    not_called = _validate_not_called_list(raw["not_called"], source=str(path))
+
+    overlap = sorted(set(durations) & not_called)
+    if overlap:
+        raise ValueError(
+            f"{path}: node id(s) present in both 'durations' and 'not_called': "
+            f"{overlap[:10]!r}"
+        )
+    return durations, not_called
+
+
 def merge_call_duration_shards(
     *, shard_paths: list[Path], collected_paths: list[Path]
-) -> tuple[dict[str, float], set[str]]:
-    """Merge call-phase shard measurements into one fresh, complete map."""
+) -> tuple[dict[str, float], set[str], set[str]]:
+    """Merge call-phase shard measurements into one fresh, complete record.
+
+    Returns ``(durations, not_called, collected)``. Every id in
+    ``collected`` lands in exactly one of ``durations``/``not_called``;
+    anything else (missing from both, or duplicated across shards in either
+    category) is a fail-closed error.
+    """
     collected = _load_collected_nodes(collected_paths)
     measured: dict[str, float] = {}
+    not_called: set[str] = set()
 
     for shard_path in shard_paths:
-        shard = _load_durations(shard_path)
-        unexpected = sorted(set(shard) - collected)
+        shard_durations, shard_not_called = _load_call_duration_shard(shard_path)
+
+        shard_known = set(shard_durations) | shard_not_called
+        unexpected = sorted(shard_known - collected)
         if unexpected:
             raise ValueError(
                 f"{shard_path}: call durations contain uncollected tests: "
                 f"{unexpected[:10]!r}"
             )
-        duplicates = sorted(set(shard) & set(measured))
+
+        already_known = set(measured) | not_called
+        duplicates = sorted(shard_known & already_known)
         if duplicates:
             raise ValueError(
                 f"{shard_path}: duplicate node id(s) across call-duration "
                 f"shards: {duplicates[:10]!r}"
             )
-        measured.update(shard)
 
-    missing = sorted(collected - set(measured))
+        measured.update(shard_durations)
+        not_called.update(shard_not_called)
+
+    missing = sorted(collected - (set(measured) | not_called))
     if missing:
         raise ValueError(
             "call-duration shards are incomplete; "
-            f"{len(missing)} collected tests have no call-phase measurement: "
-            f"{missing[:20]!r}"
+            f"{len(missing)} collected tests have no call-phase measurement "
+            f"or setup-skip record: {missing[:20]!r}"
         )
 
-    return measured, collected
+    return measured, not_called, collected
 
 
 def build_artifact(
@@ -95,16 +172,18 @@ def build_artifact(
     if not source_commit_sha or not source_commit_sha.strip():
         raise ValueError("source_commit_sha must not be empty")
 
-    measured, collected = merge_call_duration_shards(
+    measured, not_called, collected = merge_call_duration_shards(
         shard_paths=shard_paths, collected_paths=collected_paths
     )
-    durations = {node_id: measured[node_id] for node_id in sorted(collected)}
+    durations = {node_id: measured[node_id] for node_id in sorted(measured)}
+    not_called_sorted = sorted(not_called)
     return {
         "schema_version": SCHEMA_VERSION,
         "source_commit_sha": source_commit_sha,
         "collection_hash": compute_collection_hash(collected),
-        "node_count": len(durations),
+        "node_count": len(durations) + len(not_called_sorted),
         "durations": durations,
+        "not_called": not_called_sorted,
     }
 
 
@@ -139,25 +218,8 @@ def load_artifact(path: Path) -> dict[str, Any]:
             raise ValueError(f"{path}: missing required field {field!r}")
     if not isinstance(raw["durations"], dict):
         raise ValueError(f"{path}: 'durations' must be a JSON object")
+    _validate_not_called_list(raw["not_called"], source=str(path))
     return raw
-
-
-def _validate_duration_values(
-    durations: dict[str, Any], *, source: str
-) -> dict[str, float]:
-    validated: dict[str, float] = {}
-    for node_id, duration in durations.items():
-        if (
-            not isinstance(node_id, str)
-            or isinstance(duration, bool)
-            or not isinstance(duration, int | float)
-        ):
-            raise ValueError(f"{source}: invalid duration entry {node_id!r}")
-        value = float(duration)
-        if value < 0 or not math.isfinite(value):
-            raise ValueError(f"{source}: invalid duration for {node_id}: {duration!r}")
-        validated[node_id] = value
-    return validated
 
 
 def validate_freshness(
@@ -169,6 +231,16 @@ def validate_freshness(
     """Fail closed unless ``artifact`` is trustworthy telemetry for today's tree."""
     source = "call-duration artifact"
     durations = _validate_duration_values(artifact["durations"], source=source)
+    not_called = _validate_not_called_list(
+        artifact.get("not_called", []), source=source
+    )
+
+    overlap = sorted(set(durations) & not_called)
+    if overlap:
+        raise ValueError(
+            f"{source}: node id(s) present in both 'durations' and "
+            f"'not_called': {overlap[:10]!r}"
+        )
 
     if artifact["source_commit_sha"] != expected_source_commit_sha:
         raise ValueError(
@@ -186,15 +258,16 @@ def validate_freshness(
             "— refresh the call-duration artifact"
         )
 
-    missing = sorted(collected_nodes - set(durations))
+    known = set(durations) | not_called
+    missing = sorted(collected_nodes - known)
     if missing:
         raise ValueError(
-            f"{source}: missing measurement(s) for {len(missing)} currently "
-            f"collected test(s): {missing[:20]!r} "
+            f"{source}: missing measurement(s) or setup-skip record(s) for "
+            f"{len(missing)} currently collected test(s): {missing[:20]!r} "
             "— refresh the call-duration artifact"
         )
 
-    stale = sorted(set(durations) - collected_nodes)
+    stale = sorted(known - collected_nodes)
     if stale:
         raise ValueError(
             f"{source}: {len(stale)} stale/removed node id(s) present: "
@@ -237,7 +310,8 @@ def main() -> None:
         )
         args.output.write_text(serialize_artifact(artifact), encoding="utf-8")
         print(
-            f"built call-duration artifact: {artifact['node_count']} entries, "
+            f"built call-duration artifact: {len(artifact['durations'])} measured, "
+            f"{len(artifact['not_called'])} not-called, "
             f"source_commit_sha={artifact['source_commit_sha']}, "
             f"collection_hash={artifact['collection_hash']}"
         )

--- a/scripts/call_durations_test.py
+++ b/scripts/call_durations_test.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.call_durations import (
+    build_artifact,
+    compute_collection_hash,
+    load_artifact,
+    merge_call_duration_shards,
+    serialize_artifact,
+    validate_freshness,
+)
+
+pytestmark = pytest.mark.unit
+
+_NODE_A = "tests/test_a.py::test_a"
+_NODE_B = "tests/test_b.py::test_b"
+
+
+def _write(path: Path, value: str) -> Path:
+    path.write_text(value, encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, value: object) -> Path:
+    return _write(path, json.dumps(value))
+
+
+def _write_manifest(path: Path, *node_ids: str) -> Path:
+    return _write(path, "\n".join(node_ids) + "\n")
+
+
+def _build_two_node_artifact(tmp_path: Path) -> dict[str, object]:
+    shard1 = _write_json(tmp_path / "shard1.json", {_NODE_A: 0.01})
+    shard2 = _write_json(tmp_path / "shard2.json", {_NODE_B: 0.02})
+    collected1 = _write_manifest(tmp_path / "collected1.txt", _NODE_A, _NODE_B)
+    return build_artifact(
+        shard_paths=[shard1, shard2],
+        collected_paths=[collected1],
+        source_commit_sha="a" * 40,
+    )
+
+
+# --- build_artifact / merge_call_duration_shards ---------------------------
+
+
+def test_build_artifact_merges_shards_and_stamps_provenance(tmp_path: Path) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+
+    assert artifact["schema_version"] == 1
+    assert artifact["source_commit_sha"] == "a" * 40
+    assert artifact["node_count"] == 2
+    assert artifact["durations"] == {_NODE_A: 0.01, _NODE_B: 0.02}
+    assert artifact["collection_hash"] == compute_collection_hash({_NODE_A, _NODE_B})
+
+
+def test_build_artifact_output_is_deterministic(tmp_path: Path) -> None:
+    first = serialize_artifact(_build_two_node_artifact(tmp_path))
+    second = serialize_artifact(_build_two_node_artifact(tmp_path))
+    assert first == second
+
+
+def test_build_artifact_rejects_empty_source_sha(tmp_path: Path) -> None:
+    shard = _write_json(tmp_path / "shard.json", {_NODE_A: 0.01})
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
+
+    with pytest.raises(ValueError, match="source_commit_sha must not be empty"):
+        build_artifact(
+            shard_paths=[shard], collected_paths=[collected], source_commit_sha="  "
+        )
+
+
+def test_merge_rejects_duplicate_across_shards(tmp_path: Path) -> None:
+    shard1 = _write_json(tmp_path / "shard1.json", {_NODE_A: 0.01})
+    shard2 = _write_json(tmp_path / "shard2.json", {_NODE_A: 0.02})
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
+
+    with pytest.raises(ValueError, match="duplicate node id"):
+        merge_call_duration_shards(
+            shard_paths=[shard1, shard2], collected_paths=[collected]
+        )
+
+
+def test_merge_rejects_missing_measurement(tmp_path: Path) -> None:
+    shard = _write_json(tmp_path / "shard.json", {_NODE_A: 0.01})
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A, _NODE_B)
+
+    with pytest.raises(ValueError, match="have no call-phase measurement"):
+        merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
+
+
+@pytest.mark.parametrize("duration", [-0.01, float("nan")], ids=["negative", "nan"])
+def test_merge_rejects_malformed_duration(tmp_path: Path, duration: float) -> None:
+    shard = _write_json(tmp_path / "shard.json", {_NODE_A: duration})
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
+
+    with pytest.raises(ValueError, match="invalid duration"):
+        merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
+
+
+# --- load_artifact -----------------------------------------------------
+
+
+def test_load_artifact_rejects_duplicate_key(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "artifact.json",
+        '{"schema_version": 1, "source_commit_sha": "a", '
+        '"collection_hash": "b", "durations": {"x": 1, "x": 2}}',
+    )
+
+    with pytest.raises(ValueError, match="duplicate key"):
+        load_artifact(path)
+
+
+def test_load_artifact_rejects_missing_field(tmp_path: Path) -> None:
+    path = _write_json(tmp_path / "artifact.json", {"schema_version": 1})
+
+    with pytest.raises(ValueError, match="missing required field"):
+        load_artifact(path)
+
+
+# --- validate_freshness -------------------------------------------------
+
+
+def test_validate_freshness_passes_for_freshly_built_artifact(tmp_path: Path) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+
+    validate_freshness(
+        artifact,
+        collected_nodes={_NODE_A, _NODE_B},
+        expected_source_commit_sha="a" * 40,
+    )
+
+
+def test_validate_freshness_rejects_source_sha_mismatch(tmp_path: Path) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+
+    with pytest.raises(ValueError, match="source commit sha mismatch"):
+        validate_freshness(
+            artifact,
+            collected_nodes={_NODE_A, _NODE_B},
+            expected_source_commit_sha="b" * 40,
+        )
+
+
+def test_validate_freshness_rejects_collection_hash_mismatch(tmp_path: Path) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+    artifact["collection_hash"] = "not-a-real-hash"
+
+    with pytest.raises(ValueError, match="collection hash mismatch"):
+        validate_freshness(
+            artifact,
+            collected_nodes={_NODE_A, _NODE_B},
+            expected_source_commit_sha="a" * 40,
+        )
+
+
+def test_validate_freshness_rejects_missing_current_node(tmp_path: Path) -> None:
+    # A hash mismatch alone would already fail closed whenever the collected
+    # set changes, so isolate "missing" by keeping collection_hash in sync
+    # with the new collected set while durations still lack the new node —
+    # e.g. a hand-edited or half-written artifact.
+    artifact = _build_two_node_artifact(tmp_path)
+    node_c = "tests/test_c.py::test_c"
+    collected = {_NODE_A, _NODE_B, node_c}
+    artifact["collection_hash"] = compute_collection_hash(collected)
+
+    with pytest.raises(ValueError, match="missing measurement"):
+        validate_freshness(
+            artifact,
+            collected_nodes=collected,
+            expected_source_commit_sha="a" * 40,
+        )
+
+
+def test_validate_freshness_rejects_stale_node(tmp_path: Path) -> None:
+    # Same isolation as above: keep collection_hash in sync with the shrunk
+    # collected set so only the stale-entry check can fire.
+    artifact = _build_two_node_artifact(tmp_path)
+    collected = {_NODE_A}
+    artifact["collection_hash"] = compute_collection_hash(collected)
+
+    with pytest.raises(ValueError, match="stale/removed node id"):
+        validate_freshness(
+            artifact,
+            collected_nodes=collected,
+            expected_source_commit_sha="a" * 40,
+        )
+
+
+def test_validate_freshness_rejects_malformed_duration(tmp_path: Path) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+    artifact["durations"][_NODE_A] = "not-a-number"
+
+    with pytest.raises(ValueError, match="invalid duration entry"):
+        validate_freshness(
+            artifact,
+            collected_nodes={_NODE_A, _NODE_B},
+            expected_source_commit_sha="a" * 40,
+        )

--- a/scripts/call_durations_test.py
+++ b/scripts/call_durations_test.py
@@ -170,15 +170,63 @@ def test_merge_rejects_malformed_duration(tmp_path: Path, duration: float) -> No
         merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
 
 
+def test_merge_rejects_duplicate_key_in_nested_shard_durations(tmp_path: Path) -> None:
+    # ROB-1295 R2 (verifier P2-1): shard files got the same duplicate-key
+    # protection as artifact files -- a hand-tampered/corrupt shard cannot
+    # silently drop a measurement via Python's last-key-wins dict() parsing.
+    shard = _write(
+        tmp_path / "shard.json",
+        '{"durations": {"a": 1.0, "a": 2.0}, "not_called": []}',
+    )
+    collected = _write_manifest(tmp_path / "collected.txt", "a")
+
+    with pytest.raises(ValueError, match="duplicate key"):
+        merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
+
+
+def test_merge_rejects_duplicate_key_at_shard_top_level(tmp_path: Path) -> None:
+    shard = _write(
+        tmp_path / "shard.json",
+        '{"durations": {}, "not_called": [], "not_called": ["a"]}',
+    )
+    collected = _write_manifest(tmp_path / "collected.txt", "a")
+
+    with pytest.raises(ValueError, match="duplicate key"):
+        merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
+
+
+def test_merge_rejects_duplicate_not_called_entries_in_shard(tmp_path: Path) -> None:
+    # ROB-1295 R2 (verifier P3): duplicate not_called list items are a
+    # structural error, not silently collapsed by set(raw).
+    shard = _shard(tmp_path / "shard.json", not_called=[_NODE_A, _NODE_A])
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
+
+    with pytest.raises(ValueError, match="duplicate entries"):
+        merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
+
+
 # --- load_artifact -----------------------------------------------------
 
 
-def test_load_artifact_rejects_duplicate_key(tmp_path: Path) -> None:
+def test_load_artifact_rejects_duplicate_key_in_nested_durations(
+    tmp_path: Path,
+) -> None:
     path = _write(
         tmp_path / "artifact.json",
         '{"schema_version": 2, "source_commit_sha": "a", '
-        '"collection_hash": "b", "not_called": [], '
+        '"collection_hash": "b", "node_count": 0, "not_called": [], '
         '"durations": {"x": 1, "x": 2}}',
+    )
+
+    with pytest.raises(ValueError, match="duplicate key"):
+        load_artifact(path)
+
+
+def test_load_artifact_rejects_duplicate_key_at_top_level(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "artifact.json",
+        '{"schema_version": 2, "schema_version": 3, "source_commit_sha": "a", '
+        '"collection_hash": "b", "node_count": 0, "not_called": [], "durations": {}}',
     )
 
     with pytest.raises(ValueError, match="duplicate key"):
@@ -189,6 +237,28 @@ def test_load_artifact_rejects_missing_field(tmp_path: Path) -> None:
     path = _write_json(tmp_path / "artifact.json", {"schema_version": 2})
 
     with pytest.raises(ValueError, match="missing required field"):
+        load_artifact(path)
+
+
+@pytest.mark.parametrize(
+    "schema_version", [1, 99, "2", True, None], ids=["v1", "v99", "str", "bool", "null"]
+)
+def test_load_artifact_rejects_unsupported_schema_version(
+    tmp_path: Path, schema_version: object
+) -> None:
+    path = _write_json(
+        tmp_path / "artifact.json",
+        {
+            "schema_version": schema_version,
+            "source_commit_sha": "a" * 40,
+            "collection_hash": "b",
+            "node_count": 0,
+            "durations": {},
+            "not_called": [],
+        },
+    )
+
+    with pytest.raises(ValueError, match="unsupported schema_version"):
         load_artifact(path)
 
 
@@ -304,3 +374,77 @@ def test_validate_freshness_rejects_overlap_between_durations_and_not_called(
             collected_nodes={_NODE_A, _NODE_B},
             expected_source_commit_sha="a" * 40,
         )
+
+
+@pytest.mark.parametrize(
+    "schema_version", [1, 99, "2", True, None], ids=["v1", "v99", "str", "bool", "null"]
+)
+def test_validate_freshness_rejects_unsupported_schema_version(
+    tmp_path: Path, schema_version: object
+) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+    artifact["schema_version"] = schema_version
+
+    with pytest.raises(ValueError, match="unsupported schema_version"):
+        validate_freshness(
+            artifact,
+            collected_nodes={_NODE_A, _NODE_B},
+            expected_source_commit_sha="a" * 40,
+        )
+
+
+def test_validate_freshness_rejects_duplicate_not_called_entries(
+    tmp_path: Path,
+) -> None:
+    # build_artifact can never produce this (it always writes sorted(set(...))
+    # ), so hand-tamper a freshly built artifact to prove validate_freshness
+    # independently rejects a hand-edited duplicate rather than trusting
+    # build-time uniqueness.
+    shard = _shard(
+        tmp_path / "shard.json", durations={_NODE_A: 0.01}, not_called=[_NODE_B]
+    )
+    collected_nodes = {_NODE_A, _NODE_B}
+    artifact = build_artifact(
+        shard_paths=[shard],
+        collected_paths=[_write_manifest(tmp_path / "collected.txt", *collected_nodes)],
+        source_commit_sha="a" * 40,
+    )
+    artifact["not_called"] = [_NODE_B, _NODE_B]
+
+    with pytest.raises(ValueError, match="duplicate entries"):
+        validate_freshness(
+            artifact,
+            collected_nodes=collected_nodes,
+            expected_source_commit_sha="a" * 40,
+        )
+
+
+def test_validate_freshness_rejects_node_count_mismatch(tmp_path: Path) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+    artifact["node_count"] = 999
+
+    with pytest.raises(ValueError, match="node_count mismatch"):
+        validate_freshness(
+            artifact,
+            collected_nodes={_NODE_A, _NODE_B},
+            expected_source_commit_sha="a" * 40,
+        )
+
+
+def test_build_artifact_node_count_equals_durations_plus_not_called(
+    tmp_path: Path,
+) -> None:
+    shard = _shard(
+        tmp_path / "shard.json", durations={_NODE_A: 0.01}, not_called=[_NODE_B]
+    )
+    collected_nodes = {_NODE_A, _NODE_B}
+    artifact = build_artifact(
+        shard_paths=[shard],
+        collected_paths=[_write_manifest(tmp_path / "collected.txt", *collected_nodes)],
+        source_commit_sha="a" * 40,
+    )
+
+    assert artifact["node_count"] == len(artifact["durations"]) + len(
+        artifact["not_called"]
+    )
+    assert artifact["node_count"] == len(collected_nodes)

--- a/scripts/call_durations_test.py
+++ b/scripts/call_durations_test.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.unit
 
 _NODE_A = "tests/test_a.py::test_a"
 _NODE_B = "tests/test_b.py::test_b"
+_NODE_C = "tests/test_c.py::test_c"
 
 
 def _write(path: Path, value: str) -> Path:
@@ -29,13 +30,22 @@ def _write_json(path: Path, value: object) -> Path:
     return _write(path, json.dumps(value))
 
 
+def _shard(
+    path: Path, *, durations: dict[str, float] | None = None, not_called=()
+) -> Path:
+    return _write_json(
+        path,
+        {"durations": durations or {}, "not_called": list(not_called)},
+    )
+
+
 def _write_manifest(path: Path, *node_ids: str) -> Path:
     return _write(path, "\n".join(node_ids) + "\n")
 
 
 def _build_two_node_artifact(tmp_path: Path) -> dict[str, object]:
-    shard1 = _write_json(tmp_path / "shard1.json", {_NODE_A: 0.01})
-    shard2 = _write_json(tmp_path / "shard2.json", {_NODE_B: 0.02})
+    shard1 = _shard(tmp_path / "shard1.json", durations={_NODE_A: 0.01})
+    shard2 = _shard(tmp_path / "shard2.json", durations={_NODE_B: 0.02})
     collected1 = _write_manifest(tmp_path / "collected1.txt", _NODE_A, _NODE_B)
     return build_artifact(
         shard_paths=[shard1, shard2],
@@ -50,10 +60,11 @@ def _build_two_node_artifact(tmp_path: Path) -> dict[str, object]:
 def test_build_artifact_merges_shards_and_stamps_provenance(tmp_path: Path) -> None:
     artifact = _build_two_node_artifact(tmp_path)
 
-    assert artifact["schema_version"] == 1
+    assert artifact["schema_version"] == 2
     assert artifact["source_commit_sha"] == "a" * 40
     assert artifact["node_count"] == 2
     assert artifact["durations"] == {_NODE_A: 0.01, _NODE_B: 0.02}
+    assert artifact["not_called"] == []
     assert artifact["collection_hash"] == compute_collection_hash({_NODE_A, _NODE_B})
 
 
@@ -64,7 +75,7 @@ def test_build_artifact_output_is_deterministic(tmp_path: Path) -> None:
 
 
 def test_build_artifact_rejects_empty_source_sha(tmp_path: Path) -> None:
-    shard = _write_json(tmp_path / "shard.json", {_NODE_A: 0.01})
+    shard = _shard(tmp_path / "shard.json", durations={_NODE_A: 0.01})
     collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
 
     with pytest.raises(ValueError, match="source_commit_sha must not be empty"):
@@ -73,9 +84,55 @@ def test_build_artifact_rejects_empty_source_sha(tmp_path: Path) -> None:
         )
 
 
+def test_build_artifact_records_setup_skip_as_not_called(tmp_path: Path) -> None:
+    # ROB-1295 R1: a node whose setup phase itself skips (e.g.
+    # @pytest.mark.skip) never gets a "call" report at all — reproduces the
+    # weekly-refresh failure against tests/services/daily_candles/
+    # test_migration_round_trip.py on the current tree.
+    shard = _shard(
+        tmp_path / "shard.json", durations={_NODE_A: 0.01}, not_called=[_NODE_B]
+    )
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A, _NODE_B)
+
+    artifact = build_artifact(
+        shard_paths=[shard], collected_paths=[collected], source_commit_sha="a" * 40
+    )
+
+    assert artifact["durations"] == {_NODE_A: 0.01}
+    assert artifact["not_called"] == [_NODE_B]
+    assert artifact["node_count"] == 2
+
+
+def test_load_shard_rejects_overlap_between_durations_and_not_called(
+    tmp_path: Path,
+) -> None:
+    shard = _shard(
+        tmp_path / "shard.json", durations={_NODE_A: 0.01}, not_called=[_NODE_A]
+    )
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
+
+    with pytest.raises(
+        ValueError, match="present in both 'durations' and 'not_called'"
+    ):
+        merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
+
+
 def test_merge_rejects_duplicate_across_shards(tmp_path: Path) -> None:
-    shard1 = _write_json(tmp_path / "shard1.json", {_NODE_A: 0.01})
-    shard2 = _write_json(tmp_path / "shard2.json", {_NODE_A: 0.02})
+    shard1 = _shard(tmp_path / "shard1.json", durations={_NODE_A: 0.01})
+    shard2 = _shard(tmp_path / "shard2.json", durations={_NODE_A: 0.02})
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
+
+    with pytest.raises(ValueError, match="duplicate node id"):
+        merge_call_duration_shards(
+            shard_paths=[shard1, shard2], collected_paths=[collected]
+        )
+
+
+def test_merge_rejects_contradiction_across_shards(tmp_path: Path) -> None:
+    # Node measured in one shard, reported not-called in another — a real
+    # inconsistency (e.g. flaky infra), not a legitimate setup-skip.
+    shard1 = _shard(tmp_path / "shard1.json", durations={_NODE_A: 0.01})
+    shard2 = _shard(tmp_path / "shard2.json", not_called=[_NODE_A])
     collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
 
     with pytest.raises(ValueError, match="duplicate node id"):
@@ -85,7 +142,19 @@ def test_merge_rejects_duplicate_across_shards(tmp_path: Path) -> None:
 
 
 def test_merge_rejects_missing_measurement(tmp_path: Path) -> None:
-    shard = _write_json(tmp_path / "shard.json", {_NODE_A: 0.01})
+    shard = _shard(tmp_path / "shard.json", durations={_NODE_A: 0.01})
+    collected = _write_manifest(tmp_path / "collected.txt", _NODE_A, _NODE_B)
+
+    with pytest.raises(ValueError, match="have no call-phase measurement"):
+        merge_call_duration_shards(shard_paths=[shard], collected_paths=[collected])
+
+
+def test_merge_still_fails_closed_when_not_called_present_but_node_wholly_absent(
+    tmp_path: Path,
+) -> None:
+    # A not_called entry for one node must not paper over a genuinely
+    # missing measurement for a different collected node (partial shard).
+    shard = _shard(tmp_path / "shard.json", not_called=[_NODE_A])
     collected = _write_manifest(tmp_path / "collected.txt", _NODE_A, _NODE_B)
 
     with pytest.raises(ValueError, match="have no call-phase measurement"):
@@ -94,7 +163,7 @@ def test_merge_rejects_missing_measurement(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("duration", [-0.01, float("nan")], ids=["negative", "nan"])
 def test_merge_rejects_malformed_duration(tmp_path: Path, duration: float) -> None:
-    shard = _write_json(tmp_path / "shard.json", {_NODE_A: duration})
+    shard = _shard(tmp_path / "shard.json", durations={_NODE_A: duration})
     collected = _write_manifest(tmp_path / "collected.txt", _NODE_A)
 
     with pytest.raises(ValueError, match="invalid duration"):
@@ -107,8 +176,9 @@ def test_merge_rejects_malformed_duration(tmp_path: Path, duration: float) -> No
 def test_load_artifact_rejects_duplicate_key(tmp_path: Path) -> None:
     path = _write(
         tmp_path / "artifact.json",
-        '{"schema_version": 1, "source_commit_sha": "a", '
-        '"collection_hash": "b", "durations": {"x": 1, "x": 2}}',
+        '{"schema_version": 2, "source_commit_sha": "a", '
+        '"collection_hash": "b", "not_called": [], '
+        '"durations": {"x": 1, "x": 2}}',
     )
 
     with pytest.raises(ValueError, match="duplicate key"):
@@ -116,7 +186,7 @@ def test_load_artifact_rejects_duplicate_key(tmp_path: Path) -> None:
 
 
 def test_load_artifact_rejects_missing_field(tmp_path: Path) -> None:
-    path = _write_json(tmp_path / "artifact.json", {"schema_version": 1})
+    path = _write_json(tmp_path / "artifact.json", {"schema_version": 2})
 
     with pytest.raises(ValueError, match="missing required field"):
         load_artifact(path)
@@ -131,6 +201,24 @@ def test_validate_freshness_passes_for_freshly_built_artifact(tmp_path: Path) ->
     validate_freshness(
         artifact,
         collected_nodes={_NODE_A, _NODE_B},
+        expected_source_commit_sha="a" * 40,
+    )
+
+
+def test_validate_freshness_passes_with_not_called_entries(tmp_path: Path) -> None:
+    shard = _shard(
+        tmp_path / "shard.json", durations={_NODE_A: 0.01}, not_called=[_NODE_B]
+    )
+    collected_nodes = {_NODE_A, _NODE_B}
+    artifact = build_artifact(
+        shard_paths=[shard],
+        collected_paths=[_write_manifest(tmp_path / "collected.txt", *collected_nodes)],
+        source_commit_sha="a" * 40,
+    )
+
+    validate_freshness(
+        artifact,
+        collected_nodes=collected_nodes,
         expected_source_commit_sha="a" * 40,
     )
 
@@ -161,11 +249,10 @@ def test_validate_freshness_rejects_collection_hash_mismatch(tmp_path: Path) -> 
 def test_validate_freshness_rejects_missing_current_node(tmp_path: Path) -> None:
     # A hash mismatch alone would already fail closed whenever the collected
     # set changes, so isolate "missing" by keeping collection_hash in sync
-    # with the new collected set while durations still lack the new node —
-    # e.g. a hand-edited or half-written artifact.
+    # with the new collected set while durations/not_called still lack the
+    # new node — e.g. a hand-edited or half-written artifact.
     artifact = _build_two_node_artifact(tmp_path)
-    node_c = "tests/test_c.py::test_c"
-    collected = {_NODE_A, _NODE_B, node_c}
+    collected = {_NODE_A, _NODE_B, _NODE_C}
     artifact["collection_hash"] = compute_collection_hash(collected)
 
     with pytest.raises(ValueError, match="missing measurement"):
@@ -196,6 +283,22 @@ def test_validate_freshness_rejects_malformed_duration(tmp_path: Path) -> None:
     artifact["durations"][_NODE_A] = "not-a-number"
 
     with pytest.raises(ValueError, match="invalid duration entry"):
+        validate_freshness(
+            artifact,
+            collected_nodes={_NODE_A, _NODE_B},
+            expected_source_commit_sha="a" * 40,
+        )
+
+
+def test_validate_freshness_rejects_overlap_between_durations_and_not_called(
+    tmp_path: Path,
+) -> None:
+    artifact = _build_two_node_artifact(tmp_path)
+    artifact["not_called"] = [_NODE_A]
+
+    with pytest.raises(
+        ValueError, match="present in both 'durations' and 'not_called'"
+    ):
         validate_freshness(
             artifact,
             collected_nodes={_NODE_A, _NODE_B},

--- a/tests/_call_duration_plugin.py
+++ b/tests/_call_duration_plugin.py
@@ -16,6 +16,19 @@ actual test-body cost. It is strictly additive:
   ``test`` job or any other pytest invocation that does not pass both flags;
 * never reads or writes ``.test_durations`` — the pytest-split consumer of
   that file is untouched.
+
+ROB-1295 R1: a node whose ``setup`` phase itself skips (``@pytest.mark.skip``,
+``skipif``, a fixture raising ``Skipped``/``unittest.SkipTest``, ...) never
+gets a ``call`` report at all — pytest's runtest protocol only invokes the
+``call`` phase after ``setup`` passes. Such nodes are collected but never
+"called", so they cannot have a call-phase duration; they are recorded
+separately as ``not_called`` rather than silently omitted (which the
+downstream merge/validator would otherwise treat as a genuine missing
+measurement) or coerced to a bogus ``0.0`` duration (indistinguishable from a
+real, very-fast call). A node that skips *inside* its call phase (e.g.
+``pytest.skip()`` called from the test body) is unaffected: pytest still
+emits a real ``call`` report with a real ``report.duration`` for the time
+spent before the skip, so it is captured in ``durations`` as usual.
 """
 
 from __future__ import annotations
@@ -25,11 +38,12 @@ from pathlib import Path
 
 import pytest
 
-# Module-level global rather than a config stash: this needs to survive a
+# Module-level globals rather than a config stash: this needs to survive a
 # hook signature (``pytest_runtest_logreport``) that pytest does not pass
 # ``config`` into. Safe because each pytest process (controller or xdist
 # worker) gets its own fresh import of this module.
 _call_durations: dict[str, float] = {}
+_not_called: set[str] = set()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -49,6 +63,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     if report.when == "call":
         _call_durations[report.nodeid] = report.duration
+    elif report.when == "setup" and report.skipped:
+        _not_called.add(report.nodeid)
 
 
 @pytest.hookimpl(optionalhook=True)
@@ -58,8 +74,20 @@ def pytest_testnodedown(node, error) -> None:  # noqa: ARG001
     Mirrors the ``auto_trader_schema_metrics`` forwarding pattern in
     ``tests/conftest.py``.
     """
-    worker_durations = node.workeroutput.get("auto_trader_call_durations", {})
-    _call_durations.update(worker_durations)
+    worker_output = node.workeroutput
+    _call_durations.update(worker_output.get("auto_trader_call_durations", {}))
+    _not_called.update(worker_output.get("auto_trader_not_called", []))
+
+
+def _current_output() -> dict[str, object]:
+    # A node id can only end up in both sets if a plugin/rerun oddity
+    # produced a real call report for something we also saw skip at setup
+    # (should not happen under normal pytest semantics — see module
+    # docstring). Resolve deterministically in favor of the measured call
+    # report: its existence proves the test body genuinely ran, which is
+    # strictly stronger evidence than the earlier setup-skip observation.
+    not_called = sorted(_not_called - set(_call_durations))
+    return {"durations": dict(_call_durations), "not_called": not_called}
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:
@@ -69,12 +97,13 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
         # of writing a file. The controller aggregates via
         # pytest_testnodedown and is the only process that writes output.
         worker_output["auto_trader_call_durations"] = dict(_call_durations)
+        worker_output["auto_trader_not_called"] = sorted(_not_called)
         return
 
     out_path = session.config.getoption("--call-durations-out")
     if not out_path:
         return
     Path(out_path).write_text(
-        json.dumps(_call_durations, sort_keys=True, indent=2) + "\n",
+        json.dumps(_current_output(), sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
     )

--- a/tests/_call_duration_plugin.py
+++ b/tests/_call_duration_plugin.py
@@ -27,8 +27,19 @@ downstream merge/validator would otherwise treat as a genuine missing
 measurement) or coerced to a bogus ``0.0`` duration (indistinguishable from a
 real, very-fast call). A node that skips *inside* its call phase (e.g.
 ``pytest.skip()`` called from the test body) is unaffected: pytest still
-emits a real ``call`` report with a real ``report.duration`` for the time
-spent before the skip, so it is captured in ``durations`` as usual.
+emits a real ``call`` report with a real ``report.duration``, so it is
+captured in ``durations`` as usual.
+
+ROB-1295 R2: every observation of a node id — from this process's own
+``pytest_runtest_logreport`` and from every xdist worker forwarded via
+``pytest_testnodedown`` — is recorded through ``_record_duration``/
+``_record_not_called``, which keep ``durations``/``not_called`` disjoint by
+construction. A *repeated* observation for the same node id is tolerated
+only when it is identical to what is already recorded (same bucket, same
+duration value) — genuinely harmless double-delivery. Any node id reported
+with a different duration, or reported in both buckets, raises
+``ConflictingCallObservationError`` immediately rather than being resolved
+silently (dropping data or preferring one report over another).
 """
 
 from __future__ import annotations
@@ -44,6 +55,34 @@ import pytest
 # worker) gets its own fresh import of this module.
 _call_durations: dict[str, float] = {}
 _not_called: set[str] = set()
+
+
+class ConflictingCallObservationError(RuntimeError):
+    """A node id was observed twice with different data (duration or bucket)."""
+
+
+def _record_duration(nodeid: str, duration: float) -> None:
+    if nodeid in _not_called:
+        raise ConflictingCallObservationError(
+            f"{nodeid!r} was already recorded as not-called (setup-skip), but a "
+            f"call report with duration={duration!r} arrived afterward"
+        )
+    existing = _call_durations.get(nodeid)
+    if existing is not None and existing != duration:
+        raise ConflictingCallObservationError(
+            f"{nodeid!r} reported conflicting call durations: "
+            f"{existing!r} vs {duration!r}"
+        )
+    _call_durations[nodeid] = duration
+
+
+def _record_not_called(nodeid: str) -> None:
+    if nodeid in _call_durations:
+        raise ConflictingCallObservationError(
+            f"{nodeid!r} was already recorded with a measured call duration, but a "
+            "setup-skip report arrived afterward"
+        )
+    _not_called.add(nodeid)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -62,9 +101,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     if report.when == "call":
-        _call_durations[report.nodeid] = report.duration
+        _record_duration(report.nodeid, report.duration)
     elif report.when == "setup" and report.skipped:
-        _not_called.add(report.nodeid)
+        _record_not_called(report.nodeid)
 
 
 @pytest.hookimpl(optionalhook=True)
@@ -72,22 +111,23 @@ def pytest_testnodedown(node, error) -> None:  # noqa: ARG001
     """Aggregate xdist worker call durations onto the controller process.
 
     Mirrors the ``auto_trader_schema_metrics`` forwarding pattern in
-    ``tests/conftest.py``.
+    ``tests/conftest.py``, but merges through ``_record_duration``/
+    ``_record_not_called`` instead of ``dict.update``/``set.update`` so a
+    duplicate or contradictory node id across workers fails closed instead
+    of last-write-wins silently overwriting or masking it.
     """
     worker_output = node.workeroutput
-    _call_durations.update(worker_output.get("auto_trader_call_durations", {}))
-    _not_called.update(worker_output.get("auto_trader_not_called", []))
+    for nodeid, duration in worker_output.get("auto_trader_call_durations", {}).items():
+        _record_duration(nodeid, duration)
+    for nodeid in worker_output.get("auto_trader_not_called", []):
+        _record_not_called(nodeid)
 
 
 def _current_output() -> dict[str, object]:
-    # A node id can only end up in both sets if a plugin/rerun oddity
-    # produced a real call report for something we also saw skip at setup
-    # (should not happen under normal pytest semantics — see module
-    # docstring). Resolve deterministically in favor of the measured call
-    # report: its existence proves the test body genuinely ran, which is
-    # strictly stronger evidence than the earlier setup-skip observation.
-    not_called = sorted(_not_called - set(_call_durations))
-    return {"durations": dict(_call_durations), "not_called": not_called}
+    # durations and not_called are disjoint by construction (_record_duration
+    # / _record_not_called raise on any contradiction the instant it is
+    # observed), so no reconciliation is needed here.
+    return {"durations": dict(_call_durations), "not_called": sorted(_not_called)}
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:

--- a/tests/_call_duration_plugin.py
+++ b/tests/_call_duration_plugin.py
@@ -1,0 +1,80 @@
+"""Call-phase-only pytest duration telemetry (ROB-1295).
+
+pytest-split's own shard-balancing timing (``--store-durations`` /
+``--durations-path .test_durations``) measures the whole per-test protocol —
+setup + call + teardown — so shared fixture/session bootstrap cost gets
+folded into whichever test happens to trigger it. That pollutes any signal
+derived from ``.test_durations`` beyond its intended purpose (shard
+balancing, which stays unchanged and out of scope here).
+
+This plugin instead records only the ``call`` phase per node id, so
+downstream freshness telemetry (``scripts/call_durations.py``) reflects
+actual test-body cost. It is strictly additive:
+
+* opt-in only, loaded explicitly via ``-p tests._call_duration_plugin``
+  together with ``--call-durations-out=PATH``; never active in the required
+  ``test`` job or any other pytest invocation that does not pass both flags;
+* never reads or writes ``.test_durations`` — the pytest-split consumer of
+  that file is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# Module-level global rather than a config stash: this needs to survive a
+# hook signature (``pytest_runtest_logreport``) that pytest does not pass
+# ``config`` into. Safe because each pytest process (controller or xdist
+# worker) gets its own fresh import of this module.
+_call_durations: dict[str, float] = {}
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("call durations")
+    group.addoption(
+        "--call-durations-out",
+        action="store",
+        default=None,
+        metavar="PATH",
+        help=(
+            "write call-phase-only test durations (JSON) to PATH. "
+            "Requires -p tests._call_duration_plugin."
+        ),
+    )
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if report.when == "call":
+        _call_durations[report.nodeid] = report.duration
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node, error) -> None:  # noqa: ARG001
+    """Aggregate xdist worker call durations onto the controller process.
+
+    Mirrors the ``auto_trader_schema_metrics`` forwarding pattern in
+    ``tests/conftest.py``.
+    """
+    worker_durations = node.workeroutput.get("auto_trader_call_durations", {})
+    _call_durations.update(worker_durations)
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    worker_output = getattr(session.config, "workeroutput", None)
+    if worker_output is not None:
+        # Running inside an xdist worker: forward to the controller instead
+        # of writing a file. The controller aggregates via
+        # pytest_testnodedown and is the only process that writes output.
+        worker_output["auto_trader_call_durations"] = dict(_call_durations)
+        return
+
+    out_path = session.config.getoption("--call-durations-out")
+    if not out_path:
+        return
+    Path(out_path).write_text(
+        json.dumps(_call_durations, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/test_call_duration_plugin.py
+++ b/tests/test_call_duration_plugin.py
@@ -2,13 +2,22 @@
 
 Runs throwaway pytest suites in real subprocesses against the plugin and
 asserts on its written ``{"durations": {...}, "not_called": [...]}`` output.
+Also unit-tests the plugin's conflict-detection helpers directly (fast,
+in-process) for the xdist aggregation contract.
 
-ROB-1295 R1: also proves the plugin's fix for a real weekly-refresh failure
+ROB-1295 R1: proves the plugin's fix for a real weekly-refresh failure
 reproduced against tests/services/daily_candles/test_migration_round_trip.py
 on this tree — a node whose setup phase itself skips (``@pytest.mark.skip``)
 never gets a "call" report at all, so naively treating every collected node
 as measurable makes the freshness build fail closed on a false "missing"
 even though nothing is actually wrong.
+
+ROB-1295 R2 (post-verify hardening): proves xdist worker/controller
+aggregation fails closed on a duplicate node id reported with a different
+duration or a contradictory bucket (call vs. not-called), instead of
+silently last-write-wins overwriting or masking it — including under the
+weekly workflow's actual ``-n 4 --dist=loadfile`` topology, not just a
+simulated in-process counterexample.
 """
 
 from __future__ import annotations
@@ -18,8 +27,11 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+
+from tests import _call_duration_plugin as plugin
 
 pytestmark = pytest.mark.slow
 
@@ -32,8 +44,19 @@ _CALL_DURATION_CEILING_SECONDS = 0.2
 
 
 def _run_call_duration_plugin(
-    tmp_path: Path, source: str, *, extra_args: list[str] | None = None
+    tmp_path: Path,
+    source: str,
+    *,
+    extra_args: list[str] | None = None,
+    expect_returncode: int = 0,
 ) -> dict[str, object]:
+    """Run `source` as a throwaway pytest suite against the plugin.
+
+    Defaults to requiring a clean pytest exit (0) — skips are not failures,
+    so any test proving ordinary (even all-skipped) behavior should still
+    exit 0. Pass ``expect_returncode`` explicitly only for a test that is
+    deliberately proving an error-path outcome (e.g. a genuine setup error).
+    """
     suite_dir = tmp_path / "suite"
     suite_dir.mkdir(exist_ok=True)
     (suite_dir / "test_suite.py").write_text(source, encoding="utf-8")
@@ -64,7 +87,7 @@ def _run_call_duration_plugin(
         timeout=30,
     )
 
-    assert result.returncode in (0, 1), result.stdout + result.stderr
+    assert result.returncode == expect_returncode, result.stdout + result.stderr
     return json.loads(out_path.read_text(encoding="utf-8"))
 
 
@@ -143,6 +166,37 @@ def test_skips_from_inside_call_phase():
     )
 
 
+def test_setup_error_is_correctly_omitted_and_helper_requires_explicit_nonzero(
+    tmp_path: Path,
+) -> None:
+    # A genuine setup ERROR (not a skip) is neither a measured call nor a
+    # legitimate setup-skip -- the node is correctly absent from both
+    # `durations` and `not_called`. This is safe in practice only because
+    # the weekly workflow's "Measure shard" step does not run with
+    # `if: always()` on the upload -- a non-zero pytest exit fails that CI
+    # step before the incomplete artifact could ever reach build/validate.
+    source = """
+import pytest
+
+
+@pytest.fixture
+def broken_fixture():
+    raise RuntimeError("setup blows up")
+
+
+def test_setup_error(broken_fixture):
+    assert True
+
+
+def test_ok():
+    assert True
+"""
+    payload = _run_call_duration_plugin(tmp_path, source, expect_returncode=1)
+
+    assert payload["not_called"] == []
+    assert list(payload["durations"]) == ["test_suite.py::test_ok"]
+
+
 def test_setup_skip_contract_holds_under_xdist(tmp_path: Path) -> None:
     # The worker -> controller forwarding path (pytest_testnodedown) must
     # preserve the not_called/durations split exactly like the
@@ -171,3 +225,156 @@ def test_runs_normally():
         "test_suite.py::test_skipped_two",
     ]
     assert list(payload["durations"]) == ["test_suite.py::test_runs_normally"]
+
+
+def test_weekly_xdist_topology_n4_dist_loadfile_regression(tmp_path: Path) -> None:
+    # Reproduces the weekly refresh workflow's actual measure-shard
+    # concurrency (test-durations-refresh.yml: `-n 4 --dist=loadfile`) with
+    # a suite spread across several files/workers, including setup-skip and
+    # normal nodes, to prove the R2 fail-closed contradiction detection
+    # does not raise false positives under real (not simulated) worker
+    # aggregation.
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    for i in range(6):
+        (suite_dir / f"test_file_{i}.py").write_text(
+            f"""
+import pytest
+
+
+@pytest.mark.skip(reason="weekly xdist n4 regression")
+def test_skipped_{i}():
+    raise AssertionError("must never execute")
+
+
+def test_ok_{i}():
+    assert True
+""",
+            encoding="utf-8",
+        )
+    out_path = tmp_path / "call-durations.json"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            ".",
+            "-p",
+            "tests._call_duration_plugin",
+            f"--call-durations-out={out_path}",
+            "-p",
+            "no:cacheprovider",
+            "--no-header",
+            "-q",
+            "-n",
+            "4",
+            "--dist=loadfile",
+        ],
+        cwd=suite_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    expected_ok = {f"test_file_{i}.py::test_ok_{i}" for i in range(6)}
+    expected_skipped = {f"test_file_{i}.py::test_skipped_{i}" for i in range(6)}
+    assert set(payload["durations"]) == expected_ok
+    assert set(payload["not_called"]) == expected_skipped
+
+
+# --- in-process unit tests for the conflict-detection contract itself ------
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state():
+    # These tests mutate the plugin module's globals directly; subprocess
+    # tests above are unaffected (each subprocess gets its own fresh import
+    # of the module), but sibling in-process tests below must not leak
+    # state into one another.
+    plugin._call_durations.clear()
+    plugin._not_called.clear()
+    yield
+    plugin._call_durations.clear()
+    plugin._not_called.clear()
+
+
+def _fake_worker_node(
+    durations: dict[str, float] | None = None, not_called: list[str] | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        workeroutput={
+            "auto_trader_call_durations": dict(durations or {}),
+            "auto_trader_not_called": list(not_called or []),
+        }
+    )
+
+
+def test_record_duration_is_idempotent_for_an_identical_repeat() -> None:
+    plugin._record_duration("n", 1.0)
+    plugin._record_duration("n", 1.0)
+    assert plugin._call_durations == {"n": 1.0}
+
+
+def test_record_duration_raises_on_conflicting_value() -> None:
+    plugin._record_duration("n", 1.0)
+    with pytest.raises(
+        plugin.ConflictingCallObservationError, match="conflicting call durations"
+    ):
+        plugin._record_duration("n", 9.0)
+
+
+def test_record_not_called_is_idempotent_for_a_repeat() -> None:
+    plugin._record_not_called("n")
+    plugin._record_not_called("n")
+    assert plugin._not_called == {"n"}
+
+
+def test_record_not_called_after_duration_raises() -> None:
+    plugin._record_duration("n", 1.0)
+    with pytest.raises(
+        plugin.ConflictingCallObservationError,
+        match="already recorded with a measured call duration",
+    ):
+        plugin._record_not_called("n")
+
+
+def test_record_duration_after_not_called_raises() -> None:
+    plugin._record_not_called("n")
+    with pytest.raises(
+        plugin.ConflictingCallObservationError, match="already recorded as not-called"
+    ):
+        plugin._record_duration("n", 1.0)
+
+
+def test_testnodedown_merges_disjoint_worker_data_cleanly() -> None:
+    node = _fake_worker_node(durations={"a": 1.0}, not_called=["b"])
+    plugin.pytest_testnodedown(node, None)
+    assert plugin._call_durations == {"a": 1.0}
+    assert plugin._not_called == {"b"}
+
+
+def test_testnodedown_reproduces_verifier_counterexample_and_hard_fails() -> None:
+    # Verifier's exact minimal counterexample: the controller already has
+    # n=1.0 from its own logreport; a worker then forwards n with a
+    # DIFFERENT duration (9.0) *and* as not_called simultaneously. The old
+    # dict.update()/set.update() implementation resolved this to
+    # {"durations": {"n": 9.0}, "not_called": []} -- silently dropping the
+    # original value and hiding the bucket contradiction. It must now raise.
+    plugin._call_durations["n"] = 1.0
+    node = _fake_worker_node(durations={"n": 9.0}, not_called=["n"])
+
+    with pytest.raises(plugin.ConflictingCallObservationError):
+        plugin.pytest_testnodedown(node, None)
+
+
+def test_current_output_reflects_disjoint_state() -> None:
+    plugin._call_durations["a"] = 1.0
+    plugin._not_called.add("b")
+    assert plugin._current_output() == {"durations": {"a": 1.0}, "not_called": ["b"]}

--- a/tests/test_call_duration_plugin.py
+++ b/tests/test_call_duration_plugin.py
@@ -1,9 +1,14 @@
 """ROB-1295: proves tests/_call_duration_plugin.py records call-phase-only cost.
 
-Runs a throwaway pytest suite with an expensive session-scoped fixture (its
-setup and teardown sleep well past the assertion threshold below) in a real
-subprocess, then asserts the written call-duration artifact reflects only
-test-body execution — not fixture bootstrap/teardown time.
+Runs throwaway pytest suites in real subprocesses against the plugin and
+asserts on its written ``{"durations": {...}, "not_called": [...]}`` output.
+
+ROB-1295 R1: also proves the plugin's fix for a real weekly-refresh failure
+reproduced against tests/services/daily_candles/test_migration_round_trip.py
+on this tree — a node whose setup phase itself skips (``@pytest.mark.skip``)
+never gets a "call" report at all, so naively treating every collected node
+as measurable makes the freshness build fail closed on a false "missing"
+even though nothing is actually wrong.
 """
 
 from __future__ import annotations
@@ -25,28 +30,13 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE_PHASE_SLEEP_SECONDS = 0.3
 _CALL_DURATION_CEILING_SECONDS = 0.2
 
-_SUITE_SOURCE = f"""
-import time
 
-import pytest
-
-
-@pytest.fixture(scope="session")
-def slow_session_fixture():
-    time.sleep({_FIXTURE_PHASE_SLEEP_SECONDS})
-    yield "ready"
-    time.sleep({_FIXTURE_PHASE_SLEEP_SECONDS})
-
-
-def test_uses_slow_fixture(slow_session_fixture):
-    assert slow_session_fixture == "ready"
-"""
-
-
-def test_call_duration_excludes_setup_and_teardown_cost(tmp_path: Path) -> None:
+def _run_call_duration_plugin(
+    tmp_path: Path, source: str, *, extra_args: list[str] | None = None
+) -> dict[str, object]:
     suite_dir = tmp_path / "suite"
-    suite_dir.mkdir()
-    (suite_dir / "test_slow_fixture.py").write_text(_SUITE_SOURCE, encoding="utf-8")
+    suite_dir.mkdir(exist_ok=True)
+    (suite_dir / "test_suite.py").write_text(source, encoding="utf-8")
     out_path = tmp_path / "call-durations.json"
 
     env = dict(os.environ)
@@ -65,6 +55,7 @@ def test_call_duration_excludes_setup_and_teardown_cost(tmp_path: Path) -> None:
             "no:cacheprovider",
             "--no-header",
             "-q",
+            *(extra_args or []),
         ],
         cwd=suite_dir,
         env=env,
@@ -73,13 +64,110 @@ def test_call_duration_excludes_setup_and_teardown_cost(tmp_path: Path) -> None:
         timeout=30,
     )
 
-    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.returncode in (0, 1), result.stdout + result.stderr
+    return json.loads(out_path.read_text(encoding="utf-8"))
 
-    payload = json.loads(out_path.read_text(encoding="utf-8"))
-    assert list(payload) == ["test_slow_fixture.py::test_uses_slow_fixture"]
 
-    call_duration = next(iter(payload.values()))
+def test_call_duration_excludes_setup_and_teardown_cost(tmp_path: Path) -> None:
+    source = f"""
+import time
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def slow_session_fixture():
+    time.sleep({_FIXTURE_PHASE_SLEEP_SECONDS})
+    yield "ready"
+    time.sleep({_FIXTURE_PHASE_SLEEP_SECONDS})
+
+
+def test_uses_slow_fixture(slow_session_fixture):
+    assert slow_session_fixture == "ready"
+"""
+    payload = _run_call_duration_plugin(tmp_path, source)
+
+    assert payload["not_called"] == []
+    assert list(payload["durations"]) == ["test_suite.py::test_uses_slow_fixture"]
+
+    call_duration = payload["durations"]["test_suite.py::test_uses_slow_fixture"]
     assert call_duration < _CALL_DURATION_CEILING_SECONDS, (
         f"call-phase duration {call_duration}s should exclude the "
         f"{2 * _FIXTURE_PHASE_SLEEP_SECONDS}s of session setup+teardown sleep"
     )
+
+
+def test_setup_skip_is_recorded_as_not_called_not_a_missing_duration(
+    tmp_path: Path,
+) -> None:
+    # Reproduces the exact failure mode: @pytest.mark.skip makes pytest skip
+    # the item during "setup", before "call" ever runs, so there is no
+    # report.duration to record for it at all.
+    source = """
+import pytest
+
+
+@pytest.mark.skip(reason="ROB-1295 R1 repro")
+def test_setup_skipped():
+    raise AssertionError("must never execute")
+"""
+    payload = _run_call_duration_plugin(tmp_path, source)
+
+    assert payload["durations"] == {}
+    assert payload["not_called"] == ["test_suite.py::test_setup_skipped"]
+
+
+def test_call_phase_skip_is_still_recorded_as_a_real_duration(tmp_path: Path) -> None:
+    # A test that calls pytest.skip() from inside its own body *does* get a
+    # real "call" report (report.when == "call", report.skipped == True,
+    # report.duration reflects real elapsed call-phase time) — this must
+    # stay in `durations`, not be reclassified as not_called.
+    source = """
+import time
+
+import pytest
+
+
+def test_skips_from_inside_call_phase():
+    time.sleep(0.05)
+    pytest.skip("skips from inside the call phase")
+"""
+    payload = _run_call_duration_plugin(tmp_path, source)
+
+    assert payload["not_called"] == []
+    assert list(payload["durations"]) == [
+        "test_suite.py::test_skips_from_inside_call_phase"
+    ]
+    assert (
+        payload["durations"]["test_suite.py::test_skips_from_inside_call_phase"] >= 0.04
+    )
+
+
+def test_setup_skip_contract_holds_under_xdist(tmp_path: Path) -> None:
+    # The worker -> controller forwarding path (pytest_testnodedown) must
+    # preserve the not_called/durations split exactly like the
+    # single-process path above.
+    source = """
+import pytest
+
+
+@pytest.mark.skip(reason="ROB-1295 R1 repro (xdist)")
+def test_skipped_one():
+    raise AssertionError("must never execute")
+
+
+@pytest.mark.skip(reason="ROB-1295 R1 repro (xdist)")
+def test_skipped_two():
+    raise AssertionError("must never execute")
+
+
+def test_runs_normally():
+    assert True
+"""
+    payload = _run_call_duration_plugin(tmp_path, source, extra_args=["-n", "2"])
+
+    assert sorted(payload["not_called"]) == [
+        "test_suite.py::test_skipped_one",
+        "test_suite.py::test_skipped_two",
+    ]
+    assert list(payload["durations"]) == ["test_suite.py::test_runs_normally"]

--- a/tests/test_call_duration_plugin.py
+++ b/tests/test_call_duration_plugin.py
@@ -1,0 +1,85 @@
+"""ROB-1295: proves tests/_call_duration_plugin.py records call-phase-only cost.
+
+Runs a throwaway pytest suite with an expensive session-scoped fixture (its
+setup and teardown sleep well past the assertion threshold below) in a real
+subprocess, then asserts the written call-duration artifact reflects only
+test-body execution — not fixture bootstrap/teardown time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Setup and teardown alone cost >= 0.6s combined; the test body sleeps for
+# 0s. Call-phase-only capture must report well under that.
+_FIXTURE_PHASE_SLEEP_SECONDS = 0.3
+_CALL_DURATION_CEILING_SECONDS = 0.2
+
+_SUITE_SOURCE = f"""
+import time
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def slow_session_fixture():
+    time.sleep({_FIXTURE_PHASE_SLEEP_SECONDS})
+    yield "ready"
+    time.sleep({_FIXTURE_PHASE_SLEEP_SECONDS})
+
+
+def test_uses_slow_fixture(slow_session_fixture):
+    assert slow_session_fixture == "ready"
+"""
+
+
+def test_call_duration_excludes_setup_and_teardown_cost(tmp_path: Path) -> None:
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    (suite_dir / "test_slow_fixture.py").write_text(_SUITE_SOURCE, encoding="utf-8")
+    out_path = tmp_path / "call-durations.json"
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            ".",
+            "-p",
+            "tests._call_duration_plugin",
+            f"--call-durations-out={out_path}",
+            "-p",
+            "no:cacheprovider",
+            "--no-header",
+            "-q",
+        ],
+        cwd=suite_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert list(payload) == ["test_slow_fixture.py::test_uses_slow_fixture"]
+
+    call_duration = next(iter(payload.values()))
+    assert call_duration < _CALL_DURATION_CEILING_SECONDS, (
+        f"call-phase duration {call_duration}s should exclude the "
+        f"{2 * _FIXTURE_PHASE_SLEEP_SECONDS}s of session setup+teardown sleep"
+    )


### PR DESCRIPTION
## Summary

- Adds `tests/_call_duration_plugin.py`, an opt-in pytest plugin that records only the `call` phase per node id (via `report.duration` on `pytest_runtest_logreport` where `report.when == "call"`), excluding setup/teardown/fixture-bootstrap cost that pytest-split's own `--store-durations` mechanism folds into `.test_durations`.
- Adds `scripts/call_durations.py`: `build_artifact()` merges per-shard call-phase measurements into a deterministic, provenance-stamped sidecar artifact (`.call_durations.json`: `schema_version`, `source_commit_sha`, `collection_hash` (sha256 of sorted collected non-live node ids), `durations`), and `validate_freshness()` fails closed against the current tree for: duplicate node ids (JSON parse-time duplicate-key detection), missing current node ids, stale/removed node ids, source-commit-sha mismatch, collection-hash mismatch, and malformed/negative/non-finite durations.
- Wires both into `.github/workflows/test-durations-refresh.yml`: the plugin runs *inside* the existing "Measure shard" step (same pytest invocation that already produces `.test_durations` — no extra test run), and the merge job builds + self-validates `.call_durations.json` before staging it into the same weekly auto-PR that already refreshes `.test_durations`.
- Adds one fast unit-test step to the required `lint` job (`scripts/call_durations_test.py`), mirroring the existing `scripts/merge_test_durations_test.py` step.

## Compatibility / migration path

`.test_durations` and pytest-split shard balancing are **completely unchanged** — same flags (`--splits 4 --group N --durations-path ... --store-durations --clean-durations`), same consumer (`scripts/merge_test_durations.py`, untouched). `.call_durations.json` is a new, purely additive sidecar with no existing consumer to break. Unlike pytest-split's tolerant shard-balancing hint (which silently drops stale/missing entries), this new artifact is meant to be trustworthy provenance data, so `validate_freshness` treats any drift as a hard failure rather than something to silently paper over.

## Verification (raw output)

```
$ uv run pytest scripts/call_durations_test.py scripts/merge_test_durations_test.py tests/test_call_duration_plugin.py -v -ra
...
21 passed in 1.65s
```

```
$ uv run ruff check app/ tests/ research/ scripts/
All checks passed!
$ uv run ruff format --check app/ tests/ research/ scripts/
3932 files already formatted
$ uv run ty check app/ --error-on-warning
All checks passed!
$ uv run bandit -r scripts/call_durations.py tests/_call_duration_plugin.py
No issues identified.
```

Manual xdist proof (2 workers, 4 tests, one with a 0.2s session fixture + one with its own 0.05s sleep in the call phase):
```
{
  "test_multi.py::test_one": 0.00018803193233907223,
  "test_multi.py::test_three": 0.00020810996647924185,
  "test_multi.py::test_two": 0.05703949893359095,
  "test_slow_fixture.py::test_uses_slow_fixture": 0.0001885020174086094
}
```
Session-fixture setup/teardown cost (0.2s) is attributed to none of the four tests; `test_two`'s own 0.05s call-phase sleep is captured accurately.

Full current-tree recompute (matches the brief's cited evidence closely, +1 for this PR's own new test):
```
collected (non-live): 20844
.test_durations entries: 17099
missing: 3788   stale: 43
```

## Scope

CI/test-metadata only — no `app/` changes, no shard-count/pytest-split-topology changes, no required-check-name changes, no branch-protection/auto-merge changes. PR #1768 untouched.

## Test plan
- [x] `uv run pytest scripts/call_durations_test.py -v` — all 15 freshness/build unit tests pass (deterministic output, and one test per failure class: duplicate key, missing, stale, malformed, source-sha mismatch, collection-hash mismatch)
- [x] `uv run pytest tests/test_call_duration_plugin.py -v` — subprocess-pytest proof that call-phase duration excludes setup+teardown sleep
- [x] `uv run ruff check/format`, `uv run ty check`, `uv run bandit` all clean
- [x] `git rev-parse HEAD` == `git ls-remote origin refs/heads/fix/ROB-1295-duration-freshness` (`fab3b541f6e5fb046a68629b569e13ceb1246078`)

Linear: ROB-1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collection of per-test call-phase duration data, including support for parallel test execution.
  - Added tools to build, validate, and track test-duration artifacts with freshness and integrity checks.
  - Added workflow automation to detect, upload, and commit updated duration data.

- **Bug Fixes**
  - Improved detection of changed or newly created duration artifacts.

- **Tests**
  - Added coverage for duration merging, validation, serialization, and plugin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->