### PR TITLE
ci(ROB-1294): shadow change classifier + stable ci-required aggregate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,57 @@ jobs:
         path: write-fence-report.json
         if-no-files-found: warn
 
+  # ROB-1294 (R2B) — SHADOW ONLY. Classifies this run's change set into
+  # resource lanes and publishes the verdict as job outputs + an artifact.
+  # Nothing consumes those outputs to skip a job in this PR; the six
+  # branch-protection-required checks (lint, taskiq-smoke, test (3.13, 1..4))
+  # run exactly as before. See docs/runbooks/ci-required-aggregator.md.
+  #
+  # Fail-closed: an unknown path, a rename/copy/delete, any shared CI/config
+  # /test-infrastructure file, an empty change set, or an absent base SHA all
+  # yield run_all=true; an unresolvable supplied SHA, a git failure, or a
+  # malformed diff record turn this job RED instead of narrowing coverage.
+  change-classifier:
+    name: change-classifier
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      result: ${{ steps.classify.outputs.result }}
+      run_all: ${{ steps.classify.outputs.run_all }}
+      reason: ${{ steps.classify.outputs.reason }}
+      lanes: ${{ steps.classify.outputs.lanes }}
+      jobs: ${{ steps.classify.outputs.jobs }}
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        # Full history: the base commit must be locally resolvable. A shallow
+        # checkout that hides it is a hard failure in the classifier, not a
+        # reason to fall back to a narrower run.
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Classify changed paths (shadow)
+      id: classify
+      env:
+        CLASSIFY_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        CLASSIFY_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      # stdlib-only: no uv sync, no dependency install.
+      run: |
+        python3 scripts/ci/classify_changes.py \
+          --github-output \
+          --summary \
+          --json-out change-classification.json
+
+    - name: Upload change classification
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: change-classification
+        path: change-classification.json
+        if-no-files-found: warn
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -550,6 +601,56 @@ jobs:
         # H6 is the fail-closed predecessor of H5. This explicit invocation
         # keeps its 16-config/128-cell accounting boundary from disappearing
         # behind the repository's canonical tests/ discovery root.
+
+  # ROB-1294 (R2B) — fixed-name aggregate over the currently required checks.
+  #
+  # 🔴 This PR does NOT make `ci-required` a required check and writes no
+  # branch-protection setting. Branch protection still names lint,
+  # taskiq-smoke and test (3.13, 1..4) directly. The operator-only cutover
+  # procedure lives in docs/runbooks/ci-required-aggregator.md.
+  #
+  # `if: always()` is load-bearing: without it this job is skipped whenever a
+  # child fails, and a required check that vanishes on failure is a green
+  # merge button. Red on child failure, child cancellation, classifier
+  # failure, an absent child result, or any unrecognised result string; only
+  # an explicitly `--authorize-skip`ped child may be skipped and still pass.
+  ci-required:
+    name: ci-required
+    if: always()
+    needs: [lint, test, taskiq-smoke, change-classifier]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
+    - name: Evaluate required child results
+      env:
+        # toJSON(needs) -> {"lint": {"result": "success", ...}, ...}. For the
+        # matrix `test` job GitHub collapses all four shards into one result,
+        # which is failure if any shard failed.
+        CI_REQUIRED_NEEDS: ${{ toJSON(needs) }}
+      # stdlib-only: no uv sync, no dependency install.
+      run: |
+        python3 scripts/ci/aggregate_required.py \
+          --results-env CI_REQUIRED_NEEDS \
+          --required lint \
+          --required test \
+          --required taskiq-smoke \
+          --required change-classifier \
+          --summary \
+          --json-out ci-required-report.json
+
+    - name: Upload ci-required report
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: ci-required-report
+        path: ci-required-report.json
+        if-no-files-found: warn
 
   notify:
     if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,6 +627,31 @@ git branch -D <branch-name>
 - 이관: `git worktree move <old-path> <new-path>` (dirty 없는 상태에서)
 - 삭제된 원격 브랜치(`upstream gone`) 는 주기적으로 `git fetch --prune && git branch -vv | grep ': gone\]'` 로 확인하고 정리
 
+### CI required check — `ci-required` shadow 집계 (ROB-1294)
+
+branch protection 은 지금도 `lint` · `taskiq-smoke` · `test (3.13, 1..4)` **여섯 이름에 직접**
+결합돼 있다. shard 수·lane topology 를 바꾸려면 branch protection 편집이 함께 필요하고,
+그 편집을 빠뜨리면 required check 가 영구 pending 이거나 조용히 미강제가 된다.
+
+- **분류기**: `scripts/ci/classify_changes.py` — 변경 경로 → lane 결정적 매핑 (stdlib only)
+- **집계기**: `scripts/ci/aggregate_required.py` — 고정 이름 게이트의 판정 로직
+- **워크플로우 job**: `.github/workflows/test.yml` 의 `change-classifier` · `ci-required`
+- **계약 테스트**: `tests/ci/`
+- **런북**: `docs/runbooks/ci-required-aggregator.md`
+
+**현재 상태 = shadow.** 🔴 `ci-required` 는 **required check 가 아니며** 이 작업은 branch
+protection/GitHub 설정을 하나도 쓰지 않았다. 분류기 출력은 어떤 job 도 skip 시키지 않는다
+(`tests/ci/test_ci_required_workflow_contract.py` 가 이를 기계 검증한다 — 기존 여섯 job 의
+표시 이름·matrix·`if` 부재가 변하면 red).
+
+**fail-closed 규칙**: 분류기는 unknown path·rename/copy/delete·공유 CI/config/test 인프라·
+빈 change set·base SHA 부재를 전부 `run_all=true` 로 떨어뜨리고, 지정된 SHA 해석 실패·git
+실패·malformed diff 는 성공으로 세탁하지 않고 **job 을 red** 로 만든다. 집계기는 child 의
+`failure`/`cancelled`/미인가 `skipped`/결과 부재/미지의 결과 문자열을 전부 red 로 보며,
+`--authorize-skip` 로 명시된 skip 만 green 이다 (워크플로우는 현재 아무것도 인가하지 않음).
+
+**cutover 는 운영자 전용이며 이번 범위 밖** — 절차는 런북 §5.
+
 ## 주요 워크플로우
 
 ### 1. 데이터베이스 모델 변경

--- a/docs/runbooks/ci-required-aggregator.md
+++ b/docs/runbooks/ci-required-aggregator.md
@@ -62,7 +62,7 @@ Lanes and the jobs each one implies:
 | `ci_shared` | `.github/**`, `scripts/ci/**`, `pyproject.toml`, `uv.lock`, `Makefile`, `.test_durations`, `tests/conftest.py`, `tests/_socket_guard*.py`, `env.example`, `scripts/setup-test-env.sh`, `alembic.ini`, `codecov.yml` | **forces `run_all`** |
 | `unknown` | anything unmatched | **forces `run_all`** |
 
-Two design points that look conservative and are meant to be:
+Design points that look over-conservative and are meant to be:
 
 - A rename inside a single lane still forces `run_all`. The pre-image path is
   part of the blast radius and `--name-status` gives no guarantee the two
@@ -70,6 +70,35 @@ Two design points that look conservative and are meant to be:
 - The error path still writes `run_all=true` into `$GITHUB_OUTPUT` before
   exiting 1, so a consumer reading a partially written output file cannot
   infer reduced coverage from a crashed classifier.
+- **Paths are matched literally.** Nothing is stripped or normalized first.
+  Git tracks `" docs/only.md"` (leading space) as a file in a directory named
+  `" docs"`, and it is emitted verbatim under `--name-status -z`; trimming it
+  would answer "docs-only, no jobs needed" for a path that is not under
+  `docs/` at all. Unmatched literals are `unknown` → `run_all`.
+- **The `*.md` suffix rule is top-level only.** It exists for `README.md`,
+  `CLAUDE.md`, `AGENTS.md`. A bare suffix rule would swallow every unmatched
+  *nested* markdown path — including a fixture some test reads — and answer
+  "docs". Nested markdown under a directory the prefix table does not know is
+  `unknown` → `run_all`.
+
+### NUL stream and status grammar
+
+`--name-status -z` output is parsed strictly, because a parser that
+resynchronises quietly is a parser that reports the wrong lane confidently:
+
+- The stream must be NUL-terminated; a truncated one is red.
+- Exactly one trailing empty field (the terminator) is permitted. Any *other*
+  empty field means an embedded NUL, so record boundaries cannot be trusted →
+  red. (Previously such fields were filtered out, silently re-pairing statuses
+  with the wrong paths.)
+- The status token is validated as a whole *before* its first character is
+  used: a single letter from `A C D M R T U X B`, optionally followed by a
+  1–3 digit score for `R`, `C` and `M`. Anything else (`AA`, `Z`, `A1`,
+  `R1000`, `m`) is red rather than truncated into a status git never emitted.
+- A **scored `M`** (`M100`) is git's dissimilarity score for a *rewrite*,
+  emitted under `-B`. It is valid git output, so it is not red — but it is not
+  an ordinary modify either, so the whole token is kept, which places it
+  outside `CLASSIFIABLE_STATUSES` and forces `run_all`.
 
 ## 3. `ci-required` aggregate contract
 
@@ -94,6 +123,17 @@ Malformed input — non-JSON, a non-object payload, an unset env var, a child
 whose value is neither a string nor an object with `result` — is red. The
 workflow passes **no** `--authorize-skip` and **no** `--allow-undeclared`
 today, so `ci-required` is green only when all four children report `success`.
+
+The *declaration itself* is validated before the payload is even read
+(`validate_configuration`), so a malformed gate can never reach a verdict:
+
+- an empty `--required` list is red (an aggregate with no children passes
+  vacuously);
+- a blank or whitespace-only `--required` / `--authorize-skip` name is red —
+  argparse turns `--required ''` into a one-element list that satisfies the
+  non-empty check while naming no real job;
+- a duplicated `--required` / `--authorize-skip` name is red;
+- an `--authorize-skip` name that is not in `--required` is red.
 
 For the matrix `test` job, GitHub collapses all four shards into a single
 `needs.test.result`, which is `failure` if any shard failed. The aggregate

--- a/docs/runbooks/ci-required-aggregator.md
+++ b/docs/runbooks/ci-required-aggregator.md
@@ -45,7 +45,21 @@ something went wrong":
 |---|---|---|
 | `classified` | 0 | every changed path mapped to a known lane, and every change was an add or a modify |
 | `run_all` | 0 | any unknown path, any rename/copy/delete/type-change/unmerged path, any shared CI/config/test-infrastructure file, an empty change set, or an absent base SHA |
-| `error` | **1** | a head SHA that was not supplied, a supplied SHA that stays unresolvable after `git fetch` (shallow/incomplete history), a failing `git` invocation, or a malformed `--name-status` record |
+| `error` | **1** | a head SHA that was not supplied, a supplied SHA that stays unresolvable after `git fetch` (shallow/incomplete history, or an object that is not a commit), a failing `git` invocation, or a malformed `--name-status` record |
+
+**Resolution order matters.** A supplied head is resolved *before* the
+absent-base branch is taken. Otherwise an unresolvable head plus a missing or
+all-zero base returned a conservative green `run_all`, making an invalid head
+indistinguishable from a legitimate first-push one. The two cases must stay
+distinct:
+
+| base | head | outcome |
+|---|---|---|
+| absent / `0*40` | resolvable | `run_all`, exit 0 — a real first push |
+| absent / `0*40` | unresolvable or not a commit | **`error`, exit 1** |
+| present | unresolvable | **`error`, exit 1** |
+
+(`--name-status-file` remains a pure offline path and resolves no SHA at all.)
 
 Lanes and the jobs each one implies:
 

