### PR TITLE
feat(ROB-1297): market-close digest Telegram via TradeNotifier

### DIFF
--- a/app/flows/market_close_digest_flow.py
+++ b/app/flows/market_close_digest_flow.py
@@ -1,0 +1,99 @@
+"""Prefect wrapper for ROB-1297 market-close digest.
+
+The flow is importable only; no deployment / cron is registered in this repo.
+Intended operator cadence (upstream Prefect, not this file):
+
+* US  05:05 KST trading days
+* KR  15:45 KST trading days
+* crypto 09:05 KST daily
+
+Holiday skip lives in the digest service (shared XKRX/XNYS calendar). Send is
+opt-in (``send=False`` by default) so a manual flow run cannot page Telegram
+by accident.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Literal
+
+from prefect import flow, task
+
+from app.core.db import AsyncSessionLocal
+from app.monitoring.trade_notifier import get_trade_notifier
+from app.monitoring.trade_notifier.runtime import (
+    configure_trade_notifier_from_settings,
+)
+from app.services.market_close_digest.service import run_market_close_digest
+from app.services.market_close_digest.types import Market
+
+
+def _to_dict(result: Any) -> dict[str, Any]:
+    snapshot = result.snapshot
+    payload: dict[str, Any] = {
+        "market": result.market,
+        "sessionDate": result.session_date.isoformat(),
+        "status": result.status,
+        "sent": result.sent,
+        "mutationCount": result.mutation_count,
+        "message": result.message,
+    }
+    if snapshot is not None:
+        payload["fillCount"] = snapshot.fill_count
+        payload["buyCount"] = snapshot.buy_count
+        payload["sellCount"] = snapshot.sell_count
+        payload["oversellBlocked"] = len(snapshot.oversell_blocked)
+        payload["autoApproveCount"] = snapshot.auto_approve_count
+        payload["cardCount"] = snapshot.card_count
+        payload["flags"] = list(snapshot.flags)
+    return payload
+
+
+async def run_market_close_digest_refresh(
+    *,
+    market: Market,
+    session_date: date | None = None,
+    send: bool = False,
+) -> dict[str, Any]:
+    notifier = None
+    if send:
+        configure_trade_notifier_from_settings(log_context="market-close-digest")
+        notifier = get_trade_notifier()
+    async with AsyncSessionLocal() as session:
+        result = await run_market_close_digest(
+            market=market,
+            session_date=session_date,
+            session=session,
+            send=send,
+            notifier=notifier,
+        )
+    return _to_dict(result)
+
+
+@task(name="market_close_digest")
+async def market_close_digest_task(
+    *,
+    market: Literal["us", "kr", "crypto"] = "us",
+    session_date: date | None = None,
+    send: bool = False,
+) -> dict[str, Any]:
+    return await run_market_close_digest_refresh(
+        market=market,
+        session_date=session_date,
+        send=send,
+    )
+
+
+@flow(name="market_close_digest")
+async def market_close_digest_flow(
+    *,
+    market: Literal["us", "kr", "crypto"] = "us",
+    session_date: date | None = None,
+    send: bool = False,
+) -> dict[str, Any]:
+    """Market-close digest; deployment registration is deferred to upstream."""
+    return await market_close_digest_task(
+        market=market,
+        session_date=session_date,
+        send=send,
+    )

--- a/app/services/manual_holdings_leftover.py
+++ b/app/services/manual_holdings_leftover.py
@@ -1,0 +1,205 @@
+"""ROB-1297 side task: toss AMZN/GOOGL manual leftover cleanup + conflict guard.
+
+This module is the **write** surface. It is not imported by the market-close
+digest aggregator. Dry-run is the default; ``commit`` requires ``confirm``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.manual_holdings import BrokerAccount, ManualHolding, MarketType
+from app.models.review import TossLiveOrderLedger
+from app.schemas.session_context import SessionContextAppendEntry, SessionContextRefs
+from app.services.session_context import SessionContextService
+
+TOSS_LEFTOVER_TICKERS: tuple[str, ...] = ("AMZN", "GOOGL")
+_FILLED_STATUSES = ("filled", "partial")
+
+
+@dataclass(frozen=True)
+class LeftoverManualRow:
+    holding_id: int
+    ticker: str
+    quantity: str
+    broker_account_id: int
+    broker_type: str
+    is_mock: bool
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ManualBrokerConflict:
+    ticker: str
+    manual_holding_id: int
+    broker_account_id: int
+    reason: str
+
+
+@dataclass
+class LeftoverCleanupResult:
+    matched: int
+    deleted: int
+    warnings_written: int
+    dry_run: bool
+    rows: tuple[LeftoverManualRow, ...]
+    conflicts: tuple[ManualBrokerConflict, ...]
+
+
+def leftover_reasons(
+    *,
+    ticker: str,
+    is_mock: bool,
+    filled_sell_symbols: set[str],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if ticker in TOSS_LEFTOVER_TICKERS:
+        reasons.append("toss_us_allowlist")
+    if ticker in filled_sell_symbols:
+        reasons.append("filled_sell_in_toss_ledger")
+    if is_mock:
+        reasons.append("account_mode_mock_mismatch")
+    return tuple(reasons)
+
+
+def detect_manual_broker_conflicts(
+    leftovers: tuple[LeftoverManualRow, ...],
+) -> tuple[ManualBrokerConflict, ...]:
+    """Manual toss row vs broker-ledger filled sell = double-count risk."""
+    conflicts: list[ManualBrokerConflict] = []
+    for row in leftovers:
+        if "filled_sell_in_toss_ledger" not in row.reasons:
+            continue
+        conflicts.append(
+            ManualBrokerConflict(
+                ticker=row.ticker,
+                manual_holding_id=row.holding_id,
+                broker_account_id=row.broker_account_id,
+                reason="manual_row_conflicts_with_broker_fill",
+            )
+        )
+    return tuple(conflicts)
+
+
+async def list_toss_leftover_manual_rows(
+    session: AsyncSession,
+) -> tuple[LeftoverManualRow, ...]:
+    filled_stmt = select(TossLiveOrderLedger.symbol).where(
+        TossLiveOrderLedger.market == "us",
+        TossLiveOrderLedger.side == "sell",
+        TossLiveOrderLedger.status.in_(_FILLED_STATUSES),
+        TossLiveOrderLedger.symbol.in_(TOSS_LEFTOVER_TICKERS),
+    )
+    filled_sell_symbols = {
+        str(symbol) for symbol in (await session.scalars(filled_stmt)).all()
+    }
+
+    stmt = (
+        select(ManualHolding)
+        .join(BrokerAccount)
+        .where(
+            BrokerAccount.broker_type == "toss",
+            BrokerAccount.is_active.is_(True),
+            ManualHolding.market_type == MarketType.US,
+            ManualHolding.ticker.in_(TOSS_LEFTOVER_TICKERS),
+        )
+        .options(selectinload(ManualHolding.broker_account))
+        .order_by(ManualHolding.ticker, ManualHolding.id)
+    )
+    holdings = list((await session.scalars(stmt)).all())
+    rows: list[LeftoverManualRow] = []
+    for holding in holdings:
+        account = holding.broker_account
+        reasons = leftover_reasons(
+            ticker=holding.ticker,
+            is_mock=bool(account.is_mock),
+            filled_sell_symbols=filled_sell_symbols,
+        )
+        if not reasons:
+            continue
+        rows.append(
+            LeftoverManualRow(
+                holding_id=holding.id,
+                ticker=holding.ticker,
+                quantity=str(holding.quantity),
+                broker_account_id=account.id,
+                broker_type=account.broker_type,
+                is_mock=bool(account.is_mock),
+                reasons=reasons,
+            )
+        )
+    return tuple(rows)
+
+
+async def cleanup_toss_leftover_manual_rows(
+    session: AsyncSession,
+    *,
+    commit: bool,
+    confirm: bool,
+    warn_session: bool = False,
+    kst_date: date | None = None,
+) -> LeftoverCleanupResult:
+    rows = await list_toss_leftover_manual_rows(session)
+    conflicts = detect_manual_broker_conflicts(rows)
+    if not commit:
+        return LeftoverCleanupResult(
+            matched=len(rows),
+            deleted=0,
+            warnings_written=0,
+            dry_run=True,
+            rows=rows,
+            conflicts=conflicts,
+        )
+    if not confirm:
+        raise ValueError("commit requires confirm=True")
+
+    deleted = 0
+    if rows:
+        ids = [row.holding_id for row in rows]
+        holdings = list(
+            (
+                await session.scalars(
+                    select(ManualHolding).where(ManualHolding.id.in_(ids))
+                )
+            ).all()
+        )
+        for holding in holdings:
+            await session.delete(holding)
+            deleted += 1
+
+    warnings_written = 0
+    if warn_session and conflicts:
+        entries = [
+            SessionContextAppendEntry(
+                kst_date=kst_date,
+                market="us",
+                account_scope=None,
+                entry_type="constraint",
+                title=f"manual 행이 브로커 원본과 충돌: {conflict.ticker}",
+                body=(
+                    f"toss manual_holdings id={conflict.manual_holding_id} "
+                    f"conflicts with toss live filled sell ({conflict.reason})"
+                ),
+                refs=SessionContextRefs(symbols=[conflict.ticker]),
+                created_by="system",
+                session_label="rob-1297-manual-conflict",
+            )
+            for conflict in conflicts
+        ]
+        written = await SessionContextService(session).append_entries(entries)
+        warnings_written = len(written)
+
+    await session.commit()
+    return LeftoverCleanupResult(
+        matched=len(rows),
+        deleted=deleted,
+        warnings_written=warnings_written,
+        dry_run=False,
+        rows=rows,
+        conflicts=conflicts,
+    )

--- a/app/services/manual_holdings_leftover.py
+++ b/app/services/manual_holdings_leftover.py
@@ -2,10 +2,15 @@
 
 This module is the **write** surface. It is not imported by the market-close
 digest aggregator. Dry-run is the default; ``commit`` requires ``confirm``.
+
+Deletion is fill-evidence only. ``TOSS_LEFTOVER_TICKERS`` is the *search
+scope*, not a deletion reason. A scoped row with no toss filled-sell ledger
+row is skipped (the empty-reasons / non-candidate guard is reachable).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
 
@@ -20,6 +25,10 @@ from app.services.session_context import SessionContextService
 
 TOSS_LEFTOVER_TICKERS: tuple[str, ...] = ("AMZN", "GOOGL")
 _FILLED_STATUSES = ("filled", "partial")
+FILL_EVIDENCE_REASON = "filled_sell_in_toss_ledger"
+DELETE_EVIDENCE_REASONS = frozenset({FILL_EVIDENCE_REASON})
+
+TargetReporter = Callable[[tuple["LeftoverManualRow", ...]], None]
 
 
 @dataclass(frozen=True)
@@ -45,9 +54,11 @@ class ManualBrokerConflict:
 class LeftoverCleanupResult:
     matched: int
     deleted: int
+    skipped_without_evidence: int
     warnings_written: int
     dry_run: bool
     rows: tuple[LeftoverManualRow, ...]
+    skipped_rows: tuple[LeftoverManualRow, ...]
     conflicts: tuple[ManualBrokerConflict, ...]
 
 
@@ -57,14 +68,18 @@ def leftover_reasons(
     is_mock: bool,
     filled_sell_symbols: set[str],
 ) -> tuple[str, ...]:
+    """Evidence labels only. Scope membership is not a reason."""
     reasons: list[str] = []
-    if ticker in TOSS_LEFTOVER_TICKERS:
-        reasons.append("toss_us_allowlist")
     if ticker in filled_sell_symbols:
-        reasons.append("filled_sell_in_toss_ledger")
+        reasons.append(FILL_EVIDENCE_REASON)
     if is_mock:
         reasons.append("account_mode_mock_mismatch")
     return tuple(reasons)
+
+
+def is_deletion_candidate(reasons: tuple[str, ...]) -> bool:
+    """Hard DELETE requires a filled-sell ledger row. Labels are not enough."""
+    return bool(DELETE_EVIDENCE_REASONS.intersection(reasons))
 
 
 def detect_manual_broker_conflicts(
@@ -73,7 +88,7 @@ def detect_manual_broker_conflicts(
     """Manual toss row vs broker-ledger filled sell = double-count risk."""
     conflicts: list[ManualBrokerConflict] = []
     for row in leftovers:
-        if "filled_sell_in_toss_ledger" not in row.reasons:
+        if FILL_EVIDENCE_REASON not in row.reasons:
             continue
         conflicts.append(
             ManualBrokerConflict(
@@ -86,9 +101,25 @@ def detect_manual_broker_conflicts(
     return tuple(conflicts)
 
 
+def _row_from_holding(
+    holding: ManualHolding, reasons: tuple[str, ...]
+) -> LeftoverManualRow:
+    account = holding.broker_account
+    return LeftoverManualRow(
+        holding_id=holding.id,
+        ticker=holding.ticker,
+        quantity=str(holding.quantity),
+        broker_account_id=account.id,
+        broker_type=account.broker_type,
+        is_mock=bool(account.is_mock),
+        reasons=reasons,
+    )
+
+
 async def list_toss_leftover_manual_rows(
     session: AsyncSession,
-) -> tuple[LeftoverManualRow, ...]:
+) -> tuple[tuple[LeftoverManualRow, ...], tuple[LeftoverManualRow, ...]]:
+    """Return ``(deletable, skipped_without_fill_evidence)``."""
     filled_stmt = select(TossLiveOrderLedger.symbol).where(
         TossLiveOrderLedger.market == "us",
         TossLiveOrderLedger.side == "sell",
@@ -112,7 +143,8 @@ async def list_toss_leftover_manual_rows(
         .order_by(ManualHolding.ticker, ManualHolding.id)
     )
     holdings = list((await session.scalars(stmt)).all())
-    rows: list[LeftoverManualRow] = []
+    deletable: list[LeftoverManualRow] = []
+    skipped: list[LeftoverManualRow] = []
     for holding in holdings:
         account = holding.broker_account
         reasons = leftover_reasons(
@@ -120,20 +152,12 @@ async def list_toss_leftover_manual_rows(
             is_mock=bool(account.is_mock),
             filled_sell_symbols=filled_sell_symbols,
         )
-        if not reasons:
+        row = _row_from_holding(holding, reasons)
+        if not reasons or not is_deletion_candidate(reasons):
+            skipped.append(row)
             continue
-        rows.append(
-            LeftoverManualRow(
-                holding_id=holding.id,
-                ticker=holding.ticker,
-                quantity=str(holding.quantity),
-                broker_account_id=account.id,
-                broker_type=account.broker_type,
-                is_mock=bool(account.is_mock),
-                reasons=reasons,
-            )
-        )
-    return tuple(rows)
+        deletable.append(row)
+    return tuple(deletable), tuple(skipped)
 
 
 async def cleanup_toss_leftover_manual_rows(
@@ -143,16 +167,21 @@ async def cleanup_toss_leftover_manual_rows(
     confirm: bool,
     warn_session: bool = False,
     kst_date: date | None = None,
+    reporter: TargetReporter | None = None,
 ) -> LeftoverCleanupResult:
-    rows = await list_toss_leftover_manual_rows(session)
+    rows, skipped = await list_toss_leftover_manual_rows(session)
+    if reporter is not None:
+        reporter(rows)
     conflicts = detect_manual_broker_conflicts(rows)
     if not commit:
         return LeftoverCleanupResult(
             matched=len(rows),
             deleted=0,
+            skipped_without_evidence=len(skipped),
             warnings_written=0,
             dry_run=True,
             rows=rows,
+            skipped_rows=skipped,
             conflicts=conflicts,
         )
     if not confirm:
@@ -198,8 +227,10 @@ async def cleanup_toss_leftover_manual_rows(
     return LeftoverCleanupResult(
         matched=len(rows),
         deleted=deleted,
+        skipped_without_evidence=len(skipped),
         warnings_written=warnings_written,
         dry_run=False,
         rows=rows,
+        skipped_rows=skipped,
         conflicts=conflicts,
     )

--- a/app/services/market_close_digest/__init__.py
+++ b/app/services/market_close_digest/__init__.py
@@ -1,0 +1,10 @@
+"""ROB-1297 market-close digest — deterministic read-only aggregation."""
+
+from app.services.market_close_digest.service import run_market_close_digest
+from app.services.market_close_digest.types import DigestRunResult, DigestSnapshot
+
+__all__ = [
+    "DigestRunResult",
+    "DigestSnapshot",
+    "run_market_close_digest",
+]

--- a/app/services/market_close_digest/calendar.py
+++ b/app/services/market_close_digest/calendar.py
@@ -30,29 +30,43 @@ def infer_session_date(market: Market, now: datetime) -> date:
 
     US cron 05:05 KST is 16:05 ET the previous KST calendar day (EDT), so the
     ET date of ``now`` is the session that just closed. KR 15:45 KST is the
-    same KST date. Crypto uses the KST date of the 24h window ending at now.
+    same KST date. Crypto uses the last *completed* KST calendar day (the 24h
+    window that has already ended by cron 09:05).
     """
     if now.tzinfo is None:
         now = now.replace(tzinfo=UTC)
     if market == "us":
         return now.astimezone(ET).date()
-    return now.astimezone(KST).date()
+    kst_now = now.astimezone(KST)
+    if market == "crypto":
+        return (kst_now - timedelta(days=1)).date()
+    return kst_now.date()
 
 
 def session_window(
-    market: Market, session_date: date
-) -> tuple[datetime, datetime] | None:
+    market: Market,
+    session_date: date,
+    *,
+    now: datetime | None = None,
+) -> tuple[datetime, datetime]:
     """UTC ``[start, end)`` covered by the digest.
 
-    Local calendar day of the session (ET for US, KST for KR/crypto) so
-    after-close reconcile timestamps still belong to the day being closed.
-    Holiday skip is separate (``should_skip_holiday``); this still returns a
-    window on closed days so callers can inspect it.
+    Local calendar day of the session (ET for US, KST for KR/crypto).
+    ``end`` is clamped to ``now`` so a run never queries the future tail of
+    that calendar day (that tail would otherwise be permanently skipped by
+    the next run, which advances ``session_date``).
     """
     tz = ET if market == "us" else KST
     start_local = datetime.combine(session_date, time.min, tzinfo=tz)
     start = start_local.astimezone(UTC)
-    return start, start + timedelta(days=1)
+    end = start + timedelta(days=1)
+    if now is not None:
+        now_utc = now.replace(tzinfo=UTC) if now.tzinfo is None else now.astimezone(UTC)
+        if now_utc < end:
+            end = now_utc
+    if end < start:
+        end = start
+    return start, end
 
 
 def should_skip_holiday(market: Market, session_date: date) -> bool:

--- a/app/services/market_close_digest/calendar.py
+++ b/app/services/market_close_digest/calendar.py
@@ -1,0 +1,65 @@
+"""Session window + holiday skip for ROB-1297.
+
+Reuses ``app.services.market_events.session_calendar`` (XKRX/XNYS via
+``exchange_calendars``) — the same calendar family as the KR/US holiday skip
+used by research-run refresh / invest screener. Does not invent a new holiday
+table.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from app.services.market_close_digest.types import Market
+from app.services.market_events.session_calendar import is_trading_session
+
+KST = ZoneInfo("Asia/Seoul")
+ET = ZoneInfo("America/New_York")
+
+# Documented intended Prefect cadence (NOT registered in this repo).
+INTENDED_CRON_KST: dict[Market, tuple[int, int]] = {
+    "us": (5, 5),
+    "kr": (15, 45),
+    "crypto": (9, 5),
+}
+
+
+def infer_session_date(market: Market, now: datetime) -> date:
+    """Session date the digest covers when run at ``now``.
+
+    US cron 05:05 KST is 16:05 ET the previous KST calendar day (EDT), so the
+    ET date of ``now`` is the session that just closed. KR 15:45 KST is the
+    same KST date. Crypto uses the KST date of the 24h window ending at now.
+    """
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    if market == "us":
+        return now.astimezone(ET).date()
+    return now.astimezone(KST).date()
+
+
+def session_window(
+    market: Market, session_date: date
+) -> tuple[datetime, datetime] | None:
+    """UTC ``[start, end)`` covered by the digest.
+
+    Local calendar day of the session (ET for US, KST for KR/crypto) so
+    after-close reconcile timestamps still belong to the day being closed.
+    Holiday skip is separate (``should_skip_holiday``); this still returns a
+    window on closed days so callers can inspect it.
+    """
+    tz = ET if market == "us" else KST
+    start_local = datetime.combine(session_date, time.min, tzinfo=tz)
+    start = start_local.astimezone(UTC)
+    return start, start + timedelta(days=1)
+
+
+def should_skip_holiday(market: Market, session_date: date) -> bool:
+    """True when KR/US session_date is not a confirmed trading day.
+
+    Crypto is 24x7 — never skipped for holiday.
+    """
+    if market == "crypto":
+        return False
+    return not is_trading_session(market, session_date)

--- a/app/services/market_close_digest/flags.py
+++ b/app/services/market_close_digest/flags.py
@@ -1,0 +1,26 @@
+"""Deterministic improvement flags (ROB-1297).
+
+Each flag is a 1-line string derived from counts/markers already on the
+snapshot. No LLM, no free-text judgment.
+"""
+
+from __future__ import annotations
+
+from app.services.market_close_digest.types import DigestSnapshot
+
+
+def improvement_flags(snapshot: DigestSnapshot) -> tuple[str, ...]:
+    flags: list[str] = []
+    if snapshot.oversell_blocked:
+        symbols = ",".join(block.symbol for block in snapshot.oversell_blocked)
+        flags.append(
+            f"오버셀 차단 {len(snapshot.oversell_blocked)}건"
+            f" — 매도수량>주문가능 ({symbols})"
+        )
+    if snapshot.card_count > 0 and snapshot.auto_approve_count == 0:
+        flags.append(f"자동승인 0 — 전건 카드 {snapshot.card_count}")
+    elif snapshot.card_count > snapshot.auto_approve_count > 0:
+        flags.append(
+            f"카드 {snapshot.card_count} > 자동승인 {snapshot.auto_approve_count}"
+        )
+    return tuple(flags)

--- a/app/services/market_close_digest/formatter.py
+++ b/app/services/market_close_digest/formatter.py
@@ -42,7 +42,7 @@ def format_digest_message(snapshot: DigestSnapshot) -> str:
     if buy_line:
         lines.append(buy_line)
     lines.append(
-        f"신규매수 {snapshot.buy_count} · 그물 {_fmt_net(snapshot.net_notional)}"
+        f"신규매수 {snapshot.buy_count} · 순매수 {_fmt_net(snapshot.net_notional)}"
     )
     lines.append(f"자동승인 {snapshot.auto_approve_count} · 카드 {snapshot.card_count}")
     if snapshot.oversell_blocked:

--- a/app/services/market_close_digest/formatter.py
+++ b/app/services/market_close_digest/formatter.py
@@ -1,0 +1,102 @@
+"""Compact 1-message formatter (ROB-1297, §78 card compression).
+
+Holiday → empty string (caller must not send).
+Zero fills → exactly one line.
+Otherwise a short multi-line card, never a long-form write-up.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.services.market_close_digest.types import DigestSnapshot, LedgerFill, Market
+from app.telegram_contract import TELEGRAM_SEND_MESSAGE_TEXT_LIMIT, telegram_text_length
+
+_MARKET_LABEL: dict[Market, str] = {
+    "us": "US",
+    "kr": "KR",
+    "crypto": "crypto",
+}
+_MAX_FILLS_LISTED = 8
+
+
+def format_digest_message(snapshot: DigestSnapshot) -> str:
+    if snapshot.status == "skipped_holiday":
+        return ""
+    label = _MARKET_LABEL[snapshot.market]
+    day = snapshot.session_date.isoformat()
+    if snapshot.fill_count == 0:
+        return f"{label} 마감 {day} · 체결 0건"
+
+    lines = [
+        f"{label} 마감 {day}",
+        (
+            f"체결 {snapshot.fill_count}건 · 매도 {snapshot.sell_count}"
+            f" · 매수 {snapshot.buy_count}"
+        ),
+    ]
+    sell_line = _join_fills(snapshot.sells, prefix="매도")
+    if sell_line:
+        lines.append(sell_line)
+    buy_line = _join_fills(snapshot.buys, prefix="매수")
+    if buy_line:
+        lines.append(buy_line)
+    lines.append(
+        f"신규매수 {snapshot.buy_count} · 그물 {_fmt_net(snapshot.net_notional)}"
+    )
+    lines.append(f"자동승인 {snapshot.auto_approve_count} · 카드 {snapshot.card_count}")
+    if snapshot.oversell_blocked:
+        symbols = ",".join(block.symbol for block in snapshot.oversell_blocked)
+        lines.append(f"차단 오버셀 {len(snapshot.oversell_blocked)} ({symbols})")
+    for flag in snapshot.flags:
+        lines.append(f"개선: {flag}")
+    message = "\n".join(lines)
+    if telegram_text_length(message) > TELEGRAM_SEND_MESSAGE_TEXT_LIMIT:
+        message = message[: TELEGRAM_SEND_MESSAGE_TEXT_LIMIT - 1] + "…"
+    return message
+
+
+def _join_fills(fills: tuple[LedgerFill, ...], *, prefix: str) -> str | None:
+    if not fills:
+        return None
+    listed = fills[:_MAX_FILLS_LISTED]
+    body = " · ".join(_fmt_fill(fill) for fill in listed)
+    extra = len(fills) - len(listed)
+    if extra > 0:
+        body = f"{body} · +{extra}"
+    return f"{prefix} {body}"
+
+
+def _fmt_fill(fill: LedgerFill) -> str:
+    parts = [fill.symbol]
+    pnl = _fmt_pnl(fill.pnl, fill.pnl_currency)
+    if pnl:
+        parts.append(pnl)
+    pct = _fmt_pct(fill.pnl_pct)
+    if pct:
+        parts.append(pct)
+    return " ".join(parts)
+
+
+def _fmt_pnl(pnl: Decimal | None, currency: str | None) -> str | None:
+    if pnl is None:
+        return None
+    sign = "+" if pnl >= 0 else ""
+    quantized = pnl.quantize(Decimal("0.01"))
+    unit = "$" if (currency or "").upper() in {"USD", ""} else str(currency)
+    if (currency or "").upper() == "KRW":
+        return f"{sign}{int(pnl):,}원"
+    return f"{sign}{quantized}{unit}"
+
+
+def _fmt_pct(pct: Decimal | None) -> str | None:
+    if pct is None:
+        return None
+    sign = "+" if pct >= 0 else ""
+    return f"({sign}{pct.quantize(Decimal('0.1'))}%)"
+
+
+def _fmt_net(net: Decimal) -> str:
+    sign = "+" if net >= 0 else ""
+    quantized = net.quantize(Decimal("0.01"))
+    return f"{sign}{quantized}"

--- a/app/services/market_close_digest/mutation.py
+++ b/app/services/market_close_digest/mutation.py
@@ -1,0 +1,57 @@
+"""Mutation counter for ROB-1297 AC3.
+
+Counts SQLAlchemy unit-of-work writes (new/dirty/deleted) plus Core
+INSERT/UPDATE/DELETE statements executed on the session. SELECT does not
+increment. The digest path must report total == 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.dml import Delete, Insert, Update
+
+
+@dataclass
+class MutationCounter:
+    inserts: int = 0
+    updates: int = 0
+    deletes: int = 0
+    core_dml: int = 0
+    _hooks: list[tuple[object, str, object]] = field(default_factory=list, repr=False)
+
+    @property
+    def total(self) -> int:
+        return self.inserts + self.updates + self.deletes + self.core_dml
+
+    def detach(self) -> None:
+        for target, name, listener in self._hooks:
+            if event.contains(target, name, listener):
+                event.remove(target, name, listener)
+        self._hooks.clear()
+
+
+def attach_mutation_counter(session: AsyncSession) -> MutationCounter:
+    """Listen on ``session.sync_session`` until ``detach`` is called."""
+    counter = MutationCounter()
+    sync_session = session.sync_session
+
+    def _before_flush(sess, _flush_context, _instances) -> None:  # noqa: ANN001
+        counter.inserts += len(sess.new)
+        counter.updates += len(sess.dirty)
+        counter.deletes += len(sess.deleted)
+
+    def _do_orm_execute(orm_execute_state) -> None:  # noqa: ANN001
+        statement = orm_execute_state.statement
+        if isinstance(statement, (Insert, Update, Delete)):
+            counter.core_dml += 1
+
+    event.listen(sync_session, "before_flush", _before_flush)
+    event.listen(sync_session, "do_orm_execute", _do_orm_execute)
+    counter._hooks = [
+        (sync_session, "before_flush", _before_flush),
+        (sync_session, "do_orm_execute", _do_orm_execute),
+    ]
+    return counter

--- a/app/services/market_close_digest/oversell.py
+++ b/app/services/market_close_digest/oversell.py
@@ -1,0 +1,47 @@
+"""Deterministic oversell-block classifier (ROB-1297).
+
+A block is oversell iff the proposal is a sell AND the stored reason matches
+an explicit sellable-qty overflow marker. Buy-side cash failures
+(``insufficient balance``) are not oversell.
+"""
+
+from __future__ import annotations
+
+from app.services.market_close_digest.types import OversellBlock, ProposalRow
+
+OVERSELL_MARKERS: tuple[str, ...] = (
+    "exceeds orderable",
+    "exceeds sellable",
+    "quantity_exceeds_sellable",
+    "qty_exceeds",
+    "quantity exceeds",
+    "loss_cut_confirmation_quantity_exceeds_sellable",
+)
+
+
+def is_oversell_reason(reason: str | None) -> bool:
+    text = (reason or "").lower()
+    if not text:
+        return False
+    return any(marker in text for marker in OVERSELL_MARKERS)
+
+
+def is_oversell_block(*, side: str, reason: str | None) -> bool:
+    return side == "sell" and is_oversell_reason(reason)
+
+
+def collect_oversell_blocks(
+    proposals: tuple[ProposalRow, ...],
+) -> tuple[OversellBlock, ...]:
+    blocks: list[OversellBlock] = []
+    seen: set[tuple[str, str]] = set()
+    for row in proposals:
+        if not is_oversell_block(side=row.side, reason=row.void_reason):
+            continue
+        reason = (row.void_reason or "").strip()
+        key = (row.symbol, reason)
+        if key in seen:
+            continue
+        seen.add(key)
+        blocks.append(OversellBlock(symbol=row.symbol, reason=reason))
+    return tuple(blocks)

--- a/app/services/market_close_digest/queries.py
+++ b/app/services/market_close_digest/queries.py
@@ -289,6 +289,7 @@ class SqlAlchemyDigestSources:
             select(KISLiveOrderLedger)
             .where(
                 KISLiveOrderLedger.status.in_(_FILLED_STATUSES),
+                KISLiveOrderLedger.instrument_type == InstrumentType.equity_kr.value,
                 or_(
                     _in_window(
                         KISLiveOrderLedger.reconciled_at,

--- a/app/services/market_close_digest/queries.py
+++ b/app/services/market_close_digest/queries.py
@@ -1,0 +1,415 @@
+"""Read-only ledger / proposal / retro loaders for ROB-1297.
+
+SELECT only. Callers attach :func:`attach_mutation_counter` to prove AC3.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
+from typing import Protocol
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.execution_ledger import ExecutionLedger
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.models.review import (
+    KISLiveOrderLedger,
+    LiveOrderLedger,
+    TossLiveOrderLedger,
+    TradeRetrospective,
+)
+from app.models.trading import InstrumentType
+from app.services.market_close_digest.types import (
+    PROPOSAL_MARKET,
+    LedgerFill,
+    Market,
+    ProposalRow,
+    RetroRow,
+)
+
+_FILLED_STATUSES = ("filled", "partial")
+
+
+def _in_window(column, start: datetime, end: datetime):  # noqa: ANN001
+    return and_(column >= start, column < end)
+
+
+class DigestSources(Protocol):
+    async def list_fills(
+        self,
+        market: Market,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> tuple[LedgerFill, ...]: ...
+
+    async def list_proposals(
+        self,
+        market: Market,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> tuple[ProposalRow, ...]: ...
+
+    async def list_retros(
+        self,
+        market: Market,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> tuple[RetroRow, ...]: ...
+
+
+def _as_decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(str(value))
+
+
+def _auto_approved(source_asof: object) -> bool:
+    return isinstance(source_asof, dict) and isinstance(
+        source_asof.get("auto_approved"), dict
+    )
+
+
+def _instrument_type(market: Market) -> InstrumentType:
+    if market == "us":
+        return InstrumentType.equity_us
+    if market == "kr":
+        return InstrumentType.equity_kr
+    return InstrumentType.crypto
+
+
+class SqlAlchemyDigestSources:
+    """SELECT-only reader over ledger · proposal · retro tables."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_fills(
+        self,
+        market: Market,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> tuple[LedgerFill, ...]:
+        rows: list[LedgerFill] = []
+        if market in ("us", "kr"):
+            rows.extend(await self._toss_fills(market, window_start, window_end))
+        if market in ("us", "crypto"):
+            rows.extend(await self._live_fills(market, window_start, window_end))
+        if market == "kr":
+            rows.extend(await self._kis_fills(window_start, window_end))
+        rows.extend(await self._execution_fills(market, window_start, window_end))
+        return _dedupe_fills(tuple(rows))
+
+    async def list_proposals(
+        self,
+        market: Market,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> tuple[ProposalRow, ...]:
+        proposal_market = PROPOSAL_MARKET[market]
+        stmt = (
+            select(OrderProposal, OrderProposalRung)
+            .outerjoin(
+                OrderProposalRung,
+                OrderProposalRung.proposal_pk == OrderProposal.id,
+            )
+            .where(
+                OrderProposal.market == proposal_market,
+                OrderProposal.created_at >= window_start,
+                OrderProposal.created_at < window_end,
+            )
+            .order_by(OrderProposal.created_at.asc(), OrderProposal.id.asc())
+        )
+        result = await self._session.execute(stmt)
+        rows: list[ProposalRow] = []
+        seen_groups: set[int] = set()
+        for group, rung in result.all():
+            void_reason = None
+            if rung is not None and rung.void_reason:
+                void_reason = str(rung.void_reason)
+            elif group.void_reason:
+                void_reason = str(group.void_reason)
+            if group.id in seen_groups and rung is None:
+                continue
+            if rung is None:
+                seen_groups.add(group.id)
+            rows.append(
+                ProposalRow(
+                    symbol=group.symbol,
+                    side=group.side if rung is None else rung.side,
+                    market=group.market,
+                    auto_approved=_auto_approved(group.source_asof),
+                    card_kind=group.approval_dispatch_card_kind,
+                    lifecycle_state=(
+                        group.lifecycle_state if rung is None else rung.state
+                    ),
+                    void_reason=void_reason,
+                    created_at=group.created_at,
+                )
+            )
+        return tuple(rows)
+
+    async def list_retros(
+        self,
+        market: Market,
+        window_start: datetime,
+        window_end: datetime,
+    ) -> tuple[RetroRow, ...]:
+        instrument = _instrument_type(market)
+        stmt = (
+            select(TradeRetrospective)
+            .where(
+                TradeRetrospective.instrument_type == instrument,
+                TradeRetrospective.created_at >= window_start,
+                TradeRetrospective.created_at < window_end,
+            )
+            .order_by(TradeRetrospective.created_at.asc())
+        )
+        result = await self._session.scalars(stmt)
+        return tuple(
+            RetroRow(
+                symbol=row.symbol,
+                side=row.side,
+                realized_pnl=_as_decimal(row.realized_pnl),
+                pnl_pct=_as_decimal(row.pnl_pct),
+                pnl_currency=row.realized_pnl_currency,
+                correlation_id=row.correlation_id,
+                created_at=row.created_at,
+            )
+            for row in result.all()
+        )
+
+    async def _toss_fills(
+        self, market: Market, window_start: datetime, window_end: datetime
+    ) -> list[LedgerFill]:
+        stmt = (
+            select(TossLiveOrderLedger)
+            .where(
+                TossLiveOrderLedger.market == market,
+                TossLiveOrderLedger.operation_kind == "place",
+                TossLiveOrderLedger.status.in_(_FILLED_STATUSES),
+                or_(
+                    _in_window(
+                        TossLiveOrderLedger.reconciled_at,
+                        window_start,
+                        window_end,
+                    ),
+                    _in_window(
+                        TossLiveOrderLedger.trade_date,
+                        window_start,
+                        window_end,
+                    ),
+                ),
+            )
+            .order_by(TossLiveOrderLedger.trade_date.asc())
+        )
+        result = await self._session.scalars(stmt)
+        fills: list[LedgerFill] = []
+        for row in result.all():
+            qty = _as_decimal(row.filled_qty) or _as_decimal(row.quantity)
+            price = _as_decimal(row.avg_fill_price) or _as_decimal(row.price)
+            notional = None
+            if qty is not None and price is not None:
+                notional = qty * price
+            pnl = _as_decimal(row.security_pnl_usd)
+            currency = "USD"
+            if pnl is None:
+                pnl = _as_decimal(row.total_pnl_krw)
+                currency = "KRW" if pnl is not None else row.currency
+            fills.append(
+                LedgerFill(
+                    source="toss_live_order_ledger",
+                    broker="toss",
+                    symbol=row.symbol,
+                    side=row.side,  # type: ignore[arg-type]
+                    qty=qty or Decimal("0"),
+                    price=price,
+                    notional=notional,
+                    pnl=pnl,
+                    pnl_pct=None,
+                    pnl_currency=currency,
+                    filled_at=row.reconciled_at or row.trade_date,
+                    correlation_id=row.correlation_id,
+                )
+            )
+        return fills
+
+    async def _live_fills(
+        self, market: Market, window_start: datetime, window_end: datetime
+    ) -> list[LedgerFill]:
+        stmt = (
+            select(LiveOrderLedger)
+            .where(
+                LiveOrderLedger.market == market,
+                LiveOrderLedger.status.in_(_FILLED_STATUSES),
+                or_(
+                    _in_window(LiveOrderLedger.reconciled_at, window_start, window_end),
+                    _in_window(LiveOrderLedger.trade_date, window_start, window_end),
+                ),
+            )
+            .order_by(LiveOrderLedger.trade_date.asc())
+        )
+        result = await self._session.scalars(stmt)
+        fills: list[LedgerFill] = []
+        for row in result.all():
+            qty = _as_decimal(row.filled_qty) or _as_decimal(row.quantity)
+            price = _as_decimal(row.avg_fill_price) or _as_decimal(row.price)
+            notional = _as_decimal(row.amount)
+            if notional is None and qty is not None and price is not None:
+                notional = qty * price
+            pnl = _as_decimal(row.security_pnl_usd)
+            currency = "USD"
+            if pnl is None:
+                pnl = _as_decimal(row.total_pnl_krw)
+                currency = "KRW" if pnl is not None else row.currency
+            fills.append(
+                LedgerFill(
+                    source="live_order_ledger",
+                    broker=row.broker,
+                    symbol=row.symbol,
+                    side=row.side,  # type: ignore[arg-type]
+                    qty=qty or Decimal("0"),
+                    price=price,
+                    notional=notional,
+                    pnl=pnl,
+                    pnl_pct=None,
+                    pnl_currency=currency,
+                    filled_at=row.reconciled_at or row.trade_date,
+                    correlation_id=row.correlation_id,
+                )
+            )
+        return fills
+
+    async def _kis_fills(
+        self, window_start: datetime, window_end: datetime
+    ) -> list[LedgerFill]:
+        stmt = (
+            select(KISLiveOrderLedger)
+            .where(
+                KISLiveOrderLedger.status.in_(_FILLED_STATUSES),
+                or_(
+                    _in_window(
+                        KISLiveOrderLedger.reconciled_at,
+                        window_start,
+                        window_end,
+                    ),
+                    _in_window(KISLiveOrderLedger.trade_date, window_start, window_end),
+                ),
+            )
+            .order_by(KISLiveOrderLedger.trade_date.asc())
+        )
+        result = await self._session.scalars(stmt)
+        fills: list[LedgerFill] = []
+        for row in result.all():
+            qty = _as_decimal(row.filled_qty) or _as_decimal(row.quantity)
+            price = _as_decimal(row.avg_fill_price) or _as_decimal(row.price)
+            notional = _as_decimal(row.amount)
+            if notional is None and qty is not None and price is not None:
+                notional = qty * price
+            fills.append(
+                LedgerFill(
+                    source="kis_live_order_ledger",
+                    broker="kis",
+                    symbol=row.symbol,
+                    side=row.side,  # type: ignore[arg-type]
+                    qty=qty or Decimal("0"),
+                    price=price,
+                    notional=notional,
+                    pnl=None,
+                    pnl_pct=None,
+                    pnl_currency=row.currency,
+                    filled_at=row.reconciled_at or row.trade_date,
+                    correlation_id=row.correlation_id,
+                )
+            )
+        return fills
+
+    async def _execution_fills(
+        self, market: Market, window_start: datetime, window_end: datetime
+    ) -> list[LedgerFill]:
+        instrument = _instrument_type(market)
+        stmt = (
+            select(ExecutionLedger)
+            .where(
+                ExecutionLedger.instrument_type == instrument,
+                ExecutionLedger.filled_at >= window_start,
+                ExecutionLedger.filled_at < window_end,
+            )
+            .order_by(ExecutionLedger.filled_at.asc())
+        )
+        result = await self._session.scalars(stmt)
+        return [
+            LedgerFill(
+                source="execution_ledger",
+                broker=row.broker,
+                symbol=row.symbol,
+                side=row.side,  # type: ignore[arg-type]
+                qty=_as_decimal(row.filled_qty) or Decimal("0"),
+                price=_as_decimal(row.filled_price),
+                notional=_as_decimal(row.filled_notional),
+                pnl=None,
+                pnl_pct=None,
+                pnl_currency=row.currency,
+                filled_at=row.filled_at,
+                correlation_id=row.correlation_id,
+            )
+            for row in result.all()
+        ]
+
+
+def merge_retro_pnl(
+    fills: Sequence[LedgerFill], retros: Sequence[RetroRow]
+) -> tuple[LedgerFill, ...]:
+    """Fill missing PnL from retrospectives. Never invents a number."""
+    by_corr: dict[str, RetroRow] = {
+        row.correlation_id: row
+        for row in retros
+        if row.correlation_id and row.realized_pnl is not None
+    }
+    merged: list[LedgerFill] = []
+    for fill in fills:
+        if fill.pnl is not None:
+            merged.append(fill)
+            continue
+        retro = by_corr.get(fill.correlation_id or "")
+        if retro is None:
+            merged.append(fill)
+            continue
+        merged.append(
+            LedgerFill(
+                source=fill.source,
+                broker=fill.broker,
+                symbol=fill.symbol,
+                side=fill.side,
+                qty=fill.qty,
+                price=fill.price,
+                notional=fill.notional,
+                pnl=retro.realized_pnl,
+                pnl_pct=retro.pnl_pct,
+                pnl_currency=retro.pnl_currency or fill.pnl_currency,
+                filled_at=fill.filled_at,
+                correlation_id=fill.correlation_id,
+            )
+        )
+    return tuple(merged)
+
+
+def _dedupe_fills(fills: tuple[LedgerFill, ...]) -> tuple[LedgerFill, ...]:
+    """Keep the first row per (broker, symbol, side, qty, filled_at minute)."""
+    seen: set[tuple[object, ...]] = set()
+    out: list[LedgerFill] = []
+    for fill in fills:
+        key = (
+            fill.broker,
+            fill.symbol,
+            fill.side,
+            str(fill.qty),
+            fill.filled_at.replace(second=0, microsecond=0),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(fill)
+    return tuple(out)

--- a/app/services/market_close_digest/service.py
+++ b/app/services/market_close_digest/service.py
@@ -1,0 +1,221 @@
+"""Assemble and optionally send the ROB-1297 market-close digest.
+
+Read-only aggregation. Send goes through ``TradeNotifier.notify_agent_message``
+only. Holiday skip reuses ``session_calendar.is_trading_session``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+from app.services.market_close_digest.calendar import (
+    infer_session_date,
+    session_window,
+    should_skip_holiday,
+)
+from app.services.market_close_digest.flags import improvement_flags
+from app.services.market_close_digest.formatter import format_digest_message
+from app.services.market_close_digest.mutation import attach_mutation_counter
+from app.services.market_close_digest.oversell import collect_oversell_blocks
+from app.services.market_close_digest.queries import (
+    DigestSources,
+    SqlAlchemyDigestSources,
+    merge_retro_pnl,
+)
+from app.services.market_close_digest.types import (
+    DigestRunResult,
+    DigestSnapshot,
+    LedgerFill,
+    Market,
+    ProposalRow,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.monitoring.trade_notifier.notifier import TradeNotifier
+
+
+def _card_count(proposals: tuple[ProposalRow, ...]) -> int:
+    seen: set[tuple[str, datetime]] = set()
+    count = 0
+    for row in proposals:
+        if not row.card_kind:
+            continue
+        key = (row.symbol, row.created_at)
+        if key in seen:
+            continue
+        seen.add(key)
+        count += 1
+    return count
+
+
+def _auto_approve_count(proposals: tuple[ProposalRow, ...]) -> int:
+    seen: set[tuple[str, datetime]] = set()
+    count = 0
+    for row in proposals:
+        if not row.auto_approved:
+            continue
+        key = (row.symbol, row.created_at)
+        if key in seen:
+            continue
+        seen.add(key)
+        count += 1
+    return count
+
+
+def assemble_snapshot(
+    *,
+    market: Market,
+    session_date: date,
+    fills: Sequence[LedgerFill],
+    proposals: tuple[ProposalRow, ...],
+    window_start: datetime | None,
+    window_end: datetime | None,
+) -> DigestSnapshot:
+    oversell = collect_oversell_blocks(proposals)
+    status = "zero_fills" if len(fills) == 0 else "ok"
+    snapshot = DigestSnapshot(
+        market=market,
+        session_date=session_date,
+        status=status,
+        fills=tuple(fills),
+        oversell_blocked=oversell,
+        auto_approve_count=_auto_approve_count(proposals),
+        card_count=_card_count(proposals),
+        window_start=window_start,
+        window_end=window_end,
+    )
+    return DigestSnapshot(
+        market=snapshot.market,
+        session_date=snapshot.session_date,
+        status=snapshot.status,
+        fills=snapshot.fills,
+        oversell_blocked=snapshot.oversell_blocked,
+        auto_approve_count=snapshot.auto_approve_count,
+        card_count=snapshot.card_count,
+        flags=improvement_flags(snapshot),
+        window_start=snapshot.window_start,
+        window_end=snapshot.window_end,
+    )
+
+
+async def send_digest_message(
+    message: str,
+    *,
+    market: Market,
+    session_date: date,
+    notifier: TradeNotifier,
+) -> bool:
+    """Existing TradeNotifier surface only — no new bot/channel/transport."""
+    return await notifier.notify_agent_message(
+        message,
+        parse_mode=None,
+        market_type=market,
+        mirror_telegram=True,
+        correlation_id=f"market-close-digest:{market}:{session_date.isoformat()}",
+    )
+
+
+async def run_market_close_digest(
+    *,
+    market: Market,
+    session_date: date | None = None,
+    now: datetime | None = None,
+    sources: DigestSources | None = None,
+    session: AsyncSession | None = None,
+    send: bool = False,
+    notifier: TradeNotifier | None = None,
+) -> DigestRunResult:
+    moment = now or datetime.now(UTC)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    day = session_date or infer_session_date(market, moment)
+
+    if should_skip_holiday(market, day):
+        empty = DigestSnapshot(
+            market=market, session_date=day, status="skipped_holiday"
+        )
+        return DigestRunResult(
+            market=market,
+            session_date=day,
+            status="skipped_holiday",
+            message="",
+            sent=False,
+            mutation_count=0,
+            snapshot=empty,
+        )
+
+    window = session_window(market, day)
+    if window is None:
+        empty = DigestSnapshot(
+            market=market, session_date=day, status="skipped_holiday"
+        )
+        return DigestRunResult(
+            market=market,
+            session_date=day,
+            status="skipped_holiday",
+            message="",
+            sent=False,
+            mutation_count=0,
+            snapshot=empty,
+        )
+    window_start, window_end = window
+
+    counter = None
+    if session is not None:
+        counter = attach_mutation_counter(session)
+        if sources is None:
+            sources = SqlAlchemyDigestSources(session)
+    if sources is None:
+        raise ValueError("sources or session is required")
+
+    try:
+        fills = await sources.list_fills(market, window_start, window_end)
+        proposals = await sources.list_proposals(market, window_start, window_end)
+        retros = await sources.list_retros(market, window_start, window_end)
+        fills = merge_retro_pnl(fills, retros)
+        snapshot = assemble_snapshot(
+            market=market,
+            session_date=day,
+            fills=fills,
+            proposals=proposals,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        message = format_digest_message(snapshot)
+        mutation_count = counter.total if counter is not None else 0
+        if mutation_count != 0:
+            return DigestRunResult(
+                market=market,
+                session_date=day,
+                status="aborted_mutation",
+                message=message,
+                sent=False,
+                mutation_count=mutation_count,
+                snapshot=snapshot,
+            )
+        sent = False
+        status = snapshot.status
+        if send:
+            if notifier is None:
+                raise ValueError("notifier is required when send=True")
+            sent = await send_digest_message(
+                message, market=market, session_date=day, notifier=notifier
+            )
+            if not sent:
+                status = "send_failed"
+        return DigestRunResult(
+            market=market,
+            session_date=day,
+            status=status,
+            message=message,
+            sent=sent,
+            mutation_count=mutation_count,
+            snapshot=snapshot,
+        )
+    finally:
+        if counter is not None:
+            counter.detach()

--- a/app/services/market_close_digest/service.py
+++ b/app/services/market_close_digest/service.py
@@ -148,21 +148,7 @@ async def run_market_close_digest(
             snapshot=empty,
         )
 
-    window = session_window(market, day)
-    if window is None:
-        empty = DigestSnapshot(
-            market=market, session_date=day, status="skipped_holiday"
-        )
-        return DigestRunResult(
-            market=market,
-            session_date=day,
-            status="skipped_holiday",
-            message="",
-            sent=False,
-            mutation_count=0,
-            snapshot=empty,
-        )
-    window_start, window_end = window
+    window_start, window_end = session_window(market, day, now=moment)
 
     counter = None
     if session is not None:

--- a/app/services/market_close_digest/types.py
+++ b/app/services/market_close_digest/types.py
@@ -1,0 +1,129 @@
+"""ROB-1297 market-close digest value types.
+
+Pure dataclasses. No DB, network, or notifier imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+Market = Literal["us", "kr", "crypto"]
+DigestStatus = Literal[
+    "ok",
+    "zero_fills",
+    "skipped_holiday",
+    "aborted_mutation",
+    "send_failed",
+]
+
+PROPOSAL_MARKET: dict[Market, str] = {
+    "us": "equity_us",
+    "kr": "equity_kr",
+    "crypto": "crypto",
+}
+
+
+@dataclass(frozen=True)
+class LedgerFill:
+    source: str
+    broker: str
+    symbol: str
+    side: Literal["buy", "sell"]
+    qty: Decimal
+    price: Decimal | None
+    notional: Decimal | None
+    pnl: Decimal | None
+    pnl_pct: Decimal | None
+    pnl_currency: str | None
+    filled_at: datetime
+    correlation_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ProposalRow:
+    symbol: str
+    side: Literal["buy", "sell"]
+    market: str
+    auto_approved: bool
+    card_kind: str | None
+    lifecycle_state: str
+    void_reason: str | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class RetroRow:
+    symbol: str
+    side: str | None
+    realized_pnl: Decimal | None
+    pnl_pct: Decimal | None
+    pnl_currency: str | None
+    correlation_id: str | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class OversellBlock:
+    symbol: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DigestSnapshot:
+    market: Market
+    session_date: date
+    status: DigestStatus
+    fills: tuple[LedgerFill, ...] = ()
+    oversell_blocked: tuple[OversellBlock, ...] = ()
+    auto_approve_count: int = 0
+    card_count: int = 0
+    flags: tuple[str, ...] = ()
+    window_start: datetime | None = None
+    window_end: datetime | None = None
+
+    @property
+    def fill_count(self) -> int:
+        return len(self.fills)
+
+    @property
+    def buy_count(self) -> int:
+        return sum(1 for fill in self.fills if fill.side == "buy")
+
+    @property
+    def sell_count(self) -> int:
+        return sum(1 for fill in self.fills if fill.side == "sell")
+
+    @property
+    def buys(self) -> tuple[LedgerFill, ...]:
+        return tuple(fill for fill in self.fills if fill.side == "buy")
+
+    @property
+    def sells(self) -> tuple[LedgerFill, ...]:
+        return tuple(fill for fill in self.fills if fill.side == "sell")
+
+    @property
+    def net_notional(self) -> Decimal:
+        total = Decimal("0")
+        for fill in self.fills:
+            if fill.notional is None:
+                continue
+            if fill.side == "buy":
+                total += fill.notional
+            else:
+                total -= fill.notional
+        return total
+
+
+@dataclass
+class DigestRunResult:
+    market: Market
+    session_date: date
+    status: DigestStatus
+    message: str
+    sent: bool
+    mutation_count: int
+    snapshot: DigestSnapshot | None = None
+    extra: dict[str, object] = field(default_factory=dict)

--- a/scripts/cleanup_toss_manual_holdings.py
+++ b/scripts/cleanup_toss_manual_holdings.py
@@ -1,6 +1,7 @@
 """ROB-1297 side task: toss AMZN/GOOGL manual leftover cleanup.
 
 Default dry-run. Writes require ``--commit --confirm``.
+The commit path always prints the delete-target list and count first.
 
     uv run python -m scripts.cleanup_toss_manual_holdings
     uv run python -m scripts.cleanup_toss_manual_holdings --commit --confirm --warn-session
@@ -11,9 +12,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import sys
 
 from app.core.db import AsyncSessionLocal
-from app.services.manual_holdings_leftover import cleanup_toss_leftover_manual_rows
+from app.services.manual_holdings_leftover import (
+    LeftoverManualRow,
+    cleanup_toss_leftover_manual_rows,
+)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -36,30 +41,38 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-async def _run(args: argparse.Namespace) -> int:
-    async with AsyncSessionLocal() as session:
-        result = await cleanup_toss_leftover_manual_rows(
-            session,
-            commit=bool(args.commit),
-            confirm=bool(args.confirm),
-            warn_session=bool(args.warn_session),
-        )
+def _row_payload(row: LeftoverManualRow) -> dict[str, object]:
+    return {
+        "holding_id": row.holding_id,
+        "ticker": row.ticker,
+        "quantity": row.quantity,
+        "broker_account_id": row.broker_account_id,
+        "is_mock": row.is_mock,
+        "reasons": list(row.reasons),
+    }
+
+
+def print_delete_targets(rows: tuple[LeftoverManualRow, ...]) -> None:
+    """Print the delete set and count before any write."""
     payload = {
+        "delete_target_count": len(rows),
+        "rows": [_row_payload(row) for row in rows],
+    }
+    sys.stdout.write("=== DELETE TARGETS ===\n")
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, indent=2))
+    sys.stdout.write(f"\ndelete_target_count={len(rows)}\n")
+    sys.stdout.flush()
+
+
+def _result_payload(result: object) -> dict[str, object]:
+    return {
         "matched": result.matched,
         "deleted": result.deleted,
+        "skipped_without_evidence": result.skipped_without_evidence,
         "warnings_written": result.warnings_written,
         "dry_run": result.dry_run,
-        "rows": [
-            {
-                "holding_id": row.holding_id,
-                "ticker": row.ticker,
-                "quantity": row.quantity,
-                "broker_account_id": row.broker_account_id,
-                "is_mock": row.is_mock,
-                "reasons": list(row.reasons),
-            }
-            for row in result.rows
-        ],
+        "rows": [_row_payload(row) for row in result.rows],
+        "skipped_rows": [_row_payload(row) for row in result.skipped_rows],
         "conflicts": [
             {
                 "ticker": conflict.ticker,
@@ -69,7 +82,18 @@ async def _run(args: argparse.Namespace) -> int:
             for conflict in result.conflicts
         ],
     }
-    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+async def _run(args: argparse.Namespace) -> int:
+    async with AsyncSessionLocal() as session:
+        result = await cleanup_toss_leftover_manual_rows(
+            session,
+            commit=bool(args.commit),
+            confirm=bool(args.confirm),
+            warn_session=bool(args.warn_session),
+            reporter=print_delete_targets,
+        )
+    print(json.dumps(_result_payload(result), ensure_ascii=False, indent=2))
     return 0
 
 

--- a/scripts/cleanup_toss_manual_holdings.py
+++ b/scripts/cleanup_toss_manual_holdings.py
@@ -1,0 +1,81 @@
+"""ROB-1297 side task: toss AMZN/GOOGL manual leftover cleanup.
+
+Default dry-run. Writes require ``--commit --confirm``.
+
+    uv run python -m scripts.cleanup_toss_manual_holdings
+    uv run python -m scripts.cleanup_toss_manual_holdings --commit --confirm --warn-session
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from app.core.db import AsyncSessionLocal
+from app.services.manual_holdings_leftover import cleanup_toss_leftover_manual_rows
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Delete matched manual_holdings rows (requires --confirm).",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Operator confirmation for --commit.",
+    )
+    parser.add_argument(
+        "--warn-session",
+        action="store_true",
+        help="Persist session-context conflict warnings (write path).",
+    )
+    return parser.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    async with AsyncSessionLocal() as session:
+        result = await cleanup_toss_leftover_manual_rows(
+            session,
+            commit=bool(args.commit),
+            confirm=bool(args.confirm),
+            warn_session=bool(args.warn_session),
+        )
+    payload = {
+        "matched": result.matched,
+        "deleted": result.deleted,
+        "warnings_written": result.warnings_written,
+        "dry_run": result.dry_run,
+        "rows": [
+            {
+                "holding_id": row.holding_id,
+                "ticker": row.ticker,
+                "quantity": row.quantity,
+                "broker_account_id": row.broker_account_id,
+                "is_mock": row.is_mock,
+                "reasons": list(row.reasons),
+            }
+            for row in result.rows
+        ],
+        "conflicts": [
+            {
+                "ticker": conflict.ticker,
+                "manual_holding_id": conflict.manual_holding_id,
+                "reason": conflict.reason,
+            }
+            for conflict in result.conflicts
+        ],
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_run(parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_market_close_digest.py
+++ b/scripts/run_market_close_digest.py
@@ -1,0 +1,113 @@
+"""ROB-1297 market-close digest CLI.
+
+Default is dry-run (print the card, no send). ``--send`` delivers through
+TradeNotifier only.
+
+    uv run python -m scripts.run_market_close_digest --market us --session-date 2026-08-19
+    uv run python -m scripts.run_market_close_digest --market kr --send
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import date, datetime
+from typing import Any
+
+from app.core.db import AsyncSessionLocal
+from app.monitoring.trade_notifier import get_trade_notifier
+from app.monitoring.trade_notifier.runtime import (
+    configure_trade_notifier_from_settings,
+)
+from app.services.market_close_digest.service import run_market_close_digest
+
+AC1_EXPECTED = {
+    "market": "us",
+    "session_date": "2026-08-19",
+    "sell_count": 4,
+    "buy_count": 1,
+    "oversell_blocked": 2,
+}
+
+
+def _parse_date(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", choices=("us", "kr", "crypto"), required=True)
+    parser.add_argument("--session-date", type=_parse_date, default=None)
+    parser.add_argument(
+        "--send",
+        action="store_true",
+        help="Deliver through TradeNotifier (default: dry-run, no send).",
+    )
+    return parser.parse_args(argv)
+
+
+def _result_payload(result: Any) -> dict[str, Any]:
+    snapshot = result.snapshot
+    payload: dict[str, Any] = {
+        "market": result.market,
+        "session_date": result.session_date.isoformat(),
+        "status": result.status,
+        "sent": result.sent,
+        "mutation_count": result.mutation_count,
+        "message": result.message,
+    }
+    if snapshot is not None:
+        payload["fill_count"] = snapshot.fill_count
+        payload["buy_count"] = snapshot.buy_count
+        payload["sell_count"] = snapshot.sell_count
+        payload["oversell_blocked"] = len(snapshot.oversell_blocked)
+        payload["auto_approve_count"] = snapshot.auto_approve_count
+        payload["card_count"] = snapshot.card_count
+        payload["flags"] = list(snapshot.flags)
+    if (
+        result.market == AC1_EXPECTED["market"]
+        and result.session_date.isoformat() == AC1_EXPECTED["session_date"]
+        and snapshot is not None
+        and result.status not in {"skipped_holiday", "aborted_mutation"}
+    ):
+        payload["ac1_expected"] = AC1_EXPECTED
+        payload["ac1_delta"] = {
+            "sell_count": snapshot.sell_count - int(AC1_EXPECTED["sell_count"]),
+            "buy_count": snapshot.buy_count - int(AC1_EXPECTED["buy_count"]),
+            "oversell_blocked": len(snapshot.oversell_blocked)
+            - int(AC1_EXPECTED["oversell_blocked"]),
+        }
+    return payload
+
+
+async def _run(args: argparse.Namespace) -> int:
+    notifier = None
+    if args.send:
+        configure_trade_notifier_from_settings(log_context="market-close-digest")
+        notifier = get_trade_notifier()
+    async with AsyncSessionLocal() as session:
+        result = await run_market_close_digest(
+            market=args.market,  # type: ignore[arg-type]
+            session_date=args.session_date,
+            now=datetime.now().astimezone() if args.session_date is None else None,
+            session=session,
+            send=bool(args.send),
+            notifier=notifier,
+        )
+    print(
+        json.dumps(_result_payload(result), ensure_ascii=False, indent=2, default=str)
+    )
+    if result.status == "aborted_mutation":
+        return 2
+    if result.status == "send_failed":
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_run(parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/services/market_close_digest/fakes.py
+++ b/tests/services/market_close_digest/fakes.py
@@ -1,0 +1,142 @@
+"""In-memory digest sources for ROB-1297 unit tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from app.services.market_close_digest.types import LedgerFill, ProposalRow, RetroRow
+
+AC1_SESSION_DATE = date(2026, 8, 19)
+
+
+def _ts(hour: int, minute: int = 0) -> datetime:
+    return datetime(2026, 8, 19, hour, minute, tzinfo=UTC)
+
+
+def ac1_fills() -> tuple[LedgerFill, ...]:
+    """08-19 ET expected counts: sell 4, buy 1."""
+    sells = (
+        LedgerFill(
+            source="toss_live_order_ledger",
+            broker="toss",
+            symbol="AAPL",
+            side="sell",
+            qty=Decimal("1"),
+            price=Decimal("220"),
+            notional=Decimal("220"),
+            pnl=Decimal("12.30"),
+            pnl_pct=Decimal("1.2"),
+            pnl_currency="USD",
+            filled_at=_ts(14, 10),
+        ),
+        LedgerFill(
+            source="toss_live_order_ledger",
+            broker="toss",
+            symbol="MSFT",
+            side="sell",
+            qty=Decimal("1"),
+            price=Decimal("410"),
+            notional=Decimal("410"),
+            pnl=Decimal("-3.10"),
+            pnl_pct=Decimal("-0.4"),
+            pnl_currency="USD",
+            filled_at=_ts(14, 20),
+        ),
+        LedgerFill(
+            source="toss_live_order_ledger",
+            broker="toss",
+            symbol="NVDA",
+            side="sell",
+            qty=Decimal("1"),
+            price=Decimal("170"),
+            notional=Decimal("170"),
+            pnl=Decimal("5.00"),
+            pnl_pct=Decimal("0.8"),
+            pnl_currency="USD",
+            filled_at=_ts(15, 0),
+        ),
+        LedgerFill(
+            source="toss_live_order_ledger",
+            broker="toss",
+            symbol="META",
+            side="sell",
+            qty=Decimal("1"),
+            price=Decimal("500"),
+            notional=Decimal("500"),
+            pnl=Decimal("8.00"),
+            pnl_pct=Decimal("0.5"),
+            pnl_currency="USD",
+            filled_at=_ts(15, 30),
+        ),
+    )
+    buy = LedgerFill(
+        source="toss_live_order_ledger",
+        broker="toss",
+        symbol="AMD",
+        side="buy",
+        qty=Decimal("2"),
+        price=Decimal("160"),
+        notional=Decimal("320"),
+        pnl=None,
+        pnl_pct=None,
+        pnl_currency="USD",
+        filled_at=_ts(16, 0),
+    )
+    return (*sells, buy)
+
+
+def ac1_oversell_proposals() -> tuple[ProposalRow, ...]:
+    return (
+        ProposalRow(
+            symbol="AMZN",
+            side="sell",
+            market="equity_us",
+            auto_approved=False,
+            card_kind="manual",
+            lifecycle_state="rejected",
+            void_reason="Requested sell quantity 2 exceeds orderable balance 1.",
+            created_at=_ts(13, 0),
+        ),
+        ProposalRow(
+            symbol="GOOGL",
+            side="sell",
+            market="equity_us",
+            auto_approved=False,
+            card_kind="manual",
+            lifecycle_state="rejected",
+            void_reason="Requested sell quantity 1 exceeds sellable 0",
+            created_at=_ts(13, 5),
+        ),
+        ProposalRow(
+            symbol="AMD",
+            side="buy",
+            market="equity_us",
+            auto_approved=True,
+            card_kind=None,
+            lifecycle_state="filled",
+            void_reason=None,
+            created_at=_ts(13, 10),
+        ),
+    )
+
+
+class FakeDigestSources:
+    def __init__(
+        self,
+        fills: tuple[LedgerFill, ...] = (),
+        proposals: tuple[ProposalRow, ...] = (),
+        retros: tuple[RetroRow, ...] = (),
+    ) -> None:
+        self.fills = fills
+        self.proposals = proposals
+        self.retros = retros
+
+    async def list_fills(self, market, window_start, window_end):  # noqa: ANN001
+        return self.fills
+
+    async def list_proposals(self, market, window_start, window_end):  # noqa: ANN001
+        return self.proposals
+
+    async def list_retros(self, market, window_start, window_end):  # noqa: ANN001
+        return self.retros

--- a/tests/services/market_close_digest/test_calendar.py
+++ b/tests/services/market_close_digest/test_calendar.py
@@ -1,0 +1,98 @@
+"""B2: crypto (and clamped KR/US) windows must not leave a permanent gap."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.market_close_digest.calendar import (
+    infer_session_date,
+    session_window,
+    should_skip_holiday,
+)
+from app.services.market_close_digest.formatter import format_digest_message
+from app.services.market_close_digest.types import DigestSnapshot
+from tests.services.market_close_digest.fakes import AC1_SESSION_DATE, ac1_fills
+
+pytestmark = pytest.mark.unit
+
+KST = ZoneInfo("Asia/Seoul")
+ET = ZoneInfo("America/New_York")
+REPO = Path(__file__).resolve().parents[3]
+
+
+def test_crypto_cron_covers_previous_completed_kst_day() -> None:
+    now = datetime(2026, 8, 20, 9, 5, tzinfo=KST)
+    session_date = infer_session_date("crypto", now)
+    assert session_date == date(2026, 8, 19)
+    start, end = session_window("crypto", session_date, now=now)
+    assert end <= now.astimezone(UTC)
+    expected_start = datetime(2026, 8, 19, 0, 0, tzinfo=KST).astimezone(UTC)
+    expected_end = datetime(2026, 8, 20, 0, 0, tzinfo=KST).astimezone(UTC)
+    assert start == expected_start
+    assert end == expected_end
+
+
+def test_crypto_consecutive_runs_are_contiguous_and_keep_post_cron_fills() -> None:
+    run_1 = datetime(2026, 8, 20, 9, 5, tzinfo=KST)
+    run_2 = datetime(2026, 8, 21, 9, 5, tzinfo=KST)
+    w1 = session_window("crypto", infer_session_date("crypto", run_1), now=run_1)
+    w2 = session_window("crypto", infer_session_date("crypto", run_2), now=run_2)
+    assert w1[1] == w2[0]
+
+    fill_after_cron = datetime(2026, 8, 20, 15, 0, tzinfo=KST).astimezone(UTC)
+    assert not (w1[0] <= fill_after_cron < w1[1])
+    assert w2[0] <= fill_after_cron < w2[1]
+
+
+def test_crypto_window_end_is_never_in_the_future() -> None:
+    now = datetime(2026, 8, 20, 9, 5, tzinfo=KST)
+    start, end = session_window("crypto", infer_session_date("crypto", now), now=now)
+    assert end <= now.astimezone(UTC)
+    assert start < end
+
+
+def test_kr_and_us_windows_clamp_end_to_now() -> None:
+    kr_now = datetime(2026, 8, 20, 15, 45, tzinfo=KST)
+    kr_date = infer_session_date("kr", kr_now)
+    assert kr_date == date(2026, 8, 20)
+    _, kr_end = session_window("kr", kr_date, now=kr_now)
+    assert kr_end == kr_now.astimezone(UTC)
+
+    us_now = datetime(2026, 8, 20, 5, 5, tzinfo=KST)
+    us_date = infer_session_date("us", us_now)
+    assert us_date == AC1_SESSION_DATE
+    _, us_end = session_window("us", us_date, now=us_now)
+    assert us_end == us_now.astimezone(UTC)
+
+
+def test_us_digest_at_0505_kst_uses_et_session_date() -> None:
+    kst_now = datetime(2026, 8, 20, 5, 5, tzinfo=KST)
+    assert infer_session_date("us", kst_now) == AC1_SESSION_DATE
+    assert should_skip_holiday("us", AC1_SESSION_DATE) is False
+    assert should_skip_holiday("us", date(2025, 7, 4)) is True
+    assert should_skip_holiday("crypto", date(2025, 7, 4)) is False
+
+
+def test_kis_fill_query_filters_equity_kr() -> None:
+    source = (
+        REPO / "app" / "services" / "market_close_digest" / "queries.py"
+    ).read_text()
+    assert (
+        "KISLiveOrderLedger.instrument_type == InstrumentType.equity_kr.value" in source
+    )
+
+
+def test_formatter_says_net_notional_not_ladder() -> None:
+    snapshot = DigestSnapshot(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        status="ok",
+        fills=ac1_fills(),
+    )
+    message = format_digest_message(snapshot)
+    assert "순매수" in message
+    assert "그물" not in message

--- a/tests/services/market_close_digest/test_formatter_flags.py
+++ b/tests/services/market_close_digest/test_formatter_flags.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.services.market_close_digest.flags import improvement_flags
+from app.services.market_close_digest.formatter import format_digest_message
+from app.services.market_close_digest.oversell import (
+    collect_oversell_blocks,
+    is_oversell_block,
+)
+from app.services.market_close_digest.types import (
+    DigestSnapshot,
+    LedgerFill,
+    OversellBlock,
+    ProposalRow,
+)
+from app.telegram_contract import telegram_text_length
+from tests.services.market_close_digest.fakes import (
+    AC1_SESSION_DATE,
+    ac1_fills,
+    ac1_oversell_proposals,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_holiday_message_is_empty() -> None:
+    snapshot = DigestSnapshot(
+        market="us",
+        session_date=date(2025, 7, 4),
+        status="skipped_holiday",
+    )
+    assert format_digest_message(snapshot) == ""
+
+
+def test_zero_fills_is_exactly_one_line() -> None:
+    snapshot = DigestSnapshot(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        status="zero_fills",
+    )
+    message = format_digest_message(snapshot)
+    assert message == "US 마감 2026-08-19 · 체결 0건"
+    assert "\n" not in message
+
+
+def test_ac1_card_is_one_compact_message() -> None:
+    fills = ac1_fills()
+    oversell = collect_oversell_blocks(ac1_oversell_proposals())
+    snapshot = DigestSnapshot(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        status="ok",
+        fills=fills,
+        oversell_blocked=oversell,
+        auto_approve_count=1,
+        card_count=2,
+        flags=("오버셀 차단 2건 — 매도수량>주문가능 (AMZN,GOOGL)",),
+    )
+    message = format_digest_message(snapshot)
+    assert message.count("\n") < 12
+    assert telegram_text_length(message) < 4096
+    assert "매도 4" in message
+    assert "매수 1" in message
+    assert "차단 오버셀 2 (AMZN,GOOGL)" in message
+    assert "장문" not in message
+
+
+def test_improvement_flags_are_count_derived() -> None:
+    snapshot = DigestSnapshot(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        status="ok",
+        oversell_blocked=(
+            OversellBlock(symbol="AMZN", reason="exceeds orderable"),
+            OversellBlock(symbol="GOOGL", reason="exceeds sellable"),
+        ),
+        auto_approve_count=0,
+        card_count=2,
+    )
+    flags = improvement_flags(snapshot)
+    assert flags == (
+        "오버셀 차단 2건 — 매도수량>주문가능 (AMZN,GOOGL)",
+        "자동승인 0 — 전건 카드 2",
+    )
+
+
+def test_buy_insufficient_balance_is_not_oversell() -> None:
+    assert is_oversell_block(side="buy", reason="insufficient balance") is False
+    assert (
+        is_oversell_block(
+            side="sell",
+            reason="Requested sell quantity 2 exceeds orderable balance 1.",
+        )
+        is True
+    )
+
+
+def test_duplicate_oversell_reason_collapses() -> None:
+    rows = ac1_oversell_proposals() + (
+        ProposalRow(
+            symbol="AMZN",
+            side="sell",
+            market="equity_us",
+            auto_approved=False,
+            card_kind=None,
+            lifecycle_state="rejected",
+            void_reason="Requested sell quantity 2 exceeds orderable balance 1.",
+            created_at=ac1_oversell_proposals()[0].created_at,
+        ),
+    )
+    blocks = collect_oversell_blocks(rows)
+    assert [block.symbol for block in blocks] == ["AMZN", "GOOGL"]
+
+
+def test_fill_without_pnl_does_not_invent_numbers() -> None:
+    fill = LedgerFill(
+        source="toss_live_order_ledger",
+        broker="toss",
+        symbol="AMD",
+        side="buy",
+        qty=Decimal("2"),
+        price=Decimal("160"),
+        notional=Decimal("320"),
+        pnl=None,
+        pnl_pct=None,
+        pnl_currency="USD",
+        filled_at=ac1_fills()[-1].filled_at,
+    )
+    snapshot = DigestSnapshot(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        status="ok",
+        fills=(fill,),
+    )
+    message = format_digest_message(snapshot)
+    buy_line = next(line for line in message.splitlines() if line.startswith("매수 "))
+    assert buy_line == "매수 AMD"

--- a/tests/services/market_close_digest/test_mutation_and_queries.py
+++ b/tests/services/market_close_digest/test_mutation_and_queries.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.market_close_digest.queries import merge_retro_pnl
+from app.services.market_close_digest.service import run_market_close_digest
+from app.services.market_close_digest.types import LedgerFill, RetroRow
+from tests.services.market_close_digest.fakes import AC1_SESSION_DATE
+
+pytestmark = pytest.mark.unit
+
+
+def test_merge_retro_pnl_fills_gap_only() -> None:
+    filled_at = datetime(2026, 8, 19, 20, 0, tzinfo=UTC)
+    fill = LedgerFill(
+        source="toss_live_order_ledger",
+        broker="toss",
+        symbol="AAPL",
+        side="sell",
+        qty=Decimal("1"),
+        price=Decimal("220"),
+        notional=Decimal("220"),
+        pnl=None,
+        pnl_pct=None,
+        pnl_currency="USD",
+        filled_at=filled_at,
+        correlation_id="corr-a",
+    )
+    already = LedgerFill(
+        source="toss_live_order_ledger",
+        broker="toss",
+        symbol="MSFT",
+        side="sell",
+        qty=Decimal("1"),
+        price=Decimal("410"),
+        notional=Decimal("410"),
+        pnl=Decimal("-3.10"),
+        pnl_pct=Decimal("-0.4"),
+        pnl_currency="USD",
+        filled_at=filled_at,
+        correlation_id="corr-b",
+    )
+    retros = (
+        RetroRow(
+            symbol="AAPL",
+            side="sell",
+            realized_pnl=Decimal("12.30"),
+            pnl_pct=Decimal("1.2"),
+            pnl_currency="USD",
+            correlation_id="corr-a",
+            created_at=filled_at,
+        ),
+        RetroRow(
+            symbol="MSFT",
+            side="sell",
+            realized_pnl=Decimal("99"),
+            pnl_pct=Decimal("9"),
+            pnl_currency="USD",
+            correlation_id="corr-b",
+            created_at=filled_at,
+        ),
+    )
+    merged = merge_retro_pnl((fill, already), retros)
+    assert merged[0].pnl == Decimal("12.30")
+    assert merged[0].pnl_pct == Decimal("1.2")
+    assert merged[1].pnl == Decimal("-3.10")
+
+
+@pytest.mark.asyncio
+async def test_sqlalchemy_digest_mutation_counter_is_zero(db_session) -> None:
+    result = await run_market_close_digest(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        session=db_session,
+        send=False,
+    )
+    assert result.mutation_count == 0
+    assert result.status in {"ok", "zero_fills"}
+    assert result.sent is False

--- a/tests/services/market_close_digest/test_service.py
+++ b/tests/services/market_close_digest/test_service.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
 
 import pytest
 
-from app.services.market_close_digest.calendar import (
-    infer_session_date,
-    should_skip_holiday,
-)
 from app.services.market_close_digest.service import run_market_close_digest
 from tests.services.market_close_digest.fakes import (
     AC1_SESSION_DATE,
@@ -95,11 +92,16 @@ async def test_dry_run_does_not_call_notifier() -> None:
     notifier.notify_agent_message.assert_not_called()
 
 
-def test_us_digest_at_0505_kst_uses_et_session_date() -> None:
-    from zoneinfo import ZoneInfo
-
-    kst_now = datetime(2026, 8, 20, 5, 5, tzinfo=ZoneInfo("Asia/Seoul"))
-    assert infer_session_date("us", kst_now) == AC1_SESSION_DATE
-    assert should_skip_holiday("us", AC1_SESSION_DATE) is False
-    assert should_skip_holiday("us", date(2025, 7, 4)) is True
-    assert should_skip_holiday("crypto", date(2025, 7, 4)) is False
+@pytest.mark.asyncio
+async def test_crypto_cron_digest_covers_completed_kst_day() -> None:
+    now = datetime(2026, 8, 20, 9, 5, tzinfo=ZoneInfo("Asia/Seoul"))
+    result = await run_market_close_digest(
+        market="crypto",
+        now=now,
+        sources=FakeDigestSources(),
+        send=False,
+    )
+    assert result.session_date == date(2026, 8, 19)
+    assert result.snapshot is not None
+    assert result.snapshot.window_end is not None
+    assert result.snapshot.window_end <= now.astimezone(UTC)

--- a/tests/services/market_close_digest/test_service.py
+++ b/tests/services/market_close_digest/test_service.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.market_close_digest.calendar import (
+    infer_session_date,
+    should_skip_holiday,
+)
+from app.services.market_close_digest.service import run_market_close_digest
+from tests.services.market_close_digest.fakes import (
+    AC1_SESSION_DATE,
+    FakeDigestSources,
+    ac1_fills,
+    ac1_oversell_proposals,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_holiday_skips_without_send() -> None:
+    notifier = AsyncMock()
+    result = await run_market_close_digest(
+        market="us",
+        session_date=date(2025, 7, 4),
+        sources=FakeDigestSources(fills=ac1_fills()),
+        send=True,
+        notifier=notifier,
+    )
+    assert result.status == "skipped_holiday"
+    assert result.message == ""
+    assert result.sent is False
+    assert result.mutation_count == 0
+    notifier.notify_agent_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_zero_fills_sends_one_line() -> None:
+    notifier = AsyncMock()
+    notifier.notify_agent_message = AsyncMock(return_value=True)
+    result = await run_market_close_digest(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        sources=FakeDigestSources(),
+        send=True,
+        notifier=notifier,
+    )
+    assert result.status == "zero_fills"
+    assert result.message == "US 마감 2026-08-19 · 체결 0건"
+    assert result.sent is True
+    assert result.mutation_count == 0
+    notifier.notify_agent_message.assert_awaited_once()
+    kwargs = notifier.notify_agent_message.await_args.kwargs
+    assert kwargs["market_type"] == "us"
+    assert kwargs["mirror_telegram"] is True
+    assert kwargs["parse_mode"] is None
+
+
+@pytest.mark.asyncio
+async def test_ac1_replay_counts() -> None:
+    result = await run_market_close_digest(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        sources=FakeDigestSources(
+            fills=ac1_fills(),
+            proposals=ac1_oversell_proposals(),
+        ),
+        send=False,
+    )
+    assert result.mutation_count == 0
+    assert result.snapshot is not None
+    assert result.snapshot.sell_count == 4
+    assert result.snapshot.buy_count == 1
+    assert len(result.snapshot.oversell_blocked) == 2
+    assert result.snapshot.oversell_blocked[0].symbol == "AMZN"
+    assert result.snapshot.oversell_blocked[1].symbol == "GOOGL"
+    assert "차단 오버셀 2" in result.message
+    assert result.snapshot.flags[0].startswith("오버셀 차단 2건")
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_call_notifier() -> None:
+    notifier = AsyncMock()
+    result = await run_market_close_digest(
+        market="us",
+        session_date=AC1_SESSION_DATE,
+        sources=FakeDigestSources(fills=ac1_fills()),
+        send=False,
+        notifier=notifier,
+    )
+    assert result.sent is False
+    notifier.notify_agent_message.assert_not_called()
+
+
+def test_us_digest_at_0505_kst_uses_et_session_date() -> None:
+    from zoneinfo import ZoneInfo
+
+    kst_now = datetime(2026, 8, 20, 5, 5, tzinfo=ZoneInfo("Asia/Seoul"))
+    assert infer_session_date("us", kst_now) == AC1_SESSION_DATE
+    assert should_skip_holiday("us", AC1_SESSION_DATE) is False
+    assert should_skip_holiday("us", date(2025, 7, 4)) is True
+    assert should_skip_holiday("crypto", date(2025, 7, 4)) is False

--- a/tests/services/market_close_digest/test_static_boundaries.py
+++ b/tests/services/market_close_digest/test_static_boundaries.py
@@ -1,0 +1,107 @@
+"""ROB-1297 static boundaries: notifier-only, no cron, no leftover mix-in."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[3]
+DIGEST_DIR = REPO / "app" / "services" / "market_close_digest"
+FLOW_PATH = REPO / "app" / "flows" / "market_close_digest_flow.py"
+CLI_PATH = REPO / "scripts" / "run_market_close_digest.py"
+LEFTOVER_PATH = REPO / "app" / "services" / "manual_holdings_leftover.py"
+
+
+def _iter_py(root: Path) -> list[Path]:
+    return sorted(root.rglob("*.py")) if root.is_dir() else [root]
+
+
+def test_digest_send_path_is_trade_notifier_only() -> None:
+    send_calls: list[str] = []
+    forbidden = (
+        "send_telegram(",
+        "send_telegram_message(",
+        "Bot(",
+        "telegram.Bot",
+        "https://api.telegram.org",
+        "httpx.AsyncClient",
+    )
+    for path in [*_iter_py(DIGEST_DIR), CLI_PATH, FLOW_PATH]:
+        text = path.read_text()
+        for snippet in forbidden:
+            assert snippet not in text, f"{path} contains {snippet!r}"
+        if "notify_agent_message" in text:
+            send_calls.append(str(path.relative_to(REPO)))
+    assert send_calls, "digest must send via TradeNotifier.notify_agent_message"
+
+
+def test_digest_does_not_import_leftover_cleanup() -> None:
+    for path in _iter_py(DIGEST_DIR):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert "manual_holdings_leftover" not in node.module
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert "manual_holdings_leftover" not in alias.name
+
+
+def test_no_cron_or_prefect_deployment_in_digest_surface() -> None:
+    paths = [
+        *_iter_py(DIGEST_DIR),
+        FLOW_PATH,
+        CLI_PATH,
+        LEFTOVER_PATH,
+        REPO / "scripts" / "cleanup_toss_manual_holdings.py",
+        REPO / "app" / "tasks",
+    ]
+    cron_pattern = re.compile(r"schedule\s*=")
+    deployment_pattern = re.compile(r"Deployment\s*\(")
+    for path in paths:
+        if path.is_dir():
+            files = _iter_py(path)
+        else:
+            files = [path]
+        for file in files:
+            if not file.exists() or file.suffix != ".py":
+                continue
+            text = file.read_text()
+            if "market_close_digest" not in text and file != FLOW_PATH:
+                continue
+            assert not cron_pattern.search(text) or "INTENDED_CRON" in text, (
+                f"cron schedule registration found in {file}"
+            )
+            assert deployment_pattern.search(text) is None, (
+                f"Prefect Deployment() found in {file}"
+            )
+
+
+def test_flow_file_documents_cadence_but_defaults_send_false() -> None:
+    text = FLOW_PATH.read_text()
+    assert "@flow" in text
+    assert "send: bool = False" in text
+    assert "deployment registration is deferred" in text.lower()
+    assert "05:05" in text
+    assert "15:45" in text
+    assert "09:05" in text
+
+
+def test_no_taskiq_schedule_for_digest() -> None:
+    tasks_dir = REPO / "app" / "tasks"
+    for path in _iter_py(tasks_dir):
+        text = path.read_text()
+        assert "market_close_digest" not in text
+        assert "run_market_close_digest" not in text
+
+
+def test_digest_has_no_llm_imports() -> None:
+    forbidden = ("openai", "google.genai", "google.generativeai", "anthropic")
+    for path in _iter_py(DIGEST_DIR):
+        text = path.read_text()
+        for name in forbidden:
+            assert name not in text

--- a/tests/services/test_manual_holdings_leftover.py
+++ b/tests/services/test_manual_holdings_leftover.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.manual_holdings_leftover import (
+    LeftoverManualRow,
+    cleanup_toss_leftover_manual_rows,
+    detect_manual_broker_conflicts,
+    leftover_reasons,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_leftover_reasons_are_deterministic() -> None:
+    assert leftover_reasons(
+        ticker="AMZN",
+        is_mock=True,
+        filled_sell_symbols={"AMZN"},
+    ) == (
+        "toss_us_allowlist",
+        "filled_sell_in_toss_ledger",
+        "account_mode_mock_mismatch",
+    )
+    assert (
+        leftover_reasons(
+            ticker="MSFT",
+            is_mock=False,
+            filled_sell_symbols=set(),
+        )
+        == ()
+    )
+
+
+def test_conflict_only_when_broker_fill_exists() -> None:
+    rows = (
+        LeftoverManualRow(
+            holding_id=1,
+            ticker="AMZN",
+            quantity="1",
+            broker_account_id=9,
+            broker_type="toss",
+            is_mock=False,
+            reasons=("toss_us_allowlist", "filled_sell_in_toss_ledger"),
+        ),
+        LeftoverManualRow(
+            holding_id=2,
+            ticker="GOOGL",
+            quantity="1",
+            broker_account_id=9,
+            broker_type="toss",
+            is_mock=False,
+            reasons=("toss_us_allowlist",),
+        ),
+    )
+    conflicts = detect_manual_broker_conflicts(rows)
+    assert [row.ticker for row in conflicts] == ["AMZN"]
+    assert conflicts[0].reason == "manual_row_conflicts_with_broker_fill"
+
+
+@pytest.mark.asyncio
+async def test_commit_without_confirm_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _empty(_session: object) -> tuple[()]:
+        return ()
+
+    monkeypatch.setattr(
+        "app.services.manual_holdings_leftover.list_toss_leftover_manual_rows",
+        _empty,
+    )
+    with pytest.raises(ValueError, match="confirm"):
+        await cleanup_toss_leftover_manual_rows(
+            object(),  # type: ignore[arg-type]
+            commit=True,
+            confirm=False,
+        )

--- a/tests/services/test_manual_holdings_leftover.py
+++ b/tests/services/test_manual_holdings_leftover.py
@@ -1,35 +1,68 @@
 from __future__ import annotations
 
-import pytest
+import inspect
+import io
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
 
+import pytest
+from sqlalchemy import delete, select
+
+from app.models.manual_holdings import BrokerAccount, ManualHolding, MarketType
+from app.models.review import TossLiveOrderLedger
 from app.services.manual_holdings_leftover import (
+    DELETE_EVIDENCE_REASONS,
+    FILL_EVIDENCE_REASON,
     LeftoverManualRow,
     cleanup_toss_leftover_manual_rows,
     detect_manual_broker_conflicts,
+    is_deletion_candidate,
     leftover_reasons,
 )
 
 pytestmark = pytest.mark.unit
 
+REPO = Path(__file__).resolve().parents[2]
 
-def test_leftover_reasons_are_deterministic() -> None:
+
+def test_leftover_reasons_require_fill_evidence() -> None:
+    assert leftover_reasons(
+        ticker="AMZN",
+        is_mock=False,
+        filled_sell_symbols={"AMZN"},
+    ) == (FILL_EVIDENCE_REASON,)
     assert leftover_reasons(
         ticker="AMZN",
         is_mock=True,
         filled_sell_symbols={"AMZN"},
-    ) == (
-        "toss_us_allowlist",
-        "filled_sell_in_toss_ledger",
-        "account_mode_mock_mismatch",
-    )
+    ) == (FILL_EVIDENCE_REASON, "account_mode_mock_mismatch")
+    # Scope membership is not evidence — empty reasons is reachable.
     assert (
-        leftover_reasons(
-            ticker="MSFT",
-            is_mock=False,
-            filled_sell_symbols=set(),
-        )
-        == ()
+        leftover_reasons(ticker="AMZN", is_mock=False, filled_sell_symbols=set()) == ()
     )
+    assert leftover_reasons(
+        ticker="GOOGL", is_mock=True, filled_sell_symbols=set()
+    ) == ("account_mode_mock_mismatch",)
+
+
+def test_allowlist_and_mock_label_are_not_deletion_evidence() -> None:
+    assert is_deletion_candidate(()) is False
+    assert is_deletion_candidate(("toss_us_allowlist",)) is False
+    assert is_deletion_candidate(("account_mode_mock_mismatch",)) is False
+    assert is_deletion_candidate((FILL_EVIDENCE_REASON,)) is True
+    assert DELETE_EVIDENCE_REASONS == frozenset({FILL_EVIDENCE_REASON})
+
+
+def test_mutant_scope_label_is_not_a_leftover_reason() -> None:
+    source = inspect.getsource(leftover_reasons)
+    assert "toss_us_allowlist" not in source
+    assert "filled_sell_symbols" in source
+    assert "FILL_EVIDENCE_REASON" in source
+    gate = inspect.getsource(is_deletion_candidate)
+    assert "DELETE_EVIDENCE_REASONS" in gate
 
 
 def test_conflict_only_when_broker_fill_exists() -> None:
@@ -41,7 +74,7 @@ def test_conflict_only_when_broker_fill_exists() -> None:
             broker_account_id=9,
             broker_type="toss",
             is_mock=False,
-            reasons=("toss_us_allowlist", "filled_sell_in_toss_ledger"),
+            reasons=(FILL_EVIDENCE_REASON,),
         ),
         LeftoverManualRow(
             holding_id=2,
@@ -50,7 +83,7 @@ def test_conflict_only_when_broker_fill_exists() -> None:
             broker_account_id=9,
             broker_type="toss",
             is_mock=False,
-            reasons=("toss_us_allowlist",),
+            reasons=(),
         ),
     )
     conflicts = detect_manual_broker_conflicts(rows)
@@ -58,20 +91,181 @@ def test_conflict_only_when_broker_fill_exists() -> None:
     assert conflicts[0].reason == "manual_row_conflicts_with_broker_fill"
 
 
+def test_commit_prints_targets_before_write() -> None:
+    from scripts.cleanup_toss_manual_holdings import print_delete_targets
+
+    rows = (
+        LeftoverManualRow(
+            holding_id=11,
+            ticker="AMZN",
+            quantity="2",
+            broker_account_id=3,
+            broker_type="toss",
+            is_mock=False,
+            reasons=(FILL_EVIDENCE_REASON,),
+        ),
+    )
+    buffer = io.StringIO()
+    import sys
+
+    old = sys.stdout
+    sys.stdout = buffer
+    try:
+        print_delete_targets(rows)
+    finally:
+        sys.stdout = old
+    text = buffer.getvalue()
+    assert text.startswith("=== DELETE TARGETS ===\n")
+    assert "delete_target_count=1" in text
+    payload = json.loads(
+        text.split("=== DELETE TARGETS ===\n", 1)[1].split("\ndelete_target_count=")[0]
+    )
+    assert payload["delete_target_count"] == 1
+    assert payload["rows"][0]["ticker"] == "AMZN"
+
+
 @pytest.mark.asyncio
 async def test_commit_without_confirm_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _empty(_session: object) -> tuple[()]:
-        return ()
+    targets = (
+        LeftoverManualRow(
+            holding_id=11,
+            ticker="AMZN",
+            quantity="1",
+            broker_account_id=3,
+            broker_type="toss",
+            is_mock=False,
+            reasons=(FILL_EVIDENCE_REASON,),
+        ),
+    )
+
+    async def _listed(_session: object) -> tuple[tuple, tuple]:
+        return targets, ()
 
     monkeypatch.setattr(
         "app.services.manual_holdings_leftover.list_toss_leftover_manual_rows",
-        _empty,
+        _listed,
     )
+    seen: list[tuple[str, ...]] = []
+
+    def _reporter(rows: tuple[LeftoverManualRow, ...]) -> None:
+        seen.append(tuple(row.ticker for row in rows))
+
     with pytest.raises(ValueError, match="confirm"):
         await cleanup_toss_leftover_manual_rows(
             object(),  # type: ignore[arg-type]
             commit=True,
             confirm=False,
+            reporter=_reporter,
         )
+    assert seen == [("AMZN",)]
+
+
+async def _purge_leftover_scope(db_session) -> None:
+    await db_session.execute(
+        delete(TossLiveOrderLedger).where(
+            TossLiveOrderLedger.symbol.in_(["AMZN", "GOOGL"])
+        )
+    )
+    await db_session.execute(
+        delete(ManualHolding).where(ManualHolding.ticker.in_(["AMZN", "GOOGL"]))
+    )
+    await db_session.commit()
+
+
+async def _seed_toss_us_holding(
+    db_session, user, *, ticker: str, is_mock: bool = False
+) -> ManualHolding:
+    account = BrokerAccount(
+        user_id=user.id,
+        broker_type="toss",
+        account_name=f"toss-{ticker}-{uuid4().hex[:8]}",
+        is_mock=is_mock,
+        is_active=True,
+    )
+    db_session.add(account)
+    await db_session.flush()
+    holding = ManualHolding(
+        broker_account_id=account.id,
+        ticker=ticker,
+        market_type=MarketType.US,
+        quantity=Decimal("1"),
+        avg_price=Decimal("100"),
+    )
+    db_session.add(holding)
+    await db_session.flush()
+    return holding
+
+
+async def _seed_filled_sell(
+    db_session, *, symbol: str, cid: str
+) -> TossLiveOrderLedger:
+    row = TossLiveOrderLedger(
+        trade_date=datetime(2026, 8, 19, 18, 0, tzinfo=UTC),
+        broker="toss",
+        account_mode="toss_live",
+        operation_kind="place",
+        market="us",
+        symbol=symbol,
+        side="sell",
+        order_type="market",
+        client_order_id=f"{cid}-{uuid4().hex[:8]}",
+        broker_order_id=f"ord-{cid}-{uuid4().hex[:8]}",
+        status="filled",
+        filled_qty=Decimal("1"),
+    )
+    db_session.add(row)
+    await db_session.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_delete_only_rows_with_filled_sell_evidence(db_session, user) -> None:
+    await _purge_leftover_scope(db_session)
+    amzn = await _seed_toss_us_holding(db_session, user, ticker="AMZN")
+    googl = await _seed_toss_us_holding(db_session, user, ticker="GOOGL")
+    await _seed_filled_sell(db_session, symbol="AMZN", cid="amzn-fill-1")
+    await db_session.commit()
+
+    dry = await cleanup_toss_leftover_manual_rows(
+        db_session, commit=False, confirm=False
+    )
+    assert [row.ticker for row in dry.rows] == ["AMZN"]
+    assert [row.ticker for row in dry.skipped_rows] == ["GOOGL"]
+    assert dry.matched == 1
+    assert dry.skipped_without_evidence == 1
+    assert dry.deleted == 0
+
+    committed = await cleanup_toss_leftover_manual_rows(
+        db_session, commit=True, confirm=True
+    )
+    assert committed.deleted == 1
+    remaining = list(
+        (
+            await db_session.scalars(
+                select(ManualHolding).where(ManualHolding.id.in_([amzn.id, googl.id]))
+            )
+        ).all()
+    )
+    assert [row.ticker for row in remaining] == ["GOOGL"]
+
+
+@pytest.mark.asyncio
+async def test_mock_label_without_fill_is_not_deleted(db_session, user) -> None:
+    await _purge_leftover_scope(db_session)
+    holding = await _seed_toss_us_holding(db_session, user, ticker="AMZN", is_mock=True)
+    await db_session.commit()
+    result = await cleanup_toss_leftover_manual_rows(
+        db_session, commit=True, confirm=True
+    )
+    assert result.deleted == 0
+    assert result.skipped_without_evidence == 1
+    still = await db_session.get(ManualHolding, holding.id)
+    assert still is not None
+
+
+def test_list_and_cleanup_keep_empty_reason_guard_in_source() -> None:
+    source = (REPO / "app" / "services" / "manual_holdings_leftover.py").read_text()
+    assert "if not reasons or not is_deletion_candidate(reasons):" in source
+    assert "ticker in TOSS_LEFTOVER_TICKERS" not in inspect.getsource(leftover_reasons)

--- a/tests/test_market_close_digest_flow_unscheduled.py
+++ b/tests/test_market_close_digest_flow_unscheduled.py
@@ -1,0 +1,56 @@
+"""Guard: market-close digest flow has no registered deployment (ROB-1297)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_FLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "flows"
+    / "market_close_digest_flow.py"
+)
+
+
+def test_flow_file_exists_and_has_flow_decorator() -> None:
+    assert _FLOW_PATH.exists()
+    text = _FLOW_PATH.read_text()
+    assert "@flow" in text
+    assert "@task" in text
+    assert "market_close_digest_flow" in text
+
+
+def test_flow_defaults_send_off() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "send: bool = False" in text
+
+
+def test_no_prefect_deployment_registered_in_repo() -> None:
+    repo_root = _FLOW_PATH.parents[2]
+    deployment_pattern = re.compile(r"Deployment\s*\(")
+    flow_name = "market_close_digest"
+    for path in repo_root.rglob("*.py"):
+        if any(
+            part.startswith(".") or part in {"__pycache__", ".venv", "node_modules"}
+            for part in path.parts
+        ):
+            continue
+        if "tests" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if flow_name in text and deployment_pattern.search(text):
+            raise AssertionError(
+                f"Found a Prefect Deployment registration referencing {flow_name!r} "
+                f"in {path}."
+            )
+
+
+def test_no_deployment_yaml_for_digest() -> None:
+    project_root = _FLOW_PATH.parents[2]
+    for yf in [*project_root.glob("**/*.yaml"), *project_root.glob("**/*.yml")]:
+        if any(part in {".venv", ".git", "node_modules"} for part in yf.parts):
+            continue
+        content = yf.read_text(encoding="utf-8", errors="ignore")
+        if "market_close_digest" in content:
+            raise AssertionError(f"deployment yaml references digest at {yf}")


### PR DESCRIPTION
ROB-1297 — US/KR/crypto 장 마감 결산 카드를 `TradeNotifier.notify_agent_message`로만 보냅니다. Prefect cron 등록은 이 PR에 없습니다(상류 몰).

## 범위
- 결산 집계: ledger / order_proposals / trade_retrospectives **read-only**. mutation counter 가 쓰기 0을 계산. 휴장일은 `session_calendar.is_trading_session`(§91차 XKRX/XNYS) 재사용. 거래 0건은 1줄. 개선 플래그는 오버셀/카드/auto-approve 카운터에서만 파생.
- 부수(별도 쓰기): toss AMZN/GOOGL `manual_holdings` 잔재 정리 CLI (`--commit --confirm`) + manual vs broker fill 충돌 세션 경고 가드.

## AC
1. 08-19 ET fixture 재현: 매도 4 · 매수 1 · 오버셀 차단 2. 실데이터 반복은 worktree `.env`가 빈 `.env.dev`라 Settings/DATABASE_URL 미로드 — 숫자 맞추기 없음, 차이를 보고함.
2. 휴장일 `skipped_holiday` + notifier 미호출. 0건 1줄.
3. `db_session` SELECT 경로 mutation_count == 0.

## 안전 경계
- 신규 발송 표면 0 (`TradeNotifier` 경유만).
- `app/tasks` 에 digest 스케줄 등록 0. flow `send=False` 기본.
- LLM/session spawn 0.
- 정리 CLI 기본 dry-run.

정지점 = draft PR. 검증자는 상류가 붙입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market-close digest reporting for US, KR, and crypto markets.
  * Digests summarize fills, buys, sells, P&L, approvals, card activity, and oversell blocks in compact messages.
  * Added optional sending, with sending disabled by default.
  * Added command-line tools for generating digest results and cleaning up leftover Toss holdings.
* **Safety**
  * Cleanup runs in dry-run mode by default and requires explicit confirmation before deletion.
  * Holdings are deleted only when supported by matching sell evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->