### PR TITLE
feat(ROB-1293): JIT funding — deferred_with_condition + "입금 X원 시 실행 가능" 알림

### DIFF
--- a/app/services/funding_advisory/jit.py
+++ b/app/services/funding_advisory/jit.py
@@ -1,0 +1,107 @@
+"""Just-in-time funding disposition — derived label, never a cash input.
+
+Operator principle (§107): do not pre-fund.  Deposit only the cash a candidate
+actually needs, at the moment the order is confirmed.  A buy candidate that
+cleared every non-funding gate but is short on broker cash therefore must not
+be rejected; it stays open with the deposit amount attached.
+
+This module is pure (stdlib + Decimal): it consumes values that were already
+computed from broker-authoritative inputs and returns a disclosure block.
+
+Two invariants live here and are covered by tests:
+
+* The deposit amount ``X`` is the **candidate shortfall**, never the declared
+  external-cash total.  A larger declaration cannot shrink or grow ``X``.
+* Operator-declared cash is display evidence only.  Nothing returned by this
+  module is an available / required / shortfall / sizing / cap / eligibility
+  input, and no caller may route it back into one.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Literal
+
+from app.schemas.funding_advisory import canonical_decimal
+
+DEFERRED_WITH_CONDITION = "deferred_with_condition"
+FUNDABLE_NOW = "fundable_now"
+
+CONDITION_KIND = "operator_deposit_to_target_account"
+DEPOSIT_AMOUNT_BASIS = "candidate_shortfall"
+SATISFIED_BY = "target_broker_buying_power_reobservation"
+
+NEXT_STEP_DEPOSIT = "operator_deposit_then_reevaluate"
+NEXT_STEP_PROPOSAL = "existing_proposal_creation_and_approval_path"
+
+DeclaredCover = Literal["sufficient", "partial", "none"]
+
+
+def declared_cover(*, shortfall: Decimal, declared_total: Decimal) -> DeclaredCover:
+    """Classify how far declared external cash would go — display only."""
+
+    if declared_total <= 0 or shortfall <= 0:
+        return "none"
+    if declared_total >= shortfall:
+        return "sufficient"
+    return "partial"
+
+
+def build_jit_funding(
+    *,
+    shortfall: Decimal,
+    operational_gap: Decimal,
+    currency: str,
+    declared_total: Decimal,
+) -> dict[str, Any]:
+    """Return the derived JIT disposition for one evaluated candidate.
+
+    ``declared_total`` is the fresh, same-currency operator declaration sum.
+    It is echoed for disclosure and classified into ``declared_cover``; it is
+    never added to, subtracted from, or otherwise mixed into ``deposit_amount``.
+    """
+
+    common: dict[str, Any] = {
+        "rejected_for_insufficient_cash": False,
+        "creates_proposal": False,
+        "executes_money_movement": False,
+        "declared_cash_counted_toward_buying_power": False,
+        "declared_cash_is_display_evidence_only": True,
+    }
+    if shortfall <= 0:
+        return {
+            "disposition": FUNDABLE_NOW,
+            "condition": None,
+            "next_step": NEXT_STEP_PROPOSAL,
+            **common,
+        }
+    return {
+        "disposition": DEFERRED_WITH_CONDITION,
+        "condition": {
+            "kind": CONDITION_KIND,
+            "deposit_amount": canonical_decimal(shortfall),
+            "deposit_amount_basis": DEPOSIT_AMOUNT_BASIS,
+            "currency": currency,
+            "operational_gap_amount": canonical_decimal(operational_gap),
+            "declared_cover": declared_cover(
+                shortfall=shortfall, declared_total=declared_total
+            ),
+            "declared_total_disclosure_only": canonical_decimal(declared_total),
+            "satisfied_by": SATISFIED_BY,
+        },
+        "next_step": NEXT_STEP_DEPOSIT,
+        **common,
+    }
+
+
+__all__ = [
+    "CONDITION_KIND",
+    "DEFERRED_WITH_CONDITION",
+    "DEPOSIT_AMOUNT_BASIS",
+    "FUNDABLE_NOW",
+    "NEXT_STEP_DEPOSIT",
+    "NEXT_STEP_PROPOSAL",
+    "SATISFIED_BY",
+    "build_jit_funding",
+    "declared_cover",
+]

--- a/app/services/funding_advisory/service.py
+++ b/app/services/funding_advisory/service.py
@@ -22,6 +22,7 @@ from app.services.funding_advisory.contracts import (
 from app.services.funding_advisory.external_cash import (
     ExternalCashDeclarationService,
 )
+from app.services.funding_advisory.jit import build_jit_funding
 from app.services.funding_advisory.ranking import (
     build_reference_combination,
     compare_routes,
@@ -68,6 +69,24 @@ def _thread_key(event: FundingCandidateEvent) -> str:
     return f"funding:{_canonical_hash(identity)}"
 
 
+def _fresh_rows(views: list[Any], *, currency: str) -> list[Any]:
+    """Keep only fresh, same-currency declaration heads."""
+
+    return [
+        view.current
+        for view in views
+        if view.status == "fresh"
+        and view.current is not None
+        and view.current.currency == currency
+    ]
+
+
+def _declared_total(rows: list[Any]) -> Decimal:
+    """Sum declared amounts. Display evidence only -- never a buying-power input."""
+
+    return sum((row.amount for row in rows), start=Decimal("0"))
+
+
 def _unknown_route(
     route_id: str,
     label: str,
@@ -111,25 +130,33 @@ class FundingAdvisoryService:
             session
         )
 
-    async def _routes(
-        self,
-        event: FundingCandidateEvent,
-        *,
-        shortfall: Decimal,
-        now: datetime,
-    ) -> list[FundingRoute]:
+    async def _fresh_declared_rows(
+        self, event: FundingCandidateEvent, *, now: datetime
+    ) -> list[Any]:
+        """Fresh, same-currency operator declarations — read once per evaluation."""
+
         external_views = await self._external_cash.list_current(
             owner_user_id=event.evidence.owner_user_id,
             now=now,
         )
-        external_rows = [
-            view.current
-            for view in external_views
-            if view.status == "fresh"
-            and view.current is not None
-            and view.current.currency == event.evidence.currency
-        ]
-        declared_total = sum((row.amount for row in external_rows), start=Decimal("0"))
+        return _fresh_rows(external_views, currency=event.evidence.currency)
+
+    async def _declared_total_for(
+        self, *, owner_user_id: int, currency: str, now: datetime
+    ) -> Decimal:
+        views = await self._external_cash.list_current(
+            owner_user_id=owner_user_id, now=now
+        )
+        return _declared_total(_fresh_rows(views, currency=currency))
+
+    def _routes(
+        self,
+        event: FundingCandidateEvent,
+        *,
+        shortfall: Decimal,
+        external_rows: list[Any],
+    ) -> list[FundingRoute]:
+        declared_total = _declared_total(external_rows)
         if declared_total > 0:
             external = FundingRoute(
                 route_id="EXTERNAL_PARKING_KRW",
@@ -246,9 +273,21 @@ class FundingAdvisoryService:
                     ),
                     "reserved_cash": canonical_decimal(assessment.reserved_cash),
                     "operational_gap": canonical_decimal(operational_gap),
+                    # JIT (S107): the candidate is fundable from broker cash alone.
+                    # The handoff is to the existing create/approval path -- this
+                    # service still creates no proposal and moves no money.
+                    "jit_funding": build_jit_funding(
+                        shortfall=shortfall,
+                        operational_gap=operational_gap,
+                        currency=assessment.currency,
+                        declared_total=Decimal("0"),
+                    ),
                 }
 
-            routes = await self._routes(event, shortfall=shortfall, now=current_now)
+            external_rows = await self._fresh_declared_rows(event, now=current_now)
+            routes = self._routes(
+                event, shortfall=shortfall, external_rows=external_rows
+            )
             combination = build_reference_combination(routes, shortfall=shortfall)
             evidence_payload = {
                 "gate": evidence.model_dump(mode="json"),
@@ -323,7 +362,12 @@ class FundingAdvisoryService:
                     now=current_now,
                 )
             await self._session.commit()
-            return self._projection(advisory, revision, delivery=delivery)
+            return self._projection(
+                advisory,
+                revision,
+                delivery=delivery,
+                declared_total=_declared_total(external_rows),
+            )
         except Exception:
             await self._session.rollback()
             raise
@@ -406,7 +450,12 @@ class FundingAdvisoryService:
             raise
 
     def _projection(
-        self, advisory: Any, revision: Any, *, delivery: dict[str, Any]
+        self,
+        advisory: Any,
+        revision: Any,
+        *,
+        delivery: dict[str, Any],
+        declared_total: Decimal,
     ) -> dict[str, Any]:
         gate = revision.evidence["gate"]
         return {
@@ -454,6 +503,15 @@ class FundingAdvisoryService:
             },
             "routes": revision.routes,
             "combination": revision.combination,
+            # JIT (S107): derived from the persisted revision plus the declared
+            # total. No new advisory state, column, or transition backs it --
+            # ``advisory.state`` stays active/resolved/superseded.
+            "jit_funding": build_jit_funding(
+                shortfall=Decimal(revision.shortfall),
+                operational_gap=Decimal(revision.operational_gap),
+                currency=advisory.currency,
+                declared_total=declared_total,
+            ),
             "safety": {
                 "advisory_only": True,
                 "executes_money_movement": False,
@@ -501,7 +559,16 @@ class FundingAdvisoryService:
             if delivery_row is not None
             else {"action": "none", "state": "not_claimed"}
         )
-        return self._projection(advisory, revision, delivery=delivery)
+        return self._projection(
+            advisory,
+            revision,
+            delivery=delivery,
+            declared_total=await self._declared_total_for(
+                owner_user_id=owner_user_id,
+                currency=advisory.currency,
+                now=datetime.now(UTC),
+            ),
+        )
 
     async def refresh_detail(
         self, *, advisory_id: UUID, owner_user_id: int, now: datetime
@@ -528,6 +595,9 @@ class FundingAdvisoryService:
         advisories = await self._repository.list_advisories(
             owner_user_id=owner_user_id, state=state, limit=limit
         )
+        views = await self._external_cash.list_current(
+            owner_user_id=owner_user_id, now=datetime.now(UTC)
+        )
         rows: list[dict[str, Any]] = []
         for advisory in advisories:
             revision = await self._repository.latest_revision(advisory.advisory_id)
@@ -537,6 +607,9 @@ class FundingAdvisoryService:
                         advisory,
                         revision,
                         delivery={"action": "none", "state": "not_evaluated"},
+                        declared_total=_declared_total(
+                            _fresh_rows(views, currency=advisory.currency)
+                        ),
                     )
                 )
         return rows

--- a/app/services/funding_advisory/telegram.py
+++ b/app/services/funding_advisory/telegram.py
@@ -27,6 +27,16 @@ CARD_HEADER = (
     "이 카드는 입금·환전·차입·매도를 실행하지 않습니다"
 )
 HANDOFF_LABEL = "경로 설명 · 이 화면에서 주문 안 만듦"
+# JIT (S107) fixed wording. ``X`` is the candidate shortfall, never the declared
+# external-cash total, and the card never claims the deposit already happened.
+JIT_DEPOSIT_HEADER = "JIT 조달 조건 (사전 입금 금지 · 필요한 만큼만)"
+JIT_DEPOSIT_BASIS = "X = 이 후보 부족분 · 선언 총액 아님"
+JIT_DECLARED_DISCLAIMER = "선언액은 매수력에 가산되지 않습니다 · 이 카드는 알림입니다"
+JIT_COVER_LABELS = {
+    "sufficient": "선언 여력으로 커버 가능",
+    "partial": "선언 여력 일부만 커버",
+    "none": "선언 여력 없음 (급여 등 미선언 자금 필요)",
+}
 
 
 @dataclass(frozen=True)
@@ -38,6 +48,31 @@ class FundingAdvisoryCard:
 def _amount(route: dict[str, Any]) -> str:
     value = route.get("route_fundable_amount")
     return str(value) if value is not None else "금액 미상"
+
+
+def render_jit_condition_lines(view: dict[str, Any]) -> list[str]:
+    """Render the "입금 X원 시 실행 가능" block, or nothing when not deferred."""
+
+    jit = view.get("jit_funding") or {}
+    condition = jit.get("condition")
+    if jit.get("disposition") != "deferred_with_condition" or not condition:
+        return []
+    currency = condition["currency"]
+    cover = JIT_COVER_LABELS.get(
+        condition.get("declared_cover", "none"), JIT_COVER_LABELS["none"]
+    )
+    return [
+        "",
+        JIT_DEPOSIT_HEADER,
+        f"입금 {condition['deposit_amount']} {currency} 시 실행 가능",
+        f"  {JIT_DEPOSIT_BASIS} · pending/reserved 포함 시 "
+        f"{condition['operational_gap_amount']} {currency}",
+        f"  선언 커버: {cover} "
+        f"(선언 총액 {condition['declared_total_disclosure_only']} {currency})",
+        f"  {JIT_DECLARED_DISCLAIMER}",
+        "  후보 상태: 기각 아님 · 조건부 보류(deferred_with_condition)",
+        "  입금 확인 뒤 재평가에서 제안 생성 · 기존 승인 경로 그대로",
+    ]
 
 
 def render_funding_advisory_card(view: dict[str, Any]) -> FundingAdvisoryCard:
@@ -57,6 +92,9 @@ def render_funding_advisory_card(view: dict[str, Any]) -> FundingAdvisoryCard:
         f"별도 reserved: {need['reserved_cash']} {target['currency']}",
         "pending/reserved 포함 운영상 gap: "
         f"{need['operational_gap_including_other_pending']} {target['currency']}",
+    ]
+    lines.extend(render_jit_condition_lines(view))
+    lines += [
         "",
         "조달 경로:",
     ]
@@ -225,7 +263,11 @@ async def deliver_claimed_advisory(
 __all__ = [
     "CARD_HEADER",
     "HANDOFF_LABEL",
+    "JIT_DECLARED_DISCLAIMER",
+    "JIT_DEPOSIT_BASIS",
+    "JIT_DEPOSIT_HEADER",
     "FundingAdvisoryCard",
     "deliver_claimed_advisory",
     "render_funding_advisory_card",
+    "render_jit_condition_lines",
 ]

--- a/docs/runbooks/funding-advisory.md
+++ b/docs/runbooks/funding-advisory.md
@@ -95,3 +95,50 @@ Telegram과 `/invest/funding`의 두 매도 경로는 다음 고정 문구를 �
 
 카드 버튼은 읽기 전용 URL뿐이며 callback이나 proposal create 동작이 없다. 외부현금
 폼의 submit은 append-only 선언만 만들며 돈을 이동시키지 않는다.
+
+## JIT 조달 — 조건부 보류와 알림 (§107차)
+
+운영자 원칙은 **사전 입금 금지**다. 정말 필요한 현금만, 체결(주문 확정) 시점에
+입금한다. 그래서 비-자금 gate를 전부 통과한 매수 후보가 broker 현금이 모자라다는
+이유만으로 **기각되지 않는다**. 후보는 조건과 함께 열려 있고, 조건은 카드로
+알린다.
+
+평가 결과에는 `jit_funding` 블록이 붙는다. 이 블록은 **파생 표시값**이다. 새 proposal
+상태, 새 테이블, 새 컬럼, 새 상태 전이가 없다. `funding_advisories.state`는 그대로
+`active` / `resolved` / `superseded` 셋뿐이며, `deferred_with_condition`은 저장되는
+값이 아니라 매 평가마다 계산되는 라벨이다.
+
+| shortfall | disposition | 다음 단계 |
+|---|---|---|
+| `> 0` | `deferred_with_condition` | `operator_deposit_then_reevaluate` |
+| `<= 0` | `fundable_now` | `existing_proposal_creation_and_approval_path` |
+
+### 입금 금액 X
+
+카드 문구는 `입금 X {통화} 시 실행 가능` 이고, **X는 이 후보의 shortfall**
+(`required_cash - target_buying_power`)이다. **선언 총액이 아니다.** 640,000원을
+선언해 두었어도 60,000원이 모자란 후보는 60,000원만 요구한다. 같은 계좌의 다른
+pending 매수와 reserved를 포함한 운영상 gap은 별도 줄로 항상 함께 공개한다.
+
+`declared_cover`(`sufficient` / `partial` / `none`)는 선언액이 X를 어디까지 덮는지를
+보여주는 **표시 분류**일 뿐이다. `none`이어도 후보는 여전히
+`deferred_with_condition`이다 — 급여처럼 아직 선언되지 않은 자금이 조건을 채울 수
+있기 때문이다.
+
+### 선언액은 여전히 매수력이 아니다
+
+`app/services/funding_advisory/jit.py`는 순수 모듈(stdlib + Decimal)이며 DB·broker·
+order 표면을 import하지 않는다. 선언액은 `deposit_amount`에 더해지지도 빼지지도
+않고, available / required / shortfall / sizing / cap / eligibility 어디에도 들어가지
+않는다. 이 계약은 뮤턴트로 재확인한다 — 선언액을 `target_buying_power`에 가산하거나
+`deposit_amount`를 `shortfall - declared_total` 또는 `declared_total`로 바꾸면
+`tests/services/funding_advisory/`가 RED가 된다.
+
+### 입금 확인 뒤
+
+입금은 선언 갱신으로 확인되지 않는다. 선언 갱신은 돈을 옮기지 않는다. 조달 완료는
+**target broker buying power 재관측**으로만 판정한다(`satisfied_by`). 상류가 새
+`FundingCandidateEvent`(갱신된 `target_buying_power`)로 재평가하면 shortfall이 0이
+되어 advisory가 `resolved`가 되고 `fundable_now`로 바뀐다. 그 뒤는 **기존 proposal
+create + 승인 경로 그대로**다. advisory는 어떤 경우에도 proposal을 만들지 않고
+주문을 내지 않는다(`creates_proposal: false`).

--- a/tests/services/funding_advisory/test_containment.py
+++ b/tests/services/funding_advisory/test_containment.py
@@ -103,3 +103,67 @@ def test_provenance_table_has_no_classification_or_sizing_columns() -> None:
     assert "quantity" not in link_model
     assert "notional" not in link_model
     assert "eligibility" not in link_model
+
+
+JIT_VOCABULARY = (
+    "jit_funding",
+    "deferred_with_condition",
+    "declared_total",
+    "build_jit_funding",
+)
+
+
+def test_jit_vocabulary_is_absent_from_order_decision_surfaces() -> None:
+    """The JIT disposition is a notification, never a buying-power input."""
+
+    for path in PROTECTED_ORDER_FILES:
+        text = path.read_text(encoding="utf-8")
+        for token in JIT_VOCABULARY:
+            assert token not in text, (path, token)
+
+
+def test_jit_module_is_pure_and_has_no_persistence_or_mutation() -> None:
+    path = ROOT / "app/services/funding_advisory/jit.py"
+    text = path.read_text(encoding="utf-8")
+    imported = imported_modules(path)
+
+    assert not any(
+        module.startswith(
+            (
+                "app.services.order_proposals",
+                "app.services.brokers",
+                "app.mcp_server",
+                "app.models",
+                "app.core.db",
+                "sqlalchemy",
+            )
+        )
+        for module in imported
+    ), imported
+    for forbidden in ("session", "commit(", "insert", "update", "await "):
+        assert forbidden not in text, forbidden
+
+
+def test_declared_total_never_reaches_the_shortfall_expression() -> None:
+    """``shortfall`` is required_cash - target_buying_power and nothing else."""
+
+    service_text = (ROOT / "app/services/funding_advisory/service.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'shortfall = max(required - target, Decimal("0"))' in service_text, (
+        "shortfall formula changed; re-verify the no-auto-add contract"
+    )
+    assert (
+        "operational_gap = max(\n"
+        "            required\n"
+        "            + assessment.other_pending_required\n"
+        "            + assessment.reserved_cash\n"
+        "            - target,\n"
+        '            Decimal("0"),\n'
+        "        )" in service_text
+    ), "operational gap formula changed; re-verify the no-auto-add contract"
+    for line in service_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("shortfall =", "operational_gap =", "required =")):
+            assert "declared" not in stripped, stripped

--- a/tests/services/funding_advisory/test_jit.py
+++ b/tests/services/funding_advisory/test_jit.py
@@ -1,0 +1,137 @@
+"""JIT funding disposition — deposit amount is the shortfall, never the declaration."""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.services.funding_advisory.jit import (
+    build_jit_funding,
+    declared_cover,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+JIT_MODULE = ROOT / "app/services/funding_advisory/jit.py"
+
+
+def jit(*, shortfall: str, declared: str, gap: str = "90000") -> dict:
+    return build_jit_funding(
+        shortfall=Decimal(shortfall),
+        operational_gap=Decimal(gap),
+        currency="KRW",
+        declared_total=Decimal(declared),
+    )
+
+
+@pytest.mark.unit
+def test_deposit_amount_is_the_candidate_shortfall_not_the_declared_total() -> None:
+    result = jit(shortfall="60000", declared="640000")
+
+    condition = result["condition"]
+    assert condition["deposit_amount"] == "60000"
+    assert condition["deposit_amount_basis"] == "candidate_shortfall"
+    assert condition["declared_total_disclosure_only"] == "640000"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "declared", ["0", "1", "59999", "60000", "60001", "640000", "999999999999"]
+)
+def test_deposit_amount_is_invariant_under_every_declared_total(declared: str) -> None:
+    """A larger or smaller declaration can never move X."""
+
+    baseline = jit(shortfall="60000", declared="0")["condition"]["deposit_amount"]
+
+    assert (
+        jit(shortfall="60000", declared=declared)["condition"]["deposit_amount"]
+        == baseline
+        == "60000"
+    )
+
+
+@pytest.mark.unit
+def test_operational_gap_is_disclosed_separately_and_is_not_the_deposit_amount() -> (
+    None
+):
+    condition = jit(shortfall="60000", declared="640000", gap="90000")["condition"]
+
+    assert condition["deposit_amount"] == "60000"
+    assert condition["operational_gap_amount"] == "90000"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("shortfall", "declared", "expected"),
+    [
+        ("60000", "640000", "sufficient"),
+        ("60000", "60000", "sufficient"),
+        ("60000", "59999", "partial"),
+        ("60000", "1", "partial"),
+        ("60000", "0", "none"),
+    ],
+)
+def test_declared_cover_is_display_classification_only(
+    shortfall: str, declared: str, expected: str
+) -> None:
+    assert (
+        declared_cover(shortfall=Decimal(shortfall), declared_total=Decimal(declared))
+        == expected
+    )
+    assert (
+        jit(shortfall=shortfall, declared=declared)["condition"]["declared_cover"]
+        == expected
+    )
+
+
+@pytest.mark.unit
+def test_cash_short_candidate_is_deferred_with_condition_and_never_rejected() -> None:
+    result = jit(shortfall="60000", declared="640000")
+
+    assert result["disposition"] == "deferred_with_condition"
+    assert result["rejected_for_insufficient_cash"] is False
+    assert result["next_step"] == "operator_deposit_then_reevaluate"
+    assert result["condition"]["kind"] == "operator_deposit_to_target_account"
+    assert (
+        result["condition"]["satisfied_by"]
+        == "target_broker_buying_power_reobservation"
+    )
+
+
+@pytest.mark.unit
+def test_declared_cash_is_never_counted_toward_buying_power() -> None:
+    for declared in ("0", "640000"):
+        result = jit(shortfall="60000", declared=declared)
+        assert result["declared_cash_counted_toward_buying_power"] is False
+        assert result["declared_cash_is_display_evidence_only"] is True
+
+
+@pytest.mark.unit
+def test_no_shortfall_is_fundable_now_with_no_condition_and_no_proposal() -> None:
+    result = jit(shortfall="0", declared="640000", gap="0")
+
+    assert result["disposition"] == "fundable_now"
+    assert result["condition"] is None
+    assert result["next_step"] == "existing_proposal_creation_and_approval_path"
+    assert result["creates_proposal"] is False
+    assert result["executes_money_movement"] is False
+
+
+@pytest.mark.unit
+def test_jit_module_is_pure_and_imports_no_db_broker_or_order_surface() -> None:
+    tree = ast.parse(JIT_MODULE.read_text(encoding="utf-8"), filename=str(JIT_MODULE))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+
+    assert modules == {
+        "__future__",
+        "decimal",
+        "typing",
+        "app.schemas.funding_advisory",
+    }

--- a/tests/services/funding_advisory/test_service.py
+++ b/tests/services/funding_advisory/test_service.py
@@ -310,3 +310,109 @@ async def test_no_shortfall_resolves_without_route_or_delivery() -> None:
     assert result["reason"] == "no_candidate_shortfall"
     assert repository.advisory is None
     assert repository.delivery_inserts == 0
+
+
+@pytest.mark.asyncio
+async def test_cash_short_candidate_is_deferred_with_condition_not_rejected() -> None:
+    instance, _repository, _session = service(external_rows=[external_cash_view()])
+
+    result = await instance.evaluate_candidate_event(event(), now=NOW)
+
+    jit = result["jit_funding"]
+    assert jit["disposition"] == "deferred_with_condition"
+    assert jit["rejected_for_insufficient_cash"] is False
+    assert jit["next_step"] == "operator_deposit_then_reevaluate"
+    assert jit["condition"]["declared_cover"] == "sufficient"
+    assert result["state"] == "active"
+    assert result["safety"]["creates_proposal"] is False
+
+
+@pytest.mark.asyncio
+async def test_deferred_condition_amount_is_shortfall_not_declared_total() -> None:
+    """640,000 declared against a 60,000 shortfall still asks for 60,000."""
+
+    instance, _repository, _session = service(external_rows=[external_cash_view()])
+
+    result = await instance.evaluate_candidate_event(event(), now=NOW)
+
+    condition = result["jit_funding"]["condition"]
+    assert condition["deposit_amount"] == result["need"]["shortfall"] == "60000"
+    assert condition["deposit_amount_basis"] == "candidate_shortfall"
+    assert condition["declared_total_disclosure_only"] == "640000"
+    assert condition["operational_gap_amount"] == "90000"
+    assert condition["currency"] == "KRW"
+
+
+@pytest.mark.asyncio
+async def test_deferred_condition_holds_when_no_declaration_covers_it() -> None:
+    instance, _repository, _session = service()
+
+    result = await instance.evaluate_candidate_event(event(), now=NOW)
+
+    jit = result["jit_funding"]
+    assert jit["disposition"] == "deferred_with_condition"
+    assert jit["condition"]["deposit_amount"] == "60000"
+    assert jit["condition"]["declared_cover"] == "none"
+    assert jit["condition"]["declared_total_disclosure_only"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_declared_cash_does_not_change_the_jit_deposit_amount() -> None:
+    without_declaration, _repo_a, _session_a = service()
+    with_declaration, _repo_b, _session_b = service(
+        external_rows=[external_cash_view()]
+    )
+
+    baseline = await without_declaration.evaluate_candidate_event(event(), now=NOW)
+    declared = await with_declaration.evaluate_candidate_event(event(), now=NOW)
+
+    assert declared["need"] == baseline["need"]
+    assert (
+        declared["jit_funding"]["condition"]["deposit_amount"]
+        == baseline["jit_funding"]["condition"]["deposit_amount"]
+        == "60000"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reevaluation_after_deposit_hands_off_to_proposal_path() -> None:
+    """Deposit lands -> broker buying power rises -> candidate becomes fundable.
+
+    The advisory resolves and points at the existing create/approval path. It
+    never creates a proposal and never submits an order itself.
+    """
+
+    instance, repository, _session = service(external_rows=[external_cash_view()])
+    deferred = await instance.evaluate_candidate_event(event(), now=NOW)
+    assert deferred["jit_funding"]["disposition"] == "deferred_with_condition"
+    deposit = Decimal(deferred["jit_funding"]["condition"]["deposit_amount"])
+
+    funded = await instance.evaluate_candidate_event(
+        event(available=str(Decimal("40000") + deposit)),
+        now=NOW + timedelta(minutes=5),
+    )
+
+    assert funded["status"] == "not_triggered"
+    assert funded["reason"] == "no_candidate_shortfall"
+    jit = funded["jit_funding"]
+    assert jit["disposition"] == "fundable_now"
+    assert jit["condition"] is None
+    assert jit["next_step"] == "existing_proposal_creation_and_approval_path"
+    assert jit["creates_proposal"] is False
+    assert jit["executes_money_movement"] is False
+    assert repository.advisory.state == "resolved"
+    assert repository.delivery_inserts == 1
+
+
+@pytest.mark.asyncio
+async def test_detail_and_list_projections_carry_the_same_disposition() -> None:
+    instance, _repository, _session = service(external_rows=[external_cash_view()])
+    created = await instance.evaluate_candidate_event(event(), now=NOW)
+
+    detail = await instance.get_detail(
+        advisory_id=UUID(created["advisory_id"]), owner_user_id=11
+    )
+    listed = await instance.list_details(owner_user_id=11)
+
+    assert detail["jit_funding"] == created["jit_funding"]
+    assert listed[0]["jit_funding"] == created["jit_funding"]

--- a/tests/services/funding_advisory/test_telegram.py
+++ b/tests/services/funding_advisory/test_telegram.py
@@ -8,6 +8,9 @@ import pytest
 from app.services.funding_advisory.telegram import (
     CARD_HEADER,
     HANDOFF_LABEL,
+    JIT_DECLARED_DISCLAIMER,
+    JIT_DEPOSIT_BASIS,
+    JIT_DEPOSIT_HEADER,
     deliver_claimed_advisory,
     render_funding_advisory_card,
 )
@@ -106,3 +109,73 @@ async def test_unclaimed_page_view_never_calls_telegram_notifier() -> None:
     assert result == {"status": "not_sent", "reason": "page_refresh_no_delivery"}
     notifier.send_approval_message.assert_not_called()
     notifier.edit_message.assert_not_called()
+
+
+def deferred_view() -> dict:
+    view = advisory_view()
+    view["jit_funding"] = {
+        "disposition": "deferred_with_condition",
+        "condition": {
+            "kind": "operator_deposit_to_target_account",
+            "deposit_amount": "60000",
+            "deposit_amount_basis": "candidate_shortfall",
+            "currency": "KRW",
+            "operational_gap_amount": "90000",
+            "declared_cover": "sufficient",
+            "declared_total_disclosure_only": "640000",
+            "satisfied_by": "target_broker_buying_power_reobservation",
+        },
+        "next_step": "operator_deposit_then_reevaluate",
+        "rejected_for_insufficient_cash": False,
+        "creates_proposal": False,
+        "executes_money_movement": False,
+        "declared_cash_counted_toward_buying_power": False,
+        "declared_cash_is_display_evidence_only": True,
+    }
+    return view
+
+
+def test_card_asks_for_the_shortfall_not_the_declared_total() -> None:
+    card = render_funding_advisory_card(deferred_view())
+
+    assert "입금 60000 KRW 시 실행 가능" in card.text
+    assert "입금 640000 KRW 시 실행 가능" not in card.text
+    assert JIT_DEPOSIT_HEADER in card.text
+    assert JIT_DEPOSIT_BASIS in card.text
+    assert "pending/reserved 포함 시 90000 KRW" in card.text
+    assert "선언 커버: 선언 여력으로 커버 가능 (선언 총액 640000 KRW)" in card.text
+    assert JIT_DECLARED_DISCLAIMER in card.text
+    assert "조건부 보류(deferred_with_condition)" in card.text
+    assert "입금 확인 뒤 재평가에서 제안 생성 · 기존 승인 경로 그대로" in card.text
+
+
+def test_card_deposit_line_tracks_shortfall_when_declaration_is_smaller() -> None:
+    view = deferred_view()
+    view["jit_funding"]["condition"]["declared_cover"] = "partial"
+    view["jit_funding"]["condition"]["declared_total_disclosure_only"] = "10000"
+
+    card = render_funding_advisory_card(view)
+
+    assert "입금 60000 KRW 시 실행 가능" in card.text
+    assert "선언 커버: 선언 여력 일부만 커버 (선언 총액 10000 KRW)" in card.text
+
+
+def test_card_has_no_jit_block_without_a_deferred_disposition() -> None:
+    plain = render_funding_advisory_card(advisory_view())
+    fundable = advisory_view()
+    fundable["jit_funding"] = {
+        "disposition": "fundable_now",
+        "condition": None,
+        "next_step": "existing_proposal_creation_and_approval_path",
+    }
+
+    assert JIT_DEPOSIT_HEADER not in plain.text
+    assert JIT_DEPOSIT_HEADER not in render_funding_advisory_card(fundable).text
+
+
+def test_jit_block_adds_no_button_or_callback() -> None:
+    card = render_funding_advisory_card(deferred_view())
+
+    rows = card.inline_keyboard["inline_keyboard"]
+    assert all("callback_data" not in button for row in rows for button in row)
+    assert all("url" in button for row in rows for button in row)

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1799,3 +1799,203 @@ async def test_funding_evaluation_exception_never_blocks_proposal_create(monkeyp
     evaluate.assert_awaited_once()
     assert len(create_calls) == 1
     assert create_calls[0]["symbol"] == "KRW-BTC"
+
+
+def _jit_candidate_event(observed_at):
+    from app.services.funding_advisory.contracts import (
+        FundingAssessment,
+        FundingCandidateEvent,
+        PassedNonFundingGateEvidence,
+    )
+
+    evidence = PassedNonFundingGateEvidence.issue(
+        owner_user_id=1,
+        source_kind="upbit_live_candidate",
+        source_candidate_id=f"jit-{uuid.uuid4()}",
+        gate_name="crypto_non_funding_gate",
+        gate_version="crypto-gate.v1",
+        gate_verdict="passed",
+        gate_evaluated_at=observed_at,
+        valid_until=observed_at + timedelta(hours=1),
+        market="crypto",
+        target_account_mode="upbit",
+        broker_account_id="upbit-primary",
+        currency="KRW",
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="limit",
+        blocking_reasons=[],
+        non_funding_checks=[
+            {
+                "check_id": "candidate_quality",
+                "check_version": "v1",
+                "verdict": "passed",
+                "evaluated_at": observed_at,
+            }
+        ],
+    )
+    return FundingCandidateEvent(
+        evidence=evidence,
+        assessment=FundingAssessment(
+            required_cash=Decimal("100000"),
+            target_buying_power=Decimal("40000"),
+            currency="KRW",
+            observed_at=observed_at,
+            valid_until=observed_at + timedelta(minutes=30),
+            source="upbit_accounts_free_krw",
+        ),
+    )
+
+
+def _install_jit_create_fakes(monkeypatch, observed_at, create_calls):
+    proposal_id = uuid.uuid4()
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def commit(self):
+            return None
+
+    class FakeOrderService:
+        def __init__(self, _session):
+            pass
+
+        async def create_proposal(self, **kwargs):
+            create_calls.append(kwargs)
+            return SimpleNamespace(
+                proposal_id=proposal_id,
+                lifecycle_state="proposed",
+                action="place",
+                target_broker_order_id=None,
+                valid_until=observed_at + timedelta(hours=1),
+            )
+
+        async def get_proposal(self, _proposal_id):
+            rung = SimpleNamespace(
+                rung_index=0,
+                side="buy",
+                quantity=Decimal("10"),
+                limit_price=Decimal("70000"),
+                notional=None,
+                state="pending_approval",
+                broker_order_id=None,
+                correlation_id=None,
+            )
+            return SimpleNamespace(source_asof=None), [rung]
+
+    monkeypatch.setattr(opt, "AsyncSessionLocal", FakeSession)
+    monkeypatch.setattr(opt, "OrderProposalsService", FakeOrderService)
+
+    async def complete(committed_result, **_kwargs):
+        return dict(committed_result)
+
+    monkeypatch.setattr(opt, "_complete_committed_proposal_create", complete)
+    return proposal_id
+
+
+@pytest.mark.asyncio
+async def test_deferred_with_condition_notifies_without_gating_or_executing(
+    monkeypatch,
+):
+    """A cash-short candidate is announced, not rejected and not auto-executed."""
+
+    observed_at = datetime.now(UTC)
+    deferred_view = {
+        "status": "triggered",
+        "advisory_id": str(uuid.uuid4()),
+        "revision_id": str(uuid.uuid4()),
+        "jit_funding": {
+            "disposition": "deferred_with_condition",
+            "condition": {"deposit_amount": "60000", "currency": "KRW"},
+            "next_step": "operator_deposit_then_reevaluate",
+            "rejected_for_insufficient_cash": False,
+            "creates_proposal": False,
+        },
+    }
+    monkeypatch.setattr(
+        opt.FundingAdvisoryService,
+        "evaluate_candidate_event",
+        AsyncMock(return_value=deferred_view),
+    )
+    deliver = AsyncMock(return_value={"status": "sent"})
+    monkeypatch.setattr(opt, "deliver_claimed_advisory", deliver)
+    monkeypatch.setattr(
+        opt,
+        "_link_funding_provenance_fail_open",
+        AsyncMock(return_value={"status": "linked"}),
+    )
+    create_calls = []
+    _install_jit_create_fakes(monkeypatch, observed_at, create_calls)
+
+    created = await opt.order_proposal_create(
+        **_create_kwargs(
+            symbol="KRW-BTC",
+            market="crypto",
+            account_mode="upbit",
+            funding_candidate_event=_jit_candidate_event(observed_at).model_dump(
+                mode="json"
+            ),
+        )
+    )
+
+    assert created["success"] is True
+    advisory = created["funding_advisory"]
+    assert advisory["jit_funding"]["disposition"] == "deferred_with_condition"
+    assert advisory["jit_funding"]["rejected_for_insufficient_cash"] is False
+    assert advisory["telegram_delivery"] == {"status": "sent"}
+    deliver.assert_awaited_once()
+    # The advisory never submits or approves anything; the rung stays pending.
+    assert len(create_calls) == 1
+    assert created["rungs"][0]["state"] == "pending_approval"
+
+
+@pytest.mark.asyncio
+async def test_reevaluated_fundable_candidate_reaches_the_normal_approval_path(
+    monkeypatch,
+):
+    """After the deposit, re-evaluation hands off to create + existing approval."""
+
+    observed_at = datetime.now(UTC)
+    fundable_view = {
+        "status": "not_triggered",
+        "reason": "no_candidate_shortfall",
+        "shortfall": "0",
+        "jit_funding": {
+            "disposition": "fundable_now",
+            "condition": None,
+            "next_step": "existing_proposal_creation_and_approval_path",
+            "creates_proposal": False,
+            "executes_money_movement": False,
+        },
+    }
+    monkeypatch.setattr(
+        opt.FundingAdvisoryService,
+        "evaluate_candidate_event",
+        AsyncMock(return_value=fundable_view),
+    )
+    deliver = AsyncMock()
+    monkeypatch.setattr(opt, "deliver_claimed_advisory", deliver)
+    create_calls = []
+    _install_jit_create_fakes(monkeypatch, observed_at, create_calls)
+
+    created = await opt.order_proposal_create(
+        **_create_kwargs(
+            symbol="KRW-BTC",
+            market="crypto",
+            account_mode="upbit",
+            funding_candidate_event=_jit_candidate_event(observed_at).model_dump(
+                mode="json"
+            ),
+        )
+    )
+
+    assert created["success"] is True
+    assert created["funding_advisory"]["jit_funding"]["disposition"] == "fundable_now"
+    assert len(create_calls) == 1
+    assert created["rungs"][0]["state"] == "pending_approval"
+    # A resolved funding condition is not a delivery event and not an approval.
+    deliver.assert_not_awaited()


### PR DESCRIPTION
## 왜

운영자 §107차: **사전 입금 금지**. 정말 필요한 현금만, 체결(주문 확정) 시점에 입금한다.

그래서 비-자금 gate를 전부 통과한 매수 후보가 **broker 현금 부족만을 이유로 기각되면 안 된다.** 후보는 조건과 함께 열려 있어야 하고, 조건("입금 X원")은 알림으로 나가야 한다.

## 무엇

- `app/services/funding_advisory/jit.py` (신규, 순수 — stdlib + Decimal): `shortfall > 0` → `deferred_with_condition`, 아니면 `fundable_now`.
- `service.py`: 모든 projection과 no-shortfall 분기에 파생 `jit_funding` 블록 부착. 선언 read는 평가당 1회로 정리.
- `telegram.py`: `입금 X {통화} 시 실행 가능` 줄 추가. **X = 이 후보 부족분**이며 운영상 gap·선언 총액은 별도 줄로 공개.
- `docs/runbooks/funding-advisory.md`: JIT 절 추가.

## 계약 (급소)

**신규 proposal 상태·스키마 0.** 새 테이블·컬럼·enum 값·상태 전이 없음. `funding_advisories.state`는 그대로 `active`/`resolved`/`superseded`이고, `deferred_with_condition`은 **저장되지 않는 파생 라벨**이다. migration 0.

**선언액은 매수력에 가산되지 않는다** (#1866 뮤턴트 계약 유지). `jit.py`는 DB/broker/order 표면을 import하지 않으며, 선언액은 `deposit_amount`에 더해지지도 빼지지도 않는다. 기존 `test_declared_cash_never_changes_available_required_or_shortfall` 초록 유지.

**뮤턴트 재확인 5종 — 전부 RED**:

| # | 뮤턴트 | 결과 |
|---|---|---|
| M1 | 선언액을 `target_buying_power`에 가산 | 7 failed (기존 불변 테스트 포함) |
| M2 | `X = shortfall - declared_total` | 11 failed |
| M3 | `X = declared_total` | 12 failed |
| M4 | 카드가 선언 총액을 입금액으로 출력 | 2 failed |
| M5 | 현금부족 후보를 기각 처리 | 4 failed |

**자동 입금·이체·계좌 mutation·브로커 주문 0.** 승인 게이트 완화 0. auto-approve 캡·태그 스캔·손익분기 밴드·resting-only 무접촉.

## 재평가 → 제안

입금은 선언 갱신으로 확인되지 않는다. 조달 완료 판정은 **target broker buying power 재관측**뿐이다. 상류가 갱신된 `target_buying_power`로 재평가하면 shortfall 0 → advisory `resolved` → `fundable_now` → **기존 create + 승인 경로 그대로**. advisory는 어떤 경로로도 proposal을 만들거나 주문을 내지 않는다 (`creates_proposal: false`).

## 검증

```
collected 1205 items
1205 passed, 4 warnings in 97.04s
```
(`tests/services/funding_advisory/` · `tests/test_mcp_order_proposal_tools.py` · `tests/services/order_proposals/` · `tests/routers/`)

`ruff check app tests` / `ruff format --check app tests` / `ty check app/services/funding_advisory/` 전부 exit 0.

## 정지점

🔴 **draft.** 검증자 붙기 전 self-merge·배포 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)