--- a/docs/runbooks/ci-required-aggregator.md
+++ b/docs/runbooks/ci-required-aggregator.md
@@ -1,0 +1,146 @@
+# `ci-required` shadow aggregator + change classifier (ROB-1294)
+
+**Status: shadow.** Nothing here changes what CI enforces today. The two new
+jobs observe and report; the six branch-protection-required checks run exactly
+as they did before this PR.
+
+## 1. Why this exists
+
+Branch protection currently names six checks directly:
+
+```
+lint
+taskiq-smoke
+test (3.13, 1)
+test (3.13, 2)
+test (3.13, 3)
+test (3.13, 4)
+```
+
+Those names are derived from the `test` job's matrix (`python-version` ×
+`group`). Any change to shard count, shard naming, or lane topology therefore
+*also* requires a branch-protection edit, and an edit that is forgotten leaves
+either a permanently pending required check (the old name never reports) or a
+silently unenforced one (the new shard is not required). ROB-1294 builds the
+two pieces a later change needs so that topology can move behind one fixed
+name:
+
+| piece | file | what it is |
+|---|---|---|
+| change classifier | `scripts/ci/classify_changes.py` | deterministic changed-path → lane mapping, fail-closed |
+| aggregate evaluator | `scripts/ci/aggregate_required.py` | fixed-name gate over the required children's results |
+| workflow wiring | `.github/workflows/test.yml` (`change-classifier`, `ci-required`) | runs both on every PR/push run |
+
+## 2. Change classifier contract
+
+Invoked as `python3 scripts/ci/classify_changes.py` (stdlib only, no
+dependency install). It reads `$CLASSIFY_BASE_SHA` / `$CLASSIFY_HEAD_SHA` (or
+`--base-sha` / `--head-sha`, or a `--name-status-file` for offline use) and
+emits a JSON report plus `$GITHUB_OUTPUT` keys.
+
+There are exactly three outcomes, and none of them is "run less because
+something went wrong":
+
+| outcome | exit | when |
+|---|---|---|
+| `classified` | 0 | every changed path mapped to a known lane, and every change was an add or a modify |
+| `run_all` | 0 | any unknown path, any rename/copy/delete/type-change/unmerged path, any shared CI/config/test-infrastructure file, an empty change set, or an absent base SHA |
+| `error` | **1** | a head SHA that was not supplied, a supplied SHA that stays unresolvable after `git fetch` (shallow/incomplete history), a failing `git` invocation, or a malformed `--name-status` record |
+
+Lanes and the jobs each one implies:
+
+| lane | example paths | jobs |
+|---|---|---|
+| `docs` | `docs/**`, `*.md` | *(none)* |
+| `app` | `app/**` | `lint`, `test`, `taskiq-smoke`, `security` |
+| `tests` | `tests/**` | `lint`, `test` |
+| `research` | `research/**`, `research_contracts/**` | `lint`, `research` |
+| `scripts` | `scripts/**` (except `scripts/ci/**`) | `lint`, `test` |
+| `frontend` | `frontend/**` | `frontend` |
+| `migrations` | `alembic/**` | `lint`, `test` |
+| `config` | `config/**` | `lint`, `test` |
+| `ci_shared` | `.github/**`, `scripts/ci/**`, `pyproject.toml`, `uv.lock`, `Makefile`, `.test_durations`, `tests/conftest.py`, `tests/_socket_guard*.py`, `env.example`, `scripts/setup-test-env.sh`, `alembic.ini`, `codecov.yml` | **forces `run_all`** |
+| `unknown` | anything unmatched | **forces `run_all`** |
+
+Two design points that look conservative and are meant to be:
+
+- A rename inside a single lane still forces `run_all`. The pre-image path is
+  part of the blast radius and `--name-status` gives no guarantee the two
+  sides belong to the same lane's test surface.
+- The error path still writes `run_all=true` into `$GITHUB_OUTPUT` before
+  exiting 1, so a consumer reading a partially written output file cannot
+  infer reduced coverage from a crashed classifier.
+
+## 3. `ci-required` aggregate contract
+
+`ci-required` declares `if: always()` and
+`needs: [lint, test, taskiq-smoke, change-classifier]`. `always()` is
+load-bearing: a job with no `if:` is *skipped* when a `needs:` child fails, and
+a required check that disappears on failure is a green merge button.
+
+`scripts/ci/aggregate_required.py` evaluates `toJSON(needs)`:
+
+| child result | verdict |
+|---|---|
+| `success` | pass |
+| `skipped` | pass **only** with `--authorize-skip <name>`; red otherwise |
+| `failure` | red |
+| `cancelled` | red |
+| absent from the payload | red (`missing`) |
+| any other string, `""`, `null`, a missing `result` key | red (`unexpected`) |
+| present in the payload but not `--required` | red (`undeclared`) |
+
+Malformed input — non-JSON, a non-object payload, an unset env var, a child
+whose value is neither a string nor an object with `result` — is red. The
+workflow passes **no** `--authorize-skip` and **no** `--allow-undeclared`
+today, so `ci-required` is green only when all four children report `success`.
+
+For the matrix `test` job, GitHub collapses all four shards into a single
+`needs.test.result`, which is `failure` if any shard failed. The aggregate
+therefore covers all six protected checks through three child entries.
+
+## 4. Verifying the shadow property
+
+`tests/ci/test_ci_required_workflow_contract.py` machine-checks that:
+
+- the six displayed check names, the `test` matrix shape, and the absence of
+  `if:`/`name:`/`needs:` on `lint`, `test` and `taskiq-smoke` are unchanged;
+- `ci-required` exists with a constant displayed name and `if: always()`;
+- its `--required` flags match its `needs:` list exactly;
+- no job other than `ci-required` lists `change-classifier` in `needs:`, no
+  `if:` expression anywhere mentions it, and `needs.change-classifier.outputs`
+  appears nowhere in the workflow.
+
+Run the whole ROB-1294 suite with:
+
+```bash
+uv run pytest tests/ci/ -q -ra
+actionlint .github/workflows/test.yml
+```
+
+## 5. Operator-only follow-up — OUT OF SCOPE for ROB-1294
+
+🔴 **Not performed by this PR.** ROB-1294 writes no GitHub repository setting
+and no branch-protection configuration. What follows is a description of the
+work, not an instruction to run it now.
+
+Making `ci-required` the sole stable required check would be, in order:
+
+1. Let `ci-required` run on `main` for a while and confirm it reports on every
+   PR and push run and that its verdict always matches the six checks it
+   summarises. Any divergence is a bug in the aggregate, not in the children.
+2. In branch protection, **add** `ci-required` to the required-checks list
+   while keeping the existing six. Merge a few PRs in that overlapping state.
+3. Only then **remove** the six from the required list, leaving `ci-required`
+   alone. Removing them first would leave a window with no enforcement at all.
+4. From that point the shard count, the matrix shape, and lane topology can
+   change without touching branch protection — provided every new job that
+   must gate a merge is added to `ci-required`'s `needs:` **and** to its
+   `--required` flags. The contract test in §4 fails if those two lists drift.
+5. Activating the classifier (letting `run_all=false` actually skip jobs) is a
+   separate change again, and it must keep the skipped jobs' *displayed names*
+   reporting — a required check that is skipped is not a passing check unless
+   it is passed to `--authorize-skip` deliberately.
+
+Ordering matters more than any individual step: at no point should the set of
+enforced checks be empty.

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI helper scripts (fail-closed checkers used by GitHub Actions jobs)."""

--- a/scripts/ci/aggregate_required.py
+++ b/scripts/ci/aggregate_required.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Fail-closed aggregator behind the stable ``ci-required`` check.
+
+ROB-1294 (R2B). Branch protection today names six checks directly (``lint``,
+``taskiq-smoke``, ``test (3.13, 1..4)``), so any change to shard count or lane
+topology is a branch-protection edit. This script is the evaluation half of a
+single fixed-name check that could later stand in for all of them.
+
+**This PR does not make ``ci-required`` a required check.** See
+``docs/runbooks/ci-required-aggregator.md`` for the operator-only cutover.
+
+Truth table (per required child)
+--------------------------------
+==================  ==============================================
+child result        verdict
+==================  ==============================================
+``success``         pass
+``skipped``         pass **only** if the name was passed to
+                    ``--authorize-skip``; otherwise red
+``failure``         red
+``cancelled``       red
+absent from input   red (``missing``)
+anything else       red (``unexpected``) -- includes ``""``, ``null``,
+                    ``neutral`` and any future GitHub result string
+==================  ==============================================
+
+A child present in the input but not declared via ``--required`` is also red
+(``undeclared``): that means the workflow's ``needs:`` list and this script's
+required list have drifted apart, and drift is exactly what a stable gate
+must not absorb quietly. ``--allow-undeclared`` opts out.
+
+Malformed input (non-JSON, non-object, a child whose value is neither a
+string nor an object carrying ``result``) is red, never green.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Child results that are individually acceptable without an explicit
+#: authorization. Deliberately a one-element set.
+PASSING_RESULTS: frozenset[str] = frozenset({"success"})
+
+#: Results we recognise but treat as red unless authorized.
+KNOWN_RESULTS: frozenset[str] = frozenset(
+    {"success", "failure", "cancelled", "skipped"}
+)
+
+
+class AggregateError(RuntimeError):
+    """Malformed input. Always red."""
+
+
+@dataclass
+class ChildVerdict:
+    name: str
+    result: str | None
+    status: str  # pass | failure | cancelled | unauthorized_skip | missing
+    # | unexpected | undeclared
+    note: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "pass"
+
+
+@dataclass
+class AggregateVerdict:
+    children: list[ChildVerdict] = field(default_factory=list)
+
+    @property
+    def failing(self) -> list[ChildVerdict]:
+        return [child for child in self.children if not child.ok]
+
+    @property
+    def passed(self) -> bool:
+        return not self.failing
+
+    @property
+    def result(self) -> str:
+        return "pass" if self.passed else "fail"
+
+
+def _extract_result(name: str, raw: object) -> str | None:
+    """Pull the ``result`` string out of one ``needs.<job>`` value."""
+
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, Mapping):
+        if "result" not in raw:
+            return None
+        value = raw["result"]
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise AggregateError(
+                f"child {name!r} has a non-string result {value!r}; refusing to guess."
+            )
+        return value
+    raise AggregateError(
+        f"child {name!r} has an unsupported shape {type(raw).__name__}; expected "
+        "an object with a `result` field or a bare result string."
+    )
+
+
+def evaluate(
+    results: Mapping[str, object],
+    required: Sequence[str],
+    authorized_skips: Iterable[str] = (),
+    *,
+    allow_undeclared: bool = False,
+) -> AggregateVerdict:
+    """Apply the truth table above. Pure: no IO, no environment."""
+
+    authorized = set(authorized_skips)
+    unknown_authorized = authorized - set(required)
+    if unknown_authorized:
+        raise AggregateError(
+            "--authorize-skip names jobs that are not required: "
+            f"{sorted(unknown_authorized)}"
+        )
+
+    verdict = AggregateVerdict()
+    for name in required:
+        if name not in results:
+            verdict.children.append(
+                ChildVerdict(
+                    name=name,
+                    result=None,
+                    status="missing",
+                    note="declared required but absent from the results payload",
+                )
+            )
+            continue
+        result = _extract_result(name, results[name])
+        if result in PASSING_RESULTS:
+            verdict.children.append(ChildVerdict(name, result, "pass"))
+        elif result == "skipped":
+            if name in authorized:
+                verdict.children.append(
+                    ChildVerdict(name, result, "pass", "authorized skip")
+                )
+            else:
+                verdict.children.append(
+                    ChildVerdict(
+                        name,
+                        result,
+                        "unauthorized_skip",
+                        "skipped without --authorize-skip; a skipped required "
+                        "child is not coverage",
+                    )
+                )
+        elif result == "failure":
+            verdict.children.append(ChildVerdict(name, result, "failure"))
+        elif result == "cancelled":
+            verdict.children.append(
+                ChildVerdict(
+                    name, result, "cancelled", "cancelled is not a passing result"
+                )
+            )
+        else:
+            verdict.children.append(
+                ChildVerdict(
+                    name,
+                    result,
+                    "unexpected",
+                    f"unrecognised result {result!r}; known results are "
+                    f"{sorted(KNOWN_RESULTS)}",
+                )
+            )
+
+    if not allow_undeclared:
+        for name in sorted(set(results) - set(required)):
+            verdict.children.append(
+                ChildVerdict(
+                    name=name,
+                    result=_extract_result(name, results[name]),
+                    status="undeclared",
+                    note="present in the results payload but not declared "
+                    "--required; the workflow `needs:` list and the required "
+                    "list have drifted",
+                )
+            )
+
+    return verdict
+
+
+def load_results(args: argparse.Namespace) -> Mapping[str, object]:
+    sources = [
+        bool(args.results_json),
+        bool(args.results_env),
+        bool(args.results_file),
+    ]
+    if sum(sources) != 1:
+        raise AggregateError(
+            "exactly one of --results-json / --results-env / --results-file is "
+            "required."
+        )
+    if args.results_json:
+        payload = args.results_json
+        origin = "--results-json"
+    elif args.results_env:
+        origin = f"${args.results_env}"
+        raw = os.environ.get(args.results_env)
+        if raw is None:
+            raise AggregateError(f"environment variable {origin} is not set.")
+        payload = raw
+    else:
+        origin = str(args.results_file)
+        payload = Path(args.results_file).read_text(encoding="utf-8")
+
+    if not payload.strip():
+        raise AggregateError(f"{origin} is empty; refusing to treat that as green.")
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise AggregateError(f"{origin} is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise AggregateError(
+            f"{origin} must decode to an object mapping job name -> result, got "
+            f"{type(parsed).__name__}."
+        )
+    return parsed
+
+
+def _summary_lines(report: Mapping[str, object]) -> list[str]:
+    lines = [
+        f"### ci-required aggregate: **{str(report.get('result', '')).upper()}**",
+        "",
+        "| child | result | verdict | note |",
+        "|---|---|---|---|",
+    ]
+    children = report.get("children")
+    if isinstance(children, list):
+        for child in children:
+            if not isinstance(child, dict):
+                continue
+            lines.append(
+                f"| `{child.get('name')}` | `{child.get('result')}` | "
+                f"`{child.get('status')}` | {child.get('note') or ''} |"
+            )
+    if report.get("error"):
+        lines += ["", f"**error:** `{report['error']}`"]
+    return lines
+
+
+def _write_step_summary(lines: Iterable[str]) -> None:
+    target = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not target:
+        return
+    with open(target, "a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-json", help="inline JSON results payload")
+    parser.add_argument(
+        "--results-env", help="name of an env var holding the JSON payload"
+    )
+    parser.add_argument("--results-file", help="file holding the JSON payload")
+    parser.add_argument(
+        "--required",
+        action="append",
+        default=[],
+        help="a required child job name (repeatable)",
+    )
+    parser.add_argument(
+        "--authorize-skip",
+        action="append",
+        default=[],
+        help="a required child whose `skipped` result is explicitly acceptable "
+        "(repeatable). Everything else that is skipped is red.",
+    )
+    parser.add_argument(
+        "--allow-undeclared",
+        action="store_true",
+        help="do not fail on children present in the payload but not --required",
+    )
+    parser.add_argument("--json-out", help="write the machine-readable report here")
+    parser.add_argument(
+        "--summary", action="store_true", help="append a $GITHUB_STEP_SUMMARY table"
+    )
+    args = parser.parse_args(argv)
+
+    report: dict[str, object] = {
+        "result": "fail",
+        "required": list(args.required),
+        "authorized_skips": sorted(set(args.authorize_skip)),
+        "children": [],
+        "failing": [],
+        "error": None,
+    }
+    exit_code = 1
+
+    try:
+        if not args.required:
+            raise AggregateError(
+                "no --required job names given; refusing to run an aggregate "
+                "that vacuously passes."
+            )
+        results = load_results(args)
+        verdict = evaluate(
+            results,
+            args.required,
+            args.authorize_skip,
+            allow_undeclared=args.allow_undeclared,
+        )
+        report["children"] = [
+            {
+                "name": child.name,
+                "result": child.result,
+                "status": child.status,
+                "note": child.note,
+            }
+            for child in verdict.children
+        ]
+        report["failing"] = [child.name for child in verdict.failing]
+        report["result"] = verdict.result
+        exit_code = 0 if verdict.passed else 1
+        if verdict.passed:
+            print(
+                "CI-REQUIRED: PASS — "
+                f"{len(verdict.children)} child result(s) all acceptable"
+            )
+        else:
+            detail = ", ".join(
+                f"{child.name}={child.result!r}({child.status})"
+                for child in verdict.failing
+            )
+            print(f"CI-REQUIRED: FAIL — {detail}", file=sys.stderr)
+    except (AggregateError, OSError) as exc:
+        report["result"] = "fail"
+        report["error"] = str(exc)
+        exit_code = 1
+        print(f"CI-REQUIRED: FAIL — {exc}", file=sys.stderr)
+
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    print(serialized)
+    if args.json_out:
+        Path(args.json_out).write_text(serialized + "\n", encoding="utf-8")
+    if args.summary:
+        _write_step_summary(_summary_lines(report))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/aggregate_required.py
+++ b/scripts/ci/aggregate_required.py
@@ -111,23 +111,61 @@ def _extract_result(name: str, raw: object) -> str | None:
     )
 
 
-def evaluate(
-    results: Mapping[str, object],
-    required: Sequence[str],
-    authorized_skips: Iterable[str] = (),
-    *,
-    allow_undeclared: bool = False,
-) -> AggregateVerdict:
-    """Apply the truth table above. Pure: no IO, no environment."""
+def _validate_names(kind: str, names: Sequence[str]) -> None:
+    """Reject blank and duplicate job names before anything can pass.
 
