### PR TITLE
feat(ROB-1292): /invest 외부현금 선언 셀프서비스

### DIFF
--- a/app/routers/invest_funding.py
+++ b/app/routers/invest_funding.py
@@ -14,16 +14,17 @@ from app.auth.admin_router import require_admin
 from app.core.db import get_db
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
-from app.schemas.funding_advisory import ExternalCashDeclarationRequest
+from app.schemas.funding_advisory import (
+    ExternalCashDeclarationRequest,
+    canonical_decimal,
+)
 from app.services.funding_advisory.external_cash import (
+    NO_AUTO_ADD_NOTICE,
     ExternalCashAmbiguousHeadError,
     ExternalCashAuthorizationError,
     ExternalCashConflictError,
     ExternalCashDeclarationService,
     ExternalCashValidationError,
-)
-from app.services.funding_advisory.initial_declaration import (
-    INITIAL_PARKING_AMOUNT,
 )
 from app.services.funding_advisory.service import (
     FundingAdvisoryNotFound,
@@ -96,29 +97,66 @@ async def get_advisory(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND) from exc
 
 
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="as_of must include a timezone",
+        )
+    return value.astimezone(UTC)
+
+
+def _head_summary(view: Any) -> dict[str, Any] | None:
+    record = view.current
+    if record is None:
+        return None
+    return {
+        "location_key": record.location_key,
+        "display_label": record.display_label,
+        "currency": record.currency,
+        "amount": canonical_decimal(record.amount),
+        "as_of": record.as_of,
+        "status": view.status,
+        "expected_head_declaration_id": str(record.declaration_id),
+    }
+
+
 @router.get("/external-cash/current")
 async def get_external_cash_current(
     user: Annotated[User, Depends(get_authenticated_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    location_key: Annotated[str, Query(alias="locationKey")] = "parking_primary",
-    currency: Annotated[str, Query(pattern=r"^[A-Z]{3}$")] = "KRW",
+    location_key: Annotated[str | None, Query(alias="locationKey")] = None,
+    currency: Annotated[str | None, Query(pattern=r"^[A-Z]{3}$")] = None,
 ) -> dict[str, Any]:
     service = ExternalCashDeclarationService(db)
-    view = await service.current(
-        owner_user_id=user.id,
-        location_key=location_key,
-        currency=currency,
-        now=_now(),
-    )
-    return view.model_dump(mode="json")
+    views = await service.list_current(owner_user_id=user.id, now=_now())
+    if location_key is not None:
+        views = [
+            view
+            for view in views
+            if view.current is not None
+            and view.current.location_key == location_key
+            and (currency is None or view.current.currency == currency)
+        ]
+    elif currency is not None:
+        views = [
+            view
+            for view in views
+            if view.current is not None and view.current.currency == currency
+        ]
+    return {
+        "heads": [view.model_dump(mode="json") for view in views],
+        "count": len(views),
+        "notice": NO_AUTO_ADD_NOTICE,
+    }
 
 
 @router.get("/external-cash/history")
 async def get_external_cash_history(
     user: Annotated[User, Depends(get_authenticated_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    location_key: Annotated[str, Query(alias="locationKey")] = "parking_primary",
-    currency: Annotated[str, Query(pattern=r"^[A-Z]{3}$")] = "KRW",
+    location_key: Annotated[str | None, Query(alias="locationKey")] = None,
+    currency: Annotated[str | None, Query(pattern=r"^[A-Z]{3}$")] = None,
     limit: Annotated[int, Query(ge=1, le=200)] = 100,
 ) -> dict[str, Any]:
     service = ExternalCashDeclarationService(db)
@@ -131,6 +169,7 @@ async def get_external_cash_history(
     return {
         "declarations": [row.model_dump(mode="json") for row in rows],
         "count": len(rows),
+        "notice": NO_AUTO_ADD_NOTICE,
     }
 
 
@@ -141,28 +180,41 @@ async def get_external_cash_form(
     owner_user_id: Annotated[int | None, Query(alias="ownerUserId", gt=0)] = None,
 ) -> dict[str, Any]:
     owner_id = owner_user_id or admin.id
+    now = _now()
     service = ExternalCashDeclarationService(db)
-    current = await service.current(
-        owner_user_id=owner_id,
-        location_key="parking_primary",
-        currency="KRW",
-        now=_now(),
+    views = await service.list_current(owner_user_id=owner_id, now=now)
+    parking = next(
+        (
+            view
+            for view in views
+            if view.current is not None
+            and view.current.location_key == "parking_primary"
+            and view.current.currency == "KRW"
+        ),
+        None,
     )
-    head = current.current
+    head = parking.current if parking is not None else None
     return {
         "owner_user_id": owner_id,
-        "location_key": "parking_primary",
-        "display_label": head.display_label if head else "파킹통장",
-        "currency": "KRW",
-        "amount": str(head.amount if head else INITIAL_PARKING_AMOUNT),
-        "as_of": None,
-        "source_note": head.source_note if head else "토스증권 → 파킹통장 이동",
+        "as_of": now,
+        "as_of_fixed": True,
+        "creates_money_movement": False,
+        "idempotency_key": f"funding-ui:{uuid.uuid4()}",
+        "notice": NO_AUTO_ADD_NOTICE,
+        "currencies": ["KRW", "USD"],
+        "default_location_key": "parking_primary",
+        "default_display_label": head.display_label if head else "파킹통장",
+        "default_currency": "KRW",
+        "default_amount": canonical_decimal(head.amount) if head else "0",
+        "default_source_note": head.source_note if head else "운영자 선언",
         "expected_head_declaration_id": (
             str(head.declaration_id) if head is not None else None
         ),
-        "idempotency_key": f"funding-ui:{uuid.uuid4()}",
-        "requires_exact_operator_confirmed_time": True,
-        "creates_money_movement": False,
+        "heads": [
+            summary
+            for summary in (_head_summary(view) for view in views)
+            if summary is not None
+        ],
     }
 
 
@@ -172,14 +224,41 @@ async def declare_external_cash(
     admin: Annotated[User, Depends(require_admin)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict[str, Any]:
+    now = _now()
+    if _aware_utc(request.as_of) > now:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="as_of cannot be in the future",
+        )
     service = ExternalCashDeclarationService(db)
     try:
-        row = await service.declare(request, admin, _now())
-        return row.model_dump(mode="json")
-    except (ExternalCashConflictError, ExternalCashAmbiguousHeadError) as exc:
+        row = await service.declare(request, admin, now)
+        payload = row.model_dump(mode="json")
+        payload["notice"] = NO_AUTO_ADD_NOTICE
+        return payload
+    except ExternalCashConflictError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=str(exc),
+            detail={
+                "error": exc.error,
+                "message": str(exc),
+                "notice": NO_AUTO_ADD_NOTICE,
+                "current_head": (
+                    None
+                    if exc.current_head is None
+                    else exc.current_head.model_dump(mode="json")
+                ),
+            },
+        ) from exc
+    except ExternalCashAmbiguousHeadError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "ambiguous_head",
+                "message": str(exc),
+                "notice": NO_AUTO_ADD_NOTICE,
+                "current_head": None,
+            },
         ) from exc
     except ExternalCashAuthorizationError as exc:
         raise HTTPException(

--- a/app/services/funding_advisory/_external_cash_repository.py
+++ b/app/services/funding_advisory/_external_cash_repository.py
@@ -92,23 +92,21 @@ class ExternalCashDeclarationRepository:
         self,
         *,
         owner_user_id: int,
-        location_key: str,
-        currency: str,
+        location_key: str | None = None,
+        currency: str | None = None,
         limit: int,
     ) -> list[ExternalCashDeclaration]:
-        stmt = (
-            select(ExternalCashDeclaration)
-            .where(
-                ExternalCashDeclaration.owner_user_id == owner_user_id,
-                ExternalCashDeclaration.location_key == location_key,
-                ExternalCashDeclaration.currency == currency,
-            )
-            .order_by(
-                ExternalCashDeclaration.as_of.desc(),
-                ExternalCashDeclaration.recorded_at.desc(),
-            )
-            .limit(limit)
+        stmt = select(ExternalCashDeclaration).where(
+            ExternalCashDeclaration.owner_user_id == owner_user_id,
         )
+        if location_key is not None:
+            stmt = stmt.where(ExternalCashDeclaration.location_key == location_key)
+        if currency is not None:
+            stmt = stmt.where(ExternalCashDeclaration.currency == currency)
+        stmt = stmt.order_by(
+            ExternalCashDeclaration.as_of.desc(),
+            ExternalCashDeclaration.recorded_at.desc(),
+        ).limit(limit)
         return list((await self._session.execute(stmt)).scalars().all())
 
     async def insert(self, **columns: Any) -> ExternalCashDeclaration:

--- a/app/services/funding_advisory/external_cash.py
+++ b/app/services/funding_advisory/external_cash.py
@@ -28,6 +28,7 @@ from app.services.funding_advisory._external_cash_repository import (
 
 FRESHNESS_WINDOW = timedelta(hours=24)
 ORIGIN = "invest_ui"
+NO_AUTO_ADD_NOTICE = "선언은 매수력에 자동 가산되지 않음 — 입금 필요 알림의 근거"
 
 
 class ExternalCashDeclarationError(Exception):
@@ -40,6 +41,17 @@ class ExternalCashAuthorizationError(ExternalCashDeclarationError):
 
 class ExternalCashConflictError(ExternalCashDeclarationError):
     """Expected-head or idempotency compare-and-set failed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        current_head: ExternalCashDeclarationRecord | None = None,
+        error: str = "expected_head_conflict",
+    ) -> None:
+        super().__init__(message)
+        self.current_head = current_head
+        self.error = error
 
 
 class ExternalCashAmbiguousHeadError(ExternalCashDeclarationError):
@@ -177,7 +189,8 @@ class ExternalCashDeclarationService:
             if existing is not None:
                 if not _matches_replay(existing, request, actor_user_id=actor_id):
                     raise ExternalCashConflictError(
-                        "idempotency key already has a different declaration"
+                        "idempotency key already has a different declaration",
+                        error="idempotency_conflict",
                     )
                 await self._session.commit()
                 return _record(existing)
@@ -197,10 +210,18 @@ class ExternalCashDeclarationService:
                     "multiple current declaration heads; refusing to choose"
                 )
 
-            actual_head = heads[0].declaration_id if heads else None
+            actual_head_row = heads[0] if heads else None
+            actual_head = (
+                actual_head_row.declaration_id if actual_head_row is not None else None
+            )
             if actual_head != request.expected_head_declaration_id:
                 raise ExternalCashConflictError(
-                    "expected declaration head does not match current head"
+                    "expected declaration head does not match current head",
+                    current_head=(
+                        _record(actual_head_row)
+                        if actual_head_row is not None
+                        else None
+                    ),
                 )
 
             row = await self._repository.insert(
@@ -254,8 +275,8 @@ class ExternalCashDeclarationService:
         self,
         *,
         owner_user_id: int,
-        location_key: str,
-        currency: str,
+        location_key: str | None = None,
+        currency: str | None = None,
         limit: int = 100,
     ) -> list[ExternalCashDeclarationRecord]:
         if not 1 <= limit <= 200:
@@ -277,4 +298,5 @@ __all__ = [
     "ExternalCashDeclarationService",
     "ExternalCashValidationError",
     "FRESHNESS_WINDOW",
+    "NO_AUTO_ADD_NOTICE",
 ]

--- a/docs/runbooks/funding-advisory.md
+++ b/docs/runbooks/funding-advisory.md
@@ -16,8 +16,17 @@ PR-2가 typed candidate evidence, 조회 API, 페이지와 Telegram delivery cla
 
 ## 최초 640,000원 선언
 
-마이그레이션에는 business row가 없다. 초기값은 `/invest/funding` admin 폼에서 다음
-값으로 한 번 선언한다.
+`/invest/funding` 외부현금 섹션은 운영자 셀프서비스다. 위치 카드(금액·통화·as-of·경과시간),
+현재시각으로 고정된 신규 선언 폼, 이력 테이블을 제공한다. as-of 는 폼 발급 시각이며
+운영자가 미래 값을 넣을 수 없다. UI가 수정처럼 보여도 write 는 항상 새 선언 append 다.
+낙관적 동시성으로 `expected_head_declaration_id` 가 어긋나면 409 와 함께 새 head 를
+표시한다. 비-admin 세션은 읽기만 가능하고 쓰기는 거부한다.
+
+선언은 매수력에 자동 가산되지 않음 — 입금 필요 알림의 근거. 화면에도 같은 문구를 둔다.
+
+마이그레이션에는 business row가 없다. 초기 640,000원 값은 정확한 관측 시각이 필요할 때만
+`build_initial_parking_declaration()` 으로 만들고, 이후 갱신은 `/invest/funding` admin 폼에서
+현재시각 as-of 로 선언한다.
 
 - location: `parking_primary`
 - label: `파킹통장`

--- a/frontend/invest/src/__tests__/ExternalCashPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ExternalCashPanel.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExternalCashDeclareConflict } from "../api/fundingAdvisory";
+import { ExternalCashPanel } from "../pages/FundingRoute";
+import type {
+  ExternalCashDeclaration,
+  ExternalCashForm,
+  ExternalCashHeadsView,
+  ExternalCashHistoryView,
+} from "../types/fundingAdvisory";
+import { EXTERNAL_CASH_NO_AUTO_ADD_NOTICE } from "../types/fundingAdvisory";
+
+const HEAD: ExternalCashDeclaration = {
+  declaration_id: "head-zero",
+  owner_user_id: 7,
+  location_key: "parking_primary",
+  display_label: "파킹통장",
+  currency: "KRW",
+  amount: "0",
+  as_of: "2026-08-20T06:30:00Z",
+  fresh_until: "2026-08-21T06:30:00Z",
+  source_note: "운영자 선언",
+  declared_by_user_id: 7,
+  origin: "invest_ui",
+  supersedes_declaration_id: null,
+  idempotency_key: "funding-ui:zero",
+  recorded_at: "2026-08-20T06:30:00Z",
+};
+
+const CURRENT: ExternalCashHeadsView = {
+  heads: [
+    {
+      status: "fresh",
+      amount_status: "known",
+      current: HEAD,
+      route_fundable_amount: "0",
+      verification_badge: "운영자 선언 · 시스템 검증 불가",
+      warning_code: null,
+    },
+  ],
+  count: 1,
+  notice: EXTERNAL_CASH_NO_AUTO_ADD_NOTICE,
+};
+
+const HISTORY: ExternalCashHistoryView = {
+  declarations: [HEAD],
+  count: 1,
+};
+
+const FORM: ExternalCashForm = {
+  owner_user_id: 7,
+  as_of: "2026-08-20T07:30:00Z",
+  as_of_fixed: true,
+  creates_money_movement: false,
+  idempotency_key: "funding-ui:form",
+  notice: EXTERNAL_CASH_NO_AUTO_ADD_NOTICE,
+  currencies: ["KRW", "USD"],
+  default_location_key: "parking_primary",
+  default_display_label: "파킹통장",
+  default_currency: "KRW",
+  default_amount: "0",
+  default_source_note: "운영자 선언",
+  expected_head_declaration_id: "head-zero",
+  heads: [
+    {
+      location_key: "parking_primary",
+      display_label: "파킹통장",
+      currency: "KRW",
+      amount: "0",
+      as_of: "2026-08-20T06:30:00Z",
+      status: "fresh",
+      expected_head_declaration_id: "head-zero",
+    },
+  ],
+};
+
+const declareMock = vi.fn();
+
+vi.mock("../api/fundingAdvisory", async () => {
+  const actual = await vi.importActual<typeof import("../api/fundingAdvisory")>("../api/fundingAdvisory");
+  return {
+    ...actual,
+    declareExternalCash: (...args: unknown[]) => declareMock(...args),
+  };
+});
+
+afterEach(() => {
+  declareMock.mockReset();
+});
+
+function renderPanel({
+  current = CURRENT,
+  history = HISTORY,
+  form = FORM,
+  onSaved = async () => undefined,
+}: {
+  current?: ExternalCashHeadsView;
+  history?: ExternalCashHistoryView;
+  form?: ExternalCashForm | null;
+  onSaved?: () => Promise<void>;
+} = {}) {
+  return render(
+    <MemoryRouter>
+      <ExternalCashPanel current={current} history={history} form={form} onSaved={onSaved} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ExternalCashPanel self-service", () => {
+  it("shows the zero parking head, notice, frozen as-of, and history table", () => {
+    renderPanel();
+
+    expect(screen.getByTestId("external-cash-notice")).toHaveTextContent(EXTERNAL_CASH_NO_AUTO_ADD_NOTICE);
+    expect(screen.getByTestId("external-cash-card-parking_primary")).toHaveTextContent("파킹통장");
+    expect(screen.getByTestId("external-cash-card-parking_primary")).toHaveTextContent("0");
+    expect(screen.getByTestId("external-cash-as-of")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("2026-08-15T08:20:00+09:00")).toBeNull();
+    expect(screen.getByTestId("external-cash-history-table")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "통화" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "신규 위치" })).toBeInTheDocument();
+  });
+
+  it("appends a new declaration from the zero head", async () => {
+    const user = userEvent.setup();
+    declareMock.mockResolvedValue({ ...HEAD, declaration_id: "head-next", amount: "1500000" });
+    const onSaved = vi.fn(async () => undefined);
+    renderPanel({ onSaved });
+
+    await user.clear(screen.getByRole("textbox", { name: "금액 (KRW)" }));
+    await user.type(screen.getByRole("textbox", { name: "금액 (KRW)" }), "1500000");
+    await user.click(screen.getByRole("button", { name: "선언 저장 · 돈 이동 아님" }));
+
+    expect(declareMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: "1500000",
+        as_of: "2026-08-20T07:30:00Z",
+        expected_head_declaration_id: "head-zero",
+        location_key: "parking_primary",
+      }),
+    );
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it("shows the new head after a 409 stale submit", async () => {
+    const user = userEvent.setup();
+    declareMock.mockRejectedValue(
+      new ExternalCashDeclareConflict({
+        error: "expected_head_conflict",
+        message: "expected declaration head does not match current head",
+        current_head: { ...HEAD, declaration_id: "head-new", amount: "640000" },
+      }),
+    );
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "선언 저장 · 돈 이동 아님" }));
+
+    expect(screen.getByTestId("external-cash-conflict")).toHaveTextContent("다른 곳에서 선언이 갱신되었습니다");
+    expect(screen.getByTestId("external-cash-conflict-head")).toHaveTextContent("640,000");
+  });
+
+  it("hides the write form for a non-admin session", () => {
+    renderPanel({ form: null });
+    expect(screen.queryByTestId("external-cash-form")).toBeNull();
+    expect(screen.getByText("관리자만 새 선언을 append할 수 있습니다.")).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/fundingAdvisory.api.test.ts
+++ b/frontend/invest/src/__tests__/fundingAdvisory.api.test.ts
@@ -1,19 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { declareExternalCash, readCsrfCookie } from "../api/fundingAdvisory";
-import type { ExternalCashForm } from "../types/fundingAdvisory";
+import {
+  declareExternalCash,
+  ExternalCashDeclareConflict,
+  readCsrfCookie,
+} from "../api/fundingAdvisory";
+import type { ExternalCashDeclarePayload } from "../types/fundingAdvisory";
 
-const FORM: ExternalCashForm = {
+const PAYLOAD: ExternalCashDeclarePayload = {
   owner_user_id: 7,
   location_key: "parking_primary",
   display_label: "파킹통장",
   currency: "KRW",
-  amount: "640000",
-  as_of: null,
-  source_note: "토스증권 → 파킹통장 이동",
+  amount: "0",
+  as_of: "2026-08-20T07:30:00+00:00",
+  source_note: "운영자 선언",
   expected_head_declaration_id: null,
   idempotency_key: "funding-ui:test-key",
-  requires_exact_operator_confirmed_time: true,
-  creates_money_movement: false,
 };
 
 afterEach(() => {
@@ -35,11 +37,7 @@ describe("funding advisory declaration API", () => {
       }),
     );
 
-    await declareExternalCash(FORM, {
-      amount: "640000",
-      asOf: "2026-08-15T08:20:00+09:00",
-      sourceNote: "토스증권 → 파킹통장 이동",
-    });
+    await declareExternalCash(PAYLOAD);
 
     const [, init] = fetchMock.mock.calls[0] ?? [];
     expect(init).toMatchObject({
@@ -51,10 +49,39 @@ describe("funding advisory declaration API", () => {
       },
     });
     expect(JSON.parse(String(init?.body))).toMatchObject({
-      amount: "640000",
-      as_of: "2026-08-15T08:20:00+09:00",
+      amount: "0",
+      as_of: "2026-08-20T07:30:00+00:00",
       expected_head_declaration_id: null,
       idempotency_key: "funding-ui:test-key",
     });
+  });
+
+  it("surfaces a 409 current head without treating it as a generic error", async () => {
+    document.cookie = "csrftoken=signed-token; path=/";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            error: "expected_head_conflict",
+            message: "expected declaration head does not match current head",
+            current_head: {
+              declaration_id: "head-2",
+              display_label: "파킹통장",
+              amount: "1500000",
+              currency: "KRW",
+              as_of: "2026-08-20T07:31:00+00:00",
+            },
+          },
+        }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(declareExternalCash(PAYLOAD)).rejects.toMatchObject({
+      name: "ExternalCashDeclareConflict",
+      error: "expected_head_conflict",
+      currentHead: expect.objectContaining({ declaration_id: "head-2" }),
+    });
+    expect(ExternalCashDeclareConflict).toBeDefined();
   });
 });

--- a/frontend/invest/src/api/fundingAdvisory.ts
+++ b/frontend/invest/src/api/fundingAdvisory.ts
@@ -1,7 +1,8 @@
 import type {
-  ExternalCashCurrentView,
+  ExternalCashDeclarePayload,
   ExternalCashDeclaration,
   ExternalCashForm,
+  ExternalCashHeadsView,
   ExternalCashHistoryView,
   FundingAdvisoryListResponse,
   FundingAdvisoryView,
@@ -31,7 +32,7 @@ export function fetchFundingAllocation(signal?: AbortSignal): Promise<FundingAll
   return getJson(`${BASE}/allocation`, signal);
 }
 
-export function fetchExternalCashCurrent(signal?: AbortSignal): Promise<ExternalCashCurrentView> {
+export function fetchExternalCashCurrent(signal?: AbortSignal): Promise<ExternalCashHeadsView> {
   return getJson(`${BASE}/external-cash/current`, signal);
 }
 
@@ -57,9 +58,24 @@ export function readCsrfCookie(cookie = document.cookie): string | null {
   return token ? decodeURIComponent(token.slice("csrftoken=".length)) : null;
 }
 
+export class ExternalCashDeclareConflict extends Error {
+  readonly error: string;
+  readonly currentHead: ExternalCashDeclaration | null;
+
+  constructor(detail: {
+    error?: string;
+    message?: string;
+    current_head?: ExternalCashDeclaration | null;
+  }) {
+    super(detail.message ?? "expected declaration head does not match current head");
+    this.name = "ExternalCashDeclareConflict";
+    this.error = detail.error ?? "expected_head_conflict";
+    this.currentHead = detail.current_head ?? null;
+  }
+}
+
 export async function declareExternalCash(
-  form: ExternalCashForm,
-  values: { amount: string; asOf: string; sourceNote: string },
+  payload: ExternalCashDeclarePayload,
 ): Promise<ExternalCashDeclaration> {
   const csrfToken = readCsrfCookie();
   if (!csrfToken) throw new Error("CSRF token is unavailable; reload the form before submitting");
@@ -70,18 +86,18 @@ export async function declareExternalCash(
       "Content-Type": "application/json",
       "x-csrftoken": csrfToken,
     },
-    body: JSON.stringify({
-      owner_user_id: form.owner_user_id,
-      location_key: form.location_key,
-      display_label: form.display_label,
-      currency: form.currency,
-      amount: values.amount,
-      as_of: values.asOf,
-      source_note: values.sourceNote,
-      expected_head_declaration_id: form.expected_head_declaration_id,
-      idempotency_key: form.idempotency_key,
-    }),
+    body: JSON.stringify(payload),
   });
+  if (response.status === 409) {
+    const body = (await response.json()) as {
+      detail?: {
+        error?: string;
+        message?: string;
+        current_head?: ExternalCashDeclaration | null;
+      };
+    };
+    throw new ExternalCashDeclareConflict(body.detail ?? {});
+  }
   if (!response.ok) throw new Error(`${BASE}/external-cash/declarations ${response.status}`);
   return response.json();
 }

--- a/frontend/invest/src/pages/FundingRoute.tsx
+++ b/frontend/invest/src/pages/FundingRoute.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from
 import { Link, useParams } from "react-router-dom";
 import {
   declareExternalCash,
+  ExternalCashDeclareConflict,
   fetchExternalCashCurrent,
   fetchExternalCashForm,
   fetchExternalCashHistory,
@@ -11,17 +12,21 @@ import {
 } from "../api/fundingAdvisory";
 import { PageSafetyNote } from "../components/PageSafetyNote";
 import { DesktopShell } from "../desktop/DesktopShell";
+import { formatRelativeTime } from "../format/relativeTime";
 import { Button, Card, Pill } from "../ds";
 import { useViewport } from "../hooks/useViewport";
 import { MobileShell } from "../mobile/MobileShell";
 import type {
   ExternalCashCurrentView,
+  ExternalCashDeclaration,
   ExternalCashForm,
+  ExternalCashHeadsView,
   ExternalCashHistoryView,
   FundingAdvisoryView,
   FundingAllocationView,
   FundingRouteView,
 } from "../types/fundingAdvisory";
+import { EXTERNAL_CASH_NO_AUTO_ADD_NOTICE } from "../types/fundingAdvisory";
 import "../styles/funding.css";
 
 const NON_CTA_LABEL = "경로 설명 · 이 화면에서 주문 안 만듦";
@@ -31,7 +36,7 @@ interface FundingPageData {
   advisories: FundingAdvisoryView[];
   detail: FundingAdvisoryView | null;
   allocation: FundingAllocationView;
-  external: ExternalCashCurrentView;
+  external: ExternalCashHeadsView;
   history: ExternalCashHistoryView;
   declarationForm: ExternalCashForm | null;
 }
@@ -256,38 +261,98 @@ function AllocationView({ allocation }: { allocation: FundingAllocationView }) {
   );
 }
 
-function ExternalCashPanel({
+const NEW_LOCATION = "__new__";
+
+function locationCards(heads: ExternalCashCurrentView[]): ExternalCashCurrentView[] {
+  const hasParking = heads.some((view) => view.current?.location_key === "parking_primary");
+  if (hasParking) return heads;
+  return [
+    {
+      status: "missing",
+      amount_status: "unknown",
+      current: null,
+      route_fundable_amount: null,
+      verification_badge: "운영자 선언 · 시스템 검증 불가",
+      warning_code: "external_cash_missing",
+    },
+    ...heads,
+  ];
+}
+
+function locationKeyFromLabel(label: string): string {
+  const ascii = label.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  return ascii || "parking_primary";
+}
+
+export function ExternalCashPanel({
   current,
   history,
   form,
   onSaved,
 }: {
-  current: ExternalCashCurrentView;
+  current: ExternalCashHeadsView;
   history: ExternalCashHistoryView;
   form: ExternalCashForm | null;
   onSaved: () => Promise<void>;
 }) {
-  const [amount, setAmount] = useState(form?.amount ?? "640000");
-  const [asOf, setAsOf] = useState("");
-  const [sourceNote, setSourceNote] = useState(form?.source_note ?? "토스증권 → 파킹통장 이동");
-  const [submitState, setSubmitState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const cards = locationCards(current.heads);
+  const [locationChoice, setLocationChoice] = useState(form?.default_location_key ?? "parking_primary");
+  const [newLocationKey, setNewLocationKey] = useState("");
+  const [displayLabel, setDisplayLabel] = useState(form?.default_display_label ?? "파킹통장");
+  const [currency, setCurrency] = useState<"KRW" | "USD">(form?.default_currency ?? "KRW");
+  const [amount, setAmount] = useState(form?.default_amount ?? "0");
+  const [sourceNote, setSourceNote] = useState(form?.default_source_note ?? "운영자 선언");
+  const [submitState, setSubmitState] = useState<"idle" | "saving" | "saved" | "error" | "conflict">("idle");
+  const [conflictHead, setConflictHead] = useState<ExternalCashDeclaration | null>(null);
 
   useEffect(() => {
     if (!form) return;
-    setAmount(form.amount);
-    setSourceNote(form.source_note);
-    setAsOf("");
+    setLocationChoice(form.default_location_key);
+    setDisplayLabel(form.default_display_label);
+    setCurrency(form.default_currency);
+    setAmount(form.default_amount);
+    setSourceNote(form.default_source_note);
+    setNewLocationKey("");
+    setSubmitState("idle");
+    setConflictHead(null);
   }, [form]);
+
+  const selectedHead = form?.heads.find(
+    (head) =>
+      head.location_key === locationChoice
+      && head.currency === currency,
+  );
+  const isNewLocation = locationChoice === NEW_LOCATION;
+  const locationKey = isNewLocation
+    ? (newLocationKey || locationKeyFromLabel(displayLabel))
+    : locationChoice;
+  const expectedHead = isNewLocation ? null : (selectedHead?.expected_head_declaration_id ?? null);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!form || !asOf) return;
+    if (!form) return;
     setSubmitState("saving");
+    setConflictHead(null);
     try {
-      await declareExternalCash(form, { amount, asOf, sourceNote });
+      await declareExternalCash({
+        owner_user_id: form.owner_user_id,
+        location_key: locationKey,
+        display_label: displayLabel,
+        currency,
+        amount,
+        as_of: form.as_of,
+        source_note: sourceNote,
+        expected_head_declaration_id: expectedHead,
+        idempotency_key: form.idempotency_key,
+      });
       setSubmitState("saved");
       await onSaved();
-    } catch {
+    } catch (caught) {
+      if (caught instanceof ExternalCashDeclareConflict) {
+        setConflictHead(caught.currentHead);
+        setSubmitState("conflict");
+        return;
+      }
       setSubmitState("error");
     }
   }
@@ -295,43 +360,162 @@ function ExternalCashPanel({
   return (
     <section className="funding-section" id="external-cash-declaration">
       <div className="funding-section-head">
-        <div><h2>외부 현금 선언</h2><p>append-only 운영자 snapshot이며 실제 이체 또는 broker 잔고 확인이 아닙니다.</p></div>
-        <Pill tone={current.status === "fresh" ? "gain" : "warn"}>{current.status}</Pill>
+        <div>
+          <h2>외부 현금 선언</h2>
+          <p>append-only 운영자 snapshot이며 실제 이체 또는 broker 잔고 확인이 아닙니다. UI의 수정은 새 선언입니다.</p>
+        </div>
       </div>
+      <p className="funding-disclosure" data-testid="external-cash-notice">
+        {EXTERNAL_CASH_NO_AUTO_ADD_NOTICE}
+      </p>
       <div className="funding-external-grid">
-        <Card>
-          {current.current ? (
-            <dl className="funding-metrics funding-metrics--compact">
-              <Metric label="위치" value={current.current.display_label} />
-              <Metric label="선언액" value={formatAmount(current.current.amount, current.current.currency)} />
-              <Metric label="관측 시각" value={formatTime(current.current.as_of)} />
-              <Metric label="fresh until" value={formatTime(current.current.fresh_until)} />
-            </dl>
-          ) : <p className="funding-muted">현재 선언이 없습니다.</p>}
-          <p className="funding-verification">{current.verification_badge}</p>
-          {history.declarations.length ? (
-            <details className="funding-history">
-              <summary>변경 이력 {history.count}건</summary>
-              <ol>{history.declarations.map((row) => <li key={row.declaration_id}>{formatTime(row.as_of)} · {formatAmount(row.amount, row.currency)}</li>)}</ol>
-            </details>
-          ) : null}
-        </Card>
-
-        {form ? (
-          <Card>
-            <form className="funding-form" onSubmit={submit}>
-              <div className="funding-form__notice">관리자 선언 저장 · 돈 이동 아님</div>
-              <label>금액 ({form.currency})<input value={amount} inputMode="numeric" onChange={(event) => setAmount(event.target.value)} required /></label>
-              <label>정확한 관측 시각 + timezone<input value={asOf} onChange={(event) => setAsOf(event.target.value)} placeholder="2026-08-15T08:20:00+09:00" required /></label>
-              <label>출처 메모<input value={sourceNote} onChange={(event) => setSourceNote(event.target.value)} required /></label>
-              <p className="funding-disclosure">시각은 자동 채우지 않습니다. 실제 관측 시각과 timezone을 확인한 뒤 저장하세요.</p>
-              <Button type="submit" disabled={submitState === "saving"}>{submitState === "saving" ? "저장 중…" : "선언 저장 · 돈 이동 아님"}</Button>
-              {submitState === "saved" ? <p role="status">새 선언을 append했습니다. 실제 이체는 발생하지 않았습니다.</p> : null}
-              {submitState === "error" ? <p role="alert">저장하지 못했습니다. head·시각·권한을 다시 확인하세요.</p> : null}
-            </form>
-          </Card>
-        ) : <Card soft><p className="funding-muted">관리자만 새 선언을 append할 수 있습니다.</p></Card>}
+        {cards.map((view) => {
+          const record = view.current;
+          const key = record ? `${record.location_key}:${record.currency}` : "parking_primary:KRW";
+          return (
+            <Card key={key} data-testid={`external-cash-card-${record?.location_key ?? "parking_primary"}`}>
+              <dl className="funding-metrics funding-metrics--compact">
+                <Metric label="위치" value={record?.display_label ?? "파킹통장"} />
+                <Metric label="선언액" value={record ? formatAmount(record.amount, record.currency) : "선언 없음"} />
+                <Metric label="통화" value={record?.currency ?? "KRW"} />
+                <Metric label="as-of" value={record ? formatTime(record.as_of) : "—"} />
+                <Metric label="경과시간" value={record ? (formatRelativeTime(record.as_of) ?? "—") : "—"} />
+                <Metric label="상태" value={view.status} />
+              </dl>
+              <p className="funding-verification">{view.verification_badge}</p>
+            </Card>
+          );
+        })}
       </div>
+
+      <Card>
+        <div className="funding-section-head">
+          <div>
+            <h2>선언 이력</h2>
+            <p>원장은 append-only입니다. 수정처럼 보여도 새 행이 추가됩니다.</p>
+          </div>
+          <Pill tone="paper">{history.count}건</Pill>
+        </div>
+        {history.declarations.length ? (
+          <div className="funding-history-wrap">
+            <table className="funding-history-table" data-testid="external-cash-history-table">
+              <thead>
+                <tr>
+                  <th>as-of</th>
+                  <th>위치</th>
+                  <th>통화</th>
+                  <th>금액</th>
+                  <th>메모</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.declarations.map((row) => (
+                  <tr key={row.declaration_id}>
+                    <td>{formatTime(row.as_of)}</td>
+                    <td>{row.display_label}</td>
+                    <td>{row.currency}</td>
+                    <td>{formatAmount(row.amount, row.currency)}</td>
+                    <td>{row.source_note}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : <p className="funding-muted">이력이 없습니다.</p>}
+      </Card>
+
+      {form ? (
+        <Card>
+          <form className="funding-form" onSubmit={submit} data-testid="external-cash-form">
+            <div className="funding-form__notice">{EXTERNAL_CASH_NO_AUTO_ADD_NOTICE}</div>
+            <label>
+              위치
+              <select
+                value={locationChoice}
+                onChange={(event) => {
+                  const next = event.target.value;
+                  setLocationChoice(next);
+                  if (next === NEW_LOCATION) {
+                    setDisplayLabel("");
+                    setNewLocationKey("");
+                    return;
+                  }
+                  const match = form.heads.find((head) => head.location_key === next && head.currency === currency)
+                    ?? form.heads.find((head) => head.location_key === next);
+                  if (match) {
+                    setDisplayLabel(match.display_label);
+                    setAmount(match.amount);
+                    setCurrency(match.currency === "USD" ? "USD" : "KRW");
+                  }
+                }}
+              >
+                <option value="parking_primary">파킹통장</option>
+                {form.heads
+                  .filter((head) => head.location_key !== "parking_primary")
+                  .map((head) => (
+                    <option key={`${head.location_key}:${head.currency}`} value={head.location_key}>
+                      {head.display_label}
+                    </option>
+                  ))}
+                <option value={NEW_LOCATION}>신규 위치</option>
+              </select>
+            </label>
+            {isNewLocation ? (
+              <label>
+                위치 키
+                <input
+                  value={newLocationKey}
+                  onChange={(event) => setNewLocationKey(event.target.value)}
+                  placeholder="parking_secondary"
+                  required
+                />
+              </label>
+            ) : null}
+            <label>
+              표시 이름
+              <input value={displayLabel} onChange={(event) => setDisplayLabel(event.target.value)} required />
+            </label>
+            <label>
+              통화
+              <select
+                value={currency}
+                onChange={(event) => setCurrency(event.target.value === "USD" ? "USD" : "KRW")}
+              >
+                <option value="KRW">KRW</option>
+                <option value="USD">USD</option>
+              </select>
+            </label>
+            <label>
+              금액 ({currency})
+              <input value={amount} inputMode="decimal" onChange={(event) => setAmount(event.target.value)} required />
+            </label>
+            <label>
+              as-of (현재시각 고정)
+              <time data-testid="external-cash-as-of" dateTime={form.as_of}>{formatTime(form.as_of)}</time>
+            </label>
+            <label>
+              메모
+              <input value={sourceNote} onChange={(event) => setSourceNote(event.target.value)} required />
+            </label>
+            <p className="funding-disclosure">as-of는 서버 현재시각이며 미래 값을 넣을 수 없습니다. 저장은 새 선언 append입니다.</p>
+            <Button type="submit" disabled={submitState === "saving"}>
+              {submitState === "saving" ? "저장 중…" : "선언 저장 · 돈 이동 아님"}
+            </Button>
+            {submitState === "saved" ? <p role="status">새 선언을 append했습니다. 실제 이체는 발생하지 않았습니다.</p> : null}
+            {submitState === "error" ? <p role="alert">저장하지 못했습니다. head·시각·권한을 다시 확인하세요.</p> : null}
+            {submitState === "conflict" ? (
+              <div className="funding-conflict" role="alert" data-testid="external-cash-conflict">
+                <strong>다른 곳에서 선언이 갱신되었습니다. 새 head를 확인하세요.</strong>
+                {conflictHead ? (
+                  <p data-testid="external-cash-conflict-head">
+                    {conflictHead.display_label} · {formatAmount(conflictHead.amount, conflictHead.currency)} · {formatTime(conflictHead.as_of)}
+                  </p>
+                ) : <p>현재 head를 다시 불러오세요.</p>}
+              </div>
+            ) : null}
+          </form>
+        </Card>
+      ) : <Card soft><p className="funding-muted">관리자만 새 선언을 append할 수 있습니다.</p></Card>}
     </section>
   );
 }

--- a/frontend/invest/src/styles/funding.css
+++ b/frontend/invest/src/styles/funding.css
@@ -39,7 +39,13 @@
 .funding-form { display: grid; gap: 12px; }
 .funding-form__notice { padding: 9px 11px; border: 1px solid var(--accent); border-radius: 9px; color: var(--accent); font-size: 12px; font-weight: 800; }
 .funding-form label { display: grid; gap: 5px; color: var(--fg-2); font-size: 11px; font-weight: 700; }
-.funding-form input { width: 100%; padding: 9px 10px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface-2); color: var(--fg); font: inherit; }
+.funding-form input, .funding-form select, .funding-form time { width: 100%; padding: 9px 10px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface-2); color: var(--fg); font: inherit; }
+.funding-form time { display: block; font-weight: 700; }
+.funding-history-wrap { overflow-x: auto; margin-top: 12px; }
+.funding-history-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.funding-history-table th, .funding-history-table td { padding: 8px 10px; text-align: left; border-bottom: 1px solid var(--divider); }
+.funding-history-table th { color: var(--fg-3); font-size: 10px; font-weight: 700; }
+.funding-conflict { display: grid; gap: 6px; padding: 10px 12px; border: 1px solid var(--loss); border-radius: 10px; background: var(--loss-soft); color: var(--loss); font-size: 12px; }
 .funding-form [role="status"] { margin: 0; color: var(--gain); font-size: 12px; }
 .funding-form [role="alert"] { margin: 0; color: var(--loss); font-size: 12px; }
 .funding-load-state { padding: 28px; border: 1px solid var(--border); border-radius: 14px; color: var(--fg-2); background: var(--surface); }

--- a/frontend/invest/src/types/fundingAdvisory.ts
+++ b/frontend/invest/src/types/fundingAdvisory.ts
@@ -143,6 +143,9 @@ export interface ExternalCashDeclaration {
   recorded_at: string;
 }
 
+export const EXTERNAL_CASH_NO_AUTO_ADD_NOTICE =
+  "선언은 매수력에 자동 가산되지 않음 — 입금 필요 알림의 근거";
+
 export interface ExternalCashCurrentView {
   status: "missing" | "fresh" | "stale" | "future" | "ambiguous";
   amount_status: "known" | "unknown";
@@ -152,21 +155,53 @@ export interface ExternalCashCurrentView {
   warning_code: string | null;
 }
 
+export interface ExternalCashHeadsView {
+  heads: ExternalCashCurrentView[];
+  count: number;
+  notice: string;
+}
+
 export interface ExternalCashHistoryView {
   declarations: ExternalCashDeclaration[];
   count: number;
+  notice?: string;
+}
+
+export interface ExternalCashFormHead {
+  location_key: string;
+  display_label: string;
+  currency: string;
+  amount: string;
+  as_of: string;
+  status: string;
+  expected_head_declaration_id: string;
 }
 
 export interface ExternalCashForm {
   owner_user_id: number;
+  as_of: string;
+  as_of_fixed: true;
+  creates_money_movement: false;
+  idempotency_key: string;
+  notice: string;
+  currencies: Array<"KRW" | "USD">;
+  default_location_key: string;
+  default_display_label: string;
+  default_currency: "KRW" | "USD";
+  default_amount: string;
+  default_source_note: string;
+  expected_head_declaration_id: string | null;
+  heads: ExternalCashFormHead[];
+}
+
+export interface ExternalCashDeclarePayload {
+  owner_user_id: number;
   location_key: string;
   display_label: string;
-  currency: "KRW";
+  currency: "KRW" | "USD";
   amount: string;
-  as_of: null;
+  as_of: string;
   source_note: string;
   expected_head_declaration_id: string | null;
   idempotency_key: string;
-  requires_exact_operator_confirmed_time: true;
-  creates_money_movement: false;
 }

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -72,7 +72,9 @@ from sqlalchemy import text
 # persistent local test DB to re-bootstrap once.
 # v36: web loss-cut approval events/scopes are new ORM tables. The production
 # migration is deliberately not run by tests; create_all owns the test copy.
-SCHEMA_BOOTSTRAP_VERSION = 36
+# v37 (ROB-1292): review.external_cash_declarations append-only + correction
+# scope triggers (non-ORM DDL; table itself comes from create_all).
+SCHEMA_BOOTSTRAP_VERSION = 37
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -1680,6 +1682,65 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "INSERT INTO review.trade_retrospective_action_control (id, mode) "
     "VALUES (1, 'shadow') "
     "ON CONFLICT (id) DO NOTHING",
+    # ---- ROB-1292: external cash declaration append-only + correction scope.
+    # The ORM table is created by create_all; these trigger functions are
+    # non-ORM DDL mirroring alembic/versions/20260815_external_cash.py.
+    """
+    CREATE OR REPLACE FUNCTION review.validate_external_cash_correction()
+    RETURNS trigger AS $$
+    DECLARE
+        previous review.external_cash_declarations%ROWTYPE;
+    BEGIN
+        IF NEW.supersedes_declaration_id IS NULL THEN
+            RETURN NEW;
+        END IF;
+        IF NEW.supersedes_declaration_id = NEW.declaration_id THEN
+            RAISE EXCEPTION 'external cash declaration cannot supersede itself'
+                USING ERRCODE = 'check_violation';
+        END IF;
+        SELECT * INTO previous
+          FROM review.external_cash_declarations
+         WHERE declaration_id = NEW.supersedes_declaration_id
+         FOR SHARE;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'superseded external cash declaration is missing'
+                USING ERRCODE = 'foreign_key_violation';
+        END IF;
+        IF previous.owner_user_id IS DISTINCT FROM NEW.owner_user_id
+           OR previous.location_key IS DISTINCT FROM NEW.location_key
+           OR previous.currency IS DISTINCT FROM NEW.currency THEN
+            RAISE EXCEPTION 'external cash correction scope mismatch'
+                USING ERRCODE = 'check_violation';
+        END IF;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """,
+    """
+    CREATE OR REPLACE FUNCTION review.reject_external_cash_mutation()
+    RETURNS trigger AS $$
+    BEGIN
+        RAISE EXCEPTION
+            'review.external_cash_declarations is append-only; % rejected',
+            TG_OP USING ERRCODE = 'restrict_violation';
+    END;
+    $$ LANGUAGE plpgsql
+    """,
+    "DROP TRIGGER IF EXISTS trg_external_cash_correction_scope "
+    "ON review.external_cash_declarations",
+    "CREATE TRIGGER trg_external_cash_correction_scope "
+    "BEFORE INSERT ON review.external_cash_declarations "
+    "FOR EACH ROW EXECUTE FUNCTION review.validate_external_cash_correction()",
+    "DROP TRIGGER IF EXISTS trg_external_cash_append_only "
+    "ON review.external_cash_declarations",
+    "CREATE TRIGGER trg_external_cash_append_only "
+    "BEFORE UPDATE OR DELETE ON review.external_cash_declarations "
+    "FOR EACH ROW EXECUTE FUNCTION review.reject_external_cash_mutation()",
+    "DROP TRIGGER IF EXISTS trg_external_cash_truncate_append_only "
+    "ON review.external_cash_declarations",
+    "CREATE TRIGGER trg_external_cash_truncate_append_only "
+    "BEFORE TRUNCATE ON review.external_cash_declarations "
+    "FOR EACH STATEMENT EXECUTE FUNCTION review.reject_external_cash_mutation()",
 )
 
 

--- a/tests/services/funding_advisory/test_containment.py
+++ b/tests/services/funding_advisory/test_containment.py
@@ -170,6 +170,7 @@ def test_declared_total_never_reaches_the_shortfall_expression() -> None:
         if stripped.startswith(("shortfall =", "operational_gap =", "required =")):
             assert "declared" not in stripped, stripped
 
+
 def test_declaration_is_never_added_to_available_required_or_shortfall() -> None:
     service_src = (ROOT / "app/services/funding_advisory/service.py").read_text(
         encoding="utf-8"

--- a/tests/services/funding_advisory/test_containment.py
+++ b/tests/services/funding_advisory/test_containment.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
+FRONTEND = ROOT / "frontend/invest/src"
 PROTECTED_ORDER_FILES = (
     ROOT / "app/services/order_proposals/buying_power.py",
     ROOT / "app/services/order_proposals/revalidation.py",
@@ -167,3 +169,72 @@ def test_declared_total_never_reaches_the_shortfall_expression() -> None:
         stripped = line.strip()
         if stripped.startswith(("shortfall =", "operational_gap =", "required =")):
             assert "declared" not in stripped, stripped
+
+def test_declaration_is_never_added_to_available_required_or_shortfall() -> None:
+    service_src = (ROOT / "app/services/funding_advisory/service.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'shortfall = max(required - target, Decimal("0"))' in service_src
+    assert "required - target - " not in service_src
+    assert 'counted_fundable_amount=Decimal("0")' in service_src
+    router_src = (ROOT / "app/routers/invest_funding.py").read_text(encoding="utf-8")
+    for leaked in ("required_cash", "target_buying_power", "available"):
+        assert leaked not in router_src
+    for path in PROTECTED_ORDER_FILES:
+        text = path.read_text(encoding="utf-8")
+        assert "external_cash" not in text
+        assert "declared_total" not in text
+        assert "NO_AUTO_ADD_NOTICE" not in text
+
+
+def test_declared_cash_add_mutant_still_changes_need() -> None:
+    """The #1866 add-mutant remains RED: subtracting declared cash from shortfall
+    would change need, and production code must not do that."""
+
+    from decimal import Decimal
+
+    required = Decimal("100000")
+    target = Decimal("40000")
+    declared = Decimal("640000")
+    production = max(required - target, Decimal("0"))
+    mutant = max(required - target - declared, Decimal("0"))
+    assert production == Decimal("60000")
+    assert mutant == Decimal("0")
+    assert production != mutant
+
+
+def test_single_writer_no_direct_insert_outside_repository() -> None:
+    insert_sql = re.compile(
+        r"insert\s+into\s+review\.external_cash_declarations",
+        re.IGNORECASE,
+    )
+    construct = re.compile(r"ExternalCashDeclaration\(")
+    offenders: list[Path] = []
+    for path in (ROOT / "app").rglob("*.py"):
+        if path.name == "_external_cash_repository.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        if insert_sql.search(text):
+            offenders.append(path)
+            continue
+        if construct.search(text) and "class ExternalCashDeclaration" not in text:
+            offenders.append(path)
+    assert offenders == []
+
+
+def test_frontend_declaration_client_does_not_touch_order_surfaces() -> None:
+    api = (FRONTEND / "api/fundingAdvisory.ts").read_text(encoding="utf-8")
+    page = (FRONTEND / "pages/FundingRoute.tsx").read_text(encoding="utf-8")
+    panel = page.split("export function ExternalCashPanel", 1)[1].split(
+        "export function FundingPageContent", 1
+    )[0]
+    assert "/orders" not in api
+    assert "buying_power" not in api
+    assert "buying_power" not in panel
+    assert "required_cash" not in panel
+    assert "shortfall" not in panel
+    assert "declareExternalCash" in api
+    assert "/external-cash/declarations" in api
+    assert "EXTERNAL_CASH_NO_AUTO_ADD_NOTICE" in panel
+    types_src = (FRONTEND / "types/fundingAdvisory.ts").read_text(encoding="utf-8")
+    assert "선언은 매수력에 자동 가산되지 않음 — 입금 필요 알림의 근거" in types_src

--- a/tests/services/funding_advisory/test_external_cash.py
+++ b/tests/services/funding_advisory/test_external_cash.py
@@ -41,6 +41,7 @@ class FakeRepository:
     def __init__(self) -> None:
         self.locks: list[str] = []
         self.existing = None
+        self.by_key: dict[tuple[int, str], SimpleNamespace] = {}
         self.heads: list[SimpleNamespace] = []
         self.history_rows: list[SimpleNamespace] = []
         self.inserted: list[dict] = []
@@ -48,8 +49,8 @@ class FakeRepository:
     async def acquire_lock(self, lock_key: str) -> None:
         self.locks.append(lock_key)
 
-    async def get_by_idempotency(self, **_kwargs):
-        return self.existing
+    async def get_by_idempotency(self, **kwargs):
+        return self.by_key.get((kwargs["owner_user_id"], kwargs["idempotency_key"]))
 
     async def list_current_heads(self, **_kwargs):
         return list(self.heads)
@@ -63,13 +64,40 @@ class FakeRepository:
     async def insert(self, **columns):
         self.inserted.append(columns)
         row = SimpleNamespace(
-            id=1,
+            id=len(self.inserted),
             recorded_at=NOW,
             **columns,
         )
         self.existing = row
+        self.by_key[(columns["owner_user_id"], columns["idempotency_key"])] = row
         self.heads = [row]
         return row
+
+
+def stored_row(
+    *,
+    declaration_id=None,
+    amount: Decimal = Decimal("0"),
+    idempotency_key: str = "funding-seed-20260815-1",
+    supersedes_declaration_id=None,
+):
+    row_id = declaration_id or uuid4()
+    return SimpleNamespace(
+        declaration_id=row_id,
+        owner_user_id=11,
+        location_key="parking_primary",
+        display_label="파킹통장",
+        currency="KRW",
+        amount=amount,
+        as_of=NOW - timedelta(minutes=30),
+        fresh_until=NOW + timedelta(hours=23, minutes=30),
+        source_note="운영자 선언",
+        declared_by_user_id=7,
+        origin="invest_ui",
+        supersedes_declaration_id=supersedes_declaration_id,
+        idempotency_key=idempotency_key,
+        recorded_at=NOW,
+    )
 
 
 def actor(*, role: UserRole = UserRole.admin, active: bool = True):
@@ -153,18 +181,24 @@ async def test_idempotency_key_with_different_payload_is_conflict() -> None:
 async def test_stale_expected_head_and_ambiguous_heads_fail_closed() -> None:
     session = FakeSession()
     repository = FakeRepository()
-    repository.heads = [SimpleNamespace(declaration_id=uuid4())]
+    current = stored_row(amount=Decimal("0"))
+    repository.heads = [current]
     service = ExternalCashDeclarationService(
         session,  # type: ignore[arg-type]
         _repository=repository,  # type: ignore[arg-type]
     )
 
-    with pytest.raises(ExternalCashConflictError):
+    with pytest.raises(ExternalCashConflictError) as exc_info:
         await service.declare(request(expected_head=uuid4()), actor(), NOW)
 
+    assert exc_info.value.error == "expected_head_conflict"
+    assert exc_info.value.current_head is not None
+    assert exc_info.value.current_head.declaration_id == current.declaration_id
+    assert exc_info.value.current_head.amount == Decimal("0")
+
     repository.heads = [
-        SimpleNamespace(declaration_id=uuid4()),
-        SimpleNamespace(declaration_id=uuid4()),
+        stored_row(),
+        stored_row(idempotency_key="other"),
     ]
     with pytest.raises(ExternalCashAmbiguousHeadError):
         await service.declare(
@@ -172,6 +206,33 @@ async def test_stale_expected_head_and_ambiguous_heads_fail_closed() -> None:
         )
 
     assert repository.inserted == []
+
+
+@pytest.mark.asyncio
+async def test_zero_head_then_new_declaration_is_append_only_history() -> None:
+    session = FakeSession()
+    repository = FakeRepository()
+    service = ExternalCashDeclarationService(
+        session,  # type: ignore[arg-type]
+        _repository=repository,  # type: ignore[arg-type]
+    )
+
+    zero = await service.declare(request(amount=Decimal("0")), actor(), NOW)
+    next_row = await service.declare(
+        request(
+            idempotency_key="funding-ui:second",
+            expected_head=zero.declaration_id,
+            amount=Decimal("1500000"),
+        ),
+        actor(),
+        NOW,
+    )
+
+    assert zero.amount == Decimal("0")
+    assert next_row.supersedes_declaration_id == zero.declaration_id
+    assert next_row.amount == Decimal("1500000")
+    assert len(repository.inserted) == 2
+    assert session.commits == 2
 
 
 @pytest.mark.asyncio

--- a/tests/services/funding_advisory/test_external_cash_db.py
+++ b/tests/services/funding_advisory/test_external_cash_db.py
@@ -1,0 +1,146 @@
+"""Run-owned DB round-trip for append-only external-cash declarations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.models.trading import UserRole
+from app.schemas.funding_advisory import ExternalCashDeclarationRequest
+from app.services.funding_advisory.external_cash import (
+    ExternalCashConflictError,
+    ExternalCashDeclarationService,
+    ExternalCashValidationError,
+)
+
+NOW = datetime(2026, 8, 20, 7, 30, tzinfo=UTC)
+
+
+def _admin(user):
+    user.role = UserRole.admin
+    user.is_active = True
+    return user
+
+
+def _request(*, owner_id: int, amount: str, expected_head, idempotency: str, as_of):
+    return ExternalCashDeclarationRequest(
+        owner_user_id=owner_id,
+        location_key="parking_primary",
+        display_label="파킹통장",
+        currency="KRW",
+        amount=Decimal(amount),
+        as_of=as_of,
+        source_note="운영자 선언",
+        expected_head_declaration_id=expected_head,
+        idempotency_key=idempotency,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_db_zero_head_append_history_and_stale_conflict(db_session, user):
+    admin = _admin(user)
+    await db_session.flush()
+    service = ExternalCashDeclarationService(db_session)
+
+    zero = await service.declare(
+        _request(
+            owner_id=admin.id,
+            amount="0",
+            expected_head=None,
+            idempotency=f"funding-db-zero-{uuid4()}",
+            as_of=NOW - timedelta(minutes=2),
+        ),
+        admin,
+        NOW,
+    )
+    next_row = await service.declare(
+        _request(
+            owner_id=admin.id,
+            amount="1500000",
+            expected_head=zero.declaration_id,
+            idempotency=f"funding-db-next-{uuid4()}",
+            as_of=NOW - timedelta(minutes=1),
+        ),
+        admin,
+        NOW,
+    )
+
+    current = await service.current(
+        owner_user_id=admin.id,
+        location_key="parking_primary",
+        currency="KRW",
+        now=NOW,
+    )
+    history = await service.history(owner_user_id=admin.id)
+
+    assert current.current is not None
+    assert current.current.declaration_id == next_row.declaration_id
+    assert current.current.amount == Decimal("1500000")
+    assert [row.amount for row in history[:2]] == [
+        Decimal("1500000"),
+        Decimal("0"),
+    ]
+
+    with pytest.raises(ExternalCashConflictError) as exc_info:
+        await service.declare(
+            _request(
+                owner_id=admin.id,
+                amount="2",
+                expected_head=zero.declaration_id,
+                idempotency=f"funding-db-stale-{uuid4()}",
+                as_of=NOW,
+            ),
+            admin,
+            NOW,
+        )
+    assert exc_info.value.current_head is not None
+    assert exc_info.value.current_head.declaration_id == next_row.declaration_id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_db_append_only_rejects_update_and_future_as_of(db_session, user):
+    admin = _admin(user)
+    await db_session.flush()
+    service = ExternalCashDeclarationService(db_session)
+    row = await service.declare(
+        _request(
+            owner_id=admin.id,
+            amount="0",
+            expected_head=None,
+            idempotency=f"funding-db-append-{uuid4()}",
+            as_of=NOW - timedelta(minutes=1),
+        ),
+        admin,
+        NOW,
+    )
+
+    with pytest.raises(ExternalCashValidationError, match="future"):
+        await service.declare(
+            _request(
+                owner_id=admin.id,
+                amount="1",
+                expected_head=row.declaration_id,
+                idempotency=f"funding-db-future-{uuid4()}",
+                as_of=NOW + timedelta(seconds=1),
+            ),
+            admin,
+            NOW,
+        )
+
+    with pytest.raises(DBAPIError):
+        await db_session.execute(
+            text(
+                "UPDATE review.external_cash_declarations "
+                "SET amount = 1 WHERE declaration_id = :declaration_id"
+            ),
+            {"declaration_id": str(row.declaration_id)},
+        )
+        await db_session.commit()
+    await db_session.rollback()

--- a/tests/services/funding_advisory/test_router.py
+++ b/tests/services/funding_advisory/test_router.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import inspect
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
+from app.models.trading import UserRole
 from app.routers import invest_funding
 
 
@@ -68,3 +70,282 @@ def test_invest_api_prefix_remains_csrf_protected() -> None:
         encoding="utf-8"
     )
     assert 're.compile(r"^/invest/api/")' not in app_main
+
+
+NOW = datetime(2026, 8, 20, 7, 30, tzinfo=UTC)
+NOTICE = "선언은 매수력에 자동 가산되지 않음 — 입금 필요 알림의 근거"
+
+
+def _record(
+    *,
+    amount: str = "0",
+    declaration_id=None,
+    supersedes=None,
+    as_of: datetime | None = None,
+):
+    from app.schemas.funding_advisory import ExternalCashDeclarationRecord
+
+    stamp = as_of or (NOW - timedelta(minutes=5))
+    return ExternalCashDeclarationRecord(
+        declaration_id=declaration_id or uuid4(),
+        owner_user_id=11,
+        location_key="parking_primary",
+        display_label="파킹통장",
+        currency="KRW",
+        amount=Decimal(amount),
+        as_of=stamp,
+        fresh_until=stamp + timedelta(hours=24),
+        source_note="운영자 선언",
+        declared_by_user_id=7,
+        origin="invest_ui",
+        supersedes_declaration_id=supersedes,
+        idempotency_key=f"funding-ui:{uuid4()}",
+        recorded_at=stamp,
+    )
+
+
+def _view(record):
+    from app.schemas.funding_advisory import ExternalCashCurrentView
+
+    return ExternalCashCurrentView(
+        status="fresh",
+        amount_status="known",
+        current=record,
+        route_fundable_amount=record.amount,
+    )
+
+
+class MemoryCashService:
+    def __init__(self, _db=None) -> None:
+        self.rows: list = []
+
+    async def list_current(self, **_kwargs):
+        superseded = {
+            row.supersedes_declaration_id
+            for row in self.rows
+            if row.supersedes_declaration_id is not None
+        }
+        heads = [row for row in self.rows if row.declaration_id not in superseded]
+        return [_view(row) for row in heads]
+
+    async def history(self, **_kwargs):
+        return list(reversed(self.rows))
+
+    async def declare(self, request, actor, now):
+        from app.services.funding_advisory.external_cash import (
+            ExternalCashAuthorizationError,
+            ExternalCashConflictError,
+            ExternalCashValidationError,
+        )
+
+        if getattr(actor, "role", None) != UserRole.admin:
+            raise ExternalCashAuthorizationError("active admin role required")
+        if request.as_of > now:
+            raise ExternalCashValidationError("as_of cannot be in the future")
+        heads = [
+            row
+            for row in self.rows
+            if row.declaration_id
+            not in {
+                item.supersedes_declaration_id
+                for item in self.rows
+                if item.supersedes_declaration_id is not None
+            }
+        ]
+        actual = heads[0] if heads else None
+        actual_id = actual.declaration_id if actual is not None else None
+        if actual_id != request.expected_head_declaration_id:
+            raise ExternalCashConflictError(
+                "expected declaration head does not match current head",
+                current_head=actual,
+            )
+        row = _record(
+            amount=str(request.amount),
+            supersedes=request.expected_head_declaration_id,
+            as_of=request.as_of,
+        )
+        self.rows.append(row)
+        return row
+
+
+def _app(*, user, service: MemoryCashService, override_admin: bool = True):
+    from fastapi import FastAPI
+
+    from app.auth.admin_router import require_admin
+    from app.core.db import get_db
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(invest_funding.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: object()
+    if override_admin:
+        app.dependency_overrides[require_admin] = lambda: user
+    return app, service
+
+
+async def _client(app):
+    from httpx import ASGITransport, AsyncClient
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_ac1_zero_parking_head_then_append_shows_two_history_rows(
+    monkeypatch,
+) -> None:
+    service = MemoryCashService()
+    zero = _record(amount="0")
+    service.rows.append(zero)
+    monkeypatch.setattr(
+        invest_funding, "ExternalCashDeclarationService", lambda _db: service
+    )
+    monkeypatch.setattr(invest_funding, "_now", lambda: NOW)
+    admin = SimpleNamespace(id=7, role=UserRole.admin, is_active=True)
+    app, _svc = _app(user=admin, service=service)
+
+    async with await _client(app) as client:
+        current = await client.get("/invest/api/funding/external-cash/current")
+        assert current.status_code == 200
+        body = current.json()
+        assert body["notice"] == NOTICE
+        assert body["count"] == 1
+        assert body["heads"][0]["current"]["amount"] == "0"
+        assert body["heads"][0]["current"]["display_label"] == "파킹통장"
+
+        created = await client.post(
+            "/invest/api/funding/external-cash/declarations",
+            json={
+                "owner_user_id": 11,
+                "location_key": "parking_primary",
+                "display_label": "파킹통장",
+                "currency": "KRW",
+                "amount": "1500000",
+                "as_of": NOW.isoformat(),
+                "source_note": "급여 착지 후 잔액",
+                "expected_head_declaration_id": str(zero.declaration_id),
+                "idempotency_key": "funding-ui:ac1",
+            },
+        )
+        assert created.status_code == 201
+        assert created.json()["amount"] == "1500000"
+        assert created.json()["supersedes_declaration_id"] == str(zero.declaration_id)
+
+        after = await client.get("/invest/api/funding/external-cash/current")
+        assert after.json()["heads"][0]["current"]["amount"] == "1500000"
+
+        history = await client.get("/invest/api/funding/external-cash/history")
+        assert history.status_code == 200
+        assert history.json()["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_ac2_stale_head_returns_409_with_current_head(monkeypatch) -> None:
+    service = MemoryCashService()
+    head = _record(amount="0")
+    service.rows.append(head)
+    monkeypatch.setattr(
+        invest_funding, "ExternalCashDeclarationService", lambda _db: service
+    )
+    monkeypatch.setattr(invest_funding, "_now", lambda: NOW)
+    admin = SimpleNamespace(id=7, role=UserRole.admin, is_active=True)
+    app, _svc = _app(user=admin, service=service)
+
+    async with await _client(app) as client:
+        response = await client.post(
+            "/invest/api/funding/external-cash/declarations",
+            json={
+                "owner_user_id": 11,
+                "location_key": "parking_primary",
+                "display_label": "파킹통장",
+                "currency": "KRW",
+                "amount": "1",
+                "as_of": NOW.isoformat(),
+                "source_note": "stale submit",
+                "expected_head_declaration_id": str(uuid4()),
+                "idempotency_key": "funding-ui:stale",
+            },
+        )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["error"] == "expected_head_conflict"
+    assert detail["current_head"]["declaration_id"] == str(head.declaration_id)
+    assert detail["current_head"]["amount"] == "0"
+    assert detail["notice"] == NOTICE
+
+
+@pytest.mark.asyncio
+async def test_ac3_non_admin_write_is_rejected(monkeypatch) -> None:
+    trader = SimpleNamespace(id=2, role=UserRole.trader, is_active=True)
+
+    async def session_user(_request, _db):
+        return trader
+
+    monkeypatch.setattr(
+        "app.auth.admin_router.get_current_user_from_session",
+        session_user,
+    )
+    service = MemoryCashService()
+    monkeypatch.setattr(
+        invest_funding, "ExternalCashDeclarationService", lambda _db: service
+    )
+    monkeypatch.setattr(invest_funding, "_now", lambda: NOW)
+    app, _svc = _app(user=trader, service=service, override_admin=False)
+
+    async with await _client(app) as client:
+        form = await client.get("/invest/api/funding/external-cash/form")
+        write = await client.post(
+            "/invest/api/funding/external-cash/declarations",
+            json={
+                "owner_user_id": 11,
+                "location_key": "parking_primary",
+                "display_label": "파킹통장",
+                "currency": "KRW",
+                "amount": "1",
+                "as_of": NOW.isoformat(),
+                "source_note": "trader write",
+                "expected_head_declaration_id": None,
+                "idempotency_key": "funding-ui:trader",
+            },
+        )
+        current = await client.get("/invest/api/funding/external-cash/current")
+
+    assert form.status_code == 403
+    assert write.status_code == 403
+    assert current.status_code == 200
+    assert service.rows == []
+
+
+@pytest.mark.asyncio
+async def test_as_of_future_is_rejected_on_the_router_surface(monkeypatch) -> None:
+    service = MemoryCashService()
+    monkeypatch.setattr(
+        invest_funding, "ExternalCashDeclarationService", lambda _db: service
+    )
+    monkeypatch.setattr(invest_funding, "_now", lambda: NOW)
+    admin = SimpleNamespace(id=7, role=UserRole.admin, is_active=True)
+    app, _svc = _app(user=admin, service=service)
+
+    async with await _client(app) as client:
+        form = await client.get("/invest/api/funding/external-cash/form")
+        response = await client.post(
+            "/invest/api/funding/external-cash/declarations",
+            json={
+                "owner_user_id": 11,
+                "location_key": "parking_primary",
+                "display_label": "파킹통장",
+                "currency": "KRW",
+                "amount": "0",
+                "as_of": (NOW + timedelta(seconds=1)).isoformat(),
+                "source_note": "future",
+                "expected_head_declaration_id": None,
+                "idempotency_key": "funding-ui:future",
+            },
+        )
+
+    assert form.status_code == 200
+    assert form.json()["as_of_fixed"] is True
+    assert str(form.json()["as_of"]).startswith("2026-08-20T07:30:00")
+    assert response.status_code == 422
+    assert service.rows == []

--- a/tests/services/funding_advisory/test_service.py
+++ b/tests/services/funding_advisory/test_service.py
@@ -239,6 +239,16 @@ async def test_declared_cash_never_changes_available_required_or_shortfall() -> 
     assert declared["routes"][0]["route_fundable_amount"] == "60000"
     assert declared["routes"][0]["counted_fundable_amount"] == "0"
     assert declared["safety"]["authoritative_for_order_gate"] is False
+    mutant_shortfall = max(
+        Decimal(baseline["need"]["shortfall"]) - Decimal("640000"),
+        Decimal("0"),
+    )
+    assert Decimal(declared["need"]["shortfall"]) != mutant_shortfall
+    assert declared["need"]["required_cash"] == baseline["need"]["required_cash"]
+    assert (
+        declared["need"]["target_buying_power"]
+        == baseline["need"]["target_buying_power"]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

ROB-1292: `/invest/funding` 에서 외부현금 선언을 조회·신규 append 할 수 있게 합니다. 기존 `#1866` 서비스 단일 writer 를 그대로 재사용합니다.

- GET `위치별 head` + 이력, POST 신규 선언 (`ExternalCashDeclarationService.declare` 만)
- as-of 는 폼 발급 현재시각 고정, 미래 값 422
- `expected_head_declaration_id` 불일치 409 + 새 head 표시
- 비-admin 쓰기 403
- 안내: 「선언은 매수력에 자동 가산되지 않음 — 입금 필요 알림의 근거」

## 하드 가드

- 선언액을 available/required/shortfall 에 가산하지 않음 (`#1866` 뮤턴트 재확인 RED)
- 쓰기는 선언 서비스 단일 경유, append-only 유지
- 마이그레이션 없음 (기존 테이블 재사용). 테스트 스키마 부트스트랩에 append-only 트리거만 경상

## 수용

- AC1: 파킹통장 0원 head 표시 → 새 선언 → head 전환 → 이력 2행
- AC2: stale head 409 + 새 head
- AC3: 비-admin 쓰기 거부

Linear: ROB-1292

🔴 draft PR. 검증자는 orch 가 붙인다. 자가 merge/ready/배포 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - External cash now supports multiple locations and KRW/USD currencies.
  - View current balances, verification details, elapsed time, and append-only history.
  - Administrators can submit timestamped declarations with notes and location details.
  - Added clearer status indicators and standard notices.

- **Bug Fixes**
  - Prevented future-dated declarations.
  - Improved stale-update conflict handling with current declaration details.
  - Confirmed external cash does not affect required funds, available funds, or buying-power calculations.

- **Documentation**
  - Updated funding guidance for external-cash declarations and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->