### PR TITLE
feat(ROB-1290): prove the proposal-only allowlist on a real MCP server

### DIFF
--- a/app/mcp_server/tooling/watch_repricing_registration.py
+++ b/app/mcp_server/tooling/watch_repricing_registration.py
@@ -12,14 +12,32 @@ r2's B4 finding: the previous round validated the tool list carried on the
 spawn request, while nothing provisioned a session from it. A stand-in that
 requested a clean profile and granted ``toss_place_order`` passed. A profile
 that a server is actually built from turns the list into the thing that
-decides what exists, and :func:`watch_repricing_tool_names` lets the
+decides what exists, and :func:`provisioned_tool_names` lets the
 orchestrator compare the *provisioned* registry with the allowlist by
-closed equality.
+closed equality (:func:`watch_repricing_tool_names` answers the same
+question for a registration stand-in, which has no served surface to ask).
 
 The set is deliberately the same object as
 :data:`app.services.watch_trigger_repricing.capability.PROPOSAL_ONLY_TOOLS`
 -- one definition, two consumers -- so the profile and the capability
 boundary cannot drift apart.
+
+Why the process boundary, not an in-process guard
+-------------------------------------------------
+ROB-1290 r3 measured the in-process approach and found it cannot close:
+a subclass, an injected judge or a swapped module global defeats capability
+tokens, ``@final`` and in-process allowlists alike, because the raw callable
+stays reachable inside the interpreter. The boundary that does hold is the
+one the session cannot reach across -- the set of tools an MCP *server*
+hands out. :func:`build_watch_repricing_server` is that provisioning step,
+and :func:`assert_provisioned_surface` is the closed-equality check against
+the surface the server actually serves rather than the one it was asked
+for. A name outside that surface is not filtered by the client: the server
+answers ``tools/call`` for it with ``Unknown tool``.
+
+Provisioning is not arming. These helpers build an in-process server object
+and read its tool surface; they start no transport and spawn no session.
+Wiring a live spawner onto them is a separate change.
 """
 
 from __future__ import annotations
@@ -48,6 +66,7 @@ from app.mcp_server.tooling.trading_policy_registration import (
     register_trading_policy_tools,
 )
 from app.services.watch_trigger_repricing.capability import PROPOSAL_ONLY_TOOLS
+from app.services.watch_trigger_repricing.live_contract import assert_exact_grant
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -56,6 +75,9 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 
 __all__ = [
     "WATCH_REPRICING_TOOL_NAMES",
+    "assert_provisioned_surface",
+    "build_watch_repricing_server",
+    "provisioned_tool_names",
     "register_watch_repricing_tools",
     "watch_repricing_tool_names",
 ]
@@ -104,8 +126,66 @@ def register_watch_repricing_tools(mcp: FastMCP) -> None:
 
 
 def watch_repricing_tool_names(mcp: Any) -> frozenset[str]:
-    """The names a built server actually exposes, for the exact comparison."""
+    """The names a registration target collected, for the exact comparison.
+
+    Reads a name mapping, so it answers for registration stand-ins. A real
+    ``FastMCP`` keeps no such mapping -- ask it with
+    :func:`provisioned_tool_names` instead.
+    """
     tools = getattr(mcp, "tools", None)
     if tools is None:
         raise TypeError("server object exposes no tool registry to attest")
     return frozenset(tools)
+
+
+def build_watch_repricing_server(*, name: str = "auto_trader-mcp") -> FastMCP:
+    """Provision a real MCP server carrying exactly the proposal-only surface.
+
+    Goes through :func:`~app.mcp_server.tooling.registry.register_all_tools`
+    rather than calling :func:`register_watch_repricing_tools` directly, so
+    the registry's profile branch -- the early return that keeps the broad
+    "Always" block from running -- is part of what gets provisioned and
+    therefore part of what the attestation proves. ``on_duplicate="error"``
+    matches production ``main.py``.
+
+    The result is an unstarted, unauthenticated in-process object: transport,
+    auth and lifespan stay ``main.py``'s job.
+    """
+    # Deferred: ``registry`` imports this module, so a module-level import
+    # would close the cycle. ``fastmcp`` follows it for symmetry.
+    from fastmcp import FastMCP as _FastMCP
+
+    from app.mcp_server.profiles import McpProfile
+    from app.mcp_server.tooling.registry import register_all_tools
+
+    mcp = _FastMCP(name=name, on_duplicate="error")
+    register_all_tools(mcp, profile=McpProfile.WATCH_REPRICING)
+    return cast("FastMCP", mcp)
+
+
+async def provisioned_tool_names(mcp: Any) -> frozenset[str]:
+    """The names a built server actually *serves*, asked the way a client asks.
+
+    ``tools/list`` is the only surface a spawned session can see, so it is
+    the surface the comparison has to be made against. Reading a registrar's
+    bookkeeping instead would attest what registration intended rather than
+    what the server ended up serving.
+    """
+    lister = getattr(mcp, "list_tools", None)
+    if lister is None:
+        raise TypeError("server object does not serve tools/list")
+    return frozenset(str(tool.name) for tool in await lister())
+
+
+async def assert_provisioned_surface(mcp: Any) -> frozenset[str]:
+    """Refuse a built server whose served surface is not the allowlist.
+
+    Closed equality, both directions, via the same
+    :func:`~app.services.watch_trigger_repricing.live_contract.assert_exact_grant`
+    the live-spawner contract uses: an extra tool is a capability escape, a
+    missing one is a session that cannot finish its job. Returns the served
+    set so a caller can log the surface it accepted.
+    """
+    served = await provisioned_tool_names(mcp)
+    assert_exact_grant(served, who=f"MCP server {getattr(mcp, 'name', mcp)!r}")
+    return served

--- a/docs/runbooks/watch-trigger-repricing.md
+++ b/docs/runbooks/watch-trigger-repricing.md
@@ -264,6 +264,28 @@ subset 은 제안 못 하는 세션(=분석-온리 산출)이라 **둘 다 거�
 고치는 별도 리뷰가 필요하다. 테스트로 박제했다
 (`test_no_launcher_in_this_repo_can_start_the_profile`).
 
+### 8.1 스텁이 아니라 실 서버로 증명 (ROB-1290 r3 후속)
+
+r3 실측 결론: **in-process 로는 승인 경계를 닫을 수 없다.** subclass·injected
+judge·module-global 교체 앞에서 capability 토큰·`@final`·in-process allowlist 가
+전부 무력했고 raw 콜러블이 남았다. 그래서 경계를 **프로세스 경계 = MCP 서버가
+내주는 도구 집합**에서 증명한다.
+
+| 증거 | 어떻게 |
+|---|---|
+| provision | `build_watch_repricing_server()` — `register_all_tools(profile=WATCH_REPRICING)` 로 실 `FastMCP` 를 세운다 (`on_duplicate="error"`, 프로덕션 `main.py` 와 동일) |
+| 닫힌 등가 | `assert_provisioned_surface()` — 서버가 **실제로 서빙하는** `tools/list`(15개)를 `PROPOSAL_ONLY_TOOLS` 와 `==` 비교. 등록기의 장부가 아니라 세션이 볼 수 있는 유일한 표면이 비교 대상이다 |
+| 서버 거부 | `tools/call place_order` 응답이 `isError=True  "Unknown tool: 'place_order'"`. 클라이언트 필터가 아니다 — 클라이언트는 **받은 적 없는 이름**을 보내고 서버가 거절한다. 레포의 주문 registry 이름 전체를 훑는다 |
+| 공허하지 않음 | 같은 경로·허용 이름(`order_proposal_create`)은 `"Unknown tool"` 이 아니라 **인자 검증** 오류로 실패한다. "전부 실패하는 서버" 가 아니라는 대조군 |
+
+테스트 = `tests/services/watch_trigger_repricing/test_real_server_surface.py`.
+스텁 기반 `test_live_spawner_contract.py` 는 그대로 둔다 — 스텁에는 `tools/list`
+도 호출 경로도 없어서 위 두 질문에 애초에 답할 수 없다.
+
+🔴 **이 절이 증명하지 않는 것**: 스폰된 세션이 *이렇게 세운 서버에* 붙는다는 것.
+런처 배선은 여전히 없다(위 정직한 공백 · §11). 여기까지의 주장은 "프로필로 서버를
+세우면 그 서버는 주문 도구를 내주지 않는다" 이며, provision 은 arm 이 아니다.
+
 ---
 
 ## 9. live spawner 는 계약 없이 배선 불가 (§101차 ③)

--- a/tests/services/watch_trigger_repricing/test_real_server_surface.py
+++ b/tests/services/watch_trigger_repricing/test_real_server_surface.py
@@ -1,0 +1,256 @@
+"""ROB-1290 r3 follow-up — the boundary is the server, so test the server.
+
+r3's measurement: an in-process guard cannot close the approval boundary.
+Capability tokens, ``@final`` and in-process allowlists all fall to a
+subclass, an injected judge or a swapped module global, because the raw
+callable never stops being reachable inside the interpreter.
+
+The boundary that does hold is the process boundary -- the set of tools an
+MCP server hands out. So the proof has to be made against a *built server*,
+not a registration stand-in:
+
+* ``tools/list`` returns exactly the proposal-only allowlist -- closed
+  equality, not containment (:data:`PROPOSAL_ONLY_TOOLS`);
+* a ``tools/call`` naming a broker order tool comes back
+  ``isError=True  "Unknown tool"`` **from the server**. The client is not
+  filtering: it sends a name it was never given and the server refuses it.
+
+``tests/.../test_live_spawner_contract.py`` already pins registration
+against a ``_Registry`` stand-in. A stand-in cannot answer either question
+above -- it has no ``tools/list`` and no call path -- which is exactly the
+gap these tests close.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import NotFoundError
+
+from app.mcp_server.tooling.orders_kis_variants import (
+    KIS_LIVE_ORDER_TOOL_NAMES,
+    KIS_MOCK_ORDER_TOOL_NAMES,
+    LIVE_RECONCILE_TOOL_NAMES,
+)
+from app.mcp_server.tooling.orders_kiwoom_us_variants import KIWOOM_MOCK_US_TOOL_NAMES
+from app.mcp_server.tooling.orders_kiwoom_variants import KIWOOM_MOCK_TOOL_NAMES
+from app.mcp_server.tooling.orders_registration import ORDER_TOOL_NAMES
+from app.mcp_server.tooling.orders_toss_variants import TOSS_LIVE_ORDER_TOOL_NAMES
+from app.mcp_server.tooling.paper_execution_registration import (
+    PAPER_EXECUTION_TOOL_NAMES,
+)
+from app.mcp_server.tooling.watch_repricing_registration import (
+    WATCH_REPRICING_TOOL_NAMES,
+    assert_provisioned_surface,
+    build_watch_repricing_server,
+    provisioned_tool_names,
+)
+from app.services.watch_trigger_repricing.capability import (
+    EXECUTION_BOUNDARY,
+    PROPOSAL_ONLY_TOOLS,
+    CapabilityBoundaryViolation,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+# The submit-family names the raw round trip is run against one by one. Every
+# order registry in the repo is swept in
+# ``test_no_order_registry_name_can_be_called`` below; this shorter list is
+# the one that gets the full client -> server -> raw-payload treatment.
+SUBMIT_TOOLS = (
+    "place_order",
+    "kis_live_place_order",
+    "kis_mock_place_order",
+    "toss_place_order",
+    "kiwoom_mock_place_order",
+    "kiwoom_mock_us_place_order",
+    "paper_execution_submit_order",
+)
+
+# Every name any order registry registers, so a tool added to one of them
+# next quarter is swept without this file being edited.
+ORDER_REGISTRY_NAMES = frozenset(
+    set(ORDER_TOOL_NAMES)
+    | set(KIS_LIVE_ORDER_TOOL_NAMES)
+    | set(KIS_MOCK_ORDER_TOOL_NAMES)
+    | set(LIVE_RECONCILE_TOOL_NAMES)
+    | set(KIWOOM_MOCK_TOOL_NAMES)
+    | set(KIWOOM_MOCK_US_TOOL_NAMES)
+    | set(TOSS_LIVE_ORDER_TOOL_NAMES)
+    | set(PAPER_EXECUTION_TOOL_NAMES)
+)
+
+
+def _error_text(result: object) -> str:
+    """The text the server put in a ``CallToolResult``."""
+    blocks = getattr(result, "content", None) or []
+    return "\n".join(str(getattr(block, "text", "")) for block in blocks)
+
+
+# ---------------------------------------------------------------------------
+# ALLOWLIST_CLOSED — what a built server serves, compared with ==
+# ---------------------------------------------------------------------------
+async def test_a_real_server_serves_exactly_the_allowlist() -> None:
+    """Not a subset, not a superset -- asked of a real FastMCP, not a stub."""
+    server = build_watch_repricing_server()
+
+    served = await provisioned_tool_names(server)
+
+    assert served == PROPOSAL_ONLY_TOOLS
+    assert served == WATCH_REPRICING_TOOL_NAMES
+    assert len(served) == len(PROPOSAL_ONLY_TOOLS)
+
+
+async def test_the_attestation_helper_accepts_that_server() -> None:
+    server = build_watch_repricing_server()
+
+    assert await assert_provisioned_surface(server) == PROPOSAL_ONLY_TOOLS
+
+
+async def test_a_client_is_offered_exactly_the_allowlist() -> None:
+    """The same equality, over the wire this time: a real ``tools/list``."""
+    server = build_watch_repricing_server()
+
+    async with Client(server) as client:
+        offered = frozenset(tool.name for tool in await client.list_tools())
+
+    assert offered == PROPOSAL_ONLY_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# The comparison is not vacuous — drift in either direction is refused
+# ---------------------------------------------------------------------------
+async def test_a_widened_server_is_refused() -> None:
+    """One broker tool added to the built server, and attestation fails."""
+    server = build_watch_repricing_server()
+
+    @server.tool(name="toss_place_order")
+    def _leaked() -> str:  # pragma: no cover - never called
+        return "should not exist"
+
+    with pytest.raises(CapabilityBoundaryViolation) as exc:
+        await assert_provisioned_surface(server)
+    assert "toss_place_order" in str(exc.value)
+
+
+async def test_a_narrowed_server_is_refused() -> None:
+    """Dropping the boundary is the other failure: a session that can only read."""
+    server = build_watch_repricing_server()
+    server.local_provider.remove_tool(EXECUTION_BOUNDARY)
+
+    with pytest.raises(CapabilityBoundaryViolation) as exc:
+        await assert_provisioned_surface(server)
+    assert EXECUTION_BOUNDARY in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# DENIED_AT_SERVER — the call is refused, not merely absent from a list
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("denied", SUBMIT_TOOLS)
+async def test_an_order_tool_call_is_refused_by_the_server(denied: str) -> None:
+    """Raw ``tools/call`` payload, straight from the server.
+
+    ``call_tool_mcp`` returns the server's ``CallToolResult`` instead of
+    raising, so the assertion is made against the response the server
+    produced rather than against a client-side exception. The client asks
+    for a name that was never in the ``tools/list`` it received -- nothing on
+    the client side could have decided the answer.
+    """
+    server = build_watch_repricing_server()
+
+    async with Client(server) as client:
+        offered = frozenset(tool.name for tool in await client.list_tools())
+        assert denied not in offered
+        result = await client.call_tool_mcp(denied, {})
+
+    assert result.isError is True
+    assert "Unknown tool" in _error_text(result)
+    assert denied in _error_text(result)
+
+
+@pytest.mark.parametrize("denied", SUBMIT_TOOLS)
+async def test_the_servers_own_call_path_refuses_with_no_client_involved(
+    denied: str,
+) -> None:
+    """``FastMCP.call_tool`` is what the ``tools/call`` handler dispatches to.
+
+    Calling it directly removes the client and its transport from the loop
+    entirely, so what is left is the server's own refusal.
+    """
+    server = build_watch_repricing_server()
+    # Interlock: if the name did resolve, ``call_tool`` would *run* the broker
+    # tool rather than refuse it. Prove it cannot resolve before calling it.
+    assert await server.get_tool(denied) is None
+
+    with pytest.raises(NotFoundError) as exc:
+        await server.call_tool(denied, {})
+    assert denied in str(exc.value)
+
+
+async def test_no_order_registry_name_can_be_called() -> None:
+    """Sweep every name the repo's order registries define, not a curated few."""
+    server = build_watch_repricing_server()
+    # A registry rename that emptied this set would make the sweep vacuous.
+    assert len(ORDER_REGISTRY_NAMES) >= 30
+    assert ORDER_REGISTRY_NAMES & PROPOSAL_ONLY_TOOLS == frozenset()
+
+    for name in sorted(ORDER_REGISTRY_NAMES):
+        assert await server.get_tool(name) is None, name
+        with pytest.raises(NotFoundError):
+            await server.call_tool(name, {})
+
+
+# ---------------------------------------------------------------------------
+# Negative control — the refusal is name-scoped, not "everything fails"
+# ---------------------------------------------------------------------------
+async def test_an_allowed_tool_fails_the_other_way_on_the_same_path() -> None:
+    """Same client, same call, allowed name: argument validation, not absence.
+
+    Without this the denial above would also pass on a server that answers
+    every call with an error.
+    """
+    server = build_watch_repricing_server()
+
+    async with Client(server) as client:
+        result = await client.call_tool_mcp(EXECUTION_BOUNDARY, {})
+
+    assert result.isError is True
+    text = _error_text(result)
+    assert "Unknown tool" not in text
+    assert "validation error" in text.lower()
+
+
+async def test_resolution_succeeds_for_the_boundary_and_fails_for_a_broker() -> None:
+    server = build_watch_repricing_server()
+
+    assert await server.get_tool(EXECUTION_BOUNDARY) is not None
+    assert await server.get_tool("toss_place_order") is None
+
+
+# ---------------------------------------------------------------------------
+# Provisioning is not arming
+# ---------------------------------------------------------------------------
+async def test_provisioning_reaches_for_no_transport() -> None:
+    """A built server is inert until something serves it, and nothing here does.
+
+    ``scripts/mock_session_mcp.py``'s ``SAFE_MOCK_PROFILES`` still excludes
+    this profile (``test_permission_wiring.py``), so no launcher in the repo
+    can start it. This adds the other half: the provisioning helper itself
+    never opens a transport.
+    """
+    source = (
+        REPO_ROOT / "app" / "mcp_server" / "tooling" / "watch_repricing_registration.py"
+    ).read_text()
+
+    for token in (
+        ".run(",
+        "run_async",
+        "run_http_async",
+        "run_stdio_async",
+        "http_app",
+    ):
+        assert token not in source, token


### PR DESCRIPTION
## Why

ROB-1290 r3 measured the in-process approach and found it **cannot close the approval boundary**: a subclass, an injected judge or a swapped module global defeats capability tokens, `@final` and in-process allowlists alike, because the raw callable never stops being reachable inside the interpreter.

The boundary that does hold is the set of tools an MCP **server** hands out. This PR moves the proof there.

The `watch_repricing` profile itself already exists (ROB-1286). What did **not** exist was a check against a real server: every attestation ran against a `_Registry` stand-in, which has neither a `tools/list` nor a call path, so it could not answer either question that matters — *what does the server serve*, and *what happens when a broker tool is called anyway*.

## What changed

`app/mcp_server/tooling/watch_repricing_registration.py`

| helper | does |
|---|---|
| `build_watch_repricing_server()` | provisions a real `FastMCP` through `register_all_tools(profile=WATCH_REPRICING)`, `on_duplicate="error"` as in production `main.py` |
| `provisioned_tool_names()` | reads the surface the server actually **serves** on `tools/list` — the only surface a spawned session can see |
| `assert_provisioned_surface()` | closed equality against `PROPOSAL_ONLY_TOOLS` via the same `assert_exact_grant` the live-spawner contract uses; a widened **or** narrowed server is refused |

`tests/services/watch_trigger_repricing/test_real_server_surface.py` (23 tests)

- **ALLOWLIST_CLOSED** — the built server serves exactly the 15-name allowlist (`==`, not containment), asserted both directly and through a real client `tools/list`.
- **DENIED_AT_SERVER** — `tools/call place_order` comes back `isError=True  "Unknown tool: 'place_order'"`. The client sends a name it was never given; the **server** refuses. Repeated for every name in every order registry in the repo (`ORDER_TOOL_NAMES`, KIS live/mock, Kiwoom KR/US, Toss, paper execution), and again with no client in the loop at all.
- **Negative control** — the same call path with an *allowed* name (`order_proposal_create`) fails with an **argument-validation** error, never `"Unknown tool"`. So the refusal is name-scoped, not "this server errors on everything".
- **Not armed** — the provisioning helper opens no transport, and `scripts/mock_session_mcp.py`'s `SAFE_MOCK_PROFILES` still excludes the profile.

`docs/runbooks/watch-trigger-repricing.md` — new §8.1 recording the evidence and the honest limit.

## Raw evidence

```
=== ALLOWLIST_CLOSED ===
served (tools/list)  = n=15
expected PROPOSAL_ONLY_TOOLS n=15
served == PROPOSAL_ONLY_TOOLS -> True
served - expected = []      expected - served = []

=== DENIED_AT_SERVER (raw tools/call payload from the server) ===
client tools/list n=15 contains_any_denied=[]
  tools/call 'place_order'                  -> isError=True content="Unknown tool: 'place_order'"
  tools/call 'kis_live_place_order'         -> isError=True content="Unknown tool: 'kis_live_place_order'"
  tools/call 'kis_mock_place_order'         -> isError=True content="Unknown tool: 'kis_mock_place_order'"
  tools/call 'toss_place_order'             -> isError=True content="Unknown tool: 'toss_place_order'"
  tools/call 'kiwoom_mock_place_order'      -> isError=True content="Unknown tool: 'kiwoom_mock_place_order'"
  tools/call 'kiwoom_mock_us_place_order'   -> isError=True content="Unknown tool: 'kiwoom_mock_us_place_order'"
  tools/call 'paper_execution_submit_order' -> isError=True content="Unknown tool: 'paper_execution_submit_order'"

  -- negative control: same path, ALLOWED name --
  tools/call 'order_proposal_create' -> isError=True
    first line: 7 validation errors for call[order_proposal_create]
    contains 'Unknown tool': False

=== DENIED_AT_SERVER (no client in the loop) ===
  server.call_tool('place_order') raised fastmcp.exceptions.NotFoundError: Unknown tool: 'place_order'
```

## Mutation testing

| mutant | result |
|---|---|
| order tool added to `PROPOSAL_ONLY_TOOLS` | **RED** — 5 failed (closed equality + sweep) |
| `assert_exact_grant` weakened `==` → superset-permissive | **RED** — 3 failed (incl. the pre-existing r2-escape test) |
| a broker submit tool *actually provisioned* onto the profile | **RED** — 5 failed, incl. both `DENIED_AT_SERVER` tests for `toss_place_order` |

All reverted; `git status --porcelain` clean before commit.

## Scope

- **No** approval-machinery change — `app/services/order_proposals/`, `order_proposal_tools.py` and `app/services/watch_trigger_repricing/` have **zero diff**. §40차 classification, auto-approve caps and human-approved loss-sell are untouched.
- **No** migration, dependency, scheduler or env change.
- Diff: 1 app module (+86/-3), 1 runbook (+22), 1 new test file.

## Verification

```
ruff check      exit 0   (All checks passed!)
ruff format     exit 0   (3929 files already formatted)
ty check app/   exit 0   (All checks passed!)
pytest tests/services/watch_trigger_repricing/test_real_server_surface.py  -> 23 collected, 23 passed
pytest <watch_trigger_repricing + mcp_server + mcp profile/boot/proposal>  -> 1210 passed
pytest -m "unit and not integration and not slow and not live"             -> 6472 passed, 3 skipped
```

## Honest limits

- This proves the **server-side refusal semantics** of the tool set a session is handed. It does not by itself prove OS-level process isolation, and it does not prove a spawned session connects to a server built this way — there is still **no launcher wiring** (`SAFE_MOCK_PROFILES` excludes `watch_repricing`), which is deliberate.
- Provisioning is not arming; wiring a live spawner remains a separate, reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)