-    authorized = set(authorized_skips)
-    unknown_authorized = authorized - set(required)
+    argparse happily turns ``--required ''`` into a one-element list, which
+    used to satisfy the "refusing to run a vacuous aggregate" check while
+    naming no real job; and a repeated ``--required lint`` used to be counted
+    twice. Both are configuration errors, not children.
+    """
+
+    seen: set[str] = set()
+    for name in names:
+        if not isinstance(name, str) or not name.strip():
+            raise AggregateError(
+                f"{kind} contains a blank or whitespace-only job name "
+                f"({name!r}); a gate cannot be anchored to an unnamed job."
+            )
+        if name in seen:
+            raise AggregateError(
+                f"{kind} contains the duplicate job name {name!r}; each "
+                "required child must be declared exactly once."
+            )
+        seen.add(name)
+
+
+def validate_configuration(
+    required: Sequence[str], authorized_skips: Sequence[str] = ()
+) -> None:
+    """Fail closed on a malformed required/authorized-skip declaration."""
+
+    if not required:
+        raise AggregateError(
+            "no --required job names given; refusing to run an aggregate "
+            "that vacuously passes."
+        )
+    _validate_names("--required", required)
+    _validate_names("--authorize-skip", authorized_skips)
+    unknown_authorized = set(authorized_skips) - set(required)
     if unknown_authorized:
         raise AggregateError(
             "--authorize-skip names jobs that are not required: "
             f"{sorted(unknown_authorized)}"
         )
 
+
+def evaluate(
+    results: Mapping[str, object],
+    required: Sequence[str],
+    authorized_skips: Sequence[str] = (),
+    *,
+    allow_undeclared: bool = False,
+) -> AggregateVerdict:
+    """Apply the truth table above. Pure: no IO, no environment."""
+
+    validate_configuration(required, authorized_skips)
+    authorized = set(authorized_skips)
     verdict = AggregateVerdict()
     for name in required:
         if name not in results:
@@ -303,11 +341,9 @@ def main(argv: list[str] | None = None) -> int:
     exit_code = 1
 
     try:
-        if not args.required:
-            raise AggregateError(
-                "no --required job names given; refusing to run an aggregate "
-                "that vacuously passes."
-            )
+        # Validated before the payload is even read: a malformed gate
+        # declaration must never reach a verdict.
+        validate_configuration(args.required, args.authorize_skip)
         results = load_results(args)
         verdict = evaluate(
             results,

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -83,7 +83,19 @@ FORCING_LANES: frozenset[str] = frozenset({"ci_shared", "unknown"})
 CLASSIFIABLE_STATUSES: frozenset[str] = frozenset({"A", "M"})
 
 _NULL_SHA_RE = re.compile(r"\A0{7,64}\Z")
-_RENAME_STATUS_RE = re.compile(r"\A[RC]\d*\Z")
+
+# `git diff --raw`/`--name-status` status grammar: a single letter, optionally
+# followed by a similarity/dissimilarity score. Scores appear only for R and C
+# (similarity) and for M (dissimilarity, emitted for rewrites under -B). Any
+# other shape -- ``AA``, ``A1``, ``Z``, ``R1000``, an empty token -- is not
+# something git produces, so it is a hard failure rather than a token we
+# truncate to its first character and hope about.
+_STATUS_RE = re.compile(r"\A(?:[ADTUXB]|[RCM]\d{1,3})\Z|\A[RCM]\Z")
+_RENAME_STATUS_RE = re.compile(r"\A[RC]\d{0,3}\Z")
+#: A scored ``M`` is a *rewrite*, not an ordinary modify: git considers the
+#: file's content substantially replaced. It is graded with the conservative
+#: statuses so it forces ``run_all`` instead of being classified by path.
+_REWRITE_STATUS_RE = re.compile(r"\AM\d{1,3}\Z")
 
 # Ordered rule table. First match wins, so shared infrastructure must precede
 # the broad directory lanes it lives inside (``scripts/ci/`` before
@@ -118,7 +130,13 @@ _PREFIX_RULES: tuple[tuple[str, str], ...] = (
     ("config/", "config"),
 )
 
-_SUFFIX_RULES: tuple[tuple[str, str], ...] = ((".md", "docs"),)
+#: Suffix rules apply to **top-level files only** (no ``/`` in the path).
+#: A bare ``*.md`` rule would otherwise swallow every unmatched nested
+#: markdown path -- a fixture under a directory the prefix table does not know
+#: yet, or a directory whose name merely resembles a known one (git tracks
+#: ``" docs/only.md"``, with a leading space, as a *different* directory).
+#: Those must stay ``unknown`` and force ``run_all``.
+_TOP_LEVEL_SUFFIX_RULES: tuple[tuple[str, str], ...] = ((".md", "docs"),)
 
 
 class ClassifierError(RuntimeError):
@@ -152,20 +170,28 @@ class Classification:
 
 
 def classify_path(path: str) -> str:
-    """Map a repo-relative path to a lane name (``unknown`` when unmatched)."""
+    """Map a repo-relative path to a lane name (``unknown`` when unmatched).
 
-    normalized = path.strip()
-    if not normalized:
+    Matching is against the **literal** path git reported. Nothing is
+    stripped or otherwise normalized first: git happily tracks a file named
+    ``" docs/only.md"`` (leading space) and emits it verbatim under
+    ``--name-status -z``, and a classifier that trimmed it would answer
+    "docs-only, no jobs needed" for a path that is not in ``docs/`` at all.
+    An unmatched literal is ``unknown``, which forces ``run_all``.
+    """
+
+    if not path:
         return "unknown"
     for exact, lane in _EXACT_RULES:
-        if normalized == exact:
+        if path == exact:
             return lane
     for prefix, lane in _PREFIX_RULES:
-        if normalized.startswith(prefix):
+        if path.startswith(prefix):
             return lane
-    for suffix, lane in _SUFFIX_RULES:
-        if normalized.endswith(suffix):
-            return lane
+    if "/" not in path:
+        for suffix, lane in _TOP_LEVEL_SUFFIX_RULES:
+            if path.endswith(suffix):
+                return lane
     return "unknown"
 
 
@@ -227,11 +253,35 @@ def parse_name_status(payload: str) -> list[ChangeEntry]:
     a dropped record is exactly how coverage silently shrinks.
     """
 
-    fields = [item for item in payload.split("\0") if item != ""]
+    if payload == "":
+        return []
+    if not payload.endswith("\0"):
+        raise ClassifierError(
+            "git --name-status -z output is not NUL-terminated; the stream is "
+            "truncated and the missing records cannot be assumed harmless."
+        )
+    # A correctly terminated stream splits into the fields plus exactly one
+    # empty trailing sentinel. Any *other* empty field is an embedded NUL that
+    # would previously have been dropped, silently resynchronising the parser
+    # onto a different status/path pairing.
+    fields = payload.split("\0")[:-1]
+    for position, item in enumerate(fields):
+        if item == "":
+            raise ClassifierError(
+                f"git --name-status -z output has an empty field at position "
+                f"{position}; an embedded NUL means the record boundaries "
+                "cannot be trusted."
+            )
+
     entries: list[ChangeEntry] = []
     index = 0
     while index < len(fields):
         status = fields[index]
