### PR TITLE
fix(ci): live-only socket hermeticity + close the provider leaks it exposed (ROB-1296)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ make security      # bandit · safety
 ```
 
 - 마커: `unit` / `integration` / `live`(integration의 strict subset, `--run-live` 필요) / `slow`
+- 소켓 가드: 외부 소켓은 `live` 마커 **+** 명시적 `--run-live` 조합에서만 허용된다(ROB-1296). `integration` 마커는 네트워크 접근 권한을 주지 않으며, 로컬 PostgreSQL/Redis는 마커와 무관하게 loopback 주소로 허용된다 — [`docs/runbooks/hermetic-test-socket-guard.md`](docs/runbooks/hermetic-test-socket-guard.md)
 - CI(GitHub Actions): lint → 병렬 fast gate(xdist loadfile) → TaskIQ smoke → 보안 검사 → 커버리지
 
 ## 문서

--- a/docs/runbooks/hermetic-test-socket-guard.md
+++ b/docs/runbooks/hermetic-test-socket-guard.md
@@ -1,4 +1,4 @@
-# Hermetic test socket guard (ROB-1265 / ROB-1880)
+# Hermetic test socket guard (ROB-1265 / ROB-1880 / ROB-1296)
 
 `tests._socket_guard_plugin` is loaded by pytest's `-p` option before test
 collection and module import. It fails closed on outbound socket operations in
@@ -18,8 +18,9 @@ touch real broker/API endpoints.
   these exact UNIX service paths: `/tmp/.s.PGSQL.5432`,
   `/private/tmp/.s.PGSQL.5432`, `/var/run/postgresql/.s.PGSQL.5432`, and
   `/var/run/redis/redis-server.sock`. An arbitrary `AF_UNIX` path is denied.
-- Lets an explicitly marked `integration` or `live` item cross its intentional
-  boundary while retaining the default-deny policy during collection/import.
+- Lets an explicitly marked `live` item cross its intentional boundary **only
+  when the operator also passed `--run-live`**, while retaining the default-deny
+  policy during collection/import. `integration` grants nothing (ROB-1296).
 - Propagates an environment switch and dedicated `sitecustomize` directory into
   child Python processes, including children started with `env={}`. Direct
   `curl`/`wget`/`ssh`-family launchers and Python `-S`/`-E`/`-I` startup-bypass
@@ -29,11 +30,31 @@ touch real broker/API endpoints.
 
 ## Exemptions
 
-Tests marked `@pytest.mark.integration` or `@pytest.mark.live` are exempt
-during that test item's setup/call/teardown — those are the two marker families
-the repo already uses for intentional boundaries (DB, or `--run-live` network).
+There is exactly one exemption, and it needs **both** halves:
+
+| `integration` | `live` | `--run-live` | external sockets |
+| --- | --- | --- | --- |
+| – | – | – | blocked |
+| ✓ | – | – | blocked |
+| ✓ | – | ✓ | blocked |
+| – | ✓ | – | item is skipped by `tests/conftest.py`; blocked |
+| ✓ | ✓ | – | item is skipped by `tests/conftest.py`; blocked |
+| – | ✓ | ✓ | **allowed** |
+| ✓ | ✓ | ✓ | **allowed** |
+
+ROB-1296 removed the blanket `integration` exemption. It covered ~3,200 items in
+the default `-m "not live"` gate — every one of them free to reach a real
+external host from CI. Integration tests need loopback PostgreSQL/Redis, and the
+address allowlist permits that with no marker at all, so the marker was never
+the mechanism keeping DB tests working. `pytest --run-live` alone is likewise
+inert: without the `live` marker on the item, nothing is exempt.
+
+`tests/test_rob1296_live_only_socket_guard.py` pins this table end to end, in
+real nested pytest sessions, without emitting a packet.
+
 Do **not** add a new opt-out marker for "this test happens to hit the network";
-that is exactly the failure mode this guard exists to catch. Fix the test
+that is exactly the failure mode this guard exists to catch. There is no
+environment-variable bypass, and adding one is out of bounds. Fix the test
 instead:
 
 1. Find the leaf provider function the code path actually calls (e.g.
@@ -71,4 +92,47 @@ rejected. Non-Python child environments are deliberately not rewritten. A test
 that deliberately invokes a native executable through a lower-level `exec*`
 syscall or embeds a network stack in an otherwise allowlisted native binary is
 outside what Python can intercept; such a test must be treated as an
-integration/live boundary rather than an offline test.
+`live` boundary (run under `--run-live`) rather than an offline test.
+
+### Suite-wide boundary fixtures
+
+Some external calls are reached from deep inside a fan-out that individual tests
+never see — a best-effort enrichment, a cache-miss fallback, an OAuth refresh.
+`tests/conftest.py` blocks those at the boundary with autouse fixtures, each
+paired with an opt-out fixture a boundary test can request:
+
+| Boundary | Opt out with |
+| --- | --- |
+| TradingView scanner HTTP | `allow_tvscreener_http` |
+| KIS daily-candle cache-miss fallback (`fetch_kr_daily_unclamped`) | `allow_kis_daily_candle_fetch` |
+
+Each raises the same class of error the caller already handles, so observable
+behaviour is unchanged — only the socket disappears. Prefer a module-level
+autouse fixture (see `tests/test_mcp_place_order.py`,
+`tests/mcp_server/tooling/test_live_order_ledger.py`) when the boundary matters
+to one file rather than the whole suite. Do not "fix" a leak by asserting a
+success the test never verified: model the outcome the test already relies on.
+
+### Known fail-closed edges
+
+These are deliberate. They are recorded here so a future reader finds a decision
+rather than a mystery, and none of them is a reason to widen an allowlist.
+
+- **`multiprocessing` `forkserver`** brokers children over an `AF_UNIX` socket in
+  a per-process temp directory. Admitting it would mean allowlisting a directory
+  *prefix*, and "any `AF_UNIX` path is local enough" is precisely the bypass
+  ROB-1880 closed. Nothing here uses it: all three `get_context` call sites ask
+  for `spawn`. `spawn` and `fork` children are guarded and covered by tests.
+- **`python -I` / `-E` / `-S` children** are rejected, because each one discards
+  the `sitecustomize` startup hook and would run unguarded. A test that wanted an
+  isolated interpreter for *import provenance* should assert each module's
+  `__file__` instead — see `tests/services/research/test_research_contracts_wheel.py`,
+  which is a stronger check than `-I` ever was.
+- **DNS resolution is not intercepted.** `socket.getaddrinfo` resolves inside
+  libc, below the Python `socket.socket` methods the guard patches, so a
+  hostname lookup can still leave the machine. The *connection* is still blocked:
+  `socket.create_connection(("example.com", 443))` resolves and then trips the
+  guard at `connect`. Treat the guard as blocking connections, not lookups.
+- **Non-Python child environments are not rewritten**, so a native binary with
+  its own network stack is outside what Python can intercept. Direct
+  `curl`/`wget`/`ssh`-family launchers are rejected by name before they start.

--- a/docs/runbooks/hermetic-test-socket-guard.md
+++ b/docs/runbooks/hermetic-test-socket-guard.md
@@ -12,8 +12,10 @@ touch real broker/API endpoints.
 
 - Installs before collection/import, including `pytest --noconftest`. A
   missing or replaced intercept is a pytest failure, never a warning or skip.
-- Patches `socket.socket.connect`, `connect_ex`, `sendto`, and `sendmsg`. This
-  covers direct synchronous calls plus asyncio's socket connect/send paths.
+- Patches `socket.socket.connect`, `connect_ex`, `sendto` and `sendmsg`, plus
+  `socket.getaddrinfo` and `gethostbyname`. This covers direct synchronous calls,
+  asyncio's socket connect/send paths, and name resolution — which happens
+  *before* `connect` and would otherwise leave the machine on its own.
 - Allows only TCP/UDP loopback literals (`127.0.0.0/8`, `::1`, `localhost`) and
   these exact UNIX service paths: `/tmp/.s.PGSQL.5432`,
   `/private/tmp/.s.PGSQL.5432`, `/var/run/postgresql/.s.PGSQL.5432`, and
@@ -21,10 +23,13 @@ touch real broker/API endpoints.
 - Lets an explicitly marked `live` item cross its intentional boundary **only
   when the operator also passed `--run-live`**, while retaining the default-deny
   policy during collection/import. `integration` grants nothing (ROB-1296).
-- Propagates an environment switch and dedicated `sitecustomize` directory into
-  child Python processes, including children started with `env={}`. Direct
-  `curl`/`wget`/`ssh`-family launchers and Python `-S`/`-E`/`-I` startup-bypass
-  flags are rejected before they start.
+- Installs itself in every Python child — direct, `sh -c`/`bash -lc`,
+  `uv run python`, `executable=` overrides, `shell=True`, and `multiprocessing`
+  `fork`/`spawn` — including children started with `env={}`. The child's
+  *exemption* travels out of band (see below), never as an environment value.
+  Direct `curl`/`wget`/`ssh`-family launchers, Python `-S`/`-E`/`-I`, and
+  commands that strip the guard's startup state before an interpreter are
+  rejected before they start.
 - Raises `ExternalSocketBlocked` immediately for any other address instead of
   letting the test hang on or perform a real network round trip.
 
@@ -94,6 +99,58 @@ syscall or embeds a network stack in an otherwise allowlisted native binary is
 outside what Python can intercept; such a test must be treated as an
 `live` boundary (run under `--run-live`) rather than an offline test.
 
+### Three layers, and what each opt-out actually releases
+
+Hermeticity is enforced at three depths. They are not redundant — each catches
+what the one below it cannot express.
+
+| Layer | What it is | Where |
+| --- | --- | --- |
+| **Provider seams** | The actual fix. Each external provider is stopped at the narrowest function that owns its request, so a default run never even builds the request. | `tests/_provider_boundaries.py` |
+| **External HTTP backstop** | Fail-closed net for a provider nobody seamed. Patches httpx's real-network transports, the `requests` adapter, and `curl_cffi`'s session classes. | `tests/_external_http_boundary.py` |
+| **Socket guard** | Last resort, below every library. Refuses the syscall and the DNS lookup. | `tests/_socket_guard.py` |
+
+Opting out of one layer never opts out of the ones beneath it:
+
+| Opt-out | Provider seams | HTTP backstop | Socket guard |
+| --- | --- | --- | --- |
+| `allow_external_providers` | released | **still on** | **still on** |
+| `allow_external_http` | still on | released | **still on** |
+| `allow_tvscreener_http` / `allow_kis_daily_candle_fetch` | that one seam released | still on | **still on** |
+| `live` marker **and** `--run-live` | released | released | released |
+
+So a boundary test can drive a real client against a mocked transport without
+being able to reach a network, and only an operator-armed `live` item gets the
+whole way out. Reach for the narrowest opt-out that makes the test honest.
+
+Which one a test needs follows from what it is testing:
+
+- Testing *the provider client itself* against a mocked HTTP layer (see
+  `tests/test_naver_finance.py`, `tests/test_upbit_retry.py`) →
+  `allow_external_providers`.
+- Testing *the transport boundary*, with its own `AsyncHTTPTransport` stand-in →
+  `allow_external_http`.
+- Testing anything else → no opt-out. A blocked call means the test is
+  under-mocked; mock the provider at its call site.
+
+### The seam alias contract
+
+`SEAM_TARGETS` lists each seam's defining module **and** every module that
+aliased it via `from x import y` at import time. Patching only the definition
+leaves consumers such as `market_data.service.fetch_orderbook` pointing at the
+real function, and a half-patched seam is worse than none — the leak just moves
+to whichever consumer was missed.
+
+The list is explicit rather than discovered per test: the fixture runs once per
+item across ~20k items, so a `sys.modules` sweep there would be a real cost (the
+same reason `tests._mcp_tooling_support._patch_runtime_attr` keeps a fixed module
+list). `tests/test_rob1296_provider_boundaries.py` is what makes that trade safe:
+it imports the whole `app` package and recomputes the bindings, opting *out* of
+the seams so it compares original identities, and matching on identity **or** the
+`__rob1296_seam__` marker so a consumer first imported during a seamed test — and
+therefore holding a stale replacement — is caught too. Removing a known alias
+makes it fail and name the module.
+
 ### Suite-wide boundary fixtures
 
 Some external calls are reached from deep inside a fan-out that individual tests
@@ -103,64 +160,123 @@ paired with an opt-out fixture a boundary test can request:
 
 | Boundary | Opt out with |
 | --- | --- |
-| All external HTTP, via httpx's real transports and the `requests` adapter | `allow_external_http` |
+| All external providers, at their call-roots | `allow_external_providers` |
+| All external HTTP, via httpx's real transports, the `requests` adapter, and `curl_cffi` | `allow_external_http` |
 | TradingView scanner HTTP | `allow_tvscreener_http` |
 | KIS daily-candle cache-miss fallback (`fetch_kr_daily_unclamped`) | `allow_kis_daily_candle_fetch` |
 
-The external-HTTP boundary (`tests/_external_http_boundary.py`) is the broad one,
-and it replaced what would otherwise have been seven per-provider stubs (KIS,
-Upbit, KRX, Naver, CoinGecko, Binance, the USD/KRW feed). It patches **only**
-`httpx.AsyncHTTPTransport` / `httpx.HTTPTransport` and
-`requests.adapters.HTTPAdapter` — the transports that actually speak to a
-network. `ASGITransport` (FastAPI `TestClient`), `WSGITransport`,
-`MockTransport`, respx and any custom `AsyncBaseTransport` are untouched, and
-loopback stays reachable. It raises `httpx.ConnectError` /
-`requests.ConnectionError`, the same types a blocked connect already produces,
-so no `except httpx.HTTPError` or retry branch changes behaviour.
+Every layer raises the exception an unreachable host already produced —
+`httpx.ConnectError` / `requests.ConnectionError` — so every `except
+httpx.HTTPError`, retry and fail-open branch behaves exactly as it did before.
+No payload is ever invented. `ASGITransport` (FastAPI `TestClient`),
+`WSGITransport`, `MockTransport`, respx and custom transports are untouched, and
+loopback stays reachable.
 
-Every blocked request is counted by host and printed in the terminal summary:
+### Why `curl_cffi` needs its own interception
+
+`curl_cffi` binds libcurl. It is **not** an httpx transport and **not** a
+`requests` adapter, and libcurl issues `connect(2)` from C — below the Python
+`socket` methods the guard patches. So a client built on it slips past all three
+layers at once, and does it *silently*: every counter reads zero.
+
+That is not hypothetical. `yfinance` (and this repo's
+`SentryTracingCurlSession`) use it, and an audit of the first ROB-1296 landing
+found **29 non-live tests making 107 real requests to
+`query1.finance.yahoo.com`** while the guard reported `blocked_attempts=0` and
+the HTTP counter reported `0 blocked requests`.
+
+It is now intercepted at `curl_cffi.requests.Session.request` (and
+`AsyncSession`), the single Python chokepoint every curl_cffi request passes
+through, and the Yahoo client's own entry points are seamed at layer 1.
+
+The general lesson is worth keeping: **a client that reaches the network through
+a native extension is invisible to all three layers.** When adding an HTTP
+dependency, check whether it goes out through Python sockets. If it does not, it
+needs its own chokepoint here — and until it has one, its traffic will not
+appear in any counter.
+
+### The counter, and the contract it enforces
+
+Every request the HTTP backstop blocks is counted by host and printed in the
+terminal summary:
 
 ```
 ROB-1296 external HTTP boundary: 1 blocked requests across 1 hosts -- example.invalid=1
 ```
 
-Treat a **rising** count, or a new host, as a newly under-mocked provider —
-that line is the reason a leak cannot reappear silently. Do not assert on the
-counts of real provider hosts in a test: that would make an existing leak a
-required baseline. `tests/test_rob1296_external_http_boundary.py` pins the
-mechanics against a dedicated `.invalid` probe instead.
+**The contract is that a full `-m "not live"` run shows zero real provider
+hosts.** Anything other than this suite's own `.invalid` probes means a provider
+call escaped its seam — treat a new host, or a rising count, as a regression and
+add the seam. Do not assert on the counts of real provider hosts in a test:
+that would make an existing leak a required baseline.
+`tests/test_rob1296_external_http_boundary.py` pins the mechanics against a
+dedicated `.invalid` probe instead.
 
-The boundary is a backstop, not a substitute for mocking. It stops the suite
-from *attempting* an external request; a provider call whose result the test
-actually depends on must still be stubbed at its call site.
+The backstop is not a substitute for mocking. It stops the suite from
+*attempting* an external request; a provider call whose result the test actually
+depends on must still be stubbed at its call site.
 
-Each raises the same class of error the caller already handles, so observable
-behaviour is unchanged — only the socket disappears. Prefer a module-level
-autouse fixture (see `tests/test_mcp_place_order.py`,
-`tests/mcp_server/tooling/test_live_order_ledger.py`) when the boundary matters
-to one file rather than the whole suite. Do not "fix" a leak by asserting a
-success the test never verified: model the outcome the test already relies on.
+### Child processes carry the parent's policy
+
+A child must not get a *different* answer than the item that created it, and it
+must not be able to *claim* an answer of its own.
+
+The exemption therefore never travels in the environment. A boolean any test
+could export would be exactly the general bypass this guard exists to prevent —
+`os.environ[...] = "1"` followed by a `spawn` would have bought a child real
+network access. Instead:
+
+- **`subprocess` children** get a one-shot `os.pipe()` per launch. The parent
+  writes its in-memory decision, closes the write end, and passes only the read
+  descriptor (merged into the caller's `pass_fds`); `AUTO_TRADER_TEST_SOCKET_GUARD_POLICY_FD`
+  names the descriptor, never the decision. `sitecustomize` reads it once, closes
+  it and pops the variable. Inheriting a live descriptor is something a parent
+  grants, not something a child asserts.
+- **`multiprocessing` `fork`** inherits the installed state in memory.
+- **`multiprocessing` `spawn`** takes the decision from `spawn`'s preparation
+  data, and its bootstrap is rewritten (`get_command_line`) to bake the absolute
+  project root in and call `install()` before `spawn_main` — so installation does
+  not depend on any environment the child inherits.
+
+Fail-closed at every step: an absent channel means no exemption; a channel that
+is present but unreadable or malformed is a hard failure, never a silent
+downgrade; and `prepare` requires the key to be present and a real `bool`.
+
+Two consequences worth knowing:
+
+- **Integrity is not policy.** `-E`/`-I`/`-S`, `env -i`, unsetting or overriding
+  `PYTHONPATH`/the guard switch before an interpreter — all are refused *whatever
+  the parent's policy*, including an armed `live` item. The exemption is scoped
+  to one test item, and an ungovernable child outlives it. Only the
+  network-client deny list (`curl`/`wget`/`ssh`-family) is exemptible, because
+  that is a policy question rather than an integrity one.
+- **`multiprocessing` `forkserver` is unsupported and refused at the boundary.**
+  Its server interpreter boots through a path the guard does not control and then
+  forks every child, so no child policy can be guaranteed. An earlier version let
+  it proceed and leaned on the `AF_UNIX` broker socket being blocked, but "the
+  socket was refused" is not evidence that a child would have had the right
+  policy. ROB-1296 never required it and nothing here selects it — all three
+  `get_context` call sites ask for `spawn`. Use `spawn` or `fork`.
 
 ### Known fail-closed edges
 
 These are deliberate. They are recorded here so a future reader finds a decision
 rather than a mystery, and none of them is a reason to widen an allowlist.
 
-- **`multiprocessing` `forkserver`** brokers children over an `AF_UNIX` socket in
-  a per-process temp directory. Admitting it would mean allowlisting a directory
-  *prefix*, and "any `AF_UNIX` path is local enough" is precisely the bypass
-  ROB-1880 closed. Nothing here uses it: all three `get_context` call sites ask
-  for `spawn`. `spawn` and `fork` children are guarded and covered by tests.
-- **`python -I` / `-E` / `-S` children** are rejected, because each one discards
-  the `sitecustomize` startup hook and would run unguarded. A test that wanted an
-  isolated interpreter for *import provenance* should assert each module's
-  `__file__` instead — see `tests/services/research/test_research_contracts_wheel.py`,
-  which is a stronger check than `-I` ever was.
-- **DNS resolution is not intercepted.** `socket.getaddrinfo` resolves inside
-  libc, below the Python `socket.socket` methods the guard patches, so a
-  hostname lookup can still leave the machine. The *connection* is still blocked:
-  `socket.create_connection(("example.com", 443))` resolves and then trips the
-  guard at `connect`. Treat the guard as blocking connections, not lookups.
+- **`python -I` / `-E` / `-S` children** are rejected: each discards the
+  `sitecustomize` startup hook and would run unguarded. A test that wants an
+  isolated interpreter for *import provenance* should scrub `sys.path` inside the
+  child instead — see `tests/services/research/test_research_contracts_wheel.py`,
+  which keeps the guard installed, removes the checkout before importing, and
+  then sweeps every loaded `app.*` / `research_contracts.*` module for wheel
+  provenance. That is strictly stronger than `-I`: it also catches the transitive
+  imports a hand-picked `__file__` check would miss.
+- **DNS is blocked, not just connections.** `socket.getaddrinfo` and
+  `gethostbyname` fail closed for non-loopback names, because resolution happens
+  *before* `connect` — letting it through would emit a real query even though the
+  connection itself is refused. `None`/empty hosts (passive local binds) and
+  loopback are allowed, so local PostgreSQL/Redis are unaffected.
 - **Non-Python child environments are not rewritten**, so a native binary with
   its own network stack is outside what Python can intercept. Direct
   `curl`/`wget`/`ssh`-family launchers are rejected by name before they start.
+- **`multiprocessing` `forkserver`** — see above; refused outright.

--- a/docs/runbooks/hermetic-test-socket-guard.md
+++ b/docs/runbooks/hermetic-test-socket-guard.md
@@ -103,8 +103,36 @@ paired with an opt-out fixture a boundary test can request:
 
 | Boundary | Opt out with |
 | --- | --- |
+| All external HTTP, via httpx's real transports and the `requests` adapter | `allow_external_http` |
 | TradingView scanner HTTP | `allow_tvscreener_http` |
 | KIS daily-candle cache-miss fallback (`fetch_kr_daily_unclamped`) | `allow_kis_daily_candle_fetch` |
+
+The external-HTTP boundary (`tests/_external_http_boundary.py`) is the broad one,
+and it replaced what would otherwise have been seven per-provider stubs (KIS,
+Upbit, KRX, Naver, CoinGecko, Binance, the USD/KRW feed). It patches **only**
+`httpx.AsyncHTTPTransport` / `httpx.HTTPTransport` and
+`requests.adapters.HTTPAdapter` — the transports that actually speak to a
+network. `ASGITransport` (FastAPI `TestClient`), `WSGITransport`,
+`MockTransport`, respx and any custom `AsyncBaseTransport` are untouched, and
+loopback stays reachable. It raises `httpx.ConnectError` /
+`requests.ConnectionError`, the same types a blocked connect already produces,
+so no `except httpx.HTTPError` or retry branch changes behaviour.
+
+Every blocked request is counted by host and printed in the terminal summary:
+
+```
+ROB-1296 external HTTP boundary: 1 blocked requests across 1 hosts -- example.invalid=1
+```
+
+Treat a **rising** count, or a new host, as a newly under-mocked provider —
+that line is the reason a leak cannot reappear silently. Do not assert on the
+counts of real provider hosts in a test: that would make an existing leak a
+required baseline. `tests/test_rob1296_external_http_boundary.py` pins the
+mechanics against a dedicated `.invalid` probe instead.
+
+The boundary is a backstop, not a substitute for mocking. It stops the suite
+from *attempting* an external request; a provider call whose result the test
+actually depends on must still be stubbed at its call site.
 
 Each raises the same class of error the caller already handles, so observable
 behaviour is unchanged — only the socket disappears. Prefer a module-level

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,6 +19,7 @@
 - Registered markers are `slow`, `integration`, `unit`, and `live`; use only registered markers.
 - `live` marks tests that make external API calls, is always a strict subset of `integration`, and requires `--run-live` to execute.
 - Fast-gate selectors use `-m "not live"`; live execution is opt-in only.
+- The socket guard exempts external sockets **only** for a `live` item under an explicit `--run-live` (ROB-1296). `integration` grants no network access — it never had to, because loopback PostgreSQL/Redis is allowed by address, not by marker. See `docs/runbooks/hermetic-test-socket-guard.md`.
 - Naming follows `test_*.py` or `*_test.py`, test functions `test_*`, classes `Test*`.
 - Default command set comes from `Makefile` (`make test`, `make test-unit`, `make test-integration`, `make test-services-split`, `make test-live`, `make test-cov`, `make test-fast`, `make test-watch`).
 
@@ -26,6 +27,7 @@
 - Do not introduce unregistered markers when strict markers are enabled.
 - Do not assert outdated coverage requirements from stale docs; use current `pyproject.toml` threshold.
 - Do not mix long-running integration behavior into unit-only test runs without marker guards.
+- Do not reach for a marker, an env var, or an allowlist entry to get a test past the socket guard. A blocked connection means the test is under-mocked; mock the external client at its call site.
 - Do not move core fixtures out of `tests/conftest.py` unless fixture scope/ownership is explicit.
 
 ## NOTES

--- a/tests/_external_http_boundary.py
+++ b/tests/_external_http_boundary.py
@@ -1,0 +1,78 @@
+"""ROB-1296 external-HTTP boundary: policy, counter, and reporting helpers.
+
+The ROB-1880 socket guard already refuses these connections, so nothing here
+decides *whether* traffic may leave — it cannot, either way. What this adds is a
+clean failure and a visible counter. A guard refusal lands deep inside anyio, so
+the caller sees an opaque ``ExceptionGroup`` and the attempt shows up only as a
+number; blocking one layer up lets the same traffic fail as the exact exception
+type a real blocked connect produces, and lets the evidence name the host.
+
+Kept out of ``conftest.py`` so the policy is importable by the regression tests
+that pin it.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import Counter
+from collections.abc import Iterable
+from typing import Final
+
+MESSAGE: Final = (
+    "External HTTP is disabled during pytest (ROB-1296). Mock the client at its "
+    "call site, or request allow_external_http for a boundary test."
+)
+OPT_OUT_FIXTURE: Final = "allow_external_http"
+
+_LOCK = threading.Lock()
+_BLOCKED_BY_HOST: Counter[str] = Counter()
+
+
+def is_loopback_host(host: object) -> bool:
+    """Reuse the socket guard's address policy so the two never disagree."""
+
+    from tests._socket_guard import is_allowed_local_address
+
+    if not isinstance(host, str) or not host:
+        return False
+    return is_allowed_local_address((host, 0))
+
+
+def boundary_is_active(
+    *, has_live_marker: bool, run_live: bool, fixturenames: Iterable[str]
+) -> bool:
+    """Return whether the boundary should be installed for one test item.
+
+    Mirrors the socket guard's own exemption: an armed ``live`` item keeps its
+    intentional network boundary, and a test that explicitly asks to drive the
+    real transport opts out. Everything else is blocked.
+    """
+
+    if OPT_OUT_FIXTURE in set(fixturenames):
+        return False
+    return not (has_live_marker and run_live)
+
+
+def record_block(host: str) -> None:
+    with _LOCK:
+        _BLOCKED_BY_HOST[host] += 1
+
+
+def snapshot() -> dict[str, int]:
+    with _LOCK:
+        return dict(sorted(_BLOCKED_BY_HOST.items()))
+
+
+def reset() -> None:
+    with _LOCK:
+        _BLOCKED_BY_HOST.clear()
+
+
+def format_summary(counts: dict[str, int]) -> str:
+    if not counts:
+        return "ROB-1296 external HTTP boundary: 0 blocked requests"
+    hosts = " ".join(f"{host}={count}" for host, count in sorted(counts.items()))
+    return (
+        f"ROB-1296 external HTTP boundary: {sum(counts.values())} blocked "
+        f"requests across {len(counts)} hosts -- {hosts}"
+    )

--- a/tests/_external_http_boundary.py
+++ b/tests/_external_http_boundary.py
@@ -76,3 +76,48 @@ def format_summary(counts: dict[str, int]) -> str:
         f"ROB-1296 external HTTP boundary: {sum(counts.values())} blocked "
         f"requests across {len(counts)} hosts -- {hosts}"
     )
+
+
+def curl_session_classes() -> tuple[type, ...]:
+    """Every ``curl_cffi`` session class whose ``request`` must be intercepted.
+
+    Returned rather than hard-coded so an environment without ``curl_cffi``
+    installed simply has nothing to patch, and so the async variant is covered
+    when the installed version provides one.
+    """
+
+    try:
+        from curl_cffi import requests as curl_requests
+    except ImportError:  # pragma: no cover - curl_cffi is a hard dependency here
+        return ()
+
+    classes = []
+    for name in ("Session", "AsyncSession"):
+        candidate = getattr(curl_requests, name, None)
+        if isinstance(candidate, type):
+            classes.append(candidate)
+    return tuple(classes)
+
+
+def build_curl_request_blocker(session_class: type):
+    """Wrap ``session_class.request`` so non-loopback hosts fail closed.
+
+    Raises ``curl_cffi``'s own ``ConnectionError`` -- what an unreachable host
+    already produces through this client -- so callers land in the same
+    ``except`` branch they do today.
+    """
+
+    from urllib.parse import urlsplit
+
+    from curl_cffi.requests import errors as curl_errors
+
+    original = session_class.request
+
+    def _blocked(self, method, url, *args, **kwargs):
+        host = urlsplit(str(url)).hostname or ""
+        if is_loopback_host(host):
+            return original(self, method, url, *args, **kwargs)
+        record_block(host)
+        raise curl_errors.RequestsError(f"{MESSAGE} [{host}]")
+
+    return _blocked

--- a/tests/_provider_boundaries.py
+++ b/tests/_provider_boundaries.py
@@ -40,6 +40,15 @@ MESSAGE: Final = (
     "provider at its call site, or request allow_external_providers."
 )
 OPT_OUT_FIXTURE: Final = "allow_external_providers"
+SEAM_MARKER: Final = "__rob1296_seam__"
+"""Attribute stamped on every replacement, naming the seam it stands in for."""
+
+
+def seam_marker(value: object) -> str | None:
+    """Return the seam name a replacement stands in for, else ``None``."""
+
+    return getattr(value, SEAM_MARKER, None)
+
 
 # (attribute, modules binding it) — defining module first is not required; every
 # listed module is rebound to the same replacement.
@@ -94,6 +103,43 @@ SEAM_TARGETS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
         "fetch_sector_peers",
         ("app.services.naver_finance", "app.services.naver_finance.valuation"),
     ),
+    # yfinance / Yahoo. These go out over curl_cffi (libcurl), which no other
+    # layer can see: not an httpx transport, not a ``requests`` adapter, and its
+    # ``connect(2)`` happens in C below the socket guard. All four are fail-open
+    # enrichment paths, so raising the transport error they already handle keeps
+    # behaviour identical. (The session *builder* is deliberately not seamed --
+    # see SYNC_SEAM_TARGETS.)
+    ("_collect_yfinance_snapshot", ("app.mcp_server.tooling.analysis_analyze",)),
+    (
+        "_fetch_valuation_yfinance",
+        (
+            "app.mcp_server.tooling.analysis_analyze",
+            "app.mcp_server.tooling.fundamentals._valuation",
+            "app.mcp_server.tooling.fundamentals_sources_yfinance",
+        ),
+    ),
+    (
+        "_fetch_investment_opinions_yfinance",
+        (
+            "app.mcp_server.tooling.analysis_analyze",
+            "app.mcp_server.tooling.fundamentals._valuation",
+            "app.mcp_server.tooling.fundamentals_sources_yfinance",
+        ),
+    ),
+    (
+        "_fetch_investment_opinions_yfinance_screen",
+        ("app.mcp_server.tooling.fundamentals_sources_yfinance",),
+    ),
+    # Yahoo market-data client (also curl_cffi under the hood).
+    ("fetch_ohlcv", ("app.services.brokers.yahoo.client",)),
+    ("fetch_52w_high_date", ("app.services.brokers.yahoo.client",)),
+    ("fetch_price", ("app.services.brokers.yahoo.client",)),
+    (
+        "fetch_fast_info",
+        ("app.services.brokers.yahoo.client", "app.services.market_data.service"),
+    ),
+    ("fetch_prepost_quote", ("app.services.brokers.yahoo.client",)),
+    ("fetch_fundamental_info", ("app.services.brokers.yahoo.client",)),
     # CoinGecko / alternative.me / Binance public.
     (
         "fetch_btc_dominance",
@@ -124,6 +170,18 @@ SEAM_TARGETS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
         ),
     ),
 )
+
+# Synchronous seams. Same contract as ``SEAM_TARGETS`` but the replacement is a
+# plain function, because these are called outside a coroutine.
+#
+# Empty on purpose. yfinance/Yahoo was the obvious candidate -- it goes out over
+# curl_cffi (libcurl), which no other layer could see -- but seaming
+# ``build_yfinance_tracing_session`` breaks the many tests that already stub
+# ``yfinance.Ticker``/``download`` correctly and merely need a session *object*
+# to hand through. curl_cffi exposes a single Python chokepoint
+# (``Session.request``), so it is intercepted at the transport backstop instead,
+# which blocks and counts without preventing construction.
+SYNC_SEAM_TARGETS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = ()
 
 # Methods patched on a class rather than a module.
 ASYNC_METHOD_SEAMS: Final = (
@@ -175,14 +233,52 @@ def install(monkeypatch) -> Callable[[], None]:
 
     import httpx
 
-    def _async_blocked(label: str):
+    def _async_blocked(label: str, *, seam: str | None = None):
         async def _blocked(*_args, **_kwargs):
             raise httpx.ConnectError(f"{MESSAGE} [{label}]")
 
+        # Stable marker so the completeness contract can spot a *stale*
+        # replacement, not just a module still holding the original. A module
+        # imported for the first time while the seams were installed aliases the
+        # replacement at import time; monkeypatch restores the modules it patched,
+        # but not that late consumer, which would otherwise be invisible to an
+        # original-identity scan.
+        _blocked.__dict__[SEAM_MARKER] = seam if seam is not None else label
         return _blocked
 
+    # Import every target *before* patching anything. A consumer that does
+    # ``from x import y`` at module load and is first imported after ``x`` was
+    # already patched binds the replacement permanently: ``monkeypatch`` records
+    # that replacement as the "original" and restores it, leaving a stale seam
+    # behind for the rest of the session.
+    for _, module_paths in SEAM_TARGETS:
+        for module_path in module_paths:
+            importlib.import_module(module_path)
+    for _, module_paths in SYNC_SEAM_TARGETS:
+        for module_path in module_paths:
+            importlib.import_module(module_path)
+    for module_path, class_name, _ in ASYNC_METHOD_SEAMS:
+        _ = class_name
+        importlib.import_module(module_path)
+    for module_path, _ in FINNHUB_CLIENT_FACTORIES:
+        importlib.import_module(module_path)
+
     for attribute, module_paths in SEAM_TARGETS:
-        replacement = _async_blocked(attribute)
+        replacement = _async_blocked(attribute, seam=attribute)
+        for module_path in module_paths:
+            module = importlib.import_module(module_path)
+            if hasattr(module, attribute):
+                monkeypatch.setattr(module, attribute, replacement)
+
+    def _sync_blocked(label: str, *, seam: str):
+        def _blocked(*_args, **_kwargs):
+            raise httpx.ConnectError(f"{MESSAGE} [{label}]")
+
+        _blocked.__dict__[SEAM_MARKER] = seam
+        return _blocked
+
+    for attribute, module_paths in SYNC_SEAM_TARGETS:
+        replacement = _sync_blocked(attribute, seam=attribute)
         for module_path in module_paths:
             module = importlib.import_module(module_path)
             if hasattr(module, attribute):

--- a/tests/_provider_boundaries.py
+++ b/tests/_provider_boundaries.py
@@ -1,0 +1,264 @@
+"""ROB-1296 provider seams: stop external calls at the call-root, not the socket.
+
+The broad transport fixture in ``conftest.py`` is a fail-closed backstop — it
+guarantees the suite *cannot* reach a network. These seams are the actual fix:
+they stop each provider call one layer above httpx, so a default ``not live``
+run never even builds an outbound request.
+
+Every seam raises ``httpx.ConnectError`` / ``requests.ConnectionError`` — the
+exact exception a blocked connect already produced — so every ``except
+httpx.HTTPError``, retry and fail-open branch behaves exactly as before. Nothing
+here fabricates a successful payload; a test that needs real provider data must
+stub that provider itself.
+
+Seams sit at the narrowest function that owns the request, because these
+providers construct ``httpx.AsyncClient`` inline and expose no injectable client.
+
+``SEAM_TARGETS`` lists each seam's defining module *and* every module that
+aliased it via ``from x import y`` at import time. The list is explicit rather
+than discovered per test: ``install`` runs once per test item across ~20k items,
+so scanning ``sys.modules`` there would be a real cost. The same reasoning is why
+``tests._mcp_tooling_support._patch_runtime_attr`` keeps a fixed module list.
+``tests/test_rob1296_provider_boundaries.py`` recomputes the bindings from a
+fully-imported ``app`` package and fails if this contract ever misses an alias.
+
+Deliberately *not* seamed: ``fundamentals_sources_naver._fetch_binance_prices``
+and ``_fetch_exchange_rate_usd_krw``. ``TestGetKimchiPremium`` drives both
+through a monkeypatched ``httpx.AsyncClient``, so replacing the functions would
+shadow the very behaviour under test; its one test that left them live stubs
+them directly instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from typing import Final
+
+MESSAGE: Final = (
+    "External provider calls are disabled during pytest (ROB-1296). Stub this "
+    "provider at its call site, or request allow_external_providers."
+)
+OPT_OUT_FIXTURE: Final = "allow_external_providers"
+
+# (attribute, modules binding it) — defining module first is not required; every
+# listed module is rebound to the same replacement.
+SEAM_TARGETS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    # USD/KRW rate: Toss primary, open.er-api.com fallback.
+    ("_fetch_toss_usd_krw_quote", ("app.services.exchange_rate_service",)),
+    ("_fetch_open_er_api_usd_krw_quote", ("app.services.exchange_rate_service",)),
+    # Upbit: every public and private REST call funnels through these two.
+    (
+        "_request_json",
+        (
+            "app.services.brokers.upbit.client",
+            "app.services.brokers.upbit.public_trades",
+        ),
+    ),
+    ("_request_with_auth", ("app.services.brokers.upbit.client",)),
+    (
+        "fetch_orderbook",
+        ("app.services.market_data.service", "app.services.upbit_orderbook"),
+    ),
+    # KRX public data portal.
+    ("_fetch_max_working_date", ("app.services.krx",)),
+    # Naver Finance scrapes.
+    (
+        "_fetch_html",
+        (
+            "app.services.naver_finance",
+            "app.services.naver_finance.company",
+            "app.services.naver_finance.investor",
+            "app.services.naver_finance.news",
+            "app.services.naver_finance.parser",
+            "app.services.naver_finance.valuation",
+        ),
+    ),
+    (
+        "_fetch_html_with_client",
+        (
+            "app.services.naver_finance",
+            "app.services.naver_finance.investor",
+            "app.services.naver_finance.parser",
+        ),
+    ),
+    (
+        "_fetch_kr_snapshot",
+        ("app.services.naver_finance", "app.services.naver_finance.investor"),
+    ),
+    (
+        "fetch_valuation",
+        ("app.services.naver_finance", "app.services.naver_finance.valuation"),
+    ),
+    (
+        "fetch_sector_peers",
+        ("app.services.naver_finance", "app.services.naver_finance.valuation"),
+    ),
+    # CoinGecko / alternative.me / Binance public.
+    (
+        "fetch_btc_dominance",
+        (
+            "app.mcp_server.tooling.fundamentals_sources_indices",
+            "app.services.external.btc_dominance",
+        ),
+    ),
+    (
+        "fetch_alternative_me_fear_greed",
+        (
+            "app.services.crypto_insight_snapshots.builder",
+            "app.services.external.crypto_insights",
+        ),
+    ),
+    (
+        "fetch_coingecko_global",
+        (
+            "app.services.crypto_insight_snapshots.builder",
+            "app.services.external.crypto_insights",
+        ),
+    ),
+    (
+        "fetch_binance_funding_rates",
+        (
+            "app.services.crypto_insight_snapshots.builder",
+            "app.services.external.crypto_insights",
+        ),
+    ),
+)
+
+# Methods patched on a class rather than a module.
+ASYNC_METHOD_SEAMS: Final = (
+    ("app.services.krx", "KRXSession", "fetch_data"),
+    ("app.services.krx", "KRXSession", "fetch_resource"),
+    (
+        "app.mcp_server.tooling.screening.market_cap_cache",
+        "MarketCapCache",
+        "_fetch_market_caps",
+    ),
+    ("app.services.brokers.binance.rest_client", "BinancePublicRestClient", "_send"),
+)
+
+# Finnhub ships a synchronous ``requests``-backed client.
+FINNHUB_CLIENT_FACTORIES: Final = (
+    ("app.services.finnhub_news", "_get_finnhub_client"),
+    ("app.services.market_events.finnhub_helpers", "_get_finnhub_client"),
+    ("app.mcp_server.tooling.fundamentals_sources_finnhub", "_get_finnhub_client"),
+)
+
+# ``StockDetailProviders`` is a frozen, slotted dataclass and the default
+# instance is bound as a default argument, so neither the module attribute nor
+# the class attribute is reachable. The instance field is mutated in place and
+# restored by the returned undo callable.
+_FROZEN_PROVIDER_SEAM: Final = (
+    "app.services.invest_view_model.stock_detail_service",
+    "DEFAULT_STOCK_DETAIL_PROVIDERS",
+    "recent_trades",
+)
+
+
+class _OfflineFinnhubClient:
+    """Stand-in whose every call fails the way an unreachable Finnhub does."""
+
+    def __getattr__(self, name: str):
+        import requests
+
+        def _blocked(*_args, **_kwargs):
+            raise requests.ConnectionError(f"{MESSAGE} [api.finnhub.io.{name}]")
+
+        return _blocked
+
+
+def install(monkeypatch) -> Callable[[], None]:
+    """Patch every provider seam to fail as an unreachable host would.
+
+    Returns an undo callable for the one seam ``monkeypatch`` cannot revert.
+    """
+
+    import httpx
+
+    def _async_blocked(label: str):
+        async def _blocked(*_args, **_kwargs):
+            raise httpx.ConnectError(f"{MESSAGE} [{label}]")
+
+        return _blocked
+
+    for attribute, module_paths in SEAM_TARGETS:
+        replacement = _async_blocked(attribute)
+        for module_path in module_paths:
+            module = importlib.import_module(module_path)
+            if hasattr(module, attribute):
+                monkeypatch.setattr(module, attribute, replacement)
+
+    for module_path, class_name, method in ASYNC_METHOD_SEAMS:
+        module = importlib.import_module(module_path)
+        owner = getattr(module, class_name, None)
+        if owner is not None and hasattr(owner, method):
+            monkeypatch.setattr(owner, method, _async_blocked(f"{class_name}.{method}"))
+
+    # KIS exposes an injectable client factory, so give it a MockTransport that
+    # fails the way an unreachable host does. Patching the factory also flips
+    # ``_current_http_client_builder_token``, which invalidates any shared client
+    # a previous test cached instead of leaving a real one in place.
+    kis_base = importlib.import_module("app.services.brokers.kis.base")
+    kis_client_class = getattr(kis_base, "BaseKISClient", None)
+    if kis_client_class is not None:
+
+        def _kis_transport(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError(f"{MESSAGE} [{request.url.host}]", request=request)
+
+        def _build_offline_kis_client(self, timeout: float) -> object:
+            _ = self
+            return httpx.AsyncClient(
+                timeout=timeout, transport=httpx.MockTransport(_kis_transport)
+            )
+
+        monkeypatch.setattr(
+            kis_client_class, "_build_http_client", _build_offline_kis_client
+        )
+
+    for module_path, attribute in FINNHUB_CLIENT_FACTORIES:
+        module = importlib.import_module(module_path)
+        if hasattr(module, attribute):
+            monkeypatch.setattr(module, attribute, lambda: _OfflineFinnhubClient())
+
+    return _install_frozen_provider_seam(monkeypatch, _async_blocked)
+
+
+def _install_frozen_provider_seam(monkeypatch, async_blocked) -> Callable[[], None]:
+    """Rebind the recent-trades provider on both routes callers can reach it by.
+
+    ``StockDetailProviders`` is frozen and slotted, the shared default instance is
+    bound as a default argument, and callers also build fresh instances that pick
+    the field default straight out of the generated ``__init__``. So the module
+    attribute is reachable from neither: the live instance is mutated in place
+    (restored by the returned undo), and ``__init__.__defaults__`` is rewritten so
+    newly constructed instances get the seam too.
+    """
+
+    import dataclasses
+
+    module_path, instance_name, field = _FROZEN_PROVIDER_SEAM
+    module = importlib.import_module(module_path)
+    instance = getattr(module, instance_name, None)
+    if instance is None or not hasattr(instance, field):
+        return lambda: None
+
+    replacement = async_blocked(f"{instance_name}.{field}")
+    owner = type(instance)
+
+    init_defaults = owner.__init__.__defaults__ or ()
+    init_fields = [f.name for f in dataclasses.fields(owner) if f.init]
+    offset = len(init_fields) - len(init_defaults)
+    if field in init_fields:
+        index = init_fields.index(field) - offset
+        if 0 <= index < len(init_defaults):
+            rewritten = list(init_defaults)
+            rewritten[index] = replacement
+            monkeypatch.setattr(owner.__init__, "__defaults__", tuple(rewritten))
+
+    original = getattr(instance, field)
+    object.__setattr__(instance, field, replacement)
+
+    def _undo() -> None:
+        object.__setattr__(instance, field, original)
+
+    return _undo

--- a/tests/_socket_guard.py
+++ b/tests/_socket_guard.py
@@ -106,6 +106,19 @@ class ExternalSubprocessBlocked(AssertionError):
     """Raised before a known network-capable subprocess can be started."""
 
 
+class ExternalResolutionBlocked(ExternalSocketBlocked, socket.gaierror):
+    """Raised instead of resolving a non-loopback name.
+
+    Deliberately *also* a ``socket.gaierror`` -- and therefore an ``OSError`` --
+    because resolution failures are mapped by every HTTP client
+    (``httpx.ConnectError``, ``requests.ConnectionError``, …). A bare
+    ``AssertionError`` escapes that mapping and propagates as a hard crash, which
+    is how a child process died mid-request instead of seeing the ordinary
+    "cannot resolve" it already handles. Still an ``ExternalSocketBlocked`` so
+    existing guard assertions keep matching.
+    """
+
+
 _INSTALL_LOCK = threading.RLock()
 _STATE_LOCK = threading.Lock()
 _INSTALLED = False
@@ -219,7 +232,7 @@ def _assert_socket_address_allowed(operation: str, address: object) -> None:
 
 def _raise_resolution_blocked(host: object) -> None:
     _record_block("getaddrinfo")
-    raise ExternalSocketBlocked(
+    raise ExternalResolutionBlocked(
         f"Blocked DNS resolution of {host!r}. Name resolution happens *before* "
         "connect, so letting it through would emit a real query even though the "
         "connection itself is refused. External resolution is reachable only "

--- a/tests/_socket_guard.py
+++ b/tests/_socket_guard.py
@@ -147,15 +147,28 @@ def is_allowed_local_address(address: object) -> bool:
 def _raise_socket_blocked(operation: str, address: object) -> None:
     _record_block(operation)
     raise ExternalSocketBlocked(
-        f"Blocked outbound socket.{operation} to {address!r} in a "
-        "non-integration/live test. Mock the external client at its call site "
+        f"Blocked outbound socket.{operation} to {address!r}. External "
+        "sockets are reachable only from a test marked `live` under an "
+        "explicit `--run-live`; the `integration` marker does not grant "
+        "network access (ROB-1296). Mock the external client at its call site "
         "(see docs/runbooks/hermetic-test-socket-guard.md) instead of letting "
         "the test reach a real host."
     )
 
 
+def is_socket_address_permitted(address: object) -> bool:
+    """Return the guard's current verdict for *address* without side effects.
+
+    Exposed so policy tests can assert the marker/option truth table without
+    emitting a single packet and without incrementing the blocked-attempt
+    counters that back the CI evidence artifact.
+    """
+
+    return is_current_test_exempt() or is_allowed_local_address(address)
+
+
 def _assert_socket_address_allowed(operation: str, address: object) -> None:
-    if is_current_test_exempt() or is_allowed_local_address(address):
+    if is_socket_address_permitted(address):
         return
     _raise_socket_blocked(operation, address)
 

--- a/tests/_socket_guard.py
+++ b/tests/_socket_guard.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import ipaddress
 import json
 import os
+import re
 import shlex
 import socket
 import subprocess
@@ -22,6 +23,25 @@ from typing import Any, Final
 
 ENV_ENABLED: Final = "AUTO_TRADER_TEST_SOCKET_GUARD"
 """Environment switch consumed by the child-process ``sitecustomize`` hook."""
+
+ENV_POLICY_FD: Final = "AUTO_TRADER_TEST_SOCKET_GUARD_POLICY_FD"
+"""File descriptor carrying the parent's exemption to one Python child.
+
+There is deliberately **no** environment variable holding the exemption itself. A
+boolean in the environment is forgeable: any test could export it and then reach
+the network from a child, which is precisely the general bypass this guard
+exists to prevent. Instead the parent writes its in-memory decision into a
+one-shot pipe and passes only the read end's descriptor. Inheriting a live
+descriptor is something the parent grants, not something a child can assert, and
+the payload is consumed exactly once.
+
+A missing descriptor means "no exemption" (default deny). A descriptor that is
+present but unreadable or malformed is a hard failure -- never a silent
+downgrade.
+"""
+
+_PREPARATION_KEY: Final = "auto_trader_socket_guard_exempt"
+"""Key added to ``multiprocessing.spawn`` preparation data."""
 
 PROJECT_ROOT: Final = Path(__file__).resolve().parents[1]
 STARTUP_HOOK_DIRECTORY: Final = PROJECT_ROOT / "tests" / "_socket_guard_startup"
@@ -56,7 +76,22 @@ _NETWORK_CLIENT_EXECUTABLES: Final = frozenset(
     }
 )
 _SHELL_EXECUTABLES: Final = frozenset({"bash", "dash", "fish", "sh", "zsh"})
+# Launchers that start a Python interpreter without ``python`` being argv[0].
+# ``uv run python -c ...`` used to slip past the direct/shell checks entirely and
+# ran without the startup hook.
+_PYTHON_LAUNCHER_WRAPPERS: Final = frozenset(
+    {"env", "hatch", "nox", "pdm", "pipenv", "poetry", "tox", "uv", "uvx"}
+)
 _UNSAFE_PYTHON_STARTUP_FLAGS: Final = frozenset({"-E", "-I", "-S"})
+_ENV_SCRUBBING_FLAGS: Final = frozenset({"-i", "--ignore-environment"})
+_ENV_UNSET_FLAGS: Final = frozenset({"-u", "--unset"})
+_GUARD_CRITICAL_ENV_KEYS: Final = frozenset(
+    {
+        "PYTHONPATH",
+        "AUTO_TRADER_TEST_SOCKET_GUARD",
+        "AUTO_TRADER_TEST_SOCKET_GUARD_EXEMPT",
+    }
+)
 
 
 class SocketGuardInstallationError(RuntimeError):
@@ -82,6 +117,15 @@ _ORIGINAL_CONNECT_EX = socket.socket.connect_ex
 _ORIGINAL_SENDTO = socket.socket.sendto
 _ORIGINAL_SENDMSG = getattr(socket.socket, "sendmsg", None)
 _ORIGINAL_POPEN_INIT = subprocess.Popen.__init__
+_ORIGINAL_GETADDRINFO = socket.getaddrinfo
+_ORIGINAL_GETHOSTBYNAME = socket.gethostbyname
+
+# Set when the multiprocessing policy channel is installed; both are mandatory
+# members of the integrity check.
+_GUARDED_GET_PREPARATION_DATA: Any = None
+_GUARDED_PREPARE: Any = None
+_GUARDED_PROCESS_START: Any = None
+_GUARDED_GET_COMMAND_LINE: Any = None
 
 
 def _record_block(operation: str) -> None:
@@ -173,6 +217,40 @@ def _assert_socket_address_allowed(operation: str, address: object) -> None:
     _raise_socket_blocked(operation, address)
 
 
+def _raise_resolution_blocked(host: object) -> None:
+    _record_block("getaddrinfo")
+    raise ExternalSocketBlocked(
+        f"Blocked DNS resolution of {host!r}. Name resolution happens *before* "
+        "connect, so letting it through would emit a real query even though the "
+        "connection itself is refused. External resolution is reachable only "
+        "from a test marked `live` under an explicit `--run-live`. Mock the "
+        "client at its call site (see "
+        "docs/runbooks/hermetic-test-socket-guard.md)."
+    )
+
+
+def _assert_resolution_allowed(host: object) -> None:
+    if is_current_test_exempt():
+        return
+    # ``None``/empty means a passive lookup for a local bind, which never leaves
+    # the machine.
+    if host is None or host == "" or host == b"":
+        return
+    if _is_loopback_host(host):
+        return
+    _raise_resolution_blocked(host)
+
+
+def _guarded_getaddrinfo(host: object, port: object, *args: object, **kwargs: object):
+    _assert_resolution_allowed(host)
+    return _ORIGINAL_GETADDRINFO(host, port, *args, **kwargs)  # type: ignore[arg-type]
+
+
+def _guarded_gethostbyname(hostname: str) -> str:
+    _assert_resolution_allowed(hostname)
+    return _ORIGINAL_GETHOSTBYNAME(hostname)
+
+
 def _guarded_connect(self: socket.socket, address: object) -> None:
     _assert_socket_address_allowed("connect", address)
     _ORIGINAL_CONNECT(self, address)
@@ -225,9 +303,19 @@ def _command_parts(command: object) -> tuple[str, ...]:
     return ()
 
 
+_PYTHON_EXECUTABLE_PATTERN: Final = re.compile(r"^(?:py|pythonw?[0-9.]*)$")
+
+
 def _is_python_executable(value: str) -> bool:
-    executable = Path(value).name.lower()
-    return executable == "py" or executable.startswith("python")
+    """Whether *value* names a Python interpreter.
+
+    Matched exactly rather than by prefix: ``startswith("python")`` also matched
+    the literal string ``PYTHONPATH``, so ``env -u PYTHONPATH python …`` looked
+    like it had already reached the interpreter and its environment-stripping
+    prefix went unexamined.
+    """
+
+    return bool(_PYTHON_EXECUTABLE_PATTERN.fullmatch(Path(value).name.lower()))
 
 
 def _nested_command_parts(parts: Sequence[str]) -> tuple[str, ...]:
@@ -255,10 +343,88 @@ def _command_contains_python(parts: Sequence[str]) -> bool:
     )
 
 
-def _is_shell_wrapped_python(parts: Sequence[str]) -> bool:
-    if not parts or Path(parts[0]).name.lower() not in _SHELL_EXECUTABLES:
+def _is_wrapped_python_launcher(parts: Sequence[str]) -> bool:
+    """Whether *parts* starts a Python interpreter behind a known launcher.
+
+    Both halves are required. ``uv run python -c ...`` and ``/usr/bin/env python``
+    are Python children that must inherit the startup hook; ``uv build`` and
+    ``env printenv`` are not, and rewriting their environment would break
+    callers that depend on exact child-env semantics for a non-Python tool.
+    """
+
+    if not parts:
         return False
-    return "-c" in parts and _command_contains_python(_nested_command_parts(parts))
+    return Path(
+        parts[0]
+    ).name.lower() in _PYTHON_LAUNCHER_WRAPPERS and _command_contains_python(parts)
+
+
+def _shell_command_payload(parts: Sequence[str]) -> tuple[str, ...]:
+    """Return the command string a shell invocation will execute, if any.
+
+    ``sh -c '…'`` is only the tidiest spelling; ``bash -lc '…'`` and ``sh -ec '…'``
+    bundle ``c`` with other short options and used to slip past a literal
+    ``"-c" in parts`` check. Bundles are matched by decomposing the option token,
+    so an argument that merely contains the letter ``c`` is not mistaken for one.
+    """
+
+    if not parts or Path(parts[0]).name.lower() not in _SHELL_EXECUTABLES:
+        return ()
+    for index, part in enumerate(parts[1:], start=1):
+        if not part.startswith("-") or part == "--":
+            break
+        if part.startswith("--"):
+            continue
+        if "c" in part[1:]:
+            payload = parts[index + 1 : index + 2]
+            return tuple(payload)
+    return ()
+
+
+def _is_shell_wrapped_python(parts: Sequence[str]) -> bool:
+    payload = _shell_command_payload(parts)
+    if not payload:
+        return False
+    return _command_contains_python(_nested_command_parts(payload))
+
+
+def _strips_guard_environment_before_python(parts: Sequence[str]) -> bool:
+    """Whether *parts* removes the guard's startup state and then runs Python.
+
+    ``sh -c 'env -i python …'`` was the obvious case, but the same hole opens
+    with a scalpel: ``env -u PYTHONPATH python``, ``env --unset=…``,
+    ``PYTHONPATH= python``, or ``unset PYTHONPATH; python`` all leave the
+    interpreter without the ``sitecustomize`` hook. Rewriting the launcher's
+    environment cannot help -- the payload undoes it afterwards -- so the command
+    is refused instead.
+
+    Only tokens *before* the interpreter are considered, because that is where
+    environment manipulation takes effect; a ``PYTHONPATH=`` substring inside a
+    ``-c`` script is not a bypass and must not be misread as one.
+    """
+
+    python_positions = [
+        index for index, part in enumerate(parts) if _is_python_executable(part)
+    ]
+    if not python_positions:
+        return False
+
+    prefix = [part.rstrip(";") for part in parts[: python_positions[0]]]
+    for index, part in enumerate(prefix):
+        if part in _ENV_SCRUBBING_FLAGS:
+            return True
+        if part in _ENV_UNSET_FLAGS:
+            if any(key in _GUARD_CRITICAL_ENV_KEYS for key in prefix[index + 1 :][:1]):
+                return True
+        if part.startswith("--unset="):
+            if part.split("=", 1)[1] in _GUARD_CRITICAL_ENV_KEYS:
+                return True
+        if part == "unset":
+            if any(key in _GUARD_CRITICAL_ENV_KEYS for key in prefix[index + 1 :]):
+                return True
+        if "=" in part and part.split("=", 1)[0] in _GUARD_CRITICAL_ENV_KEYS:
+            return True
+    return False
 
 
 def _raise_subprocess_blocked(reason: str, command: object) -> None:
@@ -270,24 +436,153 @@ def _raise_subprocess_blocked(reason: str, command: object) -> None:
     )
 
 
-def _assert_subprocess_allowed(command: object) -> None:
-    parts = _command_parts(command)
-    expanded_parts = (*parts, *_nested_command_parts(parts))
-    executable_names = {Path(part).name.lower() for part in expanded_parts}
+def _effective_command_parts(
+    args: object, positional: tuple[object, ...], kwargs: dict[str, object]
+) -> tuple[str, ...]:
+    """argv with ``executable=`` substituted in, which is what actually runs.
+
+    Every downstream rule -- launcher classification, the network-client deny
+    list, unsafe interpreter flags, environment scrubbing -- must read the same
+    representation. Classifying on the override while denying on the raw argv let
+    ``Popen(["ignored", "-I", …], executable=sys.executable)`` start unguarded and
+    ``Popen(["ignored", url], executable="/usr/bin/curl")`` skip the deny list.
+    """
+
+    parts = _command_parts(args)
+    executable = _resolve_popen_executable(positional, kwargs)
+    if executable is None:
+        return parts
+    if _resolve_popen_shell(positional, kwargs):
+        # With ``shell=True`` the override names the *shell* and ``args`` is the
+        # command string it will run. Replacing argv[0] would throw the payload
+        # away, so keep both: the launcher and what it launches.
+        return (executable, *parts)
+    return (executable, *parts[1:])
+
+
+def _resolve_popen_shell(
+    positional: tuple[object, ...], kwargs: dict[str, object]
+) -> bool:
+    # ``Popen(args, bufsize, executable, stdin, stdout, stderr, preexec_fn,
+    #         close_fds, shell, …)`` -- ``shell`` is the eighth positional after
+    # ``args``.
+    shell = kwargs.get("shell")
+    if shell is None and len(positional) > 7:
+        shell = positional[7]
+    return bool(shell)
+
+
+def _expanded(parts):
+    return (*parts, *_nested_command_parts(parts))
+
+
+def _assert_network_client_allowed(command, parts=None) -> None:
+    """Policy half: reaching a network client directly. Exemptible."""
+
+    resolved = tuple(parts) if parts is not None else _command_parts(command)
+    executable_names = {Path(part).name.lower() for part in _expanded(resolved)}
     if _NETWORK_CLIENT_EXECUTABLES.intersection(executable_names):
         _raise_subprocess_blocked("network-client", command)
+
+
+def _assert_child_is_governable(command, parts=None) -> None:
+    """Integrity half: the child must be able to load the guard at all.
+
+    Never exemptible. An armed ``live`` test is allowed to reach the network; it
+    is not allowed to launch an interpreter the guard cannot govern, because the
+    exemption is scoped to one item and an ungovernable child outlives it.
+    """
+
+    resolved = tuple(parts) if parts is not None else _command_parts(command)
+    expanded_parts = _expanded(resolved)
+
     for position, part in enumerate(expanded_parts):
         if _is_python_executable(part) and _UNSAFE_PYTHON_STARTUP_FLAGS.intersection(
             expanded_parts[position + 1 :]
         ):
             _raise_subprocess_blocked("python-startup-bypass", command)
 
+    if _strips_guard_environment_before_python(expanded_parts):
+        _raise_subprocess_blocked("env-scrubbed-python", command)
+
+
+def _assert_subprocess_allowed(command, parts=None) -> None:
+    """Both halves, for callers that are not the ``Popen`` interceptor."""
+
+    _assert_child_is_governable(command, parts)
+    _assert_network_client_allowed(command, parts)
+
+
+def _open_policy_channel(exempt: bool) -> int:
+    """One-shot pipe carrying this launch's exemption to exactly one child.
+
+    The payload is written and the write end closed immediately, so the child
+    reads a complete message followed by EOF and never blocks. A fresh pipe per
+    launch means a descriptor cannot be replayed by a later, unrelated child.
+    """
+
+    read_fd, write_fd = os.pipe()
+    os.set_inheritable(read_fd, True)
+    try:
+        os.write(write_fd, b"1" if exempt else b"0")
+    finally:
+        # Closed immediately so the child sees a complete message then EOF.
+        os.close(write_fd)
+    return read_fd
+
+
+def _merge_pass_fds(kwargs: dict, policy_fd: int) -> dict:
+    """Add *policy_fd* to ``pass_fds`` without dropping the caller's own."""
+
+    merged = dict(kwargs)
+    existing = merged.get("pass_fds") or ()
+    merged["pass_fds"] = (*tuple(existing), policy_fd)
+    # ``pass_fds`` implies ``close_fds=True``; be explicit so a caller-supplied
+    # ``close_fds=False`` cannot strand the descriptor.
+    merged["close_fds"] = True
+    return merged
+
+
+def read_policy_channel() -> bool:
+    """Consume the inherited exemption, or fail closed.
+
+    Called once by the child's ``sitecustomize``. An absent descriptor means no
+    exemption. A descriptor that is present but unreadable or malformed is a hard
+    failure: a broken channel must never be mistaken for a policy decision.
+    """
+
+    raw = os.environ.pop(ENV_POLICY_FD, None)
+    if raw is None:
+        return False
+    try:
+        descriptor = int(raw)
+    except ValueError as error:
+        raise SocketGuardInstallationError(
+            f"malformed {ENV_POLICY_FD}: {raw!r}"
+        ) from error
+    try:
+        with os.fdopen(descriptor, "rb", closefd=True) as channel:
+            payload = channel.read()
+    except OSError as error:
+        raise SocketGuardInstallationError(
+            f"{ENV_POLICY_FD}={raw} could not be read"
+        ) from error
+    if payload not in (b"0", b"1"):
+        raise SocketGuardInstallationError(
+            f"malformed socket guard policy payload: {payload!r}"
+        )
+    return payload == b"1"
+
 
 def _with_guard_environment(
-    environment: Mapping[str, str] | None, *, enabled: bool
+    environment: Mapping[str, str] | None, *, enabled: bool = True
 ) -> dict[str, str]:
+    """Child environment carrying the startup hook -- and never an exemption."""
+
     child_environment = dict(os.environ if environment is None else environment)
     child_environment[ENV_ENABLED] = "1" if enabled else "0"
+    # A stale descriptor must never be inherited by an unrelated child.
+    child_environment.pop(ENV_POLICY_FD, None)
 
     if enabled:
         existing = [
@@ -305,6 +600,15 @@ def _with_guard_environment(
     return child_environment
 
 
+def _guard_child_environment(
+    explicit_env: Mapping[str, str] | None, policy_fd: int | None
+) -> dict[str, str]:
+    child_environment = _with_guard_environment(explicit_env, enabled=True)
+    if policy_fd is not None:
+        child_environment[ENV_POLICY_FD] = str(policy_fd)
+    return child_environment
+
+
 def activate_child_guard_environment() -> None:
     """Make every subsequently spawned child Python inherit the startup hook."""
 
@@ -312,7 +616,10 @@ def activate_child_guard_environment() -> None:
 
 
 def _replace_popen_environment(
-    positional: tuple[object, ...], kwargs: dict[str, object], *, enabled: bool
+    positional: tuple[object, ...],
+    kwargs: dict[str, object],
+    *,
+    policy_fd: int | None,
 ) -> tuple[tuple[object, ...], dict[str, object]]:
     # ``env`` is the tenth argument after ``args`` in subprocess.Popen's
     # positional signature. Keyword usage is overwhelmingly common, but
@@ -324,39 +631,234 @@ def _replace_popen_environment(
         explicit_env = rewritten[env_index]
         if explicit_env is not None and not isinstance(explicit_env, Mapping):
             raise SocketGuardInstallationError("subprocess env must be a mapping")
-        rewritten[env_index] = _with_guard_environment(explicit_env, enabled=enabled)
+        rewritten[env_index] = _guard_child_environment(explicit_env, policy_fd)
         return tuple(rewritten), kwargs
 
     rewritten_kwargs = dict(kwargs)
     explicit_env = rewritten_kwargs.get("env")
     if explicit_env is not None and not isinstance(explicit_env, Mapping):
         raise SocketGuardInstallationError("subprocess env must be a mapping")
-    rewritten_kwargs["env"] = _with_guard_environment(explicit_env, enabled=enabled)
+    rewritten_kwargs["env"] = _guard_child_environment(explicit_env, policy_fd)
     return positional, rewritten_kwargs
+
+
+def _resolve_popen_executable(
+    positional: tuple[object, ...], kwargs: dict[str, object]
+) -> str | None:
+    """The real program ``Popen`` will exec, when overridden away from argv[0].
+
+    ``Popen(["ignored", "-c", …], executable=sys.executable)`` runs Python while
+    argv[0] says otherwise, so classifying on ``args`` alone let the child start
+    without the startup hook.
+    """
+
+    # ``Popen(args, bufsize, executable, …)`` -- ``executable`` is the second
+    # positional after ``args``.
+    executable = kwargs.get("executable")
+    if executable is None and len(positional) > 1:
+        executable = positional[1]
+    if executable is None:
+        return None
+    if isinstance(executable, os.PathLike):
+        return os.fspath(executable)
+    if isinstance(executable, bytes):
+        return os.fsdecode(executable)
+    return executable if isinstance(executable, str) else None
 
 
 def _guarded_popen_init(
     self: subprocess.Popen[Any], args: object, *positional: object, **kwargs: object
 ) -> None:
     exempt = is_current_test_exempt()
-    parts = _command_parts(args)
+    parts = _effective_command_parts(args, positional, kwargs)
+
+    # Integrity first, and unconditionally. These rules are not about *policy* --
+    # they are about whether the child can be governed at all. A command that
+    # discards the startup hook produces an ungovernable interpreter whether or
+    # not the parent happens to be exempt, so an armed ``live`` test must not be
+    # able to launch one either.
+    _assert_child_is_governable(args, parts)
     if not exempt:
-        _assert_subprocess_allowed(args)
-    if (parts and _is_python_executable(parts[0])) or _is_shell_wrapped_python(parts):
-        # The marker exemption applies to a direct Python child too.  The
-        # parent process has the startup hook in its own environment, so an
-        # exempt child needs an explicit off switch rather than merely leaving
-        # its environment unchanged.  The same applies to ``sh -c python``:
-        # the shell is only a launcher, not a bypass around child inheritance.
-        rewritten_positional, rewritten_kwargs = _replace_popen_environment(
-            positional, kwargs, enabled=not exempt
+        # Reaching a network client directly is a policy question, so this half
+        # stays under the exemption.
+        _assert_network_client_allowed(args, parts)
+    launches_python = (
+        (parts and _is_python_executable(parts[0]))
+        or _is_shell_wrapped_python(parts)
+        or _is_wrapped_python_launcher(parts)
+        # ``shell=True``: the payload is a command string, so there is no ``-c``
+        # token to key on -- a Python interpreter anywhere in it is the signal.
+        or (
+            _resolve_popen_shell(positional, kwargs) and _command_contains_python(parts)
         )
+    )
+    if launches_python:
+        # The guard is always installed in a Python child; the exemption travels
+        # separately.  Disabling the guard outright for an exempt parent used to
+        # make the child's policy depend on how it was launched, and left
+        # ``uv run python`` -- neither a direct python argv[0] nor ``sh -c`` --
+        # with no hook at all.
+        policy_fd = _open_policy_channel(exempt)
+        try:
+            rewritten_positional, rewritten_kwargs = _replace_popen_environment(
+                positional, kwargs, policy_fd=policy_fd
+            )
+            rewritten_kwargs = _merge_pass_fds(rewritten_kwargs, policy_fd)
+            _ORIGINAL_POPEN_INIT(self, args, *rewritten_positional, **rewritten_kwargs)
+        finally:
+            # The child inherited its own duplicate; the parent's copy is done
+            # either way, success or failure.
+            os.close(policy_fd)
+        return
     else:
         # Do not alter the environment of non-Python tools. In particular,
         # strict subprocess harnesses must retain byte-for-byte child-env
         # semantics; direct network-client executables were rejected above.
         rewritten_positional, rewritten_kwargs = positional, kwargs
     _ORIGINAL_POPEN_INIT(self, args, *rewritten_positional, **rewritten_kwargs)
+
+
+def _install_multiprocessing_policy_channel() -> None:
+    """Carry the exemption to ``spawn``/``forkserver`` children out of band.
+
+    ``fork`` children inherit the in-memory flag, but a re-execed child starts
+    from the module default, so the same armed ``live`` test used to get a
+    different policy depending on the start method. The environment is the wrong
+    channel for this: a boolean any test could set would be exactly the general
+    bypass this guard exists to prevent. ``multiprocessing`` already ships a
+    parent-controlled, in-memory payload to each child, so the policy travels
+    there and a tampered ``os.environ`` cannot reach the child.
+
+    Installed in children too, which is what covers the ``forkserver`` server
+    process: it is a fresh interpreter that imports ``multiprocessing`` itself
+    and would otherwise run an unpatched ``prepare``.
+    """
+
+    global _GUARDED_GET_PREPARATION_DATA, _GUARDED_PREPARE
+    global _GUARDED_PROCESS_START, _GUARDED_GET_COMMAND_LINE
+
+    # Both hooks must be intact to skip: a partial installation -- one hook
+    # restored by a test or plugin -- would keep the session evidence green while
+    # ``spawn``/``forkserver`` children silently lost their policy.
+    import multiprocessing.process as _mp_process_check
+    import multiprocessing.spawn as mp_spawn
+
+    if (
+        _GUARDED_GET_PREPARATION_DATA is not None
+        and mp_spawn.get_preparation_data is _GUARDED_GET_PREPARATION_DATA
+        and _GUARDED_PREPARE is not None
+        and mp_spawn.prepare is _GUARDED_PREPARE
+        and _GUARDED_PROCESS_START is not None
+        and _mp_process_check.BaseProcess.start is _GUARDED_PROCESS_START
+        and _GUARDED_GET_COMMAND_LINE is not None
+        and mp_spawn.get_command_line is _GUARDED_GET_COMMAND_LINE
+    ):
+        return
+
+    original_get_preparation_data = getattr(
+        mp_spawn.get_preparation_data,
+        "_rob1296_original",
+        mp_spawn.get_preparation_data,
+    )
+    original_prepare = getattr(mp_spawn.prepare, "_rob1296_original", mp_spawn.prepare)
+
+    def _guarded_get_preparation_data(name: str) -> dict[str, Any]:
+        data = original_get_preparation_data(name)
+        data[_PREPARATION_KEY] = is_current_test_exempt()
+        return data
+
+    def _guarded_prepare(data: Mapping[str, Any]) -> None:
+        # Strict: the key must be present and a real bool. A missing or oddly
+        # typed value means the channel is broken, and a broken channel must be a
+        # hard failure rather than a silent "not exempt" that hides the breakage.
+        if _PREPARATION_KEY not in data:
+            raise SocketGuardInstallationError(
+                "multiprocessing child received no socket guard policy"
+            )
+        exempt = data[_PREPARATION_KEY]
+        if not isinstance(exempt, bool):
+            raise SocketGuardInstallationError(
+                f"socket guard policy must be a bool, got {exempt!r}"
+            )
+        # The interpreter must already be governed before any user module is
+        # imported by ``prepare``.
+        assert_installed()
+        set_current_test_exempt(exempt)
+        original_prepare({k: v for k, v in data.items() if k != _PREPARATION_KEY})
+
+    import multiprocessing.process as mp_process
+
+    original_start = getattr(
+        mp_process.BaseProcess.start, "_rob1296_original", mp_process.BaseProcess.start
+    )
+
+    def _guarded_start(self):
+        # ``forkserver`` boots a long-lived server interpreter through a path
+        # this guard does not control, and that server then forks every child.
+        # Rather than pretend, it is refused outright: ROB-1296 never required
+        # it, nothing in this repository selects it, and a late "the AF_UNIX
+        # socket was blocked" sentinel is not proof that a child would have had
+        # the right policy.
+        if type(self)._start_method == "forkserver":
+            raise SocketGuardInstallationError(
+                "the forkserver start method is not supported under the ROB-1296 "
+                "socket guard: its server interpreter is launched outside the "
+                "guard's control. Use 'spawn' or 'fork'."
+            )
+
+        # Integrity only -- deliberately no ``os.environ`` mutation. Repairing
+        # the environment here would leave a permanent, cross-test side effect on
+        # a shared mapping, and would silently rewrite what non-Python children
+        # of the same process see. The child's guard installation is instead
+        # forced by the bootstrap in ``get_command_line`` below, which does not
+        # depend on the ambient environment at all.
+        assert_installed()
+        return original_start(self)
+
+    _guarded_start._rob1296_original = original_start  # type: ignore[attr-defined]
+    mp_process.BaseProcess.start = _guarded_start
+    _GUARDED_PROCESS_START = _guarded_start
+
+    original_get_command_line = getattr(
+        mp_spawn.get_command_line, "_rob1296_original", mp_spawn.get_command_line
+    )
+
+    def _guarded_get_command_line(**kwds: Any) -> list[str]:
+        """Force the child to install the guard before ``spawn_main`` runs.
+
+        ``multiprocessing`` builds its own ``python -c …`` bootstrap, and that
+        interpreter is reached without ever passing through ``subprocess.Popen``.
+        Relying on ``PYTHONPATH``/``sitecustomize`` would mean relying on the
+        ambient environment, which a test can edit. Instead the absolute project
+        root is baked into the generated program, so installation does not depend
+        on anything the child inherits.
+        """
+
+        command = list(original_get_command_line(**kwds))
+        for index, token in enumerate(command):
+            if token == "-c" and index + 1 < len(command):
+                command[index + 1] = (
+                    f"import sys; sys.path.insert(0, {str(PROJECT_ROOT)!r}); "
+                    "from tests._socket_guard import install as _rob1296_install; "
+                    "_rob1296_install(); " + command[index + 1]
+                )
+                break
+        return command
+
+    _guarded_get_command_line._rob1296_original = (  # type: ignore[attr-defined]
+        original_get_command_line
+    )
+    mp_spawn.get_command_line = _guarded_get_command_line
+    _GUARDED_GET_COMMAND_LINE = _guarded_get_command_line
+
+    _guarded_get_preparation_data._rob1296_original = (  # type: ignore[attr-defined]
+        original_get_preparation_data
+    )
+    _guarded_prepare._rob1296_original = original_prepare  # type: ignore[attr-defined]
+    mp_spawn.get_preparation_data = _guarded_get_preparation_data
+    mp_spawn.prepare = _guarded_prepare
+    _GUARDED_GET_PREPARATION_DATA = _guarded_get_preparation_data
+    _GUARDED_PREPARE = _guarded_prepare
 
 
 def install() -> None:
@@ -368,6 +870,9 @@ def install() -> None:
             assert_installed()
             return
 
+        _install_multiprocessing_policy_channel()
+        socket.getaddrinfo = _guarded_getaddrinfo
+        socket.gethostbyname = _guarded_gethostbyname
         socket.socket.connect = _guarded_connect
         socket.socket.connect_ex = _guarded_connect_ex
         socket.socket.sendto = _guarded_sendto
@@ -389,19 +894,32 @@ def is_installed() -> bool:
 def assert_installed() -> None:
     """Assert all expected intercepts remain intact; never warn-and-continue."""
 
+    import multiprocessing.process as mp_process
+    import multiprocessing.spawn as mp_spawn
+
     expected: tuple[tuple[object, str, object], ...] = (
+        (socket, "getaddrinfo", _guarded_getaddrinfo),
+        (socket, "gethostbyname", _guarded_gethostbyname),
         (socket.socket, "connect", _guarded_connect),
         (socket.socket, "connect_ex", _guarded_connect_ex),
         (socket.socket, "sendto", _guarded_sendto),
         (subprocess.Popen, "__init__", _guarded_popen_init),
+        # The child-policy channel is load-bearing, not decorative: without it a
+        # re-execed child of an armed ``live`` test disagrees with a ``fork``
+        # child of the same test. A partial restore must fail the session, not
+        # merely stop propagating.
+        (mp_spawn, "get_preparation_data", _GUARDED_GET_PREPARATION_DATA),
+        (mp_spawn, "prepare", _GUARDED_PREPARE),
+        (mp_process.BaseProcess, "start", _GUARDED_PROCESS_START),
+        (mp_spawn, "get_command_line", _GUARDED_GET_COMMAND_LINE),
     )
     if _ORIGINAL_SENDMSG is not None:
         expected += ((socket.socket, "sendmsg", _guarded_sendmsg),)
 
     failures = [
-        f"{owner.__name__}.{name}"
+        f"{getattr(owner, '__name__', owner)}.{name}"
         for owner, name, replacement in expected
-        if getattr(owner, name, None) is not replacement
+        if replacement is None or getattr(owner, name, None) is not replacement
     ]
     if not _INSTALLED or failures:
         details = ", ".join(failures) if failures else "startup installation"

--- a/tests/_socket_guard_plugin.py
+++ b/tests/_socket_guard_plugin.py
@@ -39,13 +39,42 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         raise pytest.UsageError(str(error)) from error
 
 
+def live_exemption_is_armed(config: pytest.Config) -> bool:
+    """Return whether the operator explicitly armed the live-network lane.
+
+    ``--run-live`` is registered by ``tests/conftest.py``. The guard plugin is
+    loaded via ``-p`` before any conftest and is also active for pytest subtrees
+    that never register the option (``research/**``, ``--noconftest`` probes), so
+    the lookup must degrade to "not armed" instead of raising.
+    """
+
+    try:
+        return bool(config.getoption("--run-live", default=False))
+    except ValueError:  # pragma: no cover - defensive: option table absent
+        return False
+
+
+def item_is_exempt(item: pytest.Item) -> bool:
+    """Exempt only an explicitly ``live`` item under an explicit ``--run-live``.
+
+    ROB-1296: ``integration`` alone no longer grants external network access.
+    Integration tests talk to loopback PostgreSQL/Redis, which the address
+    allowlist already permits without any marker exemption, so the marker was
+    granting far more reach than the boundary it was meant to describe. A
+    ``live`` marker without ``--run-live`` is skipped by ``tests/conftest.py``
+    and stays fully blocked here as well, so both halves are required.
+    """
+
+    return bool(item.get_closest_marker("live")) and live_exemption_is_armed(
+        item.config
+    )
+
+
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_protocol(item: pytest.Item, nextitem: pytest.Item | None):
-    """Allow explicit integration/live items while retaining import-time default deny."""
+    """Allow an armed live item only; retain default deny everywhere else."""
 
-    exempt = bool(
-        item.get_closest_marker("integration") or item.get_closest_marker("live")
-    )
+    exempt = item_is_exempt(item)
     previous = socket_guard.set_current_test_exempt(exempt)
     try:
         socket_guard.assert_installed()

--- a/tests/_socket_guard_probes/child_policy_probe.py
+++ b/tests/_socket_guard_probes/child_policy_probe.py
@@ -1,0 +1,216 @@
+"""Reports the guard verdict of every child-creation route, for one pytest item.
+
+Driven by tests/test_rob1296_live_only_socket_guard.py through nested pytest
+sessions, once without ``--run-live`` and once with it, so the outer test can
+assert that a child's policy matches its parent's regardless of *how* the child
+was created. Deliberately not named ``test_*.py`` so the outer suite never
+collects it.
+
+Nothing here connects anywhere: children report the guard's own verdict for a
+reserved TEST-NET-3 address through the side-effect-free predicate.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests import _socket_guard as socket_guard
+
+EXTERNAL = ("203.0.113.1", 443)
+RECORD_PATH_ENV = "ROB1296_CHILD_POLICY_RECORD"
+
+_CHILD_SOURCE = (
+    "import json;"
+    "from tests._socket_guard import is_installed, is_current_test_exempt,"
+    " is_socket_address_permitted;"
+    "print(json.dumps({"
+    "'installed': is_installed(),"
+    "'exempt': is_current_test_exempt(),"
+    "'external_permitted': is_socket_address_permitted(('203.0.113.1', 443)),"
+    "}))"
+)
+
+
+def _child_verdict(queue) -> None:  # pragma: no cover - runs in the child
+    from tests import _socket_guard as guard
+
+    queue.put(
+        {
+            "installed": guard.is_installed(),
+            "exempt": guard.is_current_test_exempt(),
+            "external_permitted": guard.is_socket_address_permitted(
+                ("203.0.113.1", 443)
+            ),
+        }
+    )
+
+
+def _multiprocessing_verdict(start_method: str) -> dict[str, object]:
+    context = multiprocessing.get_context(start_method)
+    queue = context.Queue()
+    process = context.Process(target=_child_verdict, args=(queue,))
+    try:
+        process.start()
+    except (
+        socket_guard.ExternalSocketBlocked,
+        socket_guard.SocketGuardInstallationError,
+    ):
+        # forkserver is refused outright: its server interpreter boots outside
+        # the guard's control, so no child policy can be guaranteed.
+        return {"blocked_by_guard": True}
+    try:
+        return queue.get(timeout=60)
+    finally:
+        process.join(timeout=60)
+
+
+def _subprocess_verdict(
+    argv: list[str], env: dict[str, str] | None = None
+) -> dict[str, object]:
+    # A deliberately bare environment: whatever the child ends up with must have
+    # been injected by the guard, not inherited. The wrapper case needs ``PATH``
+    # only so the launcher itself can be found.
+    result = subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        cwd=str(socket_guard.PROJECT_ROOT),
+        env={} if env is None else env,
+        check=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def _record(suffix: str, payload: dict[str, object]) -> None:
+    # Driven by an outer test that supplies the destination. Run by hand without
+    # it, skip rather than raising KeyError -- a bare KeyError here reads like
+    # the guard collapsed, which it has not.
+    if RECORD_PATH_ENV not in os.environ:
+        pytest.skip(f"{RECORD_PATH_ENV} unset; this probe is driven by an outer test")
+    base = Path(os.environ[RECORD_PATH_ENV])
+    base.with_suffix(f".{suffix}.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+
+def _collect_routes() -> dict[str, object]:
+    parent = {
+        "installed": socket_guard.is_installed(),
+        "exempt": socket_guard.is_current_test_exempt(),
+        "external_permitted": socket_guard.is_socket_address_permitted(EXTERNAL),
+    }
+
+    routes: dict[str, object] = {"parent": parent}
+    for start_method in ("spawn", "fork", "forkserver"):
+        if start_method in multiprocessing.get_all_start_methods():
+            routes[f"multiprocessing:{start_method}"] = _multiprocessing_verdict(
+                start_method
+            )
+
+    routes["subprocess:direct-python"] = _subprocess_verdict(
+        [sys.executable, "-c", _CHILD_SOURCE]
+    )
+    uv_executable = shutil.which("uv")
+    if uv_executable is not None:
+        routes["subprocess:uv-wrapper"] = _subprocess_verdict(
+            [uv_executable, "run", "python", "-c", _CHILD_SOURCE],
+            {"PATH": os.environ.get("PATH", "")},
+        )
+    return routes
+
+
+def test_env_tampering_cannot_exempt_a_child(monkeypatch) -> None:
+    """Negative control: an ambient env value must not buy an exemption.
+
+    A non-live item sets every guard env key it can see and then creates children
+    by each route. All of them must still come back blocked -- the exemption is
+    parent in-memory state carried out of band, not something the environment can
+    assert.
+    """
+
+    # The legacy boolean is no longer consulted anywhere; setting it must be
+    # inert rather than persuasive.
+    monkeypatch.setenv("AUTO_TRADER_TEST_SOCKET_GUARD_EXEMPT", "1")
+    monkeypatch.setenv("AUTO_TRADER_TEST_SOCKET_GUARD", "1")
+    _record("tampered", _collect_routes())
+
+
+def test_a_bogus_policy_descriptor_is_a_hard_failure() -> None:
+    """A present-but-unusable channel must fail loudly, not read as "not exempt".
+
+    Silently downgrading would let a genuinely broken channel look like an
+    ordinary non-exempt child, hiding the breakage.
+    """
+
+    # ``subprocess`` cannot reach this state -- the interceptor rewrites the
+    # child environment and mints a fresh descriptor every time -- so the child
+    # is launched with ``os.posix_spawn``, which bypasses ``Popen`` entirely.
+    # That is also the route an unguarded child would take, so it doubles as the
+    # control for "no ``Popen``, still fail-closed".
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    os.close(write_fd)  # now certainly a dead descriptor number
+
+    pid = os.posix_spawn(
+        sys.executable,
+        [sys.executable, "-c", _CHILD_SOURCE],
+        {
+            "PATH": os.environ.get("PATH", ""),
+            "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+            socket_guard.ENV_ENABLED: "1",
+            socket_guard.ENV_POLICY_FD: str(read_fd),
+        },
+    )
+    _, status = os.waitpid(pid, 0)
+    _record("bogus_fd", {"exit_status": status, "failed": status != 0})
+
+
+def test_guard_env_tampering_cannot_unguard_a_child(monkeypatch) -> None:
+    """Negative control: disabling the guard env must not reach a child.
+
+    ``multiprocessing`` never goes through ``subprocess.Popen``, so nothing else
+    repairs the environment before the child interpreter boots. Clearing the
+    switch, or removing the startup directory from ``PYTHONPATH``, must still
+    yield a fully guarded child.
+    """
+
+    monkeypatch.setenv(socket_guard.ENV_ENABLED, "0")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        os.pathsep.join(
+            entry
+            for entry in os.environ.get("PYTHONPATH", "").split(os.pathsep)
+            if entry and entry != str(socket_guard.STARTUP_HOOK_DIRECTORY)
+        ),
+    )
+    _record("guard_disabled", _collect_routes())
+
+
+def test_guard_env_removal_cannot_unguard_a_child(monkeypatch) -> None:
+    """Same control, but deleting the keys outright rather than setting them."""
+
+    monkeypatch.delenv(socket_guard.ENV_ENABLED, raising=False)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    _record("guard_removed", _collect_routes())
+
+
+def test_child_policy_when_not_exempt() -> None:
+    """Unmarked item: the parent is blocked, so every child must be too."""
+
+    _record("nonlive", _collect_routes())
+
+
+@pytest.mark.integration
+@pytest.mark.live
+def test_child_policy_when_armed_live() -> None:
+    """Armed ``live`` item: the exemption must reach every child route alike."""
+
+    _record("live", _collect_routes())

--- a/tests/_socket_guard_probes/http_counter_probe.py
+++ b/tests/_socket_guard_probes/http_counter_probe.py
@@ -1,0 +1,40 @@
+"""Intentional single external request, used to verify the boundary counter.
+
+Driven by tests/test_rob1296_external_http_boundary.py through a nested xdist
+session. Deliberately not named ``test_*.py`` so the outer suite never collects
+it.
+
+This exists so the counter's worker->controller aggregation can be verified
+against traffic this probe *creates on purpose*, rather than against a real
+under-mocked provider call. Pinning a genuine leak as the fixture for a
+mechanics test would make "the leak still exists" a passing condition, which is
+the opposite of what ROB-1296 is for.
+
+The host is an RFC 6761 reserved ``.invalid`` name, so even with every guard
+removed there is nothing to connect to.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+PROBE_HOST = "rob1296-counter-probe.invalid"
+PROBE_URL = f"https://{PROBE_HOST}/aggregate"
+
+
+def test_boundary_blocks_one_intentional_external_request() -> None:
+    from tests import _socket_guard as socket_guard
+
+    before = socket_guard.summary()["blocked_attempts"]
+
+    with httpx.Client() as client:
+        try:
+            client.get(PROBE_URL)
+        except httpx.ConnectError as error:
+            assert "External HTTP is disabled" in str(error)
+        else:  # pragma: no cover - the boundary must not let this through
+            raise AssertionError("boundary did not block the probe request")
+
+    # The request must be stopped at the HTTP boundary, above the socket layer:
+    # the guard's blocked-attempt counter must not move.
+    assert socket_guard.summary()["blocked_attempts"] == before

--- a/tests/_socket_guard_probes/live_http_boundary_probe.py
+++ b/tests/_socket_guard_probes/live_http_boundary_probe.py
@@ -1,0 +1,31 @@
+"""Probe for the armed-live half of the ROB-1296 external-HTTP boundary.
+
+Driven by tests/test_rob1296_external_http_boundary.py through a nested pytest
+session, because "was the autouse fixture skipped?" can only be observed from
+inside a session that actually has ``--run-live``. Deliberately not named
+``test_*.py`` so the outer suite never collects it.
+
+It asserts an *identity*, never a request: reaching the real transport would
+still be refused by the socket guard, so nothing here can touch the network.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+@pytest.mark.live
+def test_armed_live_keeps_the_real_transport() -> None:
+    from tests import _external_http_boundary as boundary
+
+    assert (
+        httpx.AsyncHTTPTransport.handle_async_request.__qualname__
+        != "_block_external_http_boundary.<locals>._blocked_async"
+    )
+    assert (
+        boundary.boundary_is_active(
+            has_live_marker=True, run_live=True, fixturenames=()
+        )
+        is False
+    )

--- a/tests/_socket_guard_probes/marker_matrix_probe.py
+++ b/tests/_socket_guard_probes/marker_matrix_probe.py
@@ -1,0 +1,65 @@
+"""Marker/option truth-table probe driven by ``tests/test_rob1296_live_only_socket_guard.py``.
+
+Deliberately *not* named ``test_*.py``: the outer suite must never collect these
+items, because each one's expected verdict flips depending on whether the nested
+pytest run received ``--run-live``. The outer test invokes this file by path and
+compares the recorded verdicts against the expected truth table.
+
+The probe never opens a socket. It asks the guard for its verdict through the
+side-effect-free ``is_socket_address_permitted`` predicate, so running the
+matrix — including the armed-live cell — emits zero packets and leaves the
+blocked-attempt evidence counters untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests import _socket_guard as socket_guard
+
+# RFC 5737 TEST-NET-3. Used only as an *argument* to the pure policy predicate;
+# no connection is ever attempted against it from this module.
+EXTERNAL_ADDRESS = ("203.0.113.1", 443)
+LOOPBACK_ADDRESS = ("127.0.0.1", 5432)
+
+RECORD_PATH_ENV = "ROB1296_PROBE_RECORD"
+
+
+def _record(case: str) -> None:
+    payload = {
+        "case": case,
+        "exempt": socket_guard.is_current_test_exempt(),
+        "external_permitted": socket_guard.is_socket_address_permitted(
+            EXTERNAL_ADDRESS
+        ),
+        "loopback_permitted": socket_guard.is_socket_address_permitted(
+            LOOPBACK_ADDRESS
+        ),
+    }
+    destination = Path(os.environ[RECORD_PATH_ENV])
+    with destination.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def test_unmarked() -> None:
+    _record("unmarked")
+
+
+@pytest.mark.integration
+def test_integration_only() -> None:
+    _record("integration_only")
+
+
+@pytest.mark.live
+def test_live_only() -> None:
+    _record("live_only")
+
+
+@pytest.mark.integration
+@pytest.mark.live
+def test_integration_and_live() -> None:
+    _record("integration_and_live")

--- a/tests/_socket_guard_startup/sitecustomize.py
+++ b/tests/_socket_guard_startup/sitecustomize.py
@@ -1,8 +1,13 @@
-"""Install the ROB-1880 guard in Python children spawned by pytest.
+"""Install the ROB-1880/ROB-1296 guard in Python children spawned by pytest.
 
-The parent startup plugin prepends this directory to ``PYTHONPATH`` and sets
+The parent prepends this directory to ``PYTHONPATH`` and sets
 ``AUTO_TRADER_TEST_SOCKET_GUARD=1``. A failure here must abort interpreter
 startup rather than let a child quietly run without the guard.
+
+The guard is installed unconditionally. The child's *exemption* never comes from
+the environment -- a boolean any test could export would be a general bypass --
+but from a one-shot pipe whose read descriptor the parent chose to pass. Absent
+descriptor means no exemption; a present but broken one is a hard failure.
 """
 
 from __future__ import annotations
@@ -11,9 +16,14 @@ import os
 
 if os.environ.get("AUTO_TRADER_TEST_SOCKET_GUARD") == "1":
     try:
-        from tests._socket_guard import install
+        from tests._socket_guard import (
+            install,
+            read_policy_channel,
+            set_current_test_exempt,
+        )
 
         install()
+        set_current_test_exempt(read_policy_channel())
     except BaseException as error:  # pragma: no cover - fatal startup path
         raise SystemExit(
             "ROB-1880 socket guard child startup installation failed"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -591,6 +591,19 @@ def _block_external_http_boundary(request, monkeypatch):
     monkeypatch.setattr(httpx.HTTPTransport, "handle_request", _blocked_sync)
     monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", _blocked_requests)
 
+    # curl_cffi is a libcurl binding: it is neither an httpx transport nor a
+    # ``requests`` adapter, and libcurl calls ``connect(2)`` from C, so the socket
+    # guard's monkeypatches cannot reach it either. yfinance uses it, which meant
+    # 29 non-live tests were reaching query1.finance.yahoo.com for real while both
+    # counters reported zero. Blocked here at the one Python-level chokepoint
+    # every curl_cffi request passes through.
+    for session_class in external_http_boundary.curl_session_classes():
+        monkeypatch.setattr(
+            session_class,
+            "request",
+            external_http_boundary.build_curl_request_blocker(session_class),
+        )
+
 
 @pytest.fixture
 def allow_kis_daily_candle_fetch():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -474,6 +474,47 @@ def _block_tvscreener_http_boundary(request, monkeypatch):
 
 
 @pytest.fixture
+def allow_kis_daily_candle_fetch():
+    """Opt out of the default KIS daily-candle boundary block."""
+
+
+@pytest.fixture(autouse=True)
+def _block_kis_daily_candle_boundary(request, monkeypatch):
+    """ROB-1296: keep the daily-candle cache-miss fallback off the network.
+
+    ``_cache_first_kr`` (and the daily-candle sync service) fall back to
+    ``fetch_kr_daily_unclamped`` -> KIS whenever the DB cache is cold, which it
+    always is in a fresh test database. Callers treat that fetch as best-effort
+    and fall back to whatever rows they already had, so the failure never
+    surfaced — it just cost a real request to openapi.koreainvestment.com from
+    tests that only care about names, freshness flags, or price targets.
+
+    Raising the same class of error the fallback already handles keeps observable
+    behaviour identical while removing the socket. A test that genuinely covers
+    the KIS fetch path requests ``allow_kis_daily_candle_fetch`` (and supplies
+    its own stub).
+    """
+    if "allow_kis_daily_candle_fetch" in request.fixturenames:
+        return
+    if request.node.get_closest_marker("live") and request.config.getoption(
+        "--run-live"
+    ):
+        return
+
+    async def _blocked(*_args, **_kwargs):
+        raise RuntimeError(
+            "KIS daily-candle fetch is disabled during pytest; stub "
+            "fetch_kr_daily_unclamped or request allow_kis_daily_candle_fetch "
+            "for boundary/live tests."
+        )
+
+    monkeypatch.setattr(
+        "app.services.daily_candles.kis_daily_fetcher.fetch_kr_daily_unclamped",
+        _blocked,
+    )
+
+
+@pytest.fixture
 def mock_auth_middleware_db():
     """Mock AsyncSessionLocal in AuthMiddleware to prevent DB connection attempts."""
     with patch("app.middleware.auth.AsyncSessionLocal") as mock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import contextlib
 import os
 import tempfile
 import time
+from collections import Counter
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -15,6 +16,8 @@ import pandas as pd
 import pytest
 import pytest_asyncio
 
+from tests import _external_http_boundary as external_http_boundary
+from tests import _provider_boundaries as provider_boundaries
 from tests._run_owned_database import (
     DATABASE_NAME_ENV as _XDIST_DATABASE_NAME_ENV,
 )
@@ -50,6 +53,7 @@ _DATABASE_FIXTURE_NAMES = frozenset(
     }
 )
 _SCHEMA_METRICS_KEY = pytest.StashKey[list[dict[str, object]]]()
+_EXTERNAL_HTTP_KEY = pytest.StashKey["Counter[str]"]()
 _KIS_DEFAULT_SCOPE_PARTS = (
     "/brokers/kis/",
     "/services/brokers/kis/",
@@ -474,6 +478,121 @@ def _block_tvscreener_http_boundary(request, monkeypatch):
 
 
 @pytest.fixture
+def allow_external_providers():
+    """Opt out of the provider-seam stubs (the transport backstop still applies)."""
+
+
+@pytest.fixture(autouse=True)
+def _block_external_provider_calls(request, monkeypatch):
+    """ROB-1296: stop each external provider at its call-root, not at the socket.
+
+    ``_block_external_http_boundary`` below is the fail-closed backstop; this is
+    the actual fix. Without it a default ``not live`` run still *built* requests
+    to openapi.koreainvestment.com, api.upbit.com, api.finnhub.io, data.krx.co.kr,
+    finance.naver.com, api.coingecko.com and open.er-api.com — the backstop
+    merely refused them one layer later, which moves the leak rather than closing
+    it. With both in place the boundary counter should list only this suite's own
+    ``.invalid`` probes.
+
+    Each seam raises the transport error an unreachable host already produced, so
+    caller behaviour is unchanged and no payload is invented. See
+    tests/_provider_boundaries.py for the seam list and the reasoning.
+    """
+    if provider_boundaries.OPT_OUT_FIXTURE in set(request.fixturenames) or (
+        request.node.get_closest_marker("live")
+        and request.config.getoption("--run-live", default=False)
+    ):
+        yield
+        return
+
+    undo = provider_boundaries.install(monkeypatch)
+    try:
+        yield
+    finally:
+        undo()
+
+
+@pytest.fixture
+def allow_external_http():
+    """Opt out of the default external-HTTP boundary block.
+
+    For a test that must drive httpx's real-network transport (typically with its
+    own monkeypatched stand-in). Opting out does not make the network reachable:
+    the ROB-1880 socket guard still refuses any non-loopback address.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _block_external_http_boundary(request, monkeypatch):
+    """ROB-1296: turn a leaked external request into a clean, counted error.
+
+    The socket guard already refuses these connections, so this changes *how*
+    they fail, not *whether* they leave. It patches only httpx's real-network
+    transports and the ``requests`` adapter, and raises the exception type a
+    blocked connect already produces -- ``httpx.ConnectError`` /
+    ``requests.ConnectionError`` -- so every ``except httpx.HTTPError``, retry
+    and fail-open branch behaves exactly as it does today. No success is
+    fabricated and no test's contract moves.
+
+    ``ASGITransport`` (FastAPI ``TestClient``), ``WSGITransport``,
+    ``MockTransport``, respx and any custom transport are untouched, and loopback
+    stays reachable for local test servers.
+
+    This is a backstop, not a substitute for mocking: it stops the default suite
+    from *attempting* an external request, but a provider call that matters
+    should still be stubbed at its call site (see ``_patch_us_finnhub_fanout`` in
+    tests/test_mcp_fundamentals_tools.py). Blocked hosts are counted and printed
+    in the terminal summary so a newly under-mocked provider shows up instead of
+    quietly failing soft. tests/test_rob1296_external_http_boundary.py pins all
+    of this.
+    """
+    if not external_http_boundary.boundary_is_active(
+        has_live_marker=request.node.get_closest_marker("live") is not None,
+        run_live=bool(request.config.getoption("--run-live", default=False)),
+        fixturenames=request.fixturenames,
+    ):
+        return
+
+    import httpx
+    import requests
+
+    original_async = httpx.AsyncHTTPTransport.handle_async_request
+    original_sync = httpx.HTTPTransport.handle_request
+    original_requests_send = requests.adapters.HTTPAdapter.send
+
+    async def _blocked_async(self, request_, *args, **kwargs):
+        host = request_.url.host
+        if external_http_boundary.is_loopback_host(host):
+            return await original_async(self, request_, *args, **kwargs)
+        external_http_boundary.record_block(host)
+        raise httpx.ConnectError(
+            f"{external_http_boundary.MESSAGE} [{host}]", request=request_
+        )
+
+    def _blocked_sync(self, request_, *args, **kwargs):
+        host = request_.url.host
+        if external_http_boundary.is_loopback_host(host):
+            return original_sync(self, request_, *args, **kwargs)
+        external_http_boundary.record_block(host)
+        raise httpx.ConnectError(
+            f"{external_http_boundary.MESSAGE} [{host}]", request=request_
+        )
+
+    def _blocked_requests(self, request_, *args, **kwargs):
+        host = requests.compat.urlparse(request_.url).hostname or ""
+        if external_http_boundary.is_loopback_host(host):
+            return original_requests_send(self, request_, *args, **kwargs)
+        external_http_boundary.record_block(host)
+        raise requests.ConnectionError(f"{external_http_boundary.MESSAGE} [{host}]")
+
+    monkeypatch.setattr(
+        httpx.AsyncHTTPTransport, "handle_async_request", _blocked_async
+    )
+    monkeypatch.setattr(httpx.HTTPTransport, "handle_request", _blocked_sync)
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", _blocked_requests)
+
+
+@pytest.fixture
 def allow_kis_daily_candle_fetch():
     """Opt out of the default KIS daily-candle boundary block."""
 
@@ -632,6 +751,10 @@ pytest_plugins = ["pytest_asyncio", "tests._investment_reports_helpers"]
 def pytest_configure(config):
     """Configure pytest with custom markers."""
     config.stash[_SCHEMA_METRICS_KEY] = []
+    config.stash[_EXTERNAL_HTTP_KEY] = Counter()
+    # Process-global counter: reset per session so a nested or repeated session
+    # in the same interpreter reports its own traffic, not the parent's.
+    external_http_boundary.reset()
     config.addinivalue_line(
         "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
     )
@@ -643,22 +766,35 @@ def pytest_configure(config):
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:
-    """Forward per-worker schema metrics to the xdist controller."""
+    """Forward per-worker schema metrics and HTTP-boundary evidence upward."""
 
     worker_output = getattr(session.config, "workeroutput", None)
     if worker_output is not None:
         worker_output["auto_trader_schema_metrics"] = session.config.stash[
             _SCHEMA_METRICS_KEY
         ]
+        worker_output["auto_trader_external_http_blocks"] = (
+            external_http_boundary.snapshot()
+        )
+        return
+    for host, count in external_http_boundary.snapshot().items():
+        session.config.stash[_EXTERNAL_HTTP_KEY][host] += count
 
 
 @pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node, error) -> None:  # noqa: ARG001
     metrics = node.workeroutput.get("auto_trader_schema_metrics", [])
     node.config.stash[_SCHEMA_METRICS_KEY].extend(metrics)
+    for host, count in node.workeroutput.get(
+        "auto_trader_external_http_blocks", {}
+    ).items():
+        node.config.stash[_EXTERNAL_HTTP_KEY][str(host)] += int(count)
 
 
 def pytest_terminal_summary(terminalreporter) -> None:
+    blocked = dict(terminalreporter.config.stash[_EXTERNAL_HTTP_KEY])
+    terminalreporter.write_line(external_http_boundary.format_summary(blocked))
+
     metrics = terminalreporter.config.stash[_SCHEMA_METRICS_KEY]
     if not metrics:
         return

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -5,6 +5,38 @@ from sqlalchemy import delete
 pytestmark = pytest.mark.integration
 
 
+@pytest.fixture(autouse=True)
+def _offline_reconcile_spot_fx(monkeypatch):
+    """ROB-1296: default the USD/KRW reconcile-spot capture to "unavailable".
+
+    ``capture_reconcile_spot_fx`` swallows fetch errors and reports
+    ``fx_rate_source="unavailable"``, so an unmocked call reached
+    ``open.er-api.com`` for real and the failure was silently absorbed — the
+    tests below already assert ``"unavailable"``, they just got there by way of
+    a live network round trip. This states that outcome explicitly instead of
+    depending on the network being unreachable. It is not a fabricated success:
+    "unavailable" is precisely what these tests observe today. Tests that need a
+    real rate patch ``capture_reconcile_spot_fx`` themselves and still win,
+    because ``patch.object`` inside the test body applies after this fixture.
+    """
+
+    from app.mcp_server.tooling import live_order_ledger as _ll
+    from app.mcp_server.tooling.fx_pnl import (
+        FX_PNL_ACCURACY_UNAVAILABLE,
+        FX_RATE_SOURCE_UNAVAILABLE,
+        FxRateCapture,
+    )
+
+    async def _unavailable() -> FxRateCapture:
+        return FxRateCapture(
+            rate=None,
+            fx_rate_source=FX_RATE_SOURCE_UNAVAILABLE,
+            fx_pnl_accuracy=FX_PNL_ACCURACY_UNAVAILABLE,
+        )
+
+    monkeypatch.setattr(_ll, "capture_reconcile_spot_fx", _unavailable)
+
+
 @pytest.mark.unit
 def test_live_order_ledger_model_shape():
     from app.models.review import LiveOrderLedger

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -19,6 +19,36 @@ pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 pytestmark.append(pytest.mark.usefixtures("toss_ledger_cleanup_lock"))
 
 
+@pytest.fixture(autouse=True)
+def _offline_reconcile_spot_fx(monkeypatch):
+    """ROB-1296: default the USD/KRW reconcile-spot capture to "unavailable".
+
+    Most tests in this module already patch ``capture_reconcile_spot_fx``; the
+    two that did not reached ``open.er-api.com`` for real, and
+    ``capture_reconcile_spot_fx`` swallowed the failure into
+    ``fx_rate_source="unavailable"`` so nothing surfaced it. This states that
+    same outcome explicitly rather than depending on the network being
+    unreachable. Per-test ``patch.object`` calls apply after this fixture and
+    still win.
+    """
+
+    from app.mcp_server.tooling import toss_live_ledger as _mod
+    from app.mcp_server.tooling.fx_pnl import (
+        FX_PNL_ACCURACY_UNAVAILABLE,
+        FX_RATE_SOURCE_UNAVAILABLE,
+        FxRateCapture,
+    )
+
+    async def _unavailable() -> FxRateCapture:
+        return FxRateCapture(
+            rate=None,
+            fx_rate_source=FX_RATE_SOURCE_UNAVAILABLE,
+            fx_pnl_accuracy=FX_PNL_ACCURACY_UNAVAILABLE,
+        )
+
+    monkeypatch.setattr(_mod, "capture_reconcile_spot_fx", _unavailable)
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def _clean(db_session, toss_ledger_cleanup_lock):
     await db_session.execute(delete(TossLiveOrderLedger))

--- a/tests/services/brokers/binance/test_rate_limit_telemetry.py
+++ b/tests/services/brokers/binance/test_rate_limit_telemetry.py
@@ -14,6 +14,13 @@ from app.services.brokers.binance.rate_limit_telemetry import (
 )
 from app.services.brokers.binance.rest_client import BinancePublicRestClient
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 def test_parses_used_weight_and_order_count() -> None:
     snap = parse_rate_limit_headers(

--- a/tests/services/brokers/binance/test_rest_client.py
+++ b/tests/services/brokers/binance/test_rest_client.py
@@ -8,6 +8,13 @@ import pytest
 
 from app.services.brokers.binance.rest_client import BinancePublicRestClient
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 @pytest.mark.asyncio
 async def test_exchange_info_returns_symbol_metadata(httpx_mock) -> None:

--- a/tests/services/research/test_research_contracts_wheel.py
+++ b/tests/services/research/test_research_contracts_wheel.py
@@ -34,18 +34,38 @@ def test_built_wheel_ships_small_research_contract_and_clean_imports(
     assert "research_contracts/trial_evidence.py" in names
     assert not any(name.startswith("research/nautilus_scalping/") for name in names)
 
+    # Provenance is asserted explicitly rather than by isolating the child with
+    # ``-I``. An isolated interpreter also drops the hermetic-test socket guard's
+    # ``sitecustomize`` startup hook (ROB-1296), so the guard rejects ``-I``
+    # outright. Checking every import's ``__file__`` is the stronger check
+    # anyway: ``-I`` only kept the source tree off ``sys.path``, whereas this
+    # fails loudly if any module silently resolves outside the wheel.
     script = f"""
 import sys
-sys.path.insert(0, sys.argv[1])
+wheel = sys.argv[1]
+sys.path.insert(0, wheel)
+
+import app.schemas.research_backtest as research_backtest
+import app.services.research_canonical_hash as research_canonical_hash
+import research_contracts.canonical_hash as contracts_canonical_hash
 from app.schemas.research_backtest import StrategyExperimentIdentity
 from app.services import research_offline_gate_service
 from app.services.research_canonical_hash import canonical_sha256
+
+for module in (
+    research_backtest,
+    research_canonical_hash,
+    research_offline_gate_service,
+    contracts_canonical_hash,
+):
+    assert module.__file__.startswith(wheel), (module.__name__, module.__file__)
+
 assert StrategyExperimentIdentity
 assert research_offline_gate_service.finalize_offline_gate
 assert canonical_sha256({{'b': 2, 'a': 1}}) == {PINNED_DIGEST!r}
 """
     subprocess.run(
-        [sys.executable, "-I", "-c", script, str(wheel)],
+        [sys.executable, "-c", script, str(wheel)],
         cwd=tmp_path,
         check=True,
         capture_output=True,

--- a/tests/services/research/test_research_contracts_wheel.py
+++ b/tests/services/research/test_research_contracts_wheel.py
@@ -1,5 +1,23 @@
+"""The built wheel ships the research contracts and imports without the checkout.
+
+The child runs with normal Python startup so the ROB-1296 socket guard's
+``sitecustomize`` hook still installs -- ``-I`` would drop it, and the guard
+rejects an isolated interpreter outright. Isolation is instead achieved *inside*
+the child: the guard puts ``PROJECT_ROOT`` on ``PYTHONPATH``, so the script
+strips every checkout-derived entry from ``sys.path`` before importing anything,
+leaving the wheel plus the standard library and site-packages.
+
+That ordering matters. Merely asserting a handful of ``__file__`` values, with
+the checkout still importable, is weaker than the ``-I`` it replaced: a module
+missing from the wheel resolves from the source tree and the assertion never
+fires for the modules you forgot to name. ``test_checkout_fallback_is_what_the_
+path_scrub_prevents`` pins exactly that difference against a wheel with a member
+deliberately removed.
+"""
+
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 import zipfile
@@ -10,11 +28,99 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 PINNED_DIGEST = "ba383d20d8aa8fb134ca475b1439329e97ac400f91ea957db0484deaa7df8854"
 
+REQUIRED_CONTRACT_MEMBERS = (
+    "research_contracts/canonical_hash.py",
+    "research_contracts/evaluation_windows.py",
+    "research_contracts/frozen_config.py",
+    "research_contracts/honest_offline_gate.py",
+    "research_contracts/jsonb_numbers.py",
+    "research_contracts/trial_evidence.py",
+)
 
-@pytest.mark.integration
-def test_built_wheel_ships_small_research_contract_and_clean_imports(
-    tmp_path: Path,
-) -> None:
+# Strips the checkout from ``sys.path``, then proves every first-party module
+# that ended up loaded came out of the wheel.
+_PROBE = f"""
+import os
+import sys
+
+wheel = sys.argv[1]
+scrub = sys.argv[2] == "scrub"
+project_root = os.path.realpath(sys.argv[3])
+
+if scrub:
+    kept = []
+    for entry in sys.path:
+        resolved = os.path.realpath(entry or os.getcwd())
+        # The virtualenv lives *inside* the checkout, so "under project_root" on
+        # its own would also throw away site-packages and the wheel would be
+        # tested against a crippled interpreter. Installed distributions are
+        # explicitly preserved; only importable checkout source is removed --
+        # the project root itself, the guard's startup-hook directory, and the
+        # implicit cwd entry.
+        is_installed_tree = (
+            "site-packages" in resolved.split(os.sep)
+            or "dist-packages" in resolved.split(os.sep)
+        )
+        under_checkout = resolved == project_root or resolved.startswith(
+            project_root + os.sep
+        )
+        if under_checkout and not is_installed_tree:
+            continue
+        kept.append(entry)
+    sys.path[:] = kept
+
+    # Prove the scrub actually did its job before drawing conclusions from it.
+    for entry in sys.path:
+        resolved = os.path.realpath(entry or os.getcwd())
+        if resolved == project_root:
+            raise SystemExit("path scrub failed: checkout still importable")
+
+sys.path.insert(0, wheel)
+
+from app.schemas.research_backtest import StrategyExperimentIdentity
+from app.services import research_offline_gate_service
+from app.services.research_canonical_hash import canonical_sha256
+
+import research_contracts.canonical_hash  # noqa: F401
+import research_contracts.evaluation_windows  # noqa: F401
+import research_contracts.frozen_config  # noqa: F401
+import research_contracts.honest_offline_gate  # noqa: F401
+import research_contracts.jsonb_numbers  # noqa: F401
+import research_contracts.trial_evidence  # noqa: F401
+
+assert StrategyExperimentIdentity
+assert research_offline_gate_service.finalize_offline_gate
+assert canonical_sha256({{'b': 2, 'a': 1}}) == {PINNED_DIGEST!r}
+
+# Sweep *everything* first-party that got loaded, not a hand-picked few -- the
+# transitive imports are exactly where a checkout fallback would hide.
+offenders = []
+namespace_packages = []
+for name, module in sorted(sys.modules.items()):
+    if not (name == "app" or name.startswith("app.")
+            or name == "research_contracts" or name.startswith("research_contracts.")):
+        continue
+    origin = getattr(module, "__file__", None)
+    if origin is None:
+        # A namespace package (or a builtin) has no file of its own. Its
+        # submodules are checked on their own terms, so record and move on
+        # rather than silently skipping.
+        namespace_packages.append(name)
+        continue
+    if not os.path.realpath(origin).startswith(os.path.realpath(wheel)):
+        offenders.append((name, origin))
+
+if offenders:
+    raise SystemExit("resolved outside the wheel: " + repr(offenders))
+
+print("checked=%d namespace=%d" % (
+    len([n for n in sys.modules if n.split('.')[0] in ('app', 'research_contracts')]),
+    len(namespace_packages),
+))
+"""
+
+
+def _build_wheel(tmp_path: Path) -> Path:
     output = tmp_path / "dist"
     subprocess.run(
         ["uv", "build", "--wheel", "--out-dir", str(output)],
@@ -23,51 +129,118 @@ def test_built_wheel_ships_small_research_contract_and_clean_imports(
         capture_output=True,
         text=True,
     )
-    wheel = next(output.glob("*.whl"))
-    with zipfile.ZipFile(wheel) as archive:
-        names = set(archive.namelist())
-    assert "research_contracts/canonical_hash.py" in names
-    assert "research_contracts/evaluation_windows.py" in names
-    assert "research_contracts/frozen_config.py" in names
-    assert "research_contracts/honest_offline_gate.py" in names
-    assert "research_contracts/jsonb_numbers.py" in names
-    assert "research_contracts/trial_evidence.py" in names
-    assert not any(name.startswith("research/nautilus_scalping/") for name in names)
+    return next(output.glob("*.whl"))
 
-    # Provenance is asserted explicitly rather than by isolating the child with
-    # ``-I``. An isolated interpreter also drops the hermetic-test socket guard's
-    # ``sitecustomize`` startup hook (ROB-1296), so the guard rejects ``-I``
-    # outright. Checking every import's ``__file__`` is the stronger check
-    # anyway: ``-I`` only kept the source tree off ``sys.path``, whereas this
-    # fails loudly if any module silently resolves outside the wheel.
-    script = f"""
-import sys
-wheel = sys.argv[1]
-sys.path.insert(0, wheel)
 
-import app.schemas.research_backtest as research_backtest
-import app.services.research_canonical_hash as research_canonical_hash
-import research_contracts.canonical_hash as contracts_canonical_hash
-from app.schemas.research_backtest import StrategyExperimentIdentity
-from app.services import research_offline_gate_service
-from app.services.research_canonical_hash import canonical_sha256
-
-for module in (
-    research_backtest,
-    research_canonical_hash,
-    research_offline_gate_service,
-    contracts_canonical_hash,
-):
-    assert module.__file__.startswith(wheel), (module.__name__, module.__file__)
-
-assert StrategyExperimentIdentity
-assert research_offline_gate_service.finalize_offline_gate
-assert canonical_sha256({{'b': 2, 'a': 1}}) == {PINNED_DIGEST!r}
-"""
-    subprocess.run(
-        [sys.executable, "-c", script, str(wheel)],
+def _run_probe(
+    wheel: Path, tmp_path: Path, *, scrub: bool
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _PROBE,
+            str(wheel),
+            "scrub" if scrub else "inherit",
+            str(ROOT),
+        ],
         cwd=tmp_path,
-        check=True,
         capture_output=True,
         text=True,
     )
+
+
+def _wheel_without(wheel: Path, tmp_path: Path, member: str) -> Path:
+    """A copy of *wheel* with a member (or whole directory) removed."""
+
+    mutated = tmp_path / f"mutated-{wheel.name}"
+    with zipfile.ZipFile(wheel) as source, zipfile.ZipFile(mutated, "w") as target:
+        for item in source.infolist():
+            if item.filename == member or item.filename.startswith(member):
+                continue
+            target.writestr(item, source.read(item.filename))
+    return mutated
+
+
+@pytest.mark.integration
+def test_built_wheel_ships_small_research_contract_and_clean_imports(
+    tmp_path: Path,
+) -> None:
+    wheel = _build_wheel(tmp_path)
+
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+    for member in REQUIRED_CONTRACT_MEMBERS:
+        assert member in names
+    assert not any(name.startswith("research/nautilus_scalping/") for name in names)
+
+    result = _run_probe(wheel, tmp_path, scrub=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.startswith("checked="), result.stdout
+
+
+@pytest.mark.integration
+def test_checkout_fallback_is_what_the_path_scrub_prevents(tmp_path: Path) -> None:
+    """Mutation control: a wheel missing a module must not pass by accident.
+
+    With the checkout scrubbed the missing module is a hard import failure. With
+    it left on ``sys.path`` the very same wheel imports cleanly -- from the source
+    tree -- which is the false green the old ``__file__``-only check allowed.
+    """
+
+    wheel = _build_wheel(tmp_path)
+    # The whole top-level package, not a single submodule: a regular package's
+    # ``__path__`` is pinned to the distribution that provided it, so dropping
+    # one file can never fall back to the checkout. Losing the package outright
+    # is the packaging slip that can.
+    mutated = _wheel_without(wheel, tmp_path, "research_contracts/")
+
+    scrubbed = _run_probe(mutated, tmp_path, scrub=True)
+    assert scrubbed.returncode != 0, scrubbed.stdout
+    combined = scrubbed.stdout + scrubbed.stderr
+    assert (
+        "ModuleNotFoundError" in combined or "resolved outside the wheel" in combined
+    ), combined
+
+    inherited = _run_probe(mutated, tmp_path, scrub=False)
+    assert inherited.returncode != 0, (
+        "the un-scrubbed run was expected to resolve the missing module from the "
+        "checkout and be caught by the provenance sweep"
+    )
+    assert "resolved outside the wheel" in inherited.stdout + inherited.stderr
+
+
+@pytest.mark.integration
+def test_probe_child_keeps_the_socket_guard_installed(tmp_path: Path) -> None:
+    """The scrub must not cost the child its guard.
+
+    ``sitecustomize`` runs before the script, so stripping the checkout
+    afterwards leaves the already-imported guard in place -- which is the whole
+    reason this is done inside the child rather than with ``-I``.
+    """
+
+    _ = tmp_path
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os, sys\n"
+            "from tests._socket_guard import is_installed\n"
+            "root = os.path.realpath(sys.argv[1])\n"
+            "sys.path[:] = [p for p in sys.path\n"
+            "               if not os.path.realpath(p or os.getcwd()).startswith(root)]\n"
+            "print(is_installed())\n",
+            str(ROOT),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "True"
+
+
+def test_uv_is_available_for_the_wheel_build() -> None:
+    """Guards against a silent skip: these tests are meaningless without it."""
+
+    assert shutil.which("uv") is not None

--- a/tests/services/test_paper_limit_order_service.py
+++ b/tests/services/test_paper_limit_order_service.py
@@ -4,6 +4,12 @@ Heavy integration tests against the shared ``db_session`` fixture (Postgres
 ``public`` schemas pre-built via ``Base.metadata.create_all``). OHLCV fetch
 is monkeypatched to return canned bars, so these tests do not require live
 Upbit connectivity.
+
+ROB-1296: that last sentence was aspirational. Canned bars cover the fill
+decision, but booking a crypto fill also calls
+``PaperTradingService._fetch_current_price`` -> ``fetch_multiple_current_prices``,
+which reached ``api.upbit.com`` for real. The autouse fixture below closes that
+second path so the docstring is now accurate.
 """
 
 from __future__ import annotations
@@ -18,6 +24,24 @@ import pytest
 from app.core.timezone import now_kst
 from app.services.paper_limit_order_service import PaperLimitOrderService
 from app.services.paper_trading_service import PaperTradingService
+
+
+@pytest.fixture(autouse=True)
+def _offline_crypto_spot_prices(monkeypatch):
+    """Serve the crypto spot price these paper fills need, without Upbit.
+
+    ``_fetch_current_price`` raises when a crypto price is missing, so leaving
+    this unmocked did not merely skip a lookup — it pushed the booking path down
+    an error branch that happened not to change these assertions. A deterministic
+    quote models the funded, priceable account the tests describe.
+    """
+
+    async def _prices(symbols):
+        return dict.fromkeys(symbols, 90_000_000.0)
+
+    monkeypatch.setattr(
+        "app.services.paper_trading_service.fetch_multiple_current_prices", _prices
+    )
 
 
 def _candle(low: Decimal, high: Decimal, timestamp: dt.datetime | None = None) -> Any:

--- a/tests/test_btc_dominance.py
+++ b/tests/test_btc_dominance.py
@@ -7,6 +7,13 @@ import pytest
 
 from app.services.external import btc_dominance
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 class _FakeResponse:
     def __init__(self, payload):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -77,7 +77,11 @@ class TestDataFlow:
         pass
 
 
+# ROB-1296: these cases drive the real provider clients against a mocked
+# httpx.AsyncClient, so the autouse provider seams would replace the very code
+# under test. Opting out keeps the transport backstop and socket guard active.
 @pytest.mark.integration
+@pytest.mark.usefixtures("allow_external_providers")
 class TestExternalServiceMocking:
     """Test that all external services are properly mocked."""
 

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -19,6 +19,7 @@ import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.mcp_server.tooling import investment_reports_handlers as _reports_handlers
 from app.mcp_server.tooling.investment_reports_handlers import (
     INVESTMENT_REPORT_TOOL_NAMES,
     investment_report_activate_watch_impl,
@@ -40,6 +41,37 @@ from app.mcp_server.tooling.investment_reports_handlers import (
 )
 from app.services.investment_reports.ingestion import InvestmentReportIngestionService
 from tests._investment_reports_helpers import future_datetime
+
+
+@pytest.fixture
+def allow_pending_orders_collector():
+    """Opt out of the offline default to exercise the real collector wiring."""
+
+
+@pytest.fixture(autouse=True)
+def _offline_pending_orders_snapshot(request, monkeypatch):
+    """ROB-1296: resolve the ROB-274 pending-orders enrichment without a broker.
+
+    ``investment_report_context_get_impl`` enriches every response by collecting
+    a live pending-orders snapshot, so each call reached
+    ``openapi.koreainvestment.com``. The helper is documented as failing open —
+    "any collector trouble surfaces as ``None``" — and ``None`` is exactly what
+    these tests already receive, having paid for a live round trip to get it.
+    This states that outcome deterministically. It fabricates no orders; the one
+    test that asserts a populated snapshot patches the collector registry itself
+    and still wins, because that patch is applied inside the test body.
+    """
+
+    if "allow_pending_orders_collector" in request.fixturenames:
+        return
+
+    async def _no_snapshot(_db, *, market, account_scope=None):
+        _ = market, account_scope
+        return None
+
+    monkeypatch.setattr(
+        _reports_handlers, "_collect_pending_orders_snapshot", _no_snapshot
+    )
 
 
 @pytest_asyncio.fixture(name="session")
@@ -703,6 +735,7 @@ async def test_context_get_n_prior_clamped_to_ten(session: AsyncSession) -> None
 # ROB-274 — pending_orders enrichment in context_get
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("allow_pending_orders_collector")
 async def test_context_get_includes_pending_orders_when_collector_succeeds(
     monkeypatch: pytest.MonkeyPatch, session: AsyncSession
 ) -> None:
@@ -826,6 +859,7 @@ async def test_context_get_surfaces_pending_orders_unavailable_as_null(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("allow_pending_orders_collector")
 async def test_context_get_pending_orders_shape_unchanged_after_shared_helper(
     monkeypatch: pytest.MonkeyPatch,
     session: AsyncSession,

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -20,6 +20,29 @@ from sqlalchemy import delete
 from app.models.review import OrderSendIntent
 
 
+@pytest.fixture(autouse=True)
+def _offline_kis_mock_baseline(monkeypatch):
+    """ROB-1296: resolve the pre-trade holdings baseline without calling KIS VTS.
+
+    ``_fetch_kis_mock_baseline_qty`` builds its own ``KISClient(is_mock=True)``,
+    which issues an OAuth token against ``openapivts.koreainvestment.com`` before
+    any of the seams these tests patch come into play. It is explicitly
+    best-effort — it swallows every error and returns ``None`` so the reconciler
+    can flag ``baseline_missing`` later — which is exactly the value these tests
+    already observe, just reached via a live network round trip. Returning
+    ``None`` states that unchanged outcome deterministically; it asserts nothing
+    about a holding, so no fabricated position is introduced.
+    """
+
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_fetch_kis_mock_baseline_qty",
+        AsyncMock(return_value=None),
+    )
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def _kis_mock_coordinated_route():
     """ROB-1263 r4 §3: a KIS mock send needs a coordinated route to be authorized.

--- a/tests/test_market_context_service.py
+++ b/tests/test_market_context_service.py
@@ -4,6 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 @pytest.mark.unit
 class TestMarketContextService:

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -1767,6 +1767,26 @@ class TestGetKimchiPremium:
             mock_upbit,
         )
 
+        # ROB-1296: only the Upbit leg is under test here, but the Binance and
+        # USD/KRW legs of the same fan-out ran for real. The sibling tests drive
+        # both through a mocked httpx client; this one asserts nothing about
+        # them, so stub them directly rather than letting them reach the network.
+        async def mock_binance_prices(symbols):
+            _ = symbols
+            return {"BTCUSDT": 102_000.50}
+
+        async def mock_exchange_rate():
+            return 1450.0
+
+        monkeypatch.setattr(
+            fundamentals_sources_naver, "_fetch_binance_prices", mock_binance_prices
+        )
+        monkeypatch.setattr(
+            fundamentals_sources_naver,
+            "_fetch_exchange_rate_usd_krw",
+            mock_exchange_rate,
+        )
+
         result = await tools["get_kimchi_premium"]("BTC")
 
         assert "error" in result

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -73,6 +73,46 @@ def build_tools():
 # ---------------------------------------------------------------------------
 
 
+def _patch_us_finnhub_fanout(monkeypatch, symbol: str = "AAPL") -> None:
+    """Mock the Finnhub leaves that ``analyze_stock(market="us")`` fans out to.
+
+    ROB-1296: the socket guard no longer exempts `integration`, so these stop
+    being silent live Finnhub calls and become blocked connections. The profile
+    client and ``fetch_news_finnhub``'s ``AsyncRetrying`` loop then burn their
+    full retry-with-backoff budget on every test — seconds of sleep for values
+    these assertions never read. Patch both leaves deterministically rather than
+    letting a retry loop absorb the block.
+    """
+
+    async def _news(
+        requested_symbol: str, market: str, limit: int
+    ) -> dict[str, object]:
+        _ = requested_symbol, market, limit
+        return {"items": [], "source": "finnhub"}
+
+    async def _profile(requested_symbol: str) -> dict[str, object]:
+        return {
+            "symbol": requested_symbol,
+            "instrument_type": "equity_us",
+            "source": "finnhub",
+            "name": f"{requested_symbol} Test Corp",
+            "ticker": requested_symbol,
+            "country": "US",
+            "currency": "USD",
+            "exchange": "NASDAQ",
+            "ipo_date": "1980-12-12",
+            "market_cap": 1_000_000.0,
+            "shares_outstanding": 1_000.0,
+            "sector": "Technology",
+            "website": "",
+            "logo": "",
+            "phone": "",
+        }
+
+    _patch_runtime_attr(monkeypatch, "_fetch_company_profile_finnhub", _profile)
+    _patch_runtime_attr(monkeypatch, "_fetch_news_finnhub", _news)
+
+
 @pytest.mark.asyncio
 class TestAnalyzeStock:
     """Test analyze_stock tool."""
@@ -566,6 +606,7 @@ class TestAnalyzeStock:
             monkeypatch, "_get_support_resistance_impl", mock_get_support_resistance
         )
         _patch_runtime_attr(monkeypatch, "_get_quote_impl", mock_get_quote)
+        _patch_us_finnhub_fanout(monkeypatch)
 
         result = await tools["analyze_stock"]("AAPL", market="us")
 
@@ -620,6 +661,7 @@ class TestAnalyzeStock:
             monkeypatch, "_get_support_resistance_impl", mock_get_support_resistance
         )
         _patch_runtime_attr(monkeypatch, "_get_quote_impl", mock_get_quote)
+        _patch_us_finnhub_fanout(monkeypatch, symbol)
 
         result = await tools["analyze_stock"](symbol, market="us")
 

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -1275,6 +1275,10 @@ class TestGetCompanyProfile:
 # ---------------------------------------------------------------------------
 
 
+# ROB-1296: drives the real yfinance collector against stubbed yfinance
+# objects, so the provider seam would replace the code under test. The
+# curl_cffi transport backstop and the socket guard both stay in force.
+@pytest.mark.usefixtures("allow_external_providers")
 @pytest.mark.asyncio
 class TestGetValuation:
     """Test get_valuation tool."""
@@ -3618,6 +3622,10 @@ class TestGetCryptoProfile:
 # ---------------------------------------------------------------------------
 
 
+# ROB-1296: drives the real yfinance collector against stubbed yfinance
+# objects, so the provider seam would replace the code under test. The
+# curl_cffi transport backstop and the socket guard both stay in force.
+@pytest.mark.usefixtures("allow_external_providers")
 @pytest.mark.asyncio
 class TestGetInvestmentOpinions:
     """Test get_investment_opinions tool."""
@@ -4378,11 +4386,20 @@ class TestScreenEnrichmentHelpers:
         assert "recommendation" not in result
 
 
+# ROB-1296: drives the real yfinance collector against stubbed yfinance
+# objects, so the provider seam would replace the code under test. The
+# curl_cffi transport backstop and the socket guard both stay in force.
+@pytest.mark.usefixtures("allow_external_providers")
 @pytest.mark.asyncio
 async def test_analyze_stock_us_reuses_preloaded_yfinance_analyst_snapshot(
     monkeypatch,
 ):
     tools = build_tools()
+    # This test opts out of the provider seams so it can drive the real yfinance
+    # collector, which also un-stubs the Finnhub half of the same fan-out. It
+    # asserts nothing about Finnhub, so stub that leaf explicitly rather than
+    # letting it reach the transport backstop.
+    _patch_us_finnhub_fanout(monkeypatch, "AAPL")
     yf_calls = {"info": 0, "targets": 0, "recommendations": 0, "ud": 0}
 
     async def mock_fetch_ohlcv(symbol, market_type, count):

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -36,6 +36,39 @@ def _unique_order_id(prefix: str) -> str:
     return f"{prefix}-{uuid4().hex[:12]}"
 
 
+@pytest.fixture
+def allow_nxt_premarket_price():
+    """Opt out of the module default so a test can exercise the NXT probe itself."""
+
+
+@pytest.fixture(autouse=True)
+def _default_no_nxt_premarket_price(request, monkeypatch):
+    """ROB-1296: default the best-effort NXT pre-market probe to "no price".
+
+    ``order_validation._premarket_nxt_price_for_kr`` only fires while
+    ``kr_market_data_state()`` reports the KR pre-market window, so it made this
+    module's KR order tests *wall-clock dependent*: run before 09:00 KST they
+    fetched a live NXT orderbook from openapi.koreainvestment.com, run later they
+    did not. Every test here patches ``_fetch_quote_equity_kr`` and asserts against
+    that KRX quote, so "no NXT book" is the contract they already intend — two
+    tests below already say so explicitly, and their own patch still wins because
+    it is applied after this fixture.
+
+    ``None`` is the function's own documented answer for "no NXT book", not a
+    fabricated success: it is what the real call returns outside pre-market.
+    ``TestPremarketNxtPricing`` covers the probe itself and opts out.
+    """
+
+    if "allow_nxt_premarket_price" in request.fixturenames:
+        return
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "_premarket_nxt_price_for_kr",
+        AsyncMock(return_value=None),
+    )
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def _ensure_live_order_ledger_schema(db_session):
     """ROB-407: live US/crypto orders write to review.live_order_ledger directly.
@@ -765,6 +798,7 @@ async def test_kis_overseas_order_payload_fields_buy(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("allow_nxt_premarket_price")
 class TestPremarketNxtPricing:
     """ROB-463: KR pre-market orders price off the live NXT orderbook, not the
     stale KRX previous close."""
@@ -2666,6 +2700,25 @@ async def test_place_order_paper_market_sell_rejected():
 async def test_place_order_limit_still_works_after_market_block(monkeypatch):
     """Policy change must not regress the limit path."""
     tools = build_tools()
+
+    # ROB-1296: the crypto dry-run path runs a balance precheck through
+    # upbit_service. Left unmocked it reached api.upbit.com for real; the
+    # failure was merely tolerated, so the leak was invisible. Model the
+    # funded-account contract this assertion assumes, matching the idiom used
+    # by the high-amount crypto tests above.
+    monkeypatch.setattr(
+        upbit_service,
+        "fetch_multiple_current_prices",
+        AsyncMock(return_value={"KRW-BTC": 50_000_000.0}),
+    )
+    monkeypatch.setattr(
+        upbit_service,
+        "fetch_my_coins",
+        AsyncMock(
+            return_value=[{"currency": "KRW", "balance": "10000000", "locked": "0"}]
+        ),
+    )
+
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="buy",

--- a/tests/test_naver_finance.py
+++ b/tests/test_naver_finance.py
@@ -12,6 +12,13 @@ from bs4 import BeautifulSoup
 
 from app.services import naver_finance
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 # ---------------------------------------------------------------------------
 # Helper Function Tests
 # ---------------------------------------------------------------------------

--- a/tests/test_rob1296_external_http_boundary.py
+++ b/tests/test_rob1296_external_http_boundary.py
@@ -12,6 +12,7 @@ work, and the allowed cases run against in-process transports.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import subprocess
 import sys
@@ -338,3 +339,52 @@ def test_reported_counter_survives_an_xdist_run(tmp_path: Path) -> None:
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["active"] is True
     assert report["blocked_attempts"] == 0
+
+
+# --------------------------------------------------------------------------
+# curl_cffi (libcurl) — neither an httpx transport nor a requests adapter
+# --------------------------------------------------------------------------
+
+
+def test_curl_cffi_requests_are_blocked_and_counted() -> None:
+    """The layer the other two could not see.
+
+    ``curl_cffi`` binds libcurl, so it is not an httpx transport, not a
+    ``requests`` adapter, and its ``connect(2)`` happens in C where the socket
+    guard's monkeypatches cannot reach. yfinance uses it, which is how 29
+    non-live tests were reaching query1.finance.yahoo.com for real while every
+    counter read zero.
+    """
+
+    from curl_cffi.requests import Session
+
+    host = "rob1296-curl.invalid"
+    before = boundary.snapshot()
+    with Session() as session:
+        with pytest.raises(Exception, match="External HTTP is disabled"):
+            session.get(f"https://{host}/probe", timeout=3)
+    after = boundary.snapshot()
+
+    assert after.get(host, 0) == before.get(host, 0) + 1
+
+
+def test_curl_cffi_session_classes_are_discovered() -> None:
+    """Both sync and async session classes must be intercepted."""
+
+    names = {cls.__name__ for cls in boundary.curl_session_classes()}
+    assert "Session" in names
+    assert "AsyncSession" in names
+
+
+def test_curl_cffi_loopback_is_not_blocked() -> None:
+    """Local test servers must stay reachable through curl_cffi too."""
+
+    from curl_cffi.requests import Session
+
+    before = boundary.snapshot()
+    with Session() as session:
+        with contextlib.suppress(Exception):
+            # Nothing is listening; what matters is that the guard did not
+            # intercept it, so the counter must not move.
+            session.get("http://127.0.0.1:1/probe", timeout=1)
+    assert boundary.snapshot() == before

--- a/tests/test_rob1296_external_http_boundary.py
+++ b/tests/test_rob1296_external_http_boundary.py
@@ -1,0 +1,340 @@
+"""ROB-1296 — the external-HTTP boundary blocks the network and nothing else.
+
+The boundary is deliberately broad: one fixture in place of seven per-provider
+stubs. That breadth is only safe if it is pinned, so these tests fix its exact
+edges — real transports blocked, every in-process transport untouched, both
+opt-out routes honoured, and a counter that makes a newly under-mocked provider
+visible instead of silently fail-soft.
+
+Nothing here performs a real request. The blocked cases raise before any socket
+work, and the allowed cases run against in-process transports.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import requests
+
+from tests import _external_http_boundary as boundary
+from tests import _socket_guard as socket_guard
+
+EXTERNAL_URL = "https://rob1296-boundary.invalid/probe"  # RFC 6761 reserved TLD
+PROBE_PATH = (
+    Path(__file__).parent / "_socket_guard_probes" / "live_http_boundary_probe.py"
+)
+COUNTER_PROBE_PATH = (
+    Path(__file__).parent / "_socket_guard_probes" / "http_counter_probe.py"
+)
+
+
+# --------------------------------------------------------------------------
+# (a) the real network transports are blocked, sync and async
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_real_transport_is_blocked() -> None:
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.ConnectError, match="External HTTP is disabled"):
+            await client.get(EXTERNAL_URL)
+
+
+def test_sync_real_transport_is_blocked() -> None:
+    with httpx.Client() as client:
+        with pytest.raises(httpx.ConnectError, match="External HTTP is disabled"):
+            client.get(EXTERNAL_URL)
+
+
+def test_requests_adapter_is_blocked() -> None:
+    with pytest.raises(requests.ConnectionError, match="External HTTP is disabled"):
+        requests.get(EXTERNAL_URL, timeout=1)
+
+
+def test_blocked_error_type_matches_a_real_connect_failure() -> None:
+    """The boundary must not change which ``except`` clause callers land in.
+
+    Providers here are wrapped in ``except httpx.HTTPError`` / retry / fail-open
+    branches. A blocked connect surfaces as ``httpx.ConnectError``, so the
+    boundary raises the same type rather than a bare ``RuntimeError`` that would
+    escape those handlers and change behaviour.
+    """
+
+    assert issubclass(httpx.ConnectError, httpx.TransportError)
+    assert issubclass(httpx.ConnectError, httpx.HTTPError)
+    assert issubclass(requests.ConnectionError, requests.RequestException)
+
+
+# --------------------------------------------------------------------------
+# (b) in-process transports keep working
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mock_transport_is_untouched() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"seen": str(request.url)})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get(EXTERNAL_URL)
+
+    assert response.status_code == 200
+    assert response.json()["seen"] == EXTERNAL_URL
+
+
+@pytest.mark.asyncio
+async def test_asgi_transport_is_untouched() -> None:
+    async def app(scope, receive, send):
+        assert scope["type"] == "http"
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"asgi-ok"})
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://rob1296-asgi.invalid"
+    ) as client:
+        response = await client.get("/probe")
+
+    assert response.text == "asgi-ok"
+
+
+def test_wsgi_transport_is_untouched() -> None:
+    def app(environ, start_response):
+        start_response("200 OK", [("content-type", "text/plain")])
+        return [b"wsgi-ok"]
+
+    transport = httpx.WSGITransport(app=app)
+    with httpx.Client(
+        transport=transport, base_url="https://rob1296-wsgi.invalid"
+    ) as client:
+        response = client.get("/probe")
+
+    assert response.text == "wsgi-ok"
+
+
+@pytest.mark.asyncio
+async def test_custom_user_transport_is_untouched() -> None:
+    class _CustomTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, text="custom-ok")
+
+    async with httpx.AsyncClient(transport=_CustomTransport()) as client:
+        response = await client.get(EXTERNAL_URL)
+
+    assert response.status_code == 201
+    assert response.text == "custom-ok"
+
+
+# --------------------------------------------------------------------------
+# (c) the opt-out reaches the real transport slot without opening the network
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_opt_out_reaches_the_real_transport_slot(
+    allow_external_http, monkeypatch
+) -> None:
+    """With the opt-out, a stand-in patched over the real transport is reached.
+
+    This is the case the boundary would otherwise shadow: a boundary test that
+    installs its own ``AsyncHTTPTransport`` stub. Proving the stub runs proves
+    the fixture stepped aside.
+    """
+
+    _ = allow_external_http
+    seen: list[str] = []
+
+    async def _stand_in(self, request: httpx.Request, *args, **kwargs):
+        seen.append(str(request.url))
+        return httpx.Response(204, request=request)
+
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", _stand_in)
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(EXTERNAL_URL)
+
+    assert response.status_code == 204
+    assert seen == [EXTERNAL_URL]
+
+
+def test_opt_out_does_not_open_the_real_network(allow_external_http) -> None:
+    """Opting out of the boundary does not opt out of the socket guard."""
+
+    _ = allow_external_http
+    assert socket_guard.is_current_test_exempt() is False
+    assert socket_guard.is_socket_address_permitted(("203.0.113.1", 443)) is False
+
+
+# --------------------------------------------------------------------------
+# (d) armed live keeps its intentional boundary
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("has_live_marker", "run_live", "fixturenames", "expected"),
+    [
+        (False, False, (), True),
+        (False, True, (), True),
+        (True, False, (), True),
+        (True, True, (), False),
+        (False, False, ("allow_external_http",), False),
+        (True, True, ("allow_external_http",), False),
+    ],
+)
+def test_boundary_activation_truth_table(
+    has_live_marker: bool,
+    run_live: bool,
+    fixturenames: tuple[str, ...],
+    expected: bool,
+) -> None:
+    assert (
+        boundary.boundary_is_active(
+            has_live_marker=has_live_marker,
+            run_live=run_live,
+            fixturenames=fixturenames,
+        )
+        is expected
+    )
+
+
+def _nested_env() -> dict[str, str]:
+    from tests.test_rob1296_live_only_socket_guard import _nested_pytest_environment
+
+    return _nested_pytest_environment()
+
+
+def test_armed_live_session_is_not_wrapped_by_the_boundary() -> None:
+    """End to end: under ``--run-live`` the fixture leaves the transport alone.
+
+    The probe asserts an identity, never a request, so this proves the opt-out
+    without any possibility of live traffic.
+    """
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(PROBE_PATH),
+            "--run-live",
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(socket_guard.PROJECT_ROOT),
+        env=_nested_env(),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 passed" in result.stdout
+
+
+def test_a_default_session_does_wrap_the_transport() -> None:
+    """The mirror image: without ``--run-live`` the same probe is skipped."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(PROBE_PATH),
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(socket_guard.PROJECT_ROOT),
+        env=_nested_env(),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 skipped" in result.stdout
+
+
+# --------------------------------------------------------------------------
+# evidence counter
+# --------------------------------------------------------------------------
+
+
+def test_blocked_requests_are_counted_and_reported() -> None:
+    before = boundary.snapshot()
+    with httpx.Client() as client:
+        with pytest.raises(httpx.ConnectError):
+            client.get("https://rob1296-counter.invalid/probe")
+    after = boundary.snapshot()
+
+    host = "rob1296-counter.invalid"
+    assert after.get(host, 0) == before.get(host, 0) + 1
+    assert host in boundary.format_summary(after)
+
+
+def test_summary_line_is_explicit_when_nothing_was_blocked() -> None:
+    assert boundary.format_summary({}) == (
+        "ROB-1296 external HTTP boundary: 0 blocked requests"
+    )
+
+
+def test_loopback_hosts_are_never_blocked() -> None:
+    for host in ("127.0.0.1", "localhost", "::1"):
+        assert boundary.is_loopback_host(host) is True
+    for host in ("openapi.koreainvestment.com", "api.upbit.com", "", None):
+        assert boundary.is_loopback_host(host) is False
+
+
+def test_reported_counter_survives_an_xdist_run(tmp_path: Path) -> None:
+    """The controller must aggregate worker counts, not drop them.
+
+    Driven by a dedicated probe that makes one intentional request to a reserved
+    ``.invalid`` host. A real under-mocked test file must never be used here: the
+    assertion would then only pass while that leak survives, turning a defect
+    into a required baseline.
+    """
+
+    report_path = tmp_path / "guard.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(COUNTER_PROBE_PATH),
+            "-n",
+            "2",
+            "--dist=loadfile",
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+            "--socket-guard-report",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(socket_guard.PROJECT_ROOT),
+        env=_nested_env(),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ROB-1296 external HTTP boundary: 1 blocked requests" in result.stdout
+    assert "rob1296-counter-probe.invalid=1" in result.stdout
+
+    # The probe was stopped above the socket layer, so the guard saw nothing.
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["active"] is True
+    assert report["blocked_attempts"] == 0

--- a/tests/test_rob1296_live_only_socket_guard.py
+++ b/tests/test_rob1296_live_only_socket_guard.py
@@ -992,9 +992,20 @@ def test_loopback_resolution_is_permitted(host: str) -> None:
 
 @pytest.mark.parametrize("host", [None, "", b""])
 def test_passive_resolution_is_permitted(host: object) -> None:
-    """``host=None`` is a passive lookup for a local bind; it never leaves."""
+    """A passive lookup for a local bind must not be refused by the guard.
 
-    assert socket.getaddrinfo(host, 0, type=socket.SOCK_STREAM)
+    Asserts the guard's *decision*, not the resolver's success: glibc raises
+    ``gaierror`` for an empty host while macOS resolves it to loopback, so
+    calling ``getaddrinfo`` here would test the platform rather than the policy.
+    """
+
+    socket_guard._assert_resolution_allowed(host)
+
+
+def test_wildcard_resolution_still_works_end_to_end() -> None:
+    """``host=None`` is the portable spelling, so exercise it for real."""
+
+    assert socket.getaddrinfo(None, 0, type=socket.SOCK_STREAM)
 
 
 def test_blocked_resolution_is_counted_under_its_own_operation() -> None:

--- a/tests/test_rob1296_live_only_socket_guard.py
+++ b/tests/test_rob1296_live_only_socket_guard.py
@@ -1,0 +1,461 @@
+"""ROB-1296 — the socket guard exempts an armed ``live`` item and nothing else.
+
+Before ROB-1296 the guard exempted every ``integration`` item, which covered
+~3,200 tests in the default ``-m "not live"`` gate and let any of them reach a
+real external host. Integration tests need loopback PostgreSQL/Redis, which the
+address allowlist already permits without any marker, so the marker was granting
+reach it never needed.
+
+These tests pin the resulting truth table end to end. They never open a socket to
+a non-loopback address: the armed-live cell is proven through the guard's
+side-effect-free verdict predicate, so the whole matrix runs offline.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests import _socket_guard as socket_guard
+from tests import _socket_guard_plugin as socket_guard_plugin
+
+PROBE_PATH = Path(__file__).parent / "_socket_guard_probes" / "marker_matrix_probe.py"
+EXTERNAL_IPV4 = ("203.0.113.1", 443)  # RFC 5737 TEST-NET-3, never routable
+EXTERNAL_HOSTNAME = "rob1296-guard-probe.invalid"  # RFC 6761 reserved TLD
+LOOPBACK_POSTGRES = ("127.0.0.1", 5432)
+LOOPBACK_REDIS = ("127.0.0.1", 6379)
+
+
+# --------------------------------------------------------------------------
+# Policy predicate — the decision the plugin makes for one item
+# --------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    def __init__(self, run_live: object) -> None:
+        self._run_live = run_live
+
+    def getoption(self, name: str, default: object = None) -> object:
+        assert name == "--run-live"
+        if self._run_live is _MISSING:
+            return default
+        return self._run_live
+
+
+_MISSING = object()
+
+
+class _FakeItem:
+    def __init__(self, markers: set[str], config: _FakeConfig) -> None:
+        self._markers = markers
+        self.config = config
+
+    def get_closest_marker(self, name: str) -> object | None:
+        return object() if name in self._markers else None
+
+
+@pytest.mark.parametrize(
+    ("markers", "run_live", "expected"),
+    [
+        (set(), False, False),
+        (set(), True, False),
+        ({"integration"}, False, False),
+        ({"integration"}, True, False),
+        ({"live"}, False, False),
+        ({"live"}, True, True),
+        ({"integration", "live"}, False, False),
+        ({"integration", "live"}, True, True),
+        ({"slow", "unit"}, True, False),
+    ],
+)
+def test_exemption_truth_table(
+    markers: set[str], run_live: bool, expected: bool
+) -> None:
+    item = _FakeItem(markers, _FakeConfig(run_live))
+    assert socket_guard_plugin.item_is_exempt(item) is expected
+
+
+def test_live_exemption_is_not_armed_when_the_option_is_unregistered() -> None:
+    """``research/**`` subtrees and ``--noconftest`` probes never register it."""
+
+    assert socket_guard_plugin.live_exemption_is_armed(_FakeConfig(_MISSING)) is False
+
+
+def test_live_exemption_is_not_armed_when_the_option_table_raises() -> None:
+    class _RaisingConfig:
+        def getoption(self, name: str, default: object = None) -> object:
+            raise ValueError(f"no such option: {name}")
+
+    assert socket_guard_plugin.live_exemption_is_armed(_RaisingConfig()) is False
+
+
+# --------------------------------------------------------------------------
+# End-to-end: real pytest sessions over a real marker matrix
+# --------------------------------------------------------------------------
+
+
+# A nested pytest session must not inherit this session's run-owned PostgreSQL
+# identity. ``tests/_run_owned_database.py`` derives the database name from
+# ``AUTO_TRADER_PYTEST_RUN_UID`` plus ``PYTEST_XDIST_WORKER``, and the owning
+# session drops that exact database at teardown. A child that inherited both
+# would compute *this worker's* database name and drop it out from under the
+# outer run — which reliably reproduced as several hundred
+# ``InvalidCatalogNameError`` failures across unrelated tests. Stripping these
+# keys makes the child mint its own ``_main`` database and clean it up.
+_RUN_OWNED_DATABASE_ENV_KEYS = (
+    "AUTO_TRADER_PYTEST_RUN_UID",
+    "AUTO_TRADER_PYTEST_OWNER_TOKEN",
+    "AUTO_TRADER_XDIST_DATABASE_NAME",
+    "AUTO_TRADER_XDIST_BASE_DATABASE_URL",
+    "DATABASE_URL",
+    "PYTEST_XDIST_WORKER",
+    "PYTEST_XDIST_WORKER_COUNT",
+    "PYTEST_XDIST_TESTRUNUID",
+)
+
+
+def _nested_pytest_environment(**overrides: str) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _RUN_OWNED_DATABASE_ENV_KEYS
+    }
+    environment.update(overrides)
+    return environment
+
+
+def _run_probe_matrix(
+    tmp_path: Path, *extra_args: str
+) -> tuple[subprocess.CompletedProcess[str], list[dict[str, object]]]:
+    record_path = tmp_path / "records.jsonl"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(PROBE_PATH),
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(socket_guard.PROJECT_ROOT),
+        env=_nested_pytest_environment(ROB1296_PROBE_RECORD=str(record_path)),
+    )
+    records = [
+        json.loads(line)
+        for line in record_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    return result, records
+
+
+def test_default_session_exempts_nothing_and_skips_live(tmp_path: Path) -> None:
+    result, records = _run_probe_matrix(tmp_path)
+    by_case = {record["case"]: record for record in records}
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    # Live items never execute at all without --run-live, so they cannot reach
+    # a socket regardless of the guard's verdict.
+    assert set(by_case) == {"unmarked", "integration_only"}
+    assert "2 skipped" in result.stdout
+
+    for case in ("unmarked", "integration_only"):
+        assert by_case[case]["exempt"] is False, case
+        assert by_case[case]["external_permitted"] is False, case
+        assert by_case[case]["loopback_permitted"] is True, case
+
+
+def test_run_live_arms_only_the_live_items(tmp_path: Path) -> None:
+    result, records = _run_probe_matrix(tmp_path, "--run-live")
+    by_case = {record["case"]: record for record in records}
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert set(by_case) == {
+        "unmarked",
+        "integration_only",
+        "live_only",
+        "integration_and_live",
+    }
+
+    for case in ("unmarked", "integration_only"):
+        assert by_case[case]["exempt"] is False, case
+        assert by_case[case]["external_permitted"] is False, case
+
+    for case in ("live_only", "integration_and_live"):
+        assert by_case[case]["exempt"] is True, case
+        assert by_case[case]["external_permitted"] is True, case
+
+    # Loopback stays reachable in every cell — the exemption never had to be the
+    # mechanism that let integration tests talk to PostgreSQL/Redis.
+    for record in records:
+        assert record["loopback_permitted"] is True, record["case"]
+
+
+def test_a_subtree_without_the_option_registered_stays_blocked(tmp_path: Path) -> None:
+    """The real ``research/**`` shape: guard active, ``--run-live`` never registered.
+
+    ``pyproject.toml`` adds ``-p tests._socket_guard_plugin`` to *every* pytest
+    invocation, but only ``tests/conftest.py`` registers ``--run-live``. The
+    ``research/**`` subtrees have their own conftests and are collected by path,
+    so the option is absent there. If the lookup raised instead of degrading,
+    every research CI job would die on the first ``live``-marked item.
+    """
+
+    config_path = tmp_path / "pytest.ini"
+    config_path.write_text(
+        "[pytest]\nmarkers =\n    live: live API tests\n", encoding="utf-8"
+    )
+    probe_path = tmp_path / "test_unregistered_option_probe.py"
+    probe_path.write_text(
+        "import pytest\n"
+        "from tests._socket_guard import (\n"
+        "    is_current_test_exempt,\n"
+        "    is_socket_address_permitted,\n"
+        ")\n"
+        "\n"
+        "@pytest.mark.live\n"
+        "def test_live_without_a_registered_option():\n"
+        "    assert is_current_test_exempt() is False\n"
+        "    assert is_socket_address_permitted(('203.0.113.1', 443)) is False\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--noconftest",
+            "-c",
+            str(config_path),
+            "-p",
+            "tests._socket_guard_plugin",
+            str(probe_path),
+            "-q",
+            "-p",
+            "no:cacheprovider",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(socket_guard.PROJECT_ROOT),
+        env=_nested_pytest_environment(),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 passed" in result.stdout
+
+
+def test_xdist_workers_apply_the_same_policy_and_report_evidence(
+    tmp_path: Path,
+) -> None:
+    report_path = tmp_path / "guard-report.json"
+    result, records = _run_probe_matrix(
+        tmp_path,
+        "-n",
+        "2",
+        "--dist=loadfile",
+        "--socket-guard-report",
+        str(report_path),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["active"] is True
+    assert report["worker_count"] == 2
+    assert report["blocked_attempts"] == 0
+
+    by_case = {record["case"]: record for record in records}
+    assert set(by_case) == {"unmarked", "integration_only"}
+    for record in by_case.values():
+        assert record["exempt"] is False
+        assert record["external_permitted"] is False
+
+
+# --------------------------------------------------------------------------
+# Live-marker semantics without the option
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.live
+def test_an_armed_live_item_holds_the_only_exemption() -> None:
+    """Skipped in the default gate; asserts the exemption under ``--run-live``.
+
+    Reaching this body at all proves ``--run-live`` was supplied, because
+    ``tests/conftest.py`` skips every ``live`` item otherwise. The nested probe
+    matrix above covers the skipped half of the option axis.
+    """
+
+    assert socket_guard.is_current_test_exempt() is True
+    assert socket_guard.is_socket_address_permitted(EXTERNAL_IPV4) is True
+
+
+# --------------------------------------------------------------------------
+# In-session behaviour of the current (non-exempt) item
+# --------------------------------------------------------------------------
+
+
+def test_this_ordinary_item_is_not_exempt() -> None:
+    assert socket_guard.is_current_test_exempt() is False
+
+
+@pytest.mark.integration
+def test_an_integration_item_is_no_longer_exempt() -> None:
+    """The ROB-1296 inversion of the pre-existing ROB-1880 expectation."""
+
+    assert socket_guard.is_current_test_exempt() is False
+    assert socket_guard.is_socket_address_permitted(EXTERNAL_IPV4) is False
+
+
+@pytest.mark.integration
+def test_an_integration_item_still_reaches_loopback_services() -> None:
+    for address in (LOOPBACK_POSTGRES, LOOPBACK_REDIS):
+        assert socket_guard.is_socket_address_permitted(address) is True
+
+    # Prove it end to end against the local services the suite actually uses.
+    for address in (LOOPBACK_POSTGRES, LOOPBACK_REDIS):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(5)
+            sock.connect(address)
+
+
+@pytest.mark.integration
+def test_an_integration_item_is_blocked_from_an_external_host() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        with pytest.raises(socket_guard.ExternalSocketBlocked):
+            sock.connect(EXTERNAL_IPV4)
+
+
+@pytest.mark.integration
+def test_an_integration_item_is_blocked_from_a_named_host() -> None:
+    """A hostname target is denied at connect, after resolution fails or not."""
+
+    with pytest.raises((socket_guard.ExternalSocketBlocked, socket.gaierror)):
+        socket.create_connection((EXTERNAL_HOSTNAME, 443), timeout=1)
+
+
+@pytest.mark.integration
+def test_an_integration_item_is_blocked_from_launching_a_network_client() -> None:
+    with pytest.raises(socket_guard.ExternalSubprocessBlocked, match="network-client"):
+        subprocess.run(["curl", "https://203.0.113.1"], check=False)
+
+
+# --------------------------------------------------------------------------
+# State isolation and restoration
+# --------------------------------------------------------------------------
+
+
+def test_exempt_state_is_restored_after_a_nested_protocol_frame() -> None:
+    assert socket_guard.is_current_test_exempt() is False
+    previous = socket_guard.set_current_test_exempt(True)
+    try:
+        assert socket_guard.is_current_test_exempt() is True
+    finally:
+        socket_guard.set_current_test_exempt(previous)
+    assert socket_guard.is_current_test_exempt() is False
+
+
+def test_a_preceding_integration_item_does_not_leak_its_state() -> None:
+    """Ordering-independent: the plugin restores the flag in a ``finally``."""
+
+    assert socket_guard.is_current_test_exempt() is False
+    assert socket_guard.is_socket_address_permitted(EXTERNAL_IPV4) is False
+
+
+# --------------------------------------------------------------------------
+# Child-process propagation beyond subprocess.Popen
+# --------------------------------------------------------------------------
+
+
+def _child_guard_verdict(queue: object) -> None:  # pragma: no cover - child body
+    from tests import _socket_guard as child_guard
+
+    queue.put(  # type: ignore[attr-defined]
+        {
+            "installed": child_guard.is_installed(),
+            "exempt": child_guard.is_current_test_exempt(),
+            "external_permitted": child_guard.is_socket_address_permitted(
+                ("203.0.113.1", 443)
+            ),
+        }
+    )
+
+
+@pytest.mark.parametrize("start_method", ["spawn", "fork"])
+def test_multiprocessing_children_inherit_the_guard(start_method: str) -> None:
+    """``spawn`` and ``fork`` children carry the policy, by two routes.
+
+    ``fork`` inherits the already-patched ``socket`` module in memory; ``spawn``
+    re-execs and picks the guard back up from the ``sitecustomize`` hook that
+    ``activate_child_guard_environment`` planted in ``os.environ``. Neither path
+    goes through ``subprocess.Popen``, so this is a genuinely separate
+    propagation route from the direct-child tests.
+    """
+
+    if start_method not in multiprocessing.get_all_start_methods():
+        pytest.skip(f"{start_method} start method unavailable on this platform")
+
+    context = multiprocessing.get_context(start_method)
+    queue = context.Queue()
+    process = context.Process(target=_child_guard_verdict, args=(queue,))
+    process.start()
+    try:
+        verdict = queue.get(timeout=60)
+    finally:
+        process.join(timeout=60)
+
+    assert verdict["installed"] is True, start_method
+    assert verdict["exempt"] is False, start_method
+    assert verdict["external_permitted"] is False, start_method
+
+
+def test_forkserver_start_method_is_fail_closed_not_silently_allowed() -> None:
+    """Known, deliberate limitation — documented rather than allowlisted away.
+
+    ``forkserver`` brokers every child through an ``AF_UNIX`` socket under a
+    per-process temp directory. Admitting it would mean allowlisting a
+    *directory prefix*, and "any AF_UNIX path is local enough" is exactly the
+    bypass ROB-1880 closed. Nothing in this repository uses ``forkserver``: all
+    three ``get_context`` call sites ask for ``spawn`` explicitly. So the guard
+    blocks it, and this test pins that as intended behaviour so a future reader
+    finds a decision instead of a mystery.
+    """
+
+    if "forkserver" not in multiprocessing.get_all_start_methods():
+        pytest.skip("forkserver start method unavailable on this platform")
+
+    context = multiprocessing.get_context("forkserver")
+    queue = context.Queue()
+    process = context.Process(target=_child_guard_verdict, args=(queue,))
+
+    with pytest.raises(socket_guard.ExternalSocketBlocked):
+        process.start()
+
+
+def test_a_direct_python_child_of_a_non_exempt_item_is_guarded() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from tests._socket_guard import is_installed, is_socket_address_permitted;"
+            " print(is_installed(), is_socket_address_permitted(('203.0.113.1', 443)))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "True False"

--- a/tests/test_rob1296_live_only_socket_guard.py
+++ b/tests/test_rob1296_live_only_socket_guard.py
@@ -1016,6 +1016,34 @@ def test_blocked_resolution_is_counted_under_its_own_operation() -> None:
     assert after == before + 1
 
 
+def test_blocked_resolution_is_an_oserror_so_clients_map_it() -> None:
+    """A refusal must look like a resolution failure, not a crash.
+
+    Every HTTP client maps ``socket.gaierror``/``OSError`` into its own transport
+    error. A bare ``AssertionError`` escapes that mapping and propagates as a
+    hard failure -- which is how an MCP child process died mid-request in CI
+    instead of seeing the ordinary "cannot resolve" it already handles.
+    """
+
+    with pytest.raises(socket_guard.ExternalResolutionBlocked) as excinfo:
+        socket.getaddrinfo(EXTERNAL_HOSTNAME, 443)
+
+    assert isinstance(excinfo.value, socket.gaierror)
+    assert isinstance(excinfo.value, OSError)
+    # ...and still matches the assertions the rest of the guard suite uses.
+    assert isinstance(excinfo.value, socket_guard.ExternalSocketBlocked)
+
+
+def test_a_blocked_name_surfaces_as_a_connect_error_through_httpx() -> None:
+    """End to end: the client maps it, the caller's ``except`` clause still works."""
+
+    import httpx
+
+    with httpx.Client() as client:
+        with pytest.raises(httpx.ConnectError):
+            client.get(f"https://{EXTERNAL_HOSTNAME}/probe")
+
+
 def test_resolution_is_permitted_for_an_armed_live_item() -> None:
     """The exemption reaches resolution too, or an armed live test cannot connect."""
 

--- a/tests/test_rob1296_live_only_socket_guard.py
+++ b/tests/test_rob1296_live_only_socket_guard.py
@@ -340,11 +340,29 @@ def test_an_integration_item_is_blocked_from_an_external_host() -> None:
 
 
 @pytest.mark.integration
-def test_an_integration_item_is_blocked_from_a_named_host() -> None:
-    """A hostname target is denied at connect, after resolution fails or not."""
+def test_an_integration_item_is_blocked_from_a_named_host(monkeypatch) -> None:
+    """A hostname target is denied at connect -- proven without any DNS traffic.
 
-    with pytest.raises((socket_guard.ExternalSocketBlocked, socket.gaierror)):
+    Resolution is stubbed to a fixed TEST-NET-3 sockaddr. Letting the real
+    resolver run would both emit a DNS query and make the test pass for the wrong
+    reason: an NXDOMAIN raises ``gaierror`` before the guarded ``connect`` is ever
+    reached, so the guard would go untested.
+    """
+
+    resolved: list[tuple[object, ...]] = []
+
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        resolved.append((host, port))
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", (EXTERNAL_IPV4[0], 443)),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    with pytest.raises(socket_guard.ExternalSocketBlocked):
         socket.create_connection((EXTERNAL_HOSTNAME, 443), timeout=1)
+
+    assert resolved == [(EXTERNAL_HOSTNAME, 443)]
 
 
 @pytest.mark.integration
@@ -422,16 +440,17 @@ def test_multiprocessing_children_inherit_the_guard(start_method: str) -> None:
     assert verdict["external_permitted"] is False, start_method
 
 
-def test_forkserver_start_method_is_fail_closed_not_silently_allowed() -> None:
-    """Known, deliberate limitation — documented rather than allowlisted away.
+def test_forkserver_start_method_is_refused_outright() -> None:
+    """Deliberately unsupported, and refused before anything launches.
 
-    ``forkserver`` brokers every child through an ``AF_UNIX`` socket under a
-    per-process temp directory. Admitting it would mean allowlisting a
-    *directory prefix*, and "any AF_UNIX path is local enough" is exactly the
-    bypass ROB-1880 closed. Nothing in this repository uses ``forkserver``: all
-    three ``get_context`` call sites ask for ``spawn`` explicitly. So the guard
-    blocks it, and this test pins that as intended behaviour so a future reader
-    finds a decision instead of a mystery.
+    ``forkserver`` boots a long-lived server interpreter through a path this
+    guard does not control, and that server then forks every child -- so no
+    child policy can be guaranteed. An earlier version let the attempt proceed
+    and relied on the ``AF_UNIX`` broker socket being blocked, but "the socket
+    was refused" is not evidence that a child would have had the right policy.
+    ROB-1296 never required ``forkserver``; nothing here selects it (all three
+    ``get_context`` call sites ask for ``spawn``), so it fails closed at the
+    boundary with an explanation.
     """
 
     if "forkserver" not in multiprocessing.get_all_start_methods():
@@ -441,7 +460,7 @@ def test_forkserver_start_method_is_fail_closed_not_silently_allowed() -> None:
     queue = context.Queue()
     process = context.Process(target=_child_guard_verdict, args=(queue,))
 
-    with pytest.raises(socket_guard.ExternalSocketBlocked):
+    with pytest.raises(socket_guard.SocketGuardInstallationError, match="forkserver"):
         process.start()
 
 
@@ -459,3 +478,539 @@ def test_a_direct_python_child_of_a_non_exempt_item_is_guarded() -> None:
     )
 
     assert result.stdout.strip() == "True False"
+
+
+# --------------------------------------------------------------------------
+# Child-launch classification and escape hatches
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (["uv", "run", "python", "-c", "print(1)"], True),
+        (["/opt/homebrew/bin/uv", "run", "python", "-c", "print(1)"], True),
+        (["/usr/bin/env", "python3", "-c", "print(1)"], True),
+        (["env", "FOO=1", "python", "-c", "print(1)"], True),
+        (["poetry", "run", "python", "-c", "print(1)"], True),
+        # Not Python children: rewriting their environment would break callers
+        # that depend on exact child-env semantics for a non-Python tool.
+        (["uv", "build", "--wheel"], False),
+        (["env", "printenv"], False),
+        (["env"], False),
+        (["uv", "sync"], False),
+        (["git", "status"], False),
+        ([], False),
+    ],
+)
+def test_python_launcher_wrapper_classifier(command: list[str], expected: bool) -> None:
+    assert socket_guard._is_wrapped_python_launcher(tuple(command)) is expected
+
+
+def test_env_scrubbed_python_is_rejected_before_it_starts() -> None:
+    """``env -i python`` discards the startup hook, so it is refused outright.
+
+    Rewriting the shell's environment cannot help here: ``env -i`` wipes whatever
+    the parent injected, so the interpreter would come up unguarded. The command
+    is blocked instead.
+    """
+
+    with pytest.raises(
+        socket_guard.ExternalSubprocessBlocked, match="env-scrubbed-python"
+    ):
+        subprocess.run(["sh", "-c", f"env -i {sys.executable} -c 'pass'"], check=False)
+
+    with pytest.raises(
+        socket_guard.ExternalSubprocessBlocked, match="env-scrubbed-python"
+    ):
+        subprocess.run(["env", "--ignore-environment", sys.executable, "-c", "pass"])
+
+
+def test_env_without_scrubbing_is_not_rejected() -> None:
+    """The deny rule must key on the scrubbing flag, not on ``env`` itself."""
+
+    result = subprocess.run(
+        ["env", sys.executable, "-c", "print('env-ok')"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "env-ok"
+
+
+def test_a_non_python_wrapper_child_keeps_its_exact_environment() -> None:
+    """``uv build``-shaped commands must not have their environment rewritten."""
+
+    result = subprocess.run(
+        ["env"],
+        capture_output=True,
+        text=True,
+        env={"ROB1296_ONLY": "1"},
+        check=True,
+    )
+    assert result.stdout.strip() == "ROB1296_ONLY=1"
+
+
+# --------------------------------------------------------------------------
+# Child policy is identical across every creation route
+# --------------------------------------------------------------------------
+
+CHILD_POLICY_PROBE = (
+    Path(__file__).parent / "_socket_guard_probes" / "child_policy_probe.py"
+)
+
+
+def _run_child_policy_probe(tmp_path: Path, *extra_args: str) -> dict[str, dict]:
+    record = tmp_path / "childpol"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(CHILD_POLICY_PROBE),
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(socket_guard.PROJECT_ROOT),
+        env=_nested_pytest_environment(ROB1296_CHILD_POLICY_RECORD=str(record)),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    written = {}
+    for path in tmp_path.glob("childpol.*.json"):
+        written[path.name.split(".")[1]] = json.loads(path.read_text(encoding="utf-8"))
+    return written
+
+
+def _assert_routes_match_parent(routes: dict[str, dict], label: str) -> None:
+    parent = routes["parent"]
+    assert "uv-wrapper" in " ".join(routes), f"{label}: uv wrapper route not exercised"
+    for name, verdict in routes.items():
+        if verdict.get("blocked_by_guard"):
+            # ``forkserver`` is refused outright, under either parent policy: its
+            # server interpreter boots outside the guard's control. Refusing is
+            # stricter than the parent, never looser, so it does not break the
+            # same-policy contract.
+            assert "forkserver" in name, f"{label}:{name} unexpectedly refused"
+            continue
+        assert verdict == parent, f"{label}:{name} disagrees with the parent"
+
+
+def test_every_child_route_matches_a_non_exempt_parent(tmp_path: Path) -> None:
+    routes = _run_child_policy_probe(tmp_path)
+    _assert_routes_match_parent(routes["nonlive"], "nonlive")
+    assert routes["nonlive"]["parent"]["exempt"] is False
+
+
+def test_every_child_route_matches_an_armed_live_parent(tmp_path: Path) -> None:
+    routes = _run_child_policy_probe(tmp_path, "--run-live")
+    _assert_routes_match_parent(routes["live"], "live")
+    assert routes["live"]["parent"]["exempt"] is True
+    assert routes["live"]["multiprocessing:spawn"]["exempt"] is True
+    assert routes["live"]["subprocess:uv-wrapper"]["exempt"] is True
+
+
+def test_env_tampering_cannot_exempt_any_child_route(tmp_path: Path) -> None:
+    """The general-bypass negative control, end to end."""
+
+    routes = _run_child_policy_probe(tmp_path)
+    tampered = routes["tampered"]
+    assert tampered["parent"]["exempt"] is False
+    for name, verdict in tampered.items():
+        if verdict.get("blocked_by_guard"):
+            continue
+        assert verdict["exempt"] is False, f"{name} became exempt via the environment"
+        assert verdict["external_permitted"] is False, name
+
+
+def test_guard_env_tampering_cannot_unguard_any_child_route(tmp_path: Path) -> None:
+    """Disabling the guard switch, or stripping the startup path, must not stick."""
+
+    routes = _run_child_policy_probe(tmp_path)
+    for label in ("guard_disabled", "guard_removed"):
+        for name, verdict in routes[label].items():
+            if verdict.get("blocked_by_guard"):
+                continue
+            assert verdict["installed"] is True, f"{label}:{name} came up unguarded"
+            assert verdict["exempt"] is False, f"{label}:{name}"
+            assert verdict["external_permitted"] is False, f"{label}:{name}"
+
+
+# --------------------------------------------------------------------------
+# Installation integrity of the multiprocessing policy channel
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("module_path", "owner_attr", "hook"),
+    [
+        ("multiprocessing.spawn", None, "get_preparation_data"),
+        ("multiprocessing.spawn", None, "prepare"),
+        ("multiprocessing.process", "BaseProcess", "start"),
+    ],
+)
+def test_partially_restored_child_policy_channel_is_a_hard_failure(
+    monkeypatch, module_path: str, owner_attr: str | None, hook: str
+) -> None:
+    """Restoring any one hook must fail the session, not quietly stop propagating.
+
+    Each of these carries part of the child's policy. A partial restore would
+    leave the aggregate evidence reporting ``active=True`` while re-execed
+    children lost either their exemption or the guard itself.
+    """
+
+    import importlib
+
+    module = importlib.import_module(module_path)
+    owner = module if owner_attr is None else getattr(module, owner_attr)
+    installed = getattr(owner, hook)
+    original = installed._rob1296_original
+
+    monkeypatch.setattr(owner, hook, original)
+
+    with pytest.raises(socket_guard.SocketGuardInstallationError, match=hook):
+        socket_guard.assert_installed()
+
+
+def test_summary_reports_inactive_when_the_child_policy_channel_is_broken(
+    monkeypatch,
+) -> None:
+    """The session evidence must fold this channel into ``active``."""
+
+    import multiprocessing.spawn as mp_spawn
+
+    assert socket_guard.summary()["active"] is True
+
+    monkeypatch.setattr(mp_spawn, "prepare", mp_spawn.prepare._rob1296_original)
+
+    assert socket_guard.summary()["active"] is False
+
+
+# --------------------------------------------------------------------------
+# Selective environment stripping in front of an interpreter
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        # Full scrub.
+        (["env", "-i", "python", "-c", "pass"], True),
+        (["env", "--ignore-environment", "python", "-c", "pass"], True),
+        # Scalpel: unset exactly the keys the startup hook rides on.
+        (["env", "-u", "PYTHONPATH", "python", "-c", "pass"], True),
+        (["env", "--unset=PYTHONPATH", "python", "-c", "pass"], True),
+        (["env", "-u", "AUTO_TRADER_TEST_SOCKET_GUARD", "python", "-c", "pass"], True),
+        (["unset", "PYTHONPATH;", "python", "-c", "pass"], True),
+        # Override rather than unset.
+        (["env", "PYTHONPATH=", "python", "-c", "pass"], True),
+        (["env", "AUTO_TRADER_TEST_SOCKET_GUARD=0", "python3.13", "-c", "pass"], True),
+        # Unrelated variables leave the hook intact, so these stay allowed.
+        (["env", "-u", "EDITOR", "python", "-c", "pass"], False),
+        (["env", "FOO=1", "python", "-c", "pass"], False),
+        (["env", "python", "-c", "pass"], False),
+        # No interpreter follows, so there is nothing to unguard.
+        (["env", "-i", "printenv"], False),
+        (["env", "-u", "PYTHONPATH", "printenv"], False),
+        # A guard key mentioned *inside* the script is not a bypass.
+        (["python", "-c", "import os; os.environ['PYTHONPATH'] = ''"], False),
+    ],
+)
+def test_guard_environment_stripping_classifier(
+    command: list[str], expected: bool
+) -> None:
+    assert (
+        socket_guard._strips_guard_environment_before_python(tuple(command)) is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["python", "python3", "python3.13", "py", "pythonw", "/usr/bin/python3"],
+)
+def test_interpreter_names_are_recognised(name: str) -> None:
+    assert socket_guard._is_python_executable(name) is True
+
+
+@pytest.mark.parametrize("name", ["PYTHONPATH", "pythonpath", "uv", "pythonic-tool"])
+def test_non_interpreter_names_are_not_mistaken_for_python(name: str) -> None:
+    """``startswith("python")`` used to match ``PYTHONPATH`` itself.
+
+    That made ``env -u PYTHONPATH python …`` look like it had already reached the
+    interpreter, so its environment-stripping prefix was never examined.
+    """
+
+    assert socket_guard._is_python_executable(name) is False
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["env", "-u", "PYTHONPATH", sys.executable, "-c", "pass"],
+        ["env", "--unset=AUTO_TRADER_TEST_SOCKET_GUARD", sys.executable, "-c", "pass"],
+        ["env", "PYTHONPATH=", sys.executable, "-c", "pass"],
+    ],
+)
+def test_selective_env_stripping_is_rejected_before_it_starts(
+    argv: list[str],
+) -> None:
+    with pytest.raises(
+        socket_guard.ExternalSubprocessBlocked, match="env-scrubbed-python"
+    ):
+        subprocess.run(argv, check=False)
+
+
+def test_unrelated_env_manipulation_still_runs_and_stays_guarded() -> None:
+    """The deny rule must be about the guard's keys, not about ``env`` at all."""
+
+    result = subprocess.run(
+        [
+            "env",
+            "-u",
+            "EDITOR",
+            sys.executable,
+            "-c",
+            "from tests._socket_guard import is_installed; print(is_installed())",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "True"
+
+
+# --------------------------------------------------------------------------
+# Shell option bundles and executable overrides
+# --------------------------------------------------------------------------
+
+_CHILD_VERDICT_SOURCE = (
+    "from tests._socket_guard import is_installed, is_socket_address_permitted;"
+    " print(is_installed(), is_socket_address_permitted(('203.0.113.1', 443)))"
+)
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (["sh", "-c", "python -c pass"], True),
+        (["bash", "-lc", "/usr/bin/python3 -c pass"], True),
+        (["sh", "-ec", "python -c pass"], True),
+        (["bash", "--login", "-c", "python -c pass"], True),
+        (["sh", "-c", "echo hello"], False),
+        (["sh", "-lc", "printenv"], False),
+        # ``-c`` here is git's config flag, not a shell command string.
+        (["git", "-c", "user.name=x", "commit"], False),
+    ],
+)
+def test_shell_wrapped_python_classifier(command: list[str], expected: bool) -> None:
+    """``bash -lc`` bundles ``c`` with other options; a literal ``"-c" in parts``
+    check missed it and the child started unguarded."""
+
+    assert socket_guard._is_shell_wrapped_python(tuple(command)) is expected
+
+
+@pytest.mark.parametrize(
+    ("positional", "kwargs", "expected"),
+    [
+        ((), {"executable": "/usr/bin/python3"}, "/usr/bin/python3"),
+        ((-1, "/usr/bin/python3"), {}, "/usr/bin/python3"),
+        ((), {}, None),
+        ((), {"executable": None}, None),
+    ],
+)
+def test_popen_executable_override_is_resolved(
+    positional: tuple, kwargs: dict, expected: str | None
+) -> None:
+    """``executable=`` decides what actually runs, whatever argv[0] claims."""
+
+    assert socket_guard._resolve_popen_executable(positional, kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    ("label", "argv", "popen_kwargs"),
+    [
+        ("sh -c", ["sh", "-c", None], {}),
+        ("bash -lc", ["bash", "-lc", None], {}),
+        ("sh -ec", ["sh", "-ec", None], {}),
+        ("executable-override", ["ignored", "-c", _CHILD_VERDICT_SOURCE], "executable"),
+    ],
+)
+def test_every_child_launch_shape_comes_up_guarded(
+    label: str, argv: list, popen_kwargs: object
+) -> None:
+    """End to end, with a bare ``env={}``: the child must install the guard.
+
+    Asserts the guard's verdict, never a connection, so no traffic is produced.
+    """
+
+    if popen_kwargs == "executable":
+        command = argv
+        kwargs = {"executable": sys.executable}
+    else:
+        command = [*argv[:2], f"{sys.executable} -c {_CHILD_VERDICT_SOURCE!r}"]
+        kwargs = {}
+
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env={},
+        cwd=str(socket_guard.PROJECT_ROOT),
+        **kwargs,
+    )
+
+    assert result.returncode == 0, f"{label}: {result.stderr}"
+    assert result.stdout.strip() == "True False", f"{label}: {result.stdout!r}"
+
+
+# --------------------------------------------------------------------------
+# The policy channel itself
+# --------------------------------------------------------------------------
+
+
+def test_absent_policy_channel_means_no_exemption(monkeypatch) -> None:
+    """Default deny: a child that was granted nothing gets nothing."""
+
+    monkeypatch.delenv(socket_guard.ENV_POLICY_FD, raising=False)
+    assert socket_guard.read_policy_channel() is False
+
+
+@pytest.mark.parametrize("payload", [b"0", b"1"])
+def test_policy_channel_round_trips_the_parent_decision(
+    monkeypatch, payload: bytes
+) -> None:
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, payload)
+    os.close(write_fd)
+    monkeypatch.setenv(socket_guard.ENV_POLICY_FD, str(read_fd))
+
+    assert socket_guard.read_policy_channel() is (payload == b"1")
+    # Consumed exactly once: the descriptor is closed and the variable removed,
+    # so a later child cannot replay this grant.
+    assert socket_guard.ENV_POLICY_FD not in os.environ
+
+
+def test_a_dead_policy_descriptor_is_a_hard_failure(monkeypatch) -> None:
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    os.close(write_fd)
+    monkeypatch.setenv(socket_guard.ENV_POLICY_FD, str(read_fd))
+
+    with pytest.raises(socket_guard.SocketGuardInstallationError, match="could not be"):
+        socket_guard.read_policy_channel()
+
+
+def test_a_non_numeric_policy_descriptor_is_a_hard_failure(monkeypatch) -> None:
+    monkeypatch.setenv(socket_guard.ENV_POLICY_FD, "not-a-descriptor")
+
+    with pytest.raises(socket_guard.SocketGuardInstallationError, match="malformed"):
+        socket_guard.read_policy_channel()
+
+
+def test_a_malformed_policy_payload_is_a_hard_failure(monkeypatch) -> None:
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"yes please")
+    os.close(write_fd)
+    monkeypatch.setenv(socket_guard.ENV_POLICY_FD, str(read_fd))
+
+    with pytest.raises(socket_guard.SocketGuardInstallationError, match="payload"):
+        socket_guard.read_policy_channel()
+
+
+def test_integrity_denials_are_not_exemptible() -> None:
+    """Integrity is not policy: an armed ``live`` item cannot launch an
+    ungovernable interpreter either.
+
+    The exemption is scoped to one test item; a child that never installed the
+    guard outlives it.
+    """
+
+    previous = socket_guard.set_current_test_exempt(True)
+    try:
+        for flag in ("-S", "-I", "-E"):
+            with pytest.raises(
+                socket_guard.ExternalSubprocessBlocked, match="python-startup-bypass"
+            ):
+                socket_guard._assert_child_is_governable(
+                    [sys.executable, flag, "-c", "pass"]
+                )
+        with pytest.raises(
+            socket_guard.ExternalSubprocessBlocked, match="env-scrubbed-python"
+        ):
+            socket_guard._assert_child_is_governable(
+                ["env", "-i", sys.executable, "-c", "pass"]
+            )
+    finally:
+        socket_guard.set_current_test_exempt(previous)
+
+
+def test_network_client_denial_remains_a_policy_rule() -> None:
+    """Reaching ``curl`` directly is policy, so an armed live item may do it."""
+
+    with pytest.raises(socket_guard.ExternalSubprocessBlocked, match="network-client"):
+        socket_guard._assert_network_client_allowed(["curl", "https://203.0.113.1"])
+
+    # ...and the integrity half says nothing about it.
+    socket_guard._assert_child_is_governable(["curl", "https://203.0.113.1"])
+
+
+# --------------------------------------------------------------------------
+# DNS is blocked, not just connections
+# --------------------------------------------------------------------------
+
+
+def test_external_name_resolution_is_blocked() -> None:
+    """Resolution happens *before* connect, so it needs its own refusal.
+
+    Without this the guard would still refuse the connection, but the lookup
+    would already have left the machine.
+    """
+
+    with pytest.raises(socket_guard.ExternalSocketBlocked, match="DNS resolution"):
+        socket.getaddrinfo(EXTERNAL_HOSTNAME, 443)
+
+    with pytest.raises(socket_guard.ExternalSocketBlocked, match="DNS resolution"):
+        socket.gethostbyname(EXTERNAL_HOSTNAME)
+
+
+def test_external_numeric_resolution_is_blocked() -> None:
+    with pytest.raises(socket_guard.ExternalSocketBlocked, match="DNS resolution"):
+        socket.getaddrinfo(EXTERNAL_IPV4[0], 443)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_loopback_resolution_is_permitted(host: str) -> None:
+    """Local PostgreSQL/Redis resolve by name and must keep working."""
+
+    assert socket.getaddrinfo(host, 5432)
+
+
+@pytest.mark.parametrize("host", [None, "", b""])
+def test_passive_resolution_is_permitted(host: object) -> None:
+    """``host=None`` is a passive lookup for a local bind; it never leaves."""
+
+    assert socket.getaddrinfo(host, 0, type=socket.SOCK_STREAM)
+
+
+def test_blocked_resolution_is_counted_under_its_own_operation() -> None:
+    before = socket_guard.summary()["blocked_by_operation"].get("getaddrinfo", 0)
+    with pytest.raises(socket_guard.ExternalSocketBlocked):
+        socket.getaddrinfo("rob1296-dns-counter.invalid", 443)
+    after = socket_guard.summary()["blocked_by_operation"].get("getaddrinfo", 0)
+    assert after == before + 1
+
+
+def test_resolution_is_permitted_for_an_armed_live_item() -> None:
+    """The exemption reaches resolution too, or an armed live test cannot connect."""
+
+    previous = socket_guard.set_current_test_exempt(True)
+    try:
+        # Predicate only -- asserting the guard would allow it, without resolving.
+        socket_guard._assert_resolution_allowed(EXTERNAL_HOSTNAME)
+    finally:
+        socket_guard.set_current_test_exempt(previous)

--- a/tests/test_rob1296_provider_boundaries.py
+++ b/tests/test_rob1296_provider_boundaries.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib
 import pkgutil
 import sys
+import types
 import warnings
 
 import httpx
@@ -54,54 +55,162 @@ def _import_entire_app() -> list[str]:
     return failures
 
 
+def _all_seam_targets() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Async and sync seams share one alias contract -- both can go stale."""
+
+    return (
+        *provider_boundaries.SEAM_TARGETS,
+        *provider_boundaries.SYNC_SEAM_TARGETS,
+    )
+
+
+def _undeclared_holders() -> dict[str, list[str]]:
+    """Modules holding a seam's function that ``SEAM_TARGETS`` does not declare.
+
+    Two kinds of holder count, and missing either one is a false green:
+
+    * a module still bound to the **original** function — the plain stale-alias
+      case, where the seam simply never reached that consumer;
+    * a module bound to a **replacement** — a consumer first imported *while* the
+      seams were installed, which aliased the stand-in at import time.
+      ``monkeypatch`` restores the modules it patched, not that late consumer, so
+      the stale replacement survives teardown and an original-identity scan walks
+      straight past it.
+
+    Detection is therefore identity-or-marker, which makes it independent of the
+    order tests happened to run in.
+    """
+
+    undeclared: dict[str, list[str]] = {}
+    for attribute, module_paths in _all_seam_targets():
+        declared = set(module_paths)
+        originals = {
+            path: getattr(importlib.import_module(path), attribute, None)
+            for path in sorted(declared)
+        }
+        original = originals[sorted(declared)[0]]
+
+        holders = sorted(
+            name
+            for name, module in list(sys.modules.items())
+            if module is not None
+            and name.startswith("app.")
+            and (
+                getattr(module, attribute, None) is original
+                or provider_boundaries.seam_marker(getattr(module, attribute, None))
+                == attribute
+            )
+        )
+        extra = [name for name in holders if name not in declared]
+        if extra:
+            undeclared[attribute] = extra
+    return undeclared
+
+
+def test_declared_seam_modules_share_one_original_identity(
+    allow_external_providers,
+) -> None:
+    """Every declared alias of a seam must be the *same* object.
+
+    If two declared modules held different functions, patching them would only
+    look complete: one of them would be a different provider entirely.
+    """
+
+    _ = allow_external_providers
+    _import_entire_app()
+
+    mismatched: dict[str, dict[str, str]] = {}
+    for attribute, module_paths in _all_seam_targets():
+        values = {
+            path: getattr(importlib.import_module(path), attribute, None)
+            for path in module_paths
+        }
+        first = values[module_paths[0]]
+        if any(value is not first for value in values.values()):
+            mismatched[attribute] = {
+                path: f"{getattr(value, '__module__', '?')}.{getattr(value, '__qualname__', value)}"
+                for path, value in values.items()
+            }
+    assert mismatched == {}
+
+
 def test_seam_targets_cover_every_binding_module(allow_external_providers) -> None:
-    """No module may hold the real function while its siblings are seamed.
+    """No module may hold a seam's function while its siblings are seamed.
 
     A half-patched seam is worse than none: the leak just moves to whichever
     consumer was missed. If this fails, add the reported module to
     ``SEAM_TARGETS`` -- do not widen an allowlist or drop the seam.
 
-    This test **opts out of the provider fixture on purpose**. With the seams
-    installed, an undeclared consumer that still holds the original would not
-    match the replacement and would go unnoticed -- precisely the defect being
-    hunted. Comparing original identities makes the result independent of which
-    modules happened to be imported before the fixture ran.
+    This test **opts out of the provider fixture on purpose** so the declared
+    modules hold their originals. See ``_undeclared_holders`` for why detection
+    matches on identity *or* marker.
     """
 
     _ = allow_external_providers
     failures = _import_entire_app()
     assert failures == [], f"could not import app modules to check: {failures}"
 
-    for attribute, module_paths in provider_boundaries.SEAM_TARGETS:
+    for attribute, module_paths in _all_seam_targets():
         for module_path in module_paths:
             value = getattr(importlib.import_module(module_path), attribute, None)
             assert value is not None
-            assert getattr(value, "__module__", "").startswith("app."), (
+            assert provider_boundaries.seam_marker(value) is None, (
                 f"{module_path}.{attribute} is still a seam replacement; this "
                 "test must run with the provider fixture opted out"
             )
 
-    missing: dict[str, list[str]] = {}
-    for attribute, module_paths in provider_boundaries.SEAM_TARGETS:
-        declared = set(module_paths)
-        original = getattr(
-            importlib.import_module(next(iter(sorted(declared)))), attribute
-        )
-        holders = sorted(
-            name
-            for name, module in list(sys.modules.items())
-            if module is not None
-            and name.startswith("app.")
-            and getattr(module, attribute, None) is original
-        )
-        undeclared = [name for name in holders if name not in declared]
-        if undeclared:
-            missing[attribute] = undeclared
-
+    missing = _undeclared_holders()
     assert missing == {}, (
         "SEAM_TARGETS is missing consumer aliases; add them to "
         f"tests/_provider_boundaries.py: {missing}"
     )
+
+
+def test_detector_reports_a_late_consumer_holding_a_stale_replacement(
+    allow_external_providers,
+) -> None:
+    """Negative control for the marker half of the detector.
+
+    Synthesises the exact shape the identity-only scan missed: an ``app.*``
+    module that is not declared and holds a *replacement* rather than the
+    original, as a module first imported during a seamed test would.
+    """
+
+    _ = allow_external_providers
+    _import_entire_app()
+    assert _undeclared_holders() == {}
+
+    async def _stale_replacement(*_args, **_kwargs):  # pragma: no cover - never run
+        raise AssertionError("unreachable")
+
+    _stale_replacement.__dict__[provider_boundaries.SEAM_MARKER] = "fetch_orderbook"
+
+    module_name = "app._rob1296_synthetic_late_consumer"
+    synthetic = types.ModuleType(module_name)
+    synthetic.fetch_orderbook = _stale_replacement
+    sys.modules[module_name] = synthetic
+    try:
+        assert _undeclared_holders() == {"fetch_orderbook": [module_name]}
+    finally:
+        del sys.modules[module_name]
+
+    assert _undeclared_holders() == {}
+
+
+def test_install_stamps_the_seam_marker_on_every_declared_module() -> None:
+    """Ties ``install`` to the detector: real replacements must carry the marker.
+
+    Runs *without* the opt-out, so the seams are live. If ``install`` ever stopped
+    stamping, ``_undeclared_holders`` would lose its stale-replacement branch
+    silently.
+    """
+
+    for attribute, module_paths in _all_seam_targets():
+        for module_path in module_paths:
+            value = getattr(importlib.import_module(module_path), attribute, None)
+            assert provider_boundaries.seam_marker(value) == attribute, (
+                f"{module_path}.{attribute} is not a marked seam replacement"
+            )
 
 
 def test_declared_seam_modules_all_expose_their_attribute() -> None:

--- a/tests/test_rob1296_provider_boundaries.py
+++ b/tests/test_rob1296_provider_boundaries.py
@@ -1,0 +1,217 @@
+"""ROB-1296 — the provider seams cover every alias, and only what they should.
+
+``tests/_provider_boundaries.py`` hard-codes which modules bind each seam,
+because discovering them per test would mean scanning ``sys.modules`` ~20k times
+a run. The trade is that a hard-coded list can go stale: a new ``from x import
+y`` alias, or a lazily imported consumer, would silently keep calling the real
+provider. ``test_seam_targets_cover_every_binding_module`` is what makes the
+trade safe — it imports the whole ``app`` package and recomputes the bindings.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import sys
+import warnings
+
+import httpx
+import pytest
+
+from tests import _provider_boundaries as provider_boundaries
+
+# Modules that legitimately cannot import in a plain test environment, listed
+# individually with a reason. Anything else failing is reported, because a
+# consumer we could not import is a consumer we could not check.
+_KNOWN_OPTIONAL_IMPORTS = {
+    # Needs `rob941_funding_sidecar` from the research/ tree, which is not on the
+    # path for the app test suite.
+    "app.services.rob974_h6b_materializer",
+}
+_KNOWN_OPTIONAL_IMPORT_PREFIXES = ("app.flows",)  # Prefect is not a dependency
+
+
+def _import_entire_app() -> list[str]:
+    """Materialise every alias, including ones only a lazy import creates.
+
+    Returns the modules that failed to import so the caller can decide whether
+    the sweep was complete enough to trust.
+    """
+
+    warnings.filterwarnings("ignore")
+    import app
+
+    failures: list[str] = []
+    for module in pkgutil.walk_packages(app.__path__, prefix="app."):
+        try:
+            importlib.import_module(module.name)
+        except Exception as error:  # noqa: BLE001 - collected, not swallowed
+            if module.name in _KNOWN_OPTIONAL_IMPORTS or module.name.startswith(
+                _KNOWN_OPTIONAL_IMPORT_PREFIXES
+            ):
+                continue
+            failures.append(f"{module.name}: {type(error).__name__}: {error}")
+    return failures
+
+
+def test_seam_targets_cover_every_binding_module(allow_external_providers) -> None:
+    """No module may hold the real function while its siblings are seamed.
+
+    A half-patched seam is worse than none: the leak just moves to whichever
+    consumer was missed. If this fails, add the reported module to
+    ``SEAM_TARGETS`` -- do not widen an allowlist or drop the seam.
+
+    This test **opts out of the provider fixture on purpose**. With the seams
+    installed, an undeclared consumer that still holds the original would not
+    match the replacement and would go unnoticed -- precisely the defect being
+    hunted. Comparing original identities makes the result independent of which
+    modules happened to be imported before the fixture ran.
+    """
+
+    _ = allow_external_providers
+    failures = _import_entire_app()
+    assert failures == [], f"could not import app modules to check: {failures}"
+
+    for attribute, module_paths in provider_boundaries.SEAM_TARGETS:
+        for module_path in module_paths:
+            value = getattr(importlib.import_module(module_path), attribute, None)
+            assert value is not None
+            assert getattr(value, "__module__", "").startswith("app."), (
+                f"{module_path}.{attribute} is still a seam replacement; this "
+                "test must run with the provider fixture opted out"
+            )
+
+    missing: dict[str, list[str]] = {}
+    for attribute, module_paths in provider_boundaries.SEAM_TARGETS:
+        declared = set(module_paths)
+        original = getattr(
+            importlib.import_module(next(iter(sorted(declared)))), attribute
+        )
+        holders = sorted(
+            name
+            for name, module in list(sys.modules.items())
+            if module is not None
+            and name.startswith("app.")
+            and getattr(module, attribute, None) is original
+        )
+        undeclared = [name for name in holders if name not in declared]
+        if undeclared:
+            missing[attribute] = undeclared
+
+    assert missing == {}, (
+        "SEAM_TARGETS is missing consumer aliases; add them to "
+        f"tests/_provider_boundaries.py: {missing}"
+    )
+
+
+def test_declared_seam_modules_all_expose_their_attribute() -> None:
+    """Catch a renamed or relocated seam instead of silently patching nothing."""
+
+    stale = [
+        f"{module_path}.{attribute}"
+        for attribute, module_paths in provider_boundaries.SEAM_TARGETS
+        for module_path in module_paths
+        if not hasattr(importlib.import_module(module_path), attribute)
+    ]
+    assert stale == []
+
+
+@pytest.mark.asyncio
+async def test_defining_module_and_consumer_alias_share_the_replacement() -> None:
+    """Both routes to a seamed function must be blocked, not just the definition.
+
+    ``fetch_orderbook`` is the concrete case that motivated the alias list:
+    ``market_data.service`` imported it at module load, so patching only
+    ``upbit_orderbook`` left the live one reachable.
+    """
+
+    from app.services import upbit_orderbook
+    from app.services.market_data import service as market_data_service
+
+    assert market_data_service.fetch_orderbook is upbit_orderbook.fetch_orderbook
+
+    for candidate in (
+        upbit_orderbook.fetch_orderbook,
+        market_data_service.fetch_orderbook,
+    ):
+        with pytest.raises(httpx.ConnectError, match="External provider calls"):
+            await candidate("KRW-BTC")
+
+
+@pytest.mark.asyncio
+async def test_seams_raise_the_error_callers_already_handle() -> None:
+    """The seam must not change which ``except`` clause a caller lands in."""
+
+    from app.services import exchange_rate_service
+
+    with pytest.raises(httpx.ConnectError) as excinfo:
+        await exchange_rate_service._fetch_open_er_api_usd_krw_quote()
+
+    assert isinstance(excinfo.value, httpx.TransportError)
+    assert isinstance(excinfo.value, httpx.HTTPError)
+
+
+@pytest.mark.asyncio
+async def test_frozen_provider_default_is_seamed_on_both_routes() -> None:
+    """The shared instance *and* freshly built ones must carry the seam.
+
+    ``StockDetailProviders`` is frozen and slotted and its default instance is a
+    default argument, so a caller can reach the real provider either through the
+    module-level singleton or by constructing its own.
+    """
+
+    from app.services.invest_view_model import stock_detail_service
+
+    fresh = stock_detail_service.StockDetailProviders()
+    for providers in (
+        stock_detail_service.DEFAULT_STOCK_DETAIL_PROVIDERS,
+        fresh,
+    ):
+        with pytest.raises(httpx.ConnectError, match="External provider calls"):
+            await providers.recent_trades("KRW-BTC", "crypto")
+
+
+@pytest.mark.asyncio
+async def test_finnhub_client_stub_fails_like_an_unreachable_host() -> None:
+    import requests
+
+    from app.services import finnhub_news
+
+    client = finnhub_news._get_finnhub_client()
+    with pytest.raises(requests.ConnectionError, match="External provider calls"):
+        client.company_news("AAPL", _from="2026-01-01", to="2026-01-02")
+
+
+@pytest.mark.asyncio
+async def test_kis_client_factory_yields_an_offline_transport() -> None:
+    from app.services.brokers.kis.base import BaseKISClient
+
+    client = BaseKISClient._build_http_client(object(), 1.0)
+    try:
+        with pytest.raises(httpx.ConnectError, match="External provider calls"):
+            await client.get("https://openapi.koreainvestment.com/probe")
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_opt_out_restores_the_real_seam(
+    allow_external_providers,
+) -> None:
+    """With the opt-out the real function is reachable again.
+
+    Reaching it is still safe: the transport backstop and the socket guard both
+    remain in force, so this asserts identity rather than performing a request.
+    """
+
+    _ = allow_external_providers
+    from app.services import upbit_orderbook
+
+    assert upbit_orderbook.fetch_orderbook.__module__ == "app.services.upbit_orderbook"
+
+
+def test_opt_out_still_cannot_reach_the_network(allow_external_providers) -> None:
+    _ = allow_external_providers
+    from tests import _socket_guard as socket_guard
+
+    assert socket_guard.is_socket_address_permitted(("203.0.113.1", 443)) is False

--- a/tests/test_rob1880_socket_guard.py
+++ b/tests/test_rob1880_socket_guard.py
@@ -178,12 +178,19 @@ def test_import_phase_and_conftest_unloaded_mutant_are_fail_closed(tmp_path) -> 
 
 
 @pytest.mark.integration
-def test_integration_marker_enables_the_explicit_test_boundary() -> None:
-    assert socket_guard.is_current_test_exempt()
+def test_integration_marker_no_longer_opens_the_network_boundary() -> None:
+    """ROB-1296 replaced the marker exemption with a live-plus-``--run-live`` one.
+
+    Integration items keep loopback PostgreSQL/Redis through the address
+    allowlist, which never depended on a marker. See
+    ``tests/test_rob1296_live_only_socket_guard.py`` for the full truth table.
+    """
+
+    assert not socket_guard.is_current_test_exempt()
 
 
 @pytest.mark.integration
-def test_integration_marker_is_preserved_for_a_direct_python_child() -> None:
+def test_integration_marker_leaves_a_direct_python_child_guarded() -> None:
     result = subprocess.run(
         [
             sys.executable,
@@ -196,4 +203,4 @@ def test_integration_marker_is_preserved_for_a_direct_python_child() -> None:
         check=True,
     )
 
-    assert result.stdout.strip() == "False"
+    assert result.stdout.strip() == "True"

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -6,6 +6,13 @@ import httpx
 import pandas as pd
 import pytest
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 class TestKISOverseasDailyPrice:
     @pytest.mark.asyncio

--- a/tests/test_services_yahoo.py
+++ b/tests/test_services_yahoo.py
@@ -3,6 +3,13 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# Yahoo client functions against stubbed yfinance objects, which is exactly what
+# the autouse provider seams replace. Opt out so the code under test is the real
+# thing. The curl_cffi transport backstop and the socket guard both stay in
+# force, so opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 class TestYahooService:
     @pytest.mark.asyncio

--- a/tests/test_upbit_orderbook_service.py
+++ b/tests/test_upbit_orderbook_service.py
@@ -7,6 +7,13 @@ import pytest
 
 from app.services import upbit_orderbook
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 class DummyResponse:
     def __init__(self, status_code: int, payload):

--- a/tests/test_upbit_retry.py
+++ b/tests/test_upbit_retry.py
@@ -7,6 +7,13 @@ import pytest
 
 from app.core.async_rate_limiter import RateLimitExceededError
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 def _make_response(status_code: int, *, json_data=None, retry_after=None):
     """Helper: build a minimal mock httpx.Response."""

--- a/tests/test_upbit_service.py
+++ b/tests/test_upbit_service.py
@@ -7,6 +7,13 @@ import pytest
 import app.services.brokers.upbit.client as upbit
 from app.services import upbit_symbol_universe_service
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# client functions against a mocked HTTP layer, which is exactly what the
+# autouse provider seams replace. Opt out so the code under test is the real
+# thing. The transport backstop and the socket guard both stay in force, so
+# opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 @pytest.fixture(autouse=True)
 def reset_upbit_ticker_cache_state():

--- a/tests/test_yahoo_roe_rob440.py
+++ b/tests/test_yahoo_roe_rob440.py
@@ -15,6 +15,13 @@ import pytest
 
 from app.services.brokers.yahoo.client import _roe_to_percent
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# Yahoo client functions against stubbed yfinance objects, which is exactly what
+# the autouse provider seams replace. Opt out so the code under test is the real
+# thing. The curl_cffi transport backstop and the socket guard both stay in
+# force, so opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/test_yahoo_service_cache.py
+++ b/tests/test_yahoo_service_cache.py
@@ -7,6 +7,13 @@ import pytest
 import app.services.brokers.yahoo.client as yahoo
 from app.services import yahoo_ohlcv_cache as yahoo_cache
 
+# ROB-1296: this module is a provider *boundary* suite -- it drives the real
+# Yahoo client functions against stubbed yfinance objects, which is exactly what
+# the autouse provider seams replace. Opt out so the code under test is the real
+# thing. The curl_cffi transport backstop and the socket guard both stay in
+# force, so opting out here still cannot reach a network.
+pytestmark = pytest.mark.usefixtures("allow_external_providers")
+
 
 @pytest.mark.asyncio
 async def test_fetch_ohlcv_uses_cache_for_day(monkeypatch):


### PR DESCRIPTION
Closes ROB-1296.

## What this is

Defensive test-infra work: make the test suite stop sending real outbound
traffic to third-party provider hosts. No production code changes — the diff is
`tests/` and `docs/` only.

## The pivot

The ROB-1880 socket guard exempted every `integration` item, which covered
~3,200 tests in the default `-m "not live"` gate and let any of them reach a
real external host from CI. Integration tests need loopback PostgreSQL/Redis,
which the address allowlist already permits with **no marker at all**, so the
exemption was never the mechanism keeping DB tests working.

External access now requires **both** the `live` marker **and** an explicit
`--run-live`. `integration` grants nothing; `--run-live` without the marker
grants nothing; a `live` item without the option stays skipped and blocked.

Measured on identical code over the files that leak: **215 blocked attempts
under the old policy vs 257 under the new one.** That 42-attempt delta is real
traffic that used to reach `openapi.koreainvestment.com`, `api.upbit.com`,
`open.er-api.com` and Finnhub from a `not live` run.

## Three layers

| Layer | Role |
| --- | --- |
| Provider seams (`tests/_provider_boundaries.py`) | The actual fix — each provider stopped at the narrowest function owning its request |
| External HTTP backstop (`tests/_external_http_boundary.py`) | Fail-closed net: httpx real transports, the `requests` adapter, and `curl_cffi` |
| Socket guard (`tests/_socket_guard.py`) | Last resort — refuses the syscall *and* the DNS lookup |

Opting out of one layer never opts out of the ones beneath it. `allow_external_providers`
releases only the seams; `allow_external_http` only the backstop; only `live` +
`--run-live` releases everything. Boundary suites that drive a real client
against a mocked transport use the narrowest opt-out and still cannot reach a
network.

Everything raises the exception an unreachable host already produces
(`httpx.ConnectError` / `requests.ConnectionError`), so every `except
httpx.HTTPError`, retry and fail-open branch behaves exactly as before. **No
payload is ever invented.**

## Child processes

The exemption never travels in the environment — a boolean any test could export
would be exactly the general bypass this guard exists to prevent. `subprocess`
children get a one-shot pipe (read fd passed via `pass_fds`); `multiprocessing`
`spawn` takes it from preparation data with its bootstrap rewritten to install
the guard independently of inherited env; `fork` inherits in memory. Absent
channel = no exemption; broken channel = hard failure.

Integrity (`-E`/`-I`/`-S`, `env -i`, unsetting/overriding `PYTHONPATH` or the
guard switch) is refused **whatever the parent's policy** — the exemption is
scoped to one item and an ungovernable child outlives it. Only the
network-client deny list is exemptible. `forkserver` is unsupported and refused
at the boundary.

## Independent audit

An independent Claude verifier re-audited the frozen diff (T2, grade S) and
found one BLOCKER, which is fixed here:

> **`curl_cffi` (libcurl) bypassed all three layers.** It is not an httpx
> transport, not a `requests` adapter, and libcurl calls `connect(2)` from C
> below the patched Python `socket` methods. `yfinance` uses it — so **29
> non-live tests were making 107 real requests to `query1.finance.yahoo.com`
> while every counter read zero.**

It is now intercepted at `curl_cffi.requests.Session.request`, and the Yahoo
client's entry points are seamed at layer 1.

Of five mutants the verifier planted, four died immediately; the surviving one
(M5 — DNS fail-closed had no behavioural test) is also closed here with 10 DNS
regression tests.

## Scope: what is deliberately follow-up

The boundary drawn is **"a non-live test can, today, actually emit an outbound
packet to a provider host"** — judged by the full-run counters, not by
theoretical reach. That is closable and mechanically checkable; "every possible
launcher syntax" is not.

**In this PR (a):** the `integration` exemption; every provider seam;
the transport backstop incl. `curl_cffi`; DNS; every child-launch shape that
could run unguarded (direct / `sh -c` / `bash -lc` / `uv run python` /
`executable=` / `shell=True` / fork / spawn / `env -i` / selective unset);
forgeable-env exemption; `forkserver`.

**Follow-up issue (b)** — no reproduced path, unbounded surface:
launchers outside `_PYTHON_LAUNCHER_WRAPPERS` (`conda run`, `pipx run`,
`nix-shell`, …); low-level `os.posix_spawn`/`execve`/`spawnv` with a
hand-built env; additional resolver entry points (`gethostbyname_ex`,
`getnameinfo`, `gethostbyaddr`, event-loop resolvers); exotic shell quoting
beyond `shlex` decomposition; native binaries with their own network stack;
`uv build` reaching PyPI on a cold cache.

## Evidence

```
Full non-live suite: 20980 passed, 13 skipped, 0 failed   EXIT=0
ROB-1296 external HTTP boundary: 5 blocked across 3 hosts
   -- rob1296-boundary.invalid=3 rob1296-counter.invalid=1 rob1296-curl.invalid=1
ROB-1880 socket guard: active=True blocked_attempts=31 workers=4

Real provider hosts in the HTTP counter : 0
Unexpected socket attempts              : 0  (all 13 attributable to the guard's own negative controls)
Ruff check + format                     : All checks passed / 3937 files already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented stricter external socket access rules and linked the related runbook.
  * Clarified that integration tests allow only local PostgreSQL and Redis connections.

* **Tests**
  * Added comprehensive coverage for HTTP, provider, DNS, subprocess, and multiprocessing network safeguards.
  * Ensured external requests are blocked by default while loopback, mocked, and explicitly permitted live-test scenarios continue to work.
  * Prevented test suites from making unintended calls to external financial and market-data services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->