+        if not _STATUS_RE.match(status):
+            raise ClassifierError(
+                f"unrecognised git status token {status!r}: expected one of "
+                "A/C/D/M/R/T/U/X/B, optionally scored for R, C and M."
+            )
         if _RENAME_STATUS_RE.match(status):
             if index + 2 >= len(fields):
                 raise ClassifierError(
@@ -249,7 +299,11 @@ def parse_name_status(payload: str) -> list[ChangeEntry]:
             raise ClassifierError(
                 f"malformed record {status!r} in git output: expected a path"
             )
-        entries.append(ChangeEntry(status=status[0], path=fields[index + 1]))
+        # A scored M is a rewrite: keep the whole token so it lands outside
+        # CLASSIFIABLE_STATUSES and forces run_all, and so the report shows
+        # what git actually said rather than a truncated "M".
+        graded = status if _REWRITE_STATUS_RE.match(status) else status[0]
+        entries.append(ChangeEntry(status=graded, path=fields[index + 1]))
         index += 2
     return entries
 

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Deterministic changed-path classifier for CI resource lanes.
+
+ROB-1294 (R2B) ships this as **shadow output only**: nothing in
+``.github/workflows/test.yml`` consumes its outputs to skip a job. It exists so
+that a later change can move shard/lane topology behind a stable required
+check without inventing the fail-closed semantics at that moment.
+
+Fail-closed contract
+--------------------
+Two distinct non-green outcomes exist and neither is ever laundered into a
+"nothing to run" result:
+
+``run_all`` (exit 0, ``result="run_all"``)
+    The conservative answer. Emitted whenever the change set cannot be proven
+    to be confined to a known lane: an unknown/unclassified path, a rename, a
+    copy, a delete, a type change, an unmerged path, any shared CI/config/test
+    infrastructure file, an empty change set, or an absent base SHA.
+
+``error`` (exit 1, ``result="error"``)
+    A hard red. Emitted when the inputs themselves cannot be trusted: a head
+    SHA that was not supplied, a supplied SHA that cannot be resolved even
+    after a fetch (shallow/incomplete history), a failing ``git`` invocation,
+    or a malformed ``--name-status`` record.
+
+There is deliberately no third outcome in which coverage silently shrinks
+because something went wrong. ``--on-missing-base fail`` upgrades the absent
+base SHA case from ``run_all`` to ``error`` for callers that can guarantee a
+base.
+
+Run with ``-h`` for usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Lanes
+# --------------------------------------------------------------------------
+
+#: Every CI job name the classifier can address. ``run_all`` selects all of
+#: them; these strings are the vocabulary a later resource-lane change would
+#: bind actual job ``if:`` conditions to.
+ALL_JOBS: tuple[str, ...] = (
+    "lint",
+    "test",
+    "taskiq-smoke",
+    "security",
+    "research",
+    "frontend",
+)
+
+#: Lane -> jobs that lane needs. A lane mapping to an empty set is a lane that
+#: provably needs no CI job; only ``docs`` qualifies today.
+LANE_JOBS: dict[str, frozenset[str]] = {
+    "docs": frozenset(),
+    "app": frozenset({"lint", "test", "taskiq-smoke", "security"}),
+    "tests": frozenset({"lint", "test"}),
+    "research": frozenset({"lint", "research"}),
+    "scripts": frozenset({"lint", "test"}),
+    "frontend": frozenset({"frontend"}),
+    "migrations": frozenset({"lint", "test"}),
+    "config": frozenset({"lint", "test"}),
+}
+
+#: Pseudo-lanes that always force ``run_all``. They are reported so an operator
+#: can see *why* a run was not narrowed.
+FORCING_LANES: frozenset[str] = frozenset({"ci_shared", "unknown"})
+
+#: Change statuses (``git diff --name-status``) that are safe to classify by
+#: path. Everything else -- rename, copy, delete, type change, unmerged,
+#: unknown -- forces ``run_all`` because the *removed* side of the change can
+#: affect a lane the surviving path does not name.
+CLASSIFIABLE_STATUSES: frozenset[str] = frozenset({"A", "M"})
+
+_NULL_SHA_RE = re.compile(r"\A0{7,64}\Z")
+_RENAME_STATUS_RE = re.compile(r"\A[RC]\d*\Z")
+
+# Ordered rule table. First match wins, so shared infrastructure must precede
+# the broad directory lanes it lives inside (``scripts/ci/`` before
+# ``scripts/``, ``tests/conftest.py`` before ``tests/``).
+_EXACT_RULES: tuple[tuple[str, str], ...] = (
+    ("pyproject.toml", "ci_shared"),
+    ("uv.lock", "ci_shared"),
+    ("Makefile", "ci_shared"),
+    (".test_durations", "ci_shared"),
+    ("conftest.py", "ci_shared"),
+    ("tests/conftest.py", "ci_shared"),
+    ("tests/_socket_guard.py", "ci_shared"),
+    ("tests/_socket_guard_plugin.py", "ci_shared"),
+    ("alembic.ini", "ci_shared"),
+    ("env.example", "ci_shared"),
+    ("scripts/setup-test-env.sh", "ci_shared"),
+    ("codecov.yml", "ci_shared"),
+    (".codecov.yml", "ci_shared"),
+)
+
+_PREFIX_RULES: tuple[tuple[str, str], ...] = (
+    (".github/", "ci_shared"),
+    ("scripts/ci/", "ci_shared"),
+    ("docs/", "docs"),
+    ("app/", "app"),
+    ("tests/", "tests"),
+    ("research/", "research"),
+    ("research_contracts/", "research"),
+    ("scripts/", "scripts"),
+    ("frontend/", "frontend"),
+    ("alembic/", "migrations"),
+    ("config/", "config"),
+)
+
+_SUFFIX_RULES: tuple[tuple[str, str], ...] = ((".md", "docs"),)
+
+
+class ClassifierError(RuntimeError):
+    """A condition that must turn the classifier job red, never green."""
+
+
+@dataclass(frozen=True)
+class ChangeEntry:
+    """One record from ``git diff --name-status -z``."""
+
+    status: str
+    path: str
+    old_path: str | None = None
+
+
+@dataclass
+class Classification:
+    """The deterministic verdict for a change set."""
+
+    run_all: bool
+    reason: str
+    lanes: tuple[str, ...] = ()
+    jobs: tuple[str, ...] = ()
+    path_lanes: dict[str, str] = field(default_factory=dict)
+    forcing_paths: tuple[str, ...] = ()
+    changed_path_count: int = 0
+
+    @property
+    def result(self) -> str:
+        return "run_all" if self.run_all else "classified"
+
+
+def classify_path(path: str) -> str:
+    """Map a repo-relative path to a lane name (``unknown`` when unmatched)."""
+
+    normalized = path.strip()
+    if not normalized:
+        return "unknown"
+    for exact, lane in _EXACT_RULES:
+        if normalized == exact:
+            return lane
+    for prefix, lane in _PREFIX_RULES:
+        if normalized.startswith(prefix):
+            return lane
+    for suffix, lane in _SUFFIX_RULES:
+        if normalized.endswith(suffix):
+            return lane
+    return "unknown"
+
+
+def classify_entries(entries: Sequence[ChangeEntry]) -> Classification:
+    """Classify a change set. Pure: no git, no filesystem, no environment."""
+
+    if not entries:
+        return Classification(
+            run_all=True,
+            reason="empty_change_set",
+            lanes=("unknown",),
+            jobs=tuple(sorted(ALL_JOBS)),
+            changed_path_count=0,
+        )
+
+    path_lanes: dict[str, str] = {}
+    forcing: set[str] = set()
+
+    for entry in entries:
+        if entry.status not in CLASSIFIABLE_STATUSES:
+            # Rename/copy/delete/type-change/unmerged: the pre-image path is
+            # part of the blast radius, so no narrowing is defensible.
+            lane = "unknown"
+        else:
+            lane = classify_path(entry.path)
+        path_lanes[entry.path] = lane
+        if lane in FORCING_LANES:
+            forcing.add(entry.path)
+
+    lanes = tuple(sorted(set(path_lanes.values())))
+    if forcing:
+        return Classification(
+            run_all=True,
+            reason="forcing_path",
+            lanes=lanes,
+            jobs=tuple(sorted(ALL_JOBS)),
+            path_lanes=path_lanes,
+            forcing_paths=tuple(sorted(forcing)),
+            changed_path_count=len(path_lanes),
+        )
+
+    jobs: set[str] = set()
+    for lane in lanes:
+        jobs |= LANE_JOBS[lane]
+    return Classification(
+        run_all=False,
+        reason="classified",
+        lanes=lanes,
+        jobs=tuple(sorted(jobs)),
+        path_lanes=path_lanes,
+        changed_path_count=len(path_lanes),
+    )
+
+
+def parse_name_status(payload: str) -> list[ChangeEntry]:
+    """Parse NUL-separated ``git diff --name-status -z`` output.
+
+    Raises ClassifierError on a truncated record rather than dropping it --
+    a dropped record is exactly how coverage silently shrinks.
+    """
+
+    fields = [item for item in payload.split("\0") if item != ""]
+    entries: list[ChangeEntry] = []
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        if _RENAME_STATUS_RE.match(status):
+            if index + 2 >= len(fields):
+                raise ClassifierError(
+                    f"malformed rename/copy record {status!r} in git output: "
+                    "expected an old path and a new path"
+                )
+            entries.append(
+                ChangeEntry(
+                    status=status[0], path=fields[index + 2], old_path=fields[index + 1]
+                )
+            )
+            index += 3
+            continue
+        if index + 1 >= len(fields):
+            raise ClassifierError(
+                f"malformed record {status!r} in git output: expected a path"
+            )
+        entries.append(ChangeEntry(status=status[0], path=fields[index + 1]))
+        index += 2
+    return entries
+
+
+# --------------------------------------------------------------------------
+# git plumbing
+# --------------------------------------------------------------------------
+
+
+def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _resolve_commit(repo_root: Path, sha: str) -> None:
+    """Make ``sha`` locally reachable or raise. Never downgrades to a skip."""
+
+    probe = _run_git(repo_root, "cat-file", "-e", f"{sha}^{{commit}}")
+    if probe.returncode == 0:
+        return
+
+    fetch = _run_git(repo_root, "fetch", "--no-tags", "--depth", "100", "origin", sha)
+    if fetch.returncode == 0:
+        probe = _run_git(repo_root, "cat-file", "-e", f"{sha}^{{commit}}")
+        if probe.returncode == 0:
+            return
+
+    unshallow = _run_git(repo_root, "fetch", "--unshallow", "origin")
+    if unshallow.returncode == 0:
+        probe = _run_git(repo_root, "cat-file", "-e", f"{sha}^{{commit}}")
+        if probe.returncode == 0:
+            return
+
+    raise ClassifierError(
+        f"commit {sha!r} is not reachable locally and could not be fetched "
+        f"(git stderr: {fetch.stderr.strip() or unshallow.stderr.strip()!r}). "
+        "Incomplete history is a hard failure here, not a narrower run."
+    )
+
+
+def collect_entries(repo_root: Path, base_sha: str, head_sha: str) -> list[ChangeEntry]:
+    """Resolve both commits and return their change set."""
+
+    _resolve_commit(repo_root, base_sha)
+    _resolve_commit(repo_root, head_sha)
+    diff = _run_git(repo_root, "diff", "--name-status", "-z", f"{base_sha}..{head_sha}")
+    if diff.returncode != 0:
+        raise ClassifierError(
+            f"`git diff --name-status {base_sha}..{head_sha}` failed (exit "
+            f"{diff.returncode}): {diff.stderr.strip()!r}. This is a hard "
+            "failure, not a narrower run."
+        )
+    return parse_name_status(diff.stdout)
+
+
+def _is_absent_sha(value: str | None) -> bool:
+    """True for an empty value or git's all-zero 'no such commit' sentinel."""
+
+    if value is None:
+        return True
+    stripped = value.strip()
+    return not stripped or bool(_NULL_SHA_RE.match(stripped))
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+
+def build_outputs(classification: Classification) -> dict[str, str]:
+    """The flat ``key=value`` surface written to ``$GITHUB_OUTPUT``."""
+
+    selected = set(classification.jobs)
+    outputs: dict[str, str] = {
+        "result": classification.result,
+        "run_all": "true" if classification.run_all else "false",
+        "reason": classification.reason,
+        "lanes": ",".join(classification.lanes),
+        "jobs": ",".join(classification.jobs),
+        "changed_path_count": str(classification.changed_path_count),
+        # Shadow marker: ROB-1294 wires no job condition to these outputs.
+        "shadow": "true",
+    }
+    for job in ALL_JOBS:
+        key = "run_" + job.replace("-", "_")
+        outputs[key] = "true" if job in selected else "false"
+    return outputs
+
+
+def _write_github_output(outputs: Mapping[str, str]) -> None:
+    target = os.environ.get("GITHUB_OUTPUT")
+    if not target:
+        return
+    with open(target, "a", encoding="utf-8") as handle:
+        for key in sorted(outputs):
+            handle.write(f"{key}={outputs[key]}\n")
+
+
+def _write_step_summary(lines: Iterable[str]) -> None:
+    target = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not target:
+        return
+    with open(target, "a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line + "\n")
+
+
+def _summary_lines(report: Mapping[str, object]) -> list[str]:
+    lines = [
+        "### Change classifier (shadow — drives no job skip)",
+        "",
+        "| field | value |",
+        "|---|---|",
+    ]
+    for key in ("result", "reason", "run_all", "lanes", "jobs", "changed_path_count"):
+        lines.append(f"| {key} | `{report.get(key)}` |")
+    if report.get("error"):
+        lines.append(f"| error | `{report['error']}` |")
+    return lines
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-sha", help="base commit (else $CLASSIFY_BASE_SHA)")
+    parser.add_argument("--head-sha", help="head commit (else $CLASSIFY_HEAD_SHA)")
+    parser.add_argument(
+        "--name-status-file",
+        help="read `git diff --name-status -z` output from this file instead "
+        "of invoking git (used by tests and by callers that already have it)",
+    )
+    parser.add_argument(
+        "--on-missing-base",
+        choices=("run-all", "fail"),
+        default="run-all",
+        help="behaviour when no base SHA is supplied (default: run-all)",
+    )
+    parser.add_argument("--repo-root", default=".", help="repository root")
+    parser.add_argument("--json-out", help="write the machine-readable report here")
+    parser.add_argument(
+        "--github-output",
+        action="store_true",
+        help="append outputs to $GITHUB_OUTPUT",
+    )
+    parser.add_argument(
+        "--summary", action="store_true", help="append a $GITHUB_STEP_SUMMARY table"
+    )
+    args = parser.parse_args(argv)
+
+    report: dict[str, object] = {
+        "base_sha": None,
+        "head_sha": None,
+        "result": "error",
+        "reason": None,
+        "run_all": True,
+        "lanes": [],
+        "jobs": sorted(ALL_JOBS),
+        "path_lanes": {},
+        "forcing_paths": [],
+        "changed_path_count": 0,
+        "shadow": True,
+        "error": None,
+    }
+    outputs: dict[str, str] = {}
+    exit_code = 0
+
+    try:
+        if args.name_status_file:
+            payload = Path(args.name_status_file).read_text(encoding="utf-8")
+            classification = classify_entries(parse_name_status(payload))
+        else:
+            base_sha = args.base_sha or os.environ.get("CLASSIFY_BASE_SHA")
+            head_sha = args.head_sha or os.environ.get("CLASSIFY_HEAD_SHA")
+            if _is_absent_sha(head_sha):
+                raise ClassifierError(
+                    "no head commit given: pass --head-sha or set "
+                    "$CLASSIFY_HEAD_SHA. The classifier never falls back to a "
+                    "default ref such as HEAD or origin/main."
+                )
+            head_sha = str(head_sha).strip()
+            report["head_sha"] = head_sha
+            if _is_absent_sha(base_sha):
+                if args.on_missing_base == "fail":
+                    raise ClassifierError(
+                        "no base commit given (--base-sha / $CLASSIFY_BASE_SHA) "
+                        "and --on-missing-base=fail was requested."
+                    )
+                classification = Classification(
+                    run_all=True,
+                    reason="base_sha_missing",
+                    lanes=("unknown",),
+                    jobs=tuple(sorted(ALL_JOBS)),
+                )
+            else:
+                base_sha = str(base_sha).strip()
+                report["base_sha"] = base_sha
+                classification = classify_entries(
+                    collect_entries(Path(args.repo_root).resolve(), base_sha, head_sha)
+                )
+
+        report.update(
+            {
+                "result": classification.result,
+                "reason": classification.reason,
+                "run_all": classification.run_all,
+                "lanes": list(classification.lanes),
+                "jobs": list(classification.jobs),
+                "path_lanes": dict(sorted(classification.path_lanes.items())),
+                "forcing_paths": list(classification.forcing_paths),
+                "changed_path_count": classification.changed_path_count,
+            }
+        )
+        outputs = build_outputs(classification)
+    except (ClassifierError, OSError) as exc:
+        report["result"] = "error"
+        report["reason"] = "classifier_error"
+        report["error"] = str(exc)
+        # On error the outputs still say "run everything" so that any consumer
+        # reading a partially written $GITHUB_OUTPUT cannot infer a narrower
+        # run -- but the job itself is red regardless.
+        outputs = build_outputs(
+            Classification(
+                run_all=True,
+                reason="classifier_error",
+                lanes=("unknown",),
+                jobs=tuple(sorted(ALL_JOBS)),
+            )
+        )
+        outputs["result"] = "error"
+        print(f"CHANGE CLASSIFIER: ERROR — {exc}", file=sys.stderr)
+        exit_code = 1
+
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    print(serialized)
+    if args.json_out:
+        Path(args.json_out).write_text(serialized + "\n", encoding="utf-8")
+    if args.github_output:
+        _write_github_output(outputs)
+    if args.summary:
+        _write_step_summary(_summary_lines(report))
+
+    if exit_code == 0:
+        print(
+            f"CHANGE CLASSIFIER: {report['result'].upper()} — "  # type: ignore[union-attr]
+            f"reason={report['reason']} lanes={report['lanes']} "
+            f"jobs={report['jobs']} (shadow: drives no job skip)"
+        )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -488,6 +488,13 @@ def main(argv: list[str] | None = None) -> int:
                 )
             head_sha = str(head_sha).strip()
             report["head_sha"] = head_sha
+            repo_root = Path(args.repo_root).resolve()
+            # Resolve the supplied head BEFORE the absent-base short-circuit.
+            # An unresolvable supplied commit is a hard red whether or not a
+            # base was given; letting the missing-base branch return first
+            # reported an invalid head as a conservative green run_all and
+            # made it indistinguishable from a legitimate first-push head.
+            _resolve_commit(repo_root, head_sha)
             if _is_absent_sha(base_sha):
                 if args.on_missing_base == "fail":
                     raise ClassifierError(
@@ -504,7 +511,7 @@ def main(argv: list[str] | None = None) -> int:
                 base_sha = str(base_sha).strip()
                 report["base_sha"] = base_sha
                 classification = classify_entries(
-                    collect_entries(Path(args.repo_root).resolve(), base_sha, head_sha)
+                    collect_entries(repo_root, base_sha, head_sha)
                 )
 
         report.update(

--- a/tests/ci/__init__.py
+++ b/tests/ci/__init__.py
@@ -1,0 +1,1 @@
+"""ROB-1294 CI gate helpers: change classifier + ci-required aggregator."""

--- a/tests/ci/test_change_classifier.py
+++ b/tests/ci/test_change_classifier.py
@@ -573,3 +573,128 @@ def test_a_real_trailing_space_filename_from_git_is_classified_literally(
     assert code == 0
     assert report["path_lanes"] == {"docs/only.md ": "docs"}
     assert report["run_all"] is False
+
+
+# --------------------------------------------------------------------------
+# ROB-1294 re-verifier P2 — an absent base must not suppress an invalid head.
+#
+# `main()` used to take the missing-base short-circuit before resolving the
+# supplied head, so an unresolvable head was reported as a conservative green
+# run_all and was indistinguishable from a legitimate first-push head.
+#
+# These repos deliberately have no `origin` remote, so `_resolve_commit`'s
+# fetch fallbacks fail locally: the tests stay network-0.
+# --------------------------------------------------------------------------
+
+UNRESOLVABLE_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def test_repo_fixture_has_no_remote_so_resolution_stays_offline(repo: Path) -> None:
+    """Pins the precondition the two reproducers below rely on."""
+
+    assert (
+        subprocess.run(
+            ["git", "remote"], cwd=repo, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        == ""
+    )
+
+
+def test_an_unresolvable_head_with_no_base_is_red_not_green_run_all(
+    repo: Path, tmp_path: Path
+) -> None:
+    code, report = _run_cli(repo, tmp_path, "--head-sha", UNRESOLVABLE_SHA)
+    assert code == 1
+    assert report["result"] == "error"
+    assert report["run_all"] is True
+    assert report["reason"] == "classifier_error"
+    assert "not reachable" in str(report["error"])
+
+
+def test_an_unresolvable_head_with_an_all_zero_base_is_red(
+    repo: Path, tmp_path: Path
+) -> None:
+    """`github.event.before` is 0*40 on a first push; that is exactly the
+    situation in which the invalid head used to be hidden."""
+
+    code, report = _run_cli(
+        repo, tmp_path, "--base-sha", "0" * 40, "--head-sha", UNRESOLVABLE_SHA
+    )
+    assert code == 1
+    assert report["result"] == "error"
+    assert report["run_all"] is True
+    assert "not reachable" in str(report["error"])
+
+
+def test_a_valid_head_with_no_base_is_still_conservative_green_run_all(
+    repo: Path, tmp_path: Path
+) -> None:
+    """The positive half of the contract must not regress."""
+
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--head-sha", head)
+    assert code == 0
+    assert report["result"] == "run_all"
+    assert report["reason"] == "base_sha_missing"
+    assert report["error"] is None
+
+
+def test_a_valid_head_with_an_all_zero_base_is_still_green_run_all(
+    repo: Path, tmp_path: Path
+) -> None:
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", "0" * 40, "--head-sha", head)
+    assert code == 0
+    assert report["result"] == "run_all"
+    assert report["reason"] == "base_sha_missing"
+
+
+def test_a_head_that_resolves_to_a_non_commit_object_is_red(
+    repo: Path, tmp_path: Path
+) -> None:
+    """A blob SHA exists locally but is not a commit; `cat-file -e <sha>^{commit}`
+    must reject it rather than accepting any resolvable object."""
+
+    blob = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=repo,
+        input="not a commit\n",
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert _git(repo, "cat-file", "-t", blob) == "blob"
+
+    code, report = _run_cli(repo, tmp_path, "--head-sha", blob)
+    assert code == 1
+    assert report["result"] == "error"
+    assert report["run_all"] is True
+
+
+def test_the_head_is_resolved_before_the_on_missing_base_fail_switch(
+    repo: Path, tmp_path: Path
+) -> None:
+    """Both paths are red; the head diagnosis is the more specific one."""
+
+    code, report = _run_cli(
+        repo,
+        tmp_path,
+        "--head-sha",
+        UNRESOLVABLE_SHA,
+        "--on-missing-base",
+        "fail",
+    )
+    assert code == 1
+    assert "not reachable" in str(report["error"])
+
+
+def test_an_offline_name_status_file_still_needs_no_sha_resolution(
+    tmp_path: Path,
+) -> None:
+    """`--name-status-file` remains a pure offline path."""
+
+    payload = tmp_path / "diff.txt"
+    payload.write_text("A\0docs/a.md\0", encoding="utf-8")
+    out = tmp_path / "report.json"
+    assert main(["--name-status-file", str(payload), "--json-out", str(out)]) == 0
+    assert json.loads(out.read_text(encoding="utf-8"))["lanes"] == ["docs"]

--- a/tests/ci/test_change_classifier.py
+++ b/tests/ci/test_change_classifier.py
@@ -1,0 +1,435 @@
+"""ROB-1294 — the change classifier must never shrink coverage by accident.
+
+The failure this suite exists to prevent is silent: a classifier that answers
+"only docs changed" for a change set it did not actually understand, and a
+later PR that wires job ``if:`` conditions to that answer. Every ambiguity
+here has exactly two legal outcomes -- ``run_all`` or a red job -- and the
+tests pin which one applies to which input.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.classify_changes import (
+    ALL_JOBS,
+    ChangeEntry,
+    Classification,
+    ClassifierError,
+    build_outputs,
+    classify_entries,
+    classify_path,
+    main,
+    parse_name_status,
+)
+
+# --------------------------------------------------------------------------
+# Pure lane classification
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_lane"),
+    [
+        # docs
+        ("docs/runbooks/ci-required-aggregator.md", "docs"),
+        ("README.md", "docs"),
+        ("CLAUDE.md", "docs"),
+        # app / tests / research / scripts
+        ("app/services/halt_detection.py", "app"),
+        ("tests/test_symbol_conversion.py", "tests"),
+        ("research/nautilus_scalping/rob974_features.py", "research"),
+        ("scripts/policy_table/adapters/kr.py", "scripts"),
+        ("frontend/invest/src/desktop/screener/x.tsx", "frontend"),
+        ("alembic/versions/1a2b3c4d5e6f_x.py", "migrations"),
+        ("config/trading_policy.yaml", "config"),
+        # shared CI/config/test infrastructure -> forces run_all
+        (".github/workflows/test.yml", "ci_shared"),
+        (".github/workflows/taskiq-smoke.sh", "ci_shared"),
+        ("scripts/ci/classify_changes.py", "ci_shared"),
+        ("scripts/setup-test-env.sh", "ci_shared"),
+        ("pyproject.toml", "ci_shared"),
+        ("uv.lock", "ci_shared"),
+        ("Makefile", "ci_shared"),
+        (".test_durations", "ci_shared"),
+        ("tests/conftest.py", "ci_shared"),
+        ("tests/_socket_guard_plugin.py", "ci_shared"),
+        ("env.example", "ci_shared"),
+        # unrecognised -> unknown, which also forces run_all
+        (".gitignore", "unknown"),
+        ("some_new_top_level_dir/thing.py", "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_classify_path_lane_table(path: str, expected_lane: str) -> None:
+    assert classify_path(path) == expected_lane
+
+
+def test_shared_infra_rules_win_over_the_directory_lane_they_live_in() -> None:
+    """`scripts/ci/**` and `tests/conftest.py` must not fall into their dirs."""
+
+    assert classify_path("scripts/ci/aggregate_required.py") == "ci_shared"
+    assert classify_path("scripts/other_tool.py") == "scripts"
+    assert classify_path("tests/conftest.py") == "ci_shared"
+    assert classify_path("tests/services/test_x.py") == "tests"
+
+
+# --------------------------------------------------------------------------
+# Change-set classification
+# --------------------------------------------------------------------------
+
+
+def _added(*paths: str) -> list[ChangeEntry]:
+    return [ChangeEntry(status="A", path=path) for path in paths]
+
+
+def test_docs_only_change_selects_no_ci_job() -> None:
+    result = classify_entries(_added("docs/a.md", "README.md"))
+    assert result.run_all is False
+    assert result.result == "classified"
+    assert result.lanes == ("docs",)
+    assert result.jobs == ()
+
+
+def test_app_only_change_selects_the_app_lane_jobs() -> None:
+    result = classify_entries(_added("app/services/x.py", "app/models/y.py"))
+    assert result.run_all is False
+    assert result.lanes == ("app",)
+    assert result.jobs == ("lint", "security", "taskiq-smoke", "test")
+
+
+def test_tests_only_change_selects_lint_and_test() -> None:
+    result = classify_entries(_added("tests/test_a.py"))
+    assert result.run_all is False
+    assert result.lanes == ("tests",)
+    assert result.jobs == ("lint", "test")
+
+
+def test_mixed_lanes_union_their_jobs() -> None:
+    result = classify_entries(_added("docs/a.md", "tests/test_a.py"))
+    assert result.run_all is False
+    assert result.lanes == ("docs", "tests")
+    assert result.jobs == ("lint", "test")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".github/workflows/test.yml",
+        "pyproject.toml",
+        "uv.lock",
+        "tests/conftest.py",
+        "scripts/ci/classify_changes.py",
+    ],
+)
+def test_shared_infrastructure_change_forces_run_all(path: str) -> None:
+    result = classify_entries(_added("docs/a.md", path))
+    assert result.run_all is True
+    assert result.reason == "forcing_path"
+    assert path in result.forcing_paths
+    assert result.jobs == tuple(sorted(ALL_JOBS))
+
+
+def test_unknown_path_forces_run_all_even_beside_a_known_docs_path() -> None:
+    result = classify_entries(_added("docs/a.md", "brand_new_dir/file.py"))
+    assert result.run_all is True
+    assert result.reason == "forcing_path"
+    assert result.forcing_paths == ("brand_new_dir/file.py",)
+
+
+@pytest.mark.parametrize("status", ["R", "C", "D", "T", "U", "X", "B"])
+def test_non_add_modify_statuses_force_run_all(status: str) -> None:
+    """A rename/delete's pre-image is part of the blast radius."""
+
+    entries = [ChangeEntry(status=status, path="docs/renamed.md", old_path="docs/a.md")]
+    result = classify_entries(entries)
+    assert result.run_all is True, status
+    assert result.reason == "forcing_path"
+    assert result.path_lanes["docs/renamed.md"] == "unknown"
+
+
+def test_rename_within_docs_still_forces_run_all() -> None:
+    """Both sides look like docs, and it is *still* run_all. Intentional."""
+
+    result = classify_entries(
+        [ChangeEntry(status="R", path="docs/new.md", old_path="docs/old.md")]
+    )
+    assert result.run_all is True
+
+
+def test_delete_of_an_app_file_forces_run_all() -> None:
+    result = classify_entries([ChangeEntry(status="D", path="app/services/gone.py")])
+    assert result.run_all is True
+
+
+def test_empty_change_set_is_run_all_not_nothing_to_do() -> None:
+    result = classify_entries([])
+    assert result.run_all is True
+    assert result.reason == "empty_change_set"
+    assert result.jobs == tuple(sorted(ALL_JOBS))
+
+
+# --------------------------------------------------------------------------
+# --name-status parsing
+# --------------------------------------------------------------------------
+
+
+def test_parse_name_status_handles_adds_modifies_and_renames() -> None:
+    payload = "A\0app/new.py\0M\0docs/a.md\0R100\0docs/old.md\0docs/new.md\0"
+    entries = parse_name_status(payload)
+    assert entries == [
+        ChangeEntry("A", "app/new.py"),
+        ChangeEntry("M", "docs/a.md"),
+        ChangeEntry("R", "docs/new.md", "docs/old.md"),
+    ]
+
+
+def test_parse_name_status_of_empty_payload_is_empty() -> None:
+    assert parse_name_status("") == []
+
+
+def test_parse_name_status_rejects_a_truncated_rename_record() -> None:
+    with pytest.raises(ClassifierError, match="malformed rename/copy record"):
+        parse_name_status("R100\0docs/old.md\0")
+
+
+def test_parse_name_status_rejects_a_status_with_no_path() -> None:
+    with pytest.raises(ClassifierError, match="malformed record"):
+        parse_name_status("A\0app/new.py\0M\0")
+
+
+# --------------------------------------------------------------------------
+# GitHub output surface
+# --------------------------------------------------------------------------
+
+
+def test_build_outputs_marks_shadow_and_emits_every_job_flag() -> None:
+    outputs = build_outputs(classify_entries(_added("docs/a.md")))
+    assert outputs["shadow"] == "true"
+    assert outputs["result"] == "classified"
+    assert outputs["run_all"] == "false"
+    for job in ALL_JOBS:
+        assert outputs["run_" + job.replace("-", "_")] == "false"
+
+
+def test_build_outputs_for_run_all_turns_every_job_flag_on() -> None:
+    outputs = build_outputs(
+        Classification(
+            run_all=True,
+            reason="forcing_path",
+            lanes=("unknown",),
+            jobs=tuple(sorted(ALL_JOBS)),
+        )
+    )
+    assert outputs["run_all"] == "true"
+    for job in ALL_JOBS:
+        assert outputs["run_" + job.replace("-", "_")] == "true"
+
+
+# --------------------------------------------------------------------------
+# git-backed CLI behaviour (self-contained temp repos; never this repo's own
+# history, which CI clones shallowly)
+# --------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "ci@example.invalid")
+    _git(path, "config", "user.name", "ROB-1294 test")
+    _git(path, "config", "commit.gpgsign", "false")
+    (path / "docs").mkdir()
+    (path / "docs" / "seed.md").write_text("seed\n", encoding="utf-8")
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "seed")
+    return path
+
+
+def _commit(repo_path: Path, relative: str, body: str, message: str) -> str:
+    target = repo_path / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    _git(repo_path, "add", "-A")
+    _git(repo_path, "commit", "-q", "-m", message)
+    return _git(repo_path, "rev-parse", "HEAD")
+
+
+def _run_cli(repo_path: Path, tmp_path: Path, *extra: str) -> tuple[int, dict]:
+    out = tmp_path / f"report-{len(list(tmp_path.iterdir()))}.json"
+    code = main(["--repo-root", str(repo_path), "--json-out", str(out), *extra])
+    return code, json.loads(out.read_text(encoding="utf-8"))
+
+
+def test_cli_classifies_a_real_docs_only_diff(repo: Path, tmp_path: Path) -> None:
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit(repo, "docs/new.md", "hello\n", "docs")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", base, "--head-sha", head)
+    assert code == 0
+    assert report["result"] == "classified"
+    assert report["run_all"] is False
+    assert report["lanes"] == ["docs"]
+    assert report["jobs"] == []
+    assert report["shadow"] is True
+
+
+def test_cli_run_alls_on_a_real_workflow_change(repo: Path, tmp_path: Path) -> None:
+    base = _git(repo, "rev-parse", "HEAD")
+    head = _commit(repo, ".github/workflows/test.yml", "name: t\n", "ci")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", base, "--head-sha", head)
+    assert code == 0
+    assert report["run_all"] is True
+    assert report["reason"] == "forcing_path"
+    assert report["forcing_paths"] == [".github/workflows/test.yml"]
+
+
+def test_cli_run_alls_on_a_real_rename(repo: Path, tmp_path: Path) -> None:
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "mv", "docs/seed.md", "docs/renamed.md")
+    _git(repo, "commit", "-q", "-m", "rename")
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", base, "--head-sha", head)
+    assert code == 0
+    assert report["run_all"] is True
+
+
+def test_cli_run_alls_on_a_real_delete(repo: Path, tmp_path: Path) -> None:
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "rm", "-q", "docs/seed.md")
+    _git(repo, "commit", "-q", "-m", "delete")
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", base, "--head-sha", head)
+    assert code == 0
+    assert report["run_all"] is True
+
+
+def test_cli_run_alls_when_base_equals_head(repo: Path, tmp_path: Path) -> None:
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", head, "--head-sha", head)
+    assert code == 0
+    assert report["run_all"] is True
+    assert report["reason"] == "empty_change_set"
+
+
+def test_cli_run_alls_when_the_base_sha_is_absent(repo: Path, tmp_path: Path) -> None:
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--head-sha", head)
+    assert code == 0
+    assert report["run_all"] is True
+    assert report["reason"] == "base_sha_missing"
+
+
+def test_cli_treats_the_all_zero_push_sentinel_as_an_absent_base(
+    repo: Path, tmp_path: Path
+) -> None:
+    """`github.event.before` is 0*40 on the first push of a new branch."""
+
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", "0" * 40, "--head-sha", head)
+    assert code == 0
+    assert report["reason"] == "base_sha_missing"
+
+
+def test_cli_can_be_told_to_fail_instead_on_an_absent_base(
+    repo: Path, tmp_path: Path
+) -> None:
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(
+        repo, tmp_path, "--head-sha", head, "--on-missing-base", "fail"
+    )
+    assert code == 1
+    assert report["result"] == "error"
+
+
+def test_cli_is_red_when_no_head_sha_is_given(
+    repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CLASSIFY_HEAD_SHA", raising=False)
+    monkeypatch.delenv("CLASSIFY_BASE_SHA", raising=False)
+    code, report = _run_cli(repo, tmp_path)
+    assert code == 1
+    assert report["result"] == "error"
+    assert "head commit" in str(report["error"])
+
+
+def test_cli_is_red_when_a_supplied_sha_is_unresolvable(
+    repo: Path, tmp_path: Path
+) -> None:
+    """Incomplete/shallow history is a hard failure, never a narrower run."""
+
+    head = _git(repo, "rev-parse", "HEAD")
+    missing = "0123456789abcdef0123456789abcdef01234567"
+    code, report = _run_cli(repo, tmp_path, "--base-sha", missing, "--head-sha", head)
+    assert code == 1
+    assert report["result"] == "error"
+    assert "not reachable" in str(report["error"])
+
+
+def test_cli_error_path_never_publishes_a_narrower_run(
+    repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even the red path writes run_all=true outputs, so no consumer can
+    read a partially written $GITHUB_OUTPUT and infer reduced coverage."""
+
+    github_output = tmp_path / "github_output"
+    github_output.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    head = _git(repo, "rev-parse", "HEAD")
+    code, _ = _run_cli(
+        repo,
+        tmp_path,
+        "--base-sha",
+        "0123456789abcdef0123456789abcdef01234567",
+        "--head-sha",
+        head,
+        "--github-output",
+    )
+    assert code == 1
+    emitted = dict(
+        line.split("=", 1)
+        for line in github_output.read_text(encoding="utf-8").splitlines()
+        if line
+    )
+    assert emitted["result"] == "error"
+    assert emitted["run_all"] == "true"
+    assert emitted["run_test"] == "true"
+
+
+def test_cli_reads_a_name_status_file_without_touching_git(tmp_path: Path) -> None:
+    payload = tmp_path / "diff.txt"
+    payload.write_text("A\0app/x.py\0", encoding="utf-8")
+    out = tmp_path / "report.json"
+    code = main(["--name-status-file", str(payload), "--json-out", str(out)])
+    assert code == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["lanes"] == ["app"]
+
+
+def test_cli_is_red_on_a_malformed_name_status_file(tmp_path: Path) -> None:
+    payload = tmp_path / "diff.txt"
+    payload.write_text("R100\0only/one/path\0", encoding="utf-8")
+    out = tmp_path / "report.json"
+    code = main(["--name-status-file", str(payload), "--json-out", str(out)])
+    assert code == 1
+    assert json.loads(out.read_text(encoding="utf-8"))["result"] == "error"
+
+
+def test_cli_is_red_on_a_missing_name_status_file(tmp_path: Path) -> None:
+    out = tmp_path / "report.json"
+    code = main(
+        ["--name-status-file", str(tmp_path / "nope.txt"), "--json-out", str(out)]
+    )
+    assert code == 1
+    assert json.loads(out.read_text(encoding="utf-8"))["result"] == "error"

--- a/tests/ci/test_change_classifier.py
+++ b/tests/ci/test_change_classifier.py
@@ -433,3 +433,143 @@ def test_cli_is_red_on_a_missing_name_status_file(tmp_path: Path) -> None:
     )
     assert code == 1
     assert json.loads(out.read_text(encoding="utf-8"))["result"] == "error"
+
+
+# --------------------------------------------------------------------------
+# ROB-1294 verifier P1 — laundering a malformed/odd change set into a narrow
+# green classification. Every case below produced `classified, jobs=()` before
+# the fix; each must now be run_all or red.
+# --------------------------------------------------------------------------
+
+
+def test_a_literal_leading_space_path_is_not_normalized_into_the_docs_lane() -> None:
+    """git tracks `" docs/only.md"` as a file in a directory named `" docs"`.
+
+    Stripping it first turned an unrecognised path into a green docs-only
+    classification with zero jobs.
+    """
+
+    assert classify_path(" docs/only.md") == "unknown"
+    result = classify_entries(parse_name_status("M\0 docs/only.md\0"))
+    assert result.run_all is True
+    assert result.forcing_paths == (" docs/only.md",)
+
+
+def test_a_trailing_space_path_inside_docs_stays_in_the_docs_lane() -> None:
+    """The literal path really is under `docs/`, so narrowing is honest."""
+
+    assert classify_path("docs/only.md ") == "docs"
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["snapshots/expected.md", "some_new_dir/notes.md", " docs/only.md"],
+)
+def test_a_nested_markdown_path_in_an_unknown_directory_is_unknown(path: str) -> None:
+    """The `*.md` suffix rule is top-level only.
+
+    A bare suffix rule would swallow any unmatched nested markdown path --
+    including a fixture a test reads -- and answer "docs, no jobs needed".
+    """
+
+    assert classify_path(path) == "unknown"
+
+
+@pytest.mark.parametrize("path", ["README.md", "CLAUDE.md", "AGENTS.md"])
+def test_top_level_markdown_is_still_docs(path: str) -> None:
+    assert classify_path(path) == "docs"
+
+
+def test_a_scored_modify_is_a_rewrite_and_forces_run_all() -> None:
+    """`M100` is git's dissimilarity score for a rewrite (emitted under -B).
+
+    It is valid git output, so it is not red -- but it is not an ordinary
+    modify either, and truncating it to "M" classified it by path.
+    """
+
+    entries = parse_name_status("M100\0docs/only.md\0")
+    assert entries == [ChangeEntry("M100", "docs/only.md")]
+    result = classify_entries(entries)
+    assert result.run_all is True
+    assert result.reason == "forcing_path"
+
+
+def test_an_embedded_extra_nul_is_red_not_silently_dropped() -> None:
+    """A dropped empty field resynchronises the parser onto wrong pairings."""
+
+    with pytest.raises(ClassifierError, match="empty field at position"):
+        parse_name_status("A\0docs/one.md\0\0M\0docs/two.md\0")
+
+
+def test_an_unterminated_stream_is_red() -> None:
+    with pytest.raises(ClassifierError, match="not NUL-terminated"):
+        parse_name_status("A\0docs/one.md")
+
+
+@pytest.mark.parametrize(
+    "token", ["AA", "Z", "A1", "R1000", "M1234", "1", "-", "m", "RR100"]
+)
+def test_a_status_token_outside_gits_grammar_is_red(token: str) -> None:
+    """Truncating an unrecognised token to its first character invented a
+    status git never emitted."""
+
+    with pytest.raises(ClassifierError, match="unrecognised git status token"):
+        parse_name_status(f"{token}\0docs/one.md\0")
+
+
+@pytest.mark.parametrize(
+    "token", ["A", "D", "M", "T", "U", "X", "B", "R", "C", "R100", "C75", "R9"]
+)
+def test_every_token_git_actually_emits_is_accepted(token: str) -> None:
+    payload = (
+        f"{token}\0docs/old.md\0docs/new.md\0"
+        if token[0] in {"R", "C"}
+        else f"{token}\0docs/one.md\0"
+    )
+    assert parse_name_status(payload)
+
+
+def test_a_real_leading_space_filename_from_git_forces_run_all(
+    repo: Path, tmp_path: Path
+) -> None:
+    """End-to-end against real `git diff --name-status -z` output."""
+
+    odd_dir = repo / " docs"
+    odd_dir.mkdir()
+    (odd_dir / "only.md").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "odd dir")
+    base = _git(repo, "rev-parse", "HEAD")
+    (odd_dir / "only.md").write_text("y\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "modify odd dir")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    raw = subprocess.run(
+        ["git", "diff", "--name-status", "-z", f"{base}..{head}"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert raw == "M\0 docs/only.md\0", repr(raw)
+
+    code, report = _run_cli(repo, tmp_path, "--base-sha", base, "--head-sha", head)
+    assert code == 0
+    assert report["run_all"] is True
+    assert report["forcing_paths"] == [" docs/only.md"]
+    assert report["jobs"] == sorted(ALL_JOBS)
+
+
+def test_a_real_trailing_space_filename_from_git_is_classified_literally(
+    repo: Path, tmp_path: Path
+) -> None:
+    base = _git(repo, "rev-parse", "HEAD")
+    (repo / "docs" / "only.md ").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "trailing space")
+    head = _git(repo, "rev-parse", "HEAD")
+    code, report = _run_cli(repo, tmp_path, "--base-sha", base, "--head-sha", head)
+    assert code == 0
+    assert report["path_lanes"] == {"docs/only.md ": "docs"}
+    assert report["run_all"] is False

--- a/tests/ci/test_ci_required_workflow_contract.py
+++ b/tests/ci/test_ci_required_workflow_contract.py
@@ -1,0 +1,246 @@
+"""ROB-1294 — static contract on `.github/workflows/test.yml`.
+
+Two things must stay true and are easy to break by accident:
+
+1. The six checks branch protection names today -- ``lint``,
+   ``taskiq-smoke``, ``test (3.13, 1..4)`` -- keep their displayed names,
+   their matrix shape and their (absent) ``if:`` conditions. Renaming any of
+   them silently turns a required check into "expected -- waiting for status"
+   forever.
+2. The new classifier stays **shadow**: no existing job's execution may
+   depend on it in this PR.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/test.yml"
+
+#: Branch-protection snapshot (verified 2026-07-28, unchanged by ROB-1294).
+REQUIRED_CHECK_NAMES = (
+    "lint",
+    "taskiq-smoke",
+    "test (3.13, 1)",
+    "test (3.13, 2)",
+    "test (3.13, 3)",
+    "test (3.13, 4)",
+)
+REQUIRED_JOB_IDS = ("lint", "taskiq-smoke", "test")
+
+AGGREGATE_JOB_ID = "ci-required"
+CLASSIFIER_JOB_ID = "change-classifier"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _displayed_names(job_id: str, job: dict[str, Any]) -> list[str]:
+    """Reproduce the check name GitHub displays for a job."""
+
+    label = job.get("name", job_id)
+    matrix = job.get("strategy", {}).get("matrix")
+    if not matrix:
+        return [label]
+    keys = list(matrix.keys())
+    return [
+        f"{label} ({', '.join(str(value) for value in combo)})"
+        for combo in itertools.product(*(matrix[key] for key in keys))
+    ]
+
+
+# --------------------------------------------------------------------------
+# The six required checks are untouched
+# --------------------------------------------------------------------------
+
+
+def test_required_check_names_are_exactly_the_protected_six(
+    workflow: dict[str, Any],
+) -> None:
+    names: list[str] = []
+    for job_id in REQUIRED_JOB_IDS:
+        names += _displayed_names(job_id, workflow["jobs"][job_id])
+    assert sorted(names) == sorted(REQUIRED_CHECK_NAMES)
+
+
+@pytest.mark.parametrize("job_id", REQUIRED_JOB_IDS)
+def test_required_jobs_carry_no_name_override(
+    workflow: dict[str, Any], job_id: str
+) -> None:
+    """A `name:` key would decouple the displayed check from the job id."""
+
+    assert "name" not in workflow["jobs"][job_id]
+
+
+@pytest.mark.parametrize("job_id", REQUIRED_JOB_IDS)
+def test_required_jobs_carry_no_if_condition(
+    workflow: dict[str, Any], job_id: str
+) -> None:
+    """They must run unconditionally; a conditional required check can hang."""
+
+    assert "if" not in workflow["jobs"][job_id]
+
+
+@pytest.mark.parametrize("job_id", REQUIRED_JOB_IDS)
+def test_required_jobs_declare_no_needs(workflow: dict[str, Any], job_id: str) -> None:
+    """ROB-1294 must not sequence the required jobs behind the classifier."""
+
+    assert "needs" not in workflow["jobs"][job_id]
+
+
+def test_test_job_matrix_shape_is_unchanged(workflow: dict[str, Any]) -> None:
+    assert workflow["jobs"]["test"]["strategy"]["matrix"] == {
+        "python-version": ["3.13"],
+        "group": [1, 2, 3, 4],
+    }
+
+
+# --------------------------------------------------------------------------
+# The aggregate exists and cannot disappear on failure
+# --------------------------------------------------------------------------
+
+
+def test_aggregate_job_exists_with_a_constant_displayed_name(
+    workflow: dict[str, Any],
+) -> None:
+    job = workflow["jobs"][AGGREGATE_JOB_ID]
+    assert job["name"] == AGGREGATE_JOB_ID
+    assert _displayed_names(AGGREGATE_JOB_ID, job) == [AGGREGATE_JOB_ID]
+    assert "matrix" not in job.get("strategy", {})
+
+
+def test_aggregate_job_runs_even_when_children_fail(
+    workflow: dict[str, Any],
+) -> None:
+    """Without `always()` the aggregate is skipped on any child failure."""
+
+    assert workflow["jobs"][AGGREGATE_JOB_ID]["if"] == "always()"
+
+
+def test_aggregate_job_needs_every_currently_required_job_and_the_classifier(
+    workflow: dict[str, Any],
+) -> None:
+    needs = workflow["jobs"][AGGREGATE_JOB_ID]["needs"]
+    assert set(needs) == {*REQUIRED_JOB_IDS, CLASSIFIER_JOB_ID}
+
+
+def test_aggregate_required_flags_match_its_needs_list(
+    workflow: dict[str, Any],
+) -> None:
+    """A `needs:` entry with no `--required` flag would be silently ignored."""
+
+    job = workflow["jobs"][AGGREGATE_JOB_ID]
+    script = "\n".join(step.get("run", "") for step in job["steps"] if step.get("run"))
+    tokens = script.replace("\\\n", " ").split()
+    declared = [
+        tokens[index + 1]
+        for index, token in enumerate(tokens)
+        if token == "--required" and index + 1 < len(tokens)
+    ]
+    assert sorted(declared) == sorted(job["needs"])
+
+
+def test_aggregate_authorizes_no_skips(workflow: dict[str, Any]) -> None:
+    job = workflow["jobs"][AGGREGATE_JOB_ID]
+    script = "\n".join(step.get("run", "") for step in job["steps"] if step.get("run"))
+    assert "--authorize-skip" not in script
+    assert "--allow-undeclared" not in script
+
+
+def test_aggregate_invokes_the_checked_in_aggregator_script(
+    workflow: dict[str, Any],
+) -> None:
+    job = workflow["jobs"][AGGREGATE_JOB_ID]
+    script = "\n".join(step.get("run", "") for step in job["steps"] if step.get("run"))
+    assert "scripts/ci/aggregate_required.py" in script
+    assert (WORKFLOW_PATH.parents[2] / "scripts/ci/aggregate_required.py").is_file()
+
+
+# --------------------------------------------------------------------------
+# The classifier is wired, and wired to nothing
+# --------------------------------------------------------------------------
+
+
+def test_classifier_job_exists_and_checks_out_full_history(
+    workflow: dict[str, Any],
+) -> None:
+    job = workflow["jobs"][CLASSIFIER_JOB_ID]
+    checkout = next(
+        step
+        for step in job["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout")
+    )
+    assert checkout["with"]["fetch-depth"] == 0
+
+
+def test_classifier_job_invokes_the_checked_in_classifier_script(
+    workflow: dict[str, Any],
+) -> None:
+    job = workflow["jobs"][CLASSIFIER_JOB_ID]
+    script = "\n".join(step.get("run", "") for step in job["steps"] if step.get("run"))
+    assert "scripts/ci/classify_changes.py" in script
+    assert (WORKFLOW_PATH.parents[2] / "scripts/ci/classify_changes.py").is_file()
+
+
+def test_no_job_other_than_the_aggregate_depends_on_the_classifier(
+    workflow: dict[str, Any],
+) -> None:
+    for job_id, job in workflow["jobs"].items():
+        if job_id == AGGREGATE_JOB_ID:
+            continue
+        needs = job.get("needs") or []
+        if isinstance(needs, str):
+            needs = [needs]
+        assert CLASSIFIER_JOB_ID not in needs, job_id
+
+
+def test_no_job_condition_references_the_classifier(
+    workflow: dict[str, Any],
+) -> None:
+    """The shadow guarantee: classifier outputs drive no skip in this PR."""
+
+    for job_id, job in workflow["jobs"].items():
+        condition = str(job.get("if", ""))
+        assert CLASSIFIER_JOB_ID not in condition, job_id
+        for step in job["steps"]:
+            assert CLASSIFIER_JOB_ID not in str(step.get("if", "")), job_id
+
+
+def test_classifier_outputs_are_never_read_by_an_expression(
+    workflow_text: str,
+) -> None:
+    assert f"needs.{CLASSIFIER_JOB_ID}.outputs" not in workflow_text
+
+
+# --------------------------------------------------------------------------
+# Nothing else about the workflow moved
+# --------------------------------------------------------------------------
+
+
+def test_workflow_triggers_are_unchanged(workflow: dict[str, Any]) -> None:
+    # PyYAML parses the bare key `on` as the boolean True.
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers == {
+        "push": {"branches": ["main", "develop"]},
+        "pull_request": {"branches": ["main", "develop"]},
+    }
+
+
+def test_concurrency_block_is_unchanged(workflow: dict[str, Any]) -> None:
+    assert workflow["concurrency"] == {
+        "group": "${{ github.workflow }}-${{ github.event.pull_request.number "
+        "|| github.ref }}",
+        "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
+    }

--- a/tests/ci/test_required_aggregator.py
+++ b/tests/ci/test_required_aggregator.py
@@ -17,6 +17,7 @@ from scripts.ci.aggregate_required import (
     AggregateError,
     evaluate,
     main,
+    validate_configuration,
 )
 
 REQUIRED = ["lint", "test", "taskiq-smoke", "change-classifier"]
@@ -267,3 +268,107 @@ def test_cli_report_records_every_child_verdict(tmp_path: Path) -> None:
         "taskiq-smoke": "pass",
         "change-classifier": "pass",
     }
+
+
+# --------------------------------------------------------------------------
+# ROB-1294 verifier P2 — a malformed gate declaration must never reach a
+# verdict. Both CLI cases below exited 0 with result=pass before the fix.
+# --------------------------------------------------------------------------
+
+
+def test_a_blank_required_name_is_a_configuration_error() -> None:
+    with pytest.raises(AggregateError, match="blank or whitespace-only"):
+        evaluate({"": {"result": "success"}}, [""])
+
+
+@pytest.mark.parametrize("name", ["", " ", "\t", "\n"])
+def test_every_blank_shape_of_required_name_is_rejected(name: str) -> None:
+    with pytest.raises(AggregateError, match="blank or whitespace-only"):
+        validate_configuration([name])
+
+
+def test_a_duplicate_required_name_is_a_configuration_error() -> None:
+    with pytest.raises(AggregateError, match="duplicate job name 'lint'"):
+        evaluate(_all_success(), ["lint", "lint", "test"])
+
+
+def test_a_blank_authorize_skip_name_is_a_configuration_error() -> None:
+    with pytest.raises(AggregateError, match="blank or whitespace-only"):
+        evaluate(_all_success(), REQUIRED, authorized_skips=[""])
+
+
+def test_a_duplicate_authorize_skip_name_is_a_configuration_error() -> None:
+    with pytest.raises(AggregateError, match="duplicate job name 'lint'"):
+        evaluate(_all_success(), REQUIRED, authorized_skips=["lint", "lint"])
+
+
+def test_an_empty_required_list_is_a_configuration_error() -> None:
+    with pytest.raises(AggregateError, match="vacuously"):
+        validate_configuration([])
+
+
+def test_validate_configuration_accepts_the_shipped_workflow_declaration() -> None:
+    validate_configuration(REQUIRED)
+
+
+def test_cli_is_red_on_a_blank_required_name(tmp_path: Path) -> None:
+    code, report = _cli(
+        tmp_path, "--results-json", '{"":{"result":"success"}}', "--required", ""
+    )
+    assert code == 1
+    assert report["result"] == "fail"
+    assert "blank or whitespace-only" in str(report["error"])
+
+
+def test_cli_is_red_on_a_duplicated_required_name(tmp_path: Path) -> None:
+    code, report = _cli(
+        tmp_path,
+        "--results-json",
+        json.dumps(_all_success()),
+        "--required",
+        "lint",
+        "--required",
+        "lint",
+        "--required",
+        "test",
+        "--required",
+        "taskiq-smoke",
+        "--required",
+        "change-classifier",
+    )
+    assert code == 1
+    assert report["result"] == "fail"
+    assert "duplicate job name 'lint'" in str(report["error"])
+
+
+def test_cli_is_red_on_a_blank_authorize_skip_name(tmp_path: Path) -> None:
+    code, report = _cli(
+        tmp_path,
+        "--results-json",
+        json.dumps(_all_success()),
+        *_required_flags(),
+        "--authorize-skip",
+        "",
+    )
+    assert code == 1
+    assert "blank or whitespace-only" in str(report["error"])
+
+
+def test_a_malformed_declaration_is_rejected_before_the_payload_is_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate declaration is validated first, so an unreadable payload
+    cannot mask -- or be masked by -- a bad required list."""
+
+    monkeypatch.delenv("CI_REQUIRED_NEEDS", raising=False)
+    code, report = _cli(
+        tmp_path,
+        "--results-env",
+        "CI_REQUIRED_NEEDS",
+        "--required",
+        "",
+        "--required",
+        "",
+    )
+    assert code == 1
+    assert "blank or whitespace-only" in str(report["error"])

--- a/tests/ci/test_required_aggregator.py
+++ b/tests/ci/test_required_aggregator.py
@@ -1,0 +1,269 @@
+"""ROB-1294 — the ci-required aggregate must have no green path to false.
+
+A stable required check is only worth having if every way a child can fail to
+produce coverage -- failure, cancellation, an unauthorized skip, a missing
+result, a result string GitHub has not shipped yet -- lands red. These tests
+are the truth table.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.aggregate_required import (
+    AggregateError,
+    evaluate,
+    main,
+)
+
+REQUIRED = ["lint", "test", "taskiq-smoke", "change-classifier"]
+
+
+def _needs(**results: object) -> dict[str, object]:
+    """Shape a `toJSON(needs)` payload."""
+
+    return {name: {"result": value, "outputs": {}} for name, value in results.items()}
+
+
+def _all_success() -> dict[str, object]:
+    return _needs(**dict.fromkeys(REQUIRED, "success"))
+
+
+# --------------------------------------------------------------------------
+# Truth table
+# --------------------------------------------------------------------------
+
+
+def test_all_children_successful_is_the_only_unconditional_pass() -> None:
+    verdict = evaluate(_all_success(), REQUIRED)
+    assert verdict.passed is True
+    assert verdict.result == "pass"
+    assert verdict.failing == []
+
+
+@pytest.mark.parametrize("child", REQUIRED)
+@pytest.mark.parametrize(
+    ("result", "expected_status"),
+    [
+        ("failure", "failure"),
+        ("cancelled", "cancelled"),
+        ("skipped", "unauthorized_skip"),
+        ("neutral", "unexpected"),
+        ("", "unexpected"),
+        ("SUCCESS", "unexpected"),
+        ("success ", "unexpected"),
+        (None, "unexpected"),
+    ],
+)
+def test_any_non_success_child_result_is_red(
+    child: str, result: object, expected_status: str
+) -> None:
+    payload = _all_success()
+    payload[child] = {"result": result, "outputs": {}}
+    verdict = evaluate(payload, REQUIRED)
+    assert verdict.passed is False
+    failing = {c.name: c.status for c in verdict.failing}
+    assert failing == {child: expected_status}
+
+
+@pytest.mark.parametrize("child", REQUIRED)
+def test_a_missing_child_result_is_red(child: str) -> None:
+    payload = _all_success()
+    del payload[child]
+    verdict = evaluate(payload, REQUIRED)
+    assert verdict.passed is False
+    assert [(c.name, c.status) for c in verdict.failing] == [(child, "missing")]
+
+
+def test_classifier_failure_alone_turns_the_aggregate_red() -> None:
+    payload = _all_success()
+    payload["change-classifier"] = {"result": "failure"}
+    verdict = evaluate(payload, REQUIRED)
+    assert verdict.passed is False
+
+
+def test_cancelled_child_is_red_even_when_every_other_child_passed() -> None:
+    payload = _all_success()
+    payload["test"] = {"result": "cancelled"}
+    verdict = evaluate(payload, REQUIRED)
+    assert verdict.passed is False
+    assert verdict.failing[0].status == "cancelled"
+
+
+def test_only_an_explicitly_authorized_skip_is_green() -> None:
+    payload = _all_success()
+    payload["taskiq-smoke"] = {"result": "skipped"}
+
+    assert evaluate(payload, REQUIRED).passed is False
+    authorized = evaluate(payload, REQUIRED, authorized_skips=["taskiq-smoke"])
+    assert authorized.passed is True
+    assert [c.note for c in authorized.children if c.name == "taskiq-smoke"] == [
+        "authorized skip"
+    ]
+
+
+def test_authorizing_a_skip_does_not_authorize_a_failure() -> None:
+    payload = _all_success()
+    payload["taskiq-smoke"] = {"result": "failure"}
+    verdict = evaluate(payload, REQUIRED, authorized_skips=["taskiq-smoke"])
+    assert verdict.passed is False
+
+
+def test_authorize_skip_for_a_non_required_job_is_a_configuration_error() -> None:
+    with pytest.raises(AggregateError, match="not required"):
+        evaluate(_all_success(), REQUIRED, authorized_skips=["security"])
+
+
+def test_empty_results_payload_fails_every_required_child() -> None:
+    verdict = evaluate({}, REQUIRED)
+    assert verdict.passed is False
+    assert {c.status for c in verdict.failing} == {"missing"}
+
+
+def test_an_undeclared_child_in_the_payload_is_red_by_default() -> None:
+    payload = _all_success()
+    payload["security"] = {"result": "success"}
+    verdict = evaluate(payload, REQUIRED)
+    assert verdict.passed is False
+    assert [(c.name, c.status) for c in verdict.failing] == [("security", "undeclared")]
+    assert evaluate(payload, REQUIRED, allow_undeclared=True).passed is True
+
+
+def test_a_bare_result_string_child_is_accepted() -> None:
+    payload: dict[str, object] = dict.fromkeys(REQUIRED, "success")
+    assert evaluate(payload, REQUIRED).passed is True
+
+
+@pytest.mark.parametrize("bad", [123, [1, 2], True])
+def test_a_child_with_an_unsupported_shape_raises(bad: object) -> None:
+    payload = _all_success()
+    payload["lint"] = bad
+    with pytest.raises(AggregateError, match="unsupported shape"):
+        evaluate(payload, REQUIRED)
+
+
+def test_a_child_object_with_a_non_string_result_raises() -> None:
+    payload = _all_success()
+    payload["lint"] = {"result": 0}
+    with pytest.raises(AggregateError, match="non-string result"):
+        evaluate(payload, REQUIRED)
+
+
+def test_a_child_object_without_a_result_key_is_unexpected_not_pass() -> None:
+    payload = _all_success()
+    payload["lint"] = {"outputs": {}}
+    verdict = evaluate(payload, REQUIRED)
+    assert verdict.passed is False
+    assert verdict.failing[0].status == "unexpected"
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _cli(tmp_path: Path, *extra: str) -> tuple[int, dict]:
+    out = tmp_path / f"report-{len(list(tmp_path.iterdir()))}.json"
+    code = main([*extra, "--json-out", str(out)])
+    return code, json.loads(out.read_text(encoding="utf-8"))
+
+
+def _required_flags() -> list[str]:
+    flags: list[str] = []
+    for name in REQUIRED:
+        flags += ["--required", name]
+    return flags
+
+
+def test_cli_exits_zero_only_when_every_child_succeeded(tmp_path: Path) -> None:
+    code, report = _cli(
+        tmp_path,
+        "--results-json",
+        json.dumps(_all_success()),
+        *_required_flags(),
+    )
+    assert code == 0
+    assert report["result"] == "pass"
+    assert report["failing"] == []
+
+
+def test_cli_exits_nonzero_on_a_failed_child(tmp_path: Path) -> None:
+    payload = _all_success()
+    payload["test"] = {"result": "failure"}
+    code, report = _cli(
+        tmp_path, "--results-json", json.dumps(payload), *_required_flags()
+    )
+    assert code == 1
+    assert report["result"] == "fail"
+    assert report["failing"] == ["test"]
+
+
+def test_cli_reads_the_results_from_an_environment_variable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CI_REQUIRED_NEEDS", json.dumps(_all_success()))
+    code, report = _cli(
+        tmp_path, "--results-env", "CI_REQUIRED_NEEDS", *_required_flags()
+    )
+    assert code == 0
+    assert report["result"] == "pass"
+
+
+def test_cli_is_red_when_the_results_env_var_is_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CI_REQUIRED_NEEDS", raising=False)
+    code, report = _cli(
+        tmp_path, "--results-env", "CI_REQUIRED_NEEDS", *_required_flags()
+    )
+    assert code == 1
+    assert "not set" in str(report["error"])
+
+
+@pytest.mark.parametrize("payload", ["", "   ", "not json", "[]", '"success"', "null"])
+def test_cli_is_red_on_a_malformed_results_payload(
+    tmp_path: Path, payload: str
+) -> None:
+    code, report = _cli(tmp_path, "--results-json", payload, *_required_flags())
+    assert code == 1
+    assert report["result"] == "fail"
+    assert report["error"]
+
+
+def test_cli_refuses_to_run_without_any_required_names(tmp_path: Path) -> None:
+    """An aggregate with an empty required list would pass vacuously."""
+
+    code, report = _cli(tmp_path, "--results-json", json.dumps(_all_success()))
+    assert code == 1
+    assert "vacuously" in str(report["error"])
+
+
+def test_cli_requires_exactly_one_results_source(tmp_path: Path) -> None:
+    code, report = _cli(
+        tmp_path,
+        "--results-json",
+        "{}",
+        "--results-file",
+        str(tmp_path / "x.json"),
+        *_required_flags(),
+    )
+    assert code == 1
+    assert "exactly one" in str(report["error"])
+
+
+def test_cli_report_records_every_child_verdict(tmp_path: Path) -> None:
+    payload = _all_success()
+    payload["lint"] = {"result": "cancelled"}
+    _, report = _cli(
+        tmp_path, "--results-json", json.dumps(payload), *_required_flags()
+    )
+    statuses = {child["name"]: child["status"] for child in report["children"]}
+    assert statuses == {
+        "lint": "cancelled",
+        "test": "pass",
+        "taskiq-smoke": "pass",
+        "change-classifier": "pass",
+    }


### PR DESCRIPTION
Linear: [ROB-1294 — CI R2B: stable required aggregator + change classifier (shadow)](https://linear.app/mgh3326/issue/ROB-1294/ci-r2b-stable-required-aggregator-change-classifier-shadow)

## Why

Branch protection names six checks directly — `lint`, `taskiq-smoke`, `test (3.13, 1)`…`test (3.13, 4)`. Those last four are derived from the `test` job's matrix, so any change to shard count or lane topology is *also* a branch-protection edit. A forgotten edit leaves either a permanently pending required check (the old name never reports) or a silently unenforced one (the new shard is not required).

This PR builds the two pieces a later change needs to move topology behind one fixed name. **It changes nothing that CI enforces today.**

## What

| file | what |
|---|---|
| `scripts/ci/classify_changes.py` | deterministic changed-path → lane classifier (stdlib only) |
| `scripts/ci/aggregate_required.py` | fixed-name gate evaluator over `toJSON(needs)` (stdlib only) |
| `.github/workflows/test.yml` | new `change-classifier` and `ci-required` jobs |
| `tests/ci/` | 152 tests — lane table, git-backed fixtures, aggregator truth table, static workflow contract |
| `docs/runbooks/ci-required-aggregator.md` | contracts + the operator-only cutover, explicitly marked out of scope |

### Classifier — three outcomes, none of which is "run less because something went wrong"

| outcome | exit | when |
|---|---|---|
| `classified` | 0 | every changed path mapped to a known lane, and every change was an add or a modify |
| `run_all` | 0 | unknown path, rename/copy/delete/type-change/unmerged path, shared CI/config/test infrastructure, empty change set, or absent base SHA |
| `error` | **1** | head SHA not supplied, a supplied SHA still unresolvable after `git fetch` (shallow/incomplete history), a failing `git` invocation, or a malformed `--name-status` record |

Two deliberately conservative choices: a rename *inside* one lane still forces `run_all` (the pre-image path is part of the blast radius), and the error path still writes `run_all=true` into `$GITHUB_OUTPUT` before exiting 1, so a consumer reading a partially written output file cannot infer reduced coverage from a crashed classifier.

### `ci-required` — aggregator truth table

`if: always()` is load-bearing: a job with no `if:` is *skipped* when a `needs:` child fails, and a required check that disappears on failure is a green merge button.

| child result | verdict |
|---|---|
| `success` | pass |
| `skipped` | pass **only** with `--authorize-skip <name>`; red otherwise |
| `failure` | red |
| `cancelled` | red |
| absent from payload | red (`missing`) |
| any other string, `""`, `null`, missing `result` key | red (`unexpected`) |
| present but not `--required` | red (`undeclared`) |

Malformed input — non-JSON, non-object payload, unset env var, unsupported child shape — is red. The workflow passes **no** `--authorize-skip` and **no** `--allow-undeclared`, so `ci-required` is green only when all four children report `success`. For the matrix `test` job GitHub collapses all four shards into one `needs.test.result`, so three child entries cover all six protected checks.

## Shadow guarantee

The classifier's outputs drive nothing. `tests/ci/test_ci_required_workflow_contract.py` machine-checks it: no job other than `ci-required` lists `change-classifier` in `needs:`, no `if:` expression anywhere mentions it, and `needs.change-classifier.outputs` appears nowhere in the workflow.

## Existing required checks: proof of zero change

The workflow edit is a **pure insertion** — 101 lines added, 0 deleted:

```
$ git diff --stat -- .github/workflows/test.yml
 .github/workflows/test.yml | 101 +++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 101 insertions(+)

$ git diff -U0 -- .github/workflows/test.yml | grep '^-' | grep -v '^---'
(no output — no deleted lines)
```

A YAML extraction of the displayed names, `name:` override, `if:`, matrix, `runs-on`, `needs`, `timeout-minutes` and step list for `lint` / `test` / `taskiq-smoke`, taken before and after the edit, diffs empty:

```
$ diff -u before.json after.json && echo "REQUIRED-CHECK DIFF: EMPTY"
REQUIRED-CHECK DIFF: EMPTY
```

Displayed names, unchanged: `lint`, `taskiq-smoke`, `test (3.13, 1)`, `test (3.13, 2)`, `test (3.13, 3)`, `test (3.13, 4)`.

## Verification (raw)

```
$ uv run ruff check app/ tests/ research/ scripts/
All checks passed!                                      ruff_check_exit=0

$ uv run ruff format --check app/ tests/ research/ scripts/
3935 files already formatted                            ruff_fmt_exit=0

$ uv run ty check app/ --error-on-warning
All checks passed!                                      ty_exit=0

$ uv run pytest scripts/merge_test_durations_test.py -q
5 passed in 0.07s                                       durations_exit=0

$ actionlint .github/workflows/test.yml
(no output)                                             actionlint_exit=0

$ uv run pytest tests/ci/ -q -ra
152 passed in 4.81s                                     ci_tests_exit=0

$ uv run pytest tests/ --collect-only -q
21002 tests collected in 88.38s

$ uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -q
3 passed in 7.55s
```

No skips, no failures, no xfails in the new suite.

## Out of scope / not done

- 🔴 **No GitHub repository or branch-protection setting was written.** `ci-required` is *not* a required check. The cutover procedure (add alongside the six → overlap → remove the six) is written up in `docs/runbooks/ci-required-aggregator.md` §5 as operator-only, and is explicitly not performed here.
- No job is skipped based on classifier output. No existing check renamed, no matrix changed, no `if:` semantics altered.
- No `cancel-in-progress` / concurrency change. No duration-freshness or call telemetry (ROB-1295), no shard manifests/planner, no resource lanes, no coverage extraction, no socket-guard change.
- No broker/order/live surface touched; no DB write, no scheduler or deploy registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
