### PR TITLE
feat(ROB-1298): breakeven extension ladder for zero-named-resistance holdings (§115차)

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -69,6 +69,11 @@ class PolicyDecisionRuleTier(BaseModel):
     sizing: str
 
 
+BREAKEVEN_EXTENSION_LADDER_TIER_ID = "breakeven_extension_ladder"
+NO_RESISTANCE_REFERENCE_EXCLUSION = "no_resistance_reference"
+_RESISTANCE_CONDITION_MARKER = "resistance_near_pct"
+
+
 class PolicyDecisionRule(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -77,6 +82,146 @@ class PolicyDecisionRule(BaseModel):
     tiers: list[PolicyDecisionRuleTier]
     tie_breaks: dict[str, str] = Field(default_factory=dict)
     exclusions: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_breakeven_extension_ladder_stays_a_fallback(
+        self,
+    ) -> PolicyDecisionRule:
+        """ROB-1298 §115차 — machine-enforce the fallback contract.
+
+        The §115차 tier closes the zero-fresh-named-resistance profit-take gap.
+        It must stay a *fallback* for that excluded case, never a replacement
+        for the named-resistance tiers and never a route that reopens them by
+        deleting the ``no_resistance_reference`` exclusion. Every invariant the
+        operator forbade drifting is asserted here so the drift fails the build
+        instead of silently shipping.
+        """
+
+        tier_ids = [tier.id for tier in self.tiers]
+        if BREAKEVEN_EXTENSION_LADDER_TIER_ID not in tier_ids:
+            return self
+
+        # NO_EXCLUSION_REMOVAL — the dedicated tier is the only sanctioned fix;
+        # dropping the exclusion is explicitly not.
+        if NO_RESISTANCE_REFERENCE_EXCLUSION not in self.exclusions:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} requires the "
+                f"{NO_RESISTANCE_REFERENCE_EXCLUSION!r} exclusion to be retained"
+            )
+
+        # FALLBACK_ORDER — declared last, so first-match-wins can only reach it
+        # after every named-resistance tier has failed.
+        if tier_ids[-1] != BREAKEVEN_EXTENSION_LADDER_TIER_ID:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must be the last declared "
+                "tier so named-resistance tiers keep priority"
+            )
+        if tier_ids.count(BREAKEVEN_EXTENSION_LADDER_TIER_ID) != 1:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must be declared exactly once"
+            )
+
+        priority = self.tie_breaks.get("tier_priority")
+        if priority is None:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} requires tie_breaks."
+                "tier_priority to state the fallback order"
+            )
+        if [part.strip() for part in priority.split(">")] != tier_ids:
+            raise ValueError(
+                "tie_breaks.tier_priority must match the declared tier order "
+                f"{tier_ids}"
+            )
+
+        tier = self.tiers[-1]
+        conditions = tier.conditions
+
+        # Eligibility — reachable only when the holding has zero fresh named
+        # resistance, i.e. exactly the excluded case.
+        if conditions.get("fresh_named_resistance_count_eq") != 0:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must require "
+                "fresh_named_resistance_count_eq: 0"
+            )
+        if (
+            conditions.get("matched_exclusion_case")
+            != NO_RESISTANCE_REFERENCE_EXCLUSION
+        ):
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must declare "
+                f"matched_exclusion_case: {NO_RESISTANCE_REFERENCE_EXCLUSION}"
+            )
+        if conditions.get("resistance_tier_fallback_only") is not True:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must declare "
+                "resistance_tier_fallback_only: true"
+            )
+        # A resistance-proximity condition here would let the fallback tier
+        # speak about holdings that still have a resistance frame.
+        resistance_keys = [
+            key for key in conditions if _RESISTANCE_CONDITION_MARKER in key
+        ]
+        if resistance_keys:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must not carry "
+                f"resistance-proximity conditions: {resistance_keys}"
+            )
+
+        # SIZING_REUSE — no new quantity rule is invented by this tier.
+        if tier.sizing != "existing_trim_rule":
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must reuse the existing "
+                "trim sizing rule (sizing: existing_trim_rule)"
+            )
+
+        # Anchors — 3 strictly ascending profit-side multiples of average cost,
+        # the lowest of which quotes the existing loss-guard multiple key.
+        if (
+            conditions.get("anchor_lowest_rung_policy_key")
+            != "sell.loss_guard_min_multiple"
+        ):
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} lowest rung must quote "
+                "sell.loss_guard_min_multiple"
+            )
+        multiples = conditions.get("anchor_average_cost_multiples")
+        if not isinstance(multiples, list) or not multiples:
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} requires a non-empty "
+                "anchor_average_cost_multiples list"
+            )
+        if any(
+            not isinstance(value, int | float) or isinstance(value, bool)
+            for value in multiples
+        ):
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} anchor multiples must be numeric"
+            )
+        if conditions.get("rungs_max") != len(multiples):
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} rungs_max must equal the "
+                "number of declared anchor multiples"
+            )
+        if any(value <= 1 for value in multiples):
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} anchor multiples must all "
+                "sit above average cost"
+            )
+        if any(a >= b for a, b in zip(multiples, multiples[1:], strict=False)):
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} anchor multiples must be "
+                "strictly ascending"
+            )
+
+        # A sell-side rung rounds up onto the tick grid; rounding down could
+        # place a rung below the loss-guard anchor it quotes.
+        if conditions.get("tick_snap_direction") != "ceil":
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must snap rungs up "
+                "(tick_snap_direction: ceil)"
+            )
+
+        return self
 
 
 class SupportReserveNetAutoSubmitNotional(BaseModel):

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -5,9 +5,13 @@
 # §104차 (2026-08-19): crash-day 신규진입은 표준 매수 게이트를 통과한
 # strong 지지 후보에 한해 조건부로만 전면 hold를 해제한다. 즉석 판단이나
 # 게이트 면제·완화·대체가 아니며, preplanned ladder도 advisory로만 남긴다.
-version: "2026-08-19.2"
+# §115차 (2026-08-20): fresh 명명 저항이 0개인 보유(ETH·LINK 랠리 실사고)는
+# 저항 기반 매도 티어에 하나도 매칭되지 않아 익절 경로가 소멸한다. 그 공백만
+# 닫는 폴백 티어 sell.trim_preplace.breakeven_extension_ladder 를 신설한다.
+# 저항 티어의 대체가 아니며, exclusions.no_resistance_reference 는 유지된다.
+version: "2026-08-20.1"
 captured_as_of: "2026-08-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits)"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change)"
 
 authority:
   scope: judgment_policy_only
@@ -394,6 +398,10 @@ decision_rules:
       limits size, not eligibility. sell.breakeven_reserve_trim is an advisory
       pre-guard reserve-trim contract: calculate its guard-and-D7 anchor before
       consumption, and use WATCH only when that anchor cannot be calculated.
+      breakeven_extension_ladder is the last-resort fallback for a holding with
+      zero fresh named resistance: it is reached only after every named-
+      resistance tier has failed to match, never instead of one, and it does not
+      remove or weaken the no_resistance_reference exclusion.
     tiers:
       - id: de_minimis_trim_watch
         conditions:
@@ -469,8 +477,49 @@ decision_rules:
           resistance_near_pct_max_policy_key: sell.resistance_near_pct
         action: register_watch
         sizing: no_preplaced_trim
+      # §115차 (ROB-1298, 2026-08-20). 무저항 보유분 익절 그물.
+      # 문제: ETH·LINK 가 120일 명명 구조 전체를 상회해 fresh 명명 저항이
+      # 0개가 되면 위 저항 기반 티어(single_share_full_exit_review,
+      # momentum_spike_profit_ladder, rsi_confirmed_resistance,
+      # ultra_near_resistance, watch_zone)가 전부 미매칭이고
+      # exclusions.no_resistance_reference 로 떨어진다. 손익분기 돌파 워치가
+      # 발화해도 그물을 깔 앵커가 없다 — 강한 랠리 보유일수록 익절 경로가
+      # 소멸하는 역설.
+      # 해법의 형태: exclusions 에서 no_resistance_reference 를 제거해 저항
+      # 티어를 무저항 보유에 흘려보내는 방식은 금지된다(저항 조건이 없는
+      # 보유에 저항 임계를 적용하게 되어 의미가 없다). 대신 그 제외 케이스
+      # 전용 폴백 티어를 마지막에 하나 둔다. 이 티어는 저항 티어의 폴백이지
+      # 대체가 아니다 — fresh 명명 저항이 하나라도 복원되면
+      # fresh_named_resistance_count_eq: 0 이 깨져 이 티어는 진입 불가이고
+      # 위 저항 티어가 먼저 매칭된다(tie_breaks.tier_priority 참조).
+      # Parameter status: 하위 rung 은 기존 sell.loss_guard_min_multiple 을
+      # 그대로 인용한 동일 산식이고(평단×1.01), 신규 수량 규칙은 없다
+      # (sizing: existing_trim_rule). 손실가드·D7 순실현 하한·자동승인 게이트
+      # 키는 하나도 바뀌지 않는다. Advisory judgment metadata only.
+      - id: breakeven_extension_ladder
+        conditions:
+          markets: [kr, us, crypto]
+          fresh_named_resistance_count_eq: 0
+          matched_exclusion_case: no_resistance_reference
+          resistance_tier_fallback_only: true
+          lot_pnl_basis: current_price_vs_average_cost
+          anchor_basis: average_cost
+          anchor_lowest_rung_policy_key: sell.loss_guard_min_multiple
+          anchor_average_cost_multiples: [1.01, 1.05, 1.10]
+          rungs_max: 3
+          tick_snap_direction: ceil
+          tick_grid: market_native_sell_side_tick_grid
+          resting_limit_order: true
+          time_in_force: DAY
+          regeneration: daily_rep
+          day_expiry_policy_key: order.day_expiry_kst
+          submission_contract: section_40_auto_approve_with_veto
+          watch_fallback: anchor_or_tick_grid_uncomputable_only
+          advisory: true
+        action: preplace_resting_breakeven_extension_ladder
+        sizing: existing_trim_rule
     tie_breaks:
-      tier_priority: "de_minimis_trim_watch > sell.breakeven_reserve_trim > single_share_full_exit_review > momentum_spike_profit_ladder > rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
+      tier_priority: "de_minimis_trim_watch > sell.breakeven_reserve_trim > single_share_full_exit_review > momentum_spike_profit_ladder > rsi_confirmed_resistance > ultra_near_resistance > watch_zone > breakeven_extension_ladder"
       multiple_tiers_matched: first_matching_tier_wins
       sell.upside_place_max_pct: size_limit_only
       momentum_spike_rsi_exception: matched_tier_only
@@ -478,6 +527,9 @@ decision_rules:
       momentum_spike_integer_rounding: floor_without_exceeding_one_third_or_watch
       single_share_disposition: full_static_target_or_full_trailing_verdict_never_partial
       minimum_benefit_boundary: at_or_above_threshold_may_trim_below_threshold_watch
+      breakeven_extension_fallback_order: named_resistance_tiers_first_extension_ladder_only_when_zero_fresh_named_resistance
+      breakeven_extension_exclusion_retained: no_resistance_reference_stays_in_exclusions_dedicated_tier_not_exclusion_removal
+      breakeven_extension_minimum_benefit: de_minimis_trim_watch_still_preempts
     exclusions:
       - no_resistance_reference
       - composite_gates

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -103,6 +103,23 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     )
     assert tiers["ultra_near_resistance"]["conditions"]["resistance_near_pct_max"] == 2
     assert tiers["watch_zone"]["action"] == "register_watch"
+    # ROB-1298 §115차 — the zero-named-resistance fallback ships through the
+    # same read tool, last in priority, reusing the existing trim sizing.
+    ladder = tiers["breakeven_extension_ladder"]
+    assert list(tiers)[-1] == "breakeven_extension_ladder"
+    assert ladder["sizing"] == "existing_trim_rule"
+    assert ladder["conditions"]["fresh_named_resistance_count_eq"] == 0
+    assert ladder["conditions"]["markets"] == ["kr", "us", "crypto"]
+    assert ladder["conditions"]["anchor_average_cost_multiples"] == [1.01, 1.05, 1.10]
+    assert ladder["conditions"]["tick_snap_direction"] == "ceil"
+    assert (
+        ladder["conditions"]["anchor_lowest_rung_policy_key"]
+        == "sell.loss_guard_min_multiple"
+    )
+    assert "no_resistance_reference" in rule["exclusions"]
+    assert rule["tie_breaks"]["tier_priority"].endswith(
+        "watch_zone > breakeven_extension_ladder"
+    )
     reserve_trim = tiers["sell.breakeven_reserve_trim"]
     assert reserve_trim["conditions"]["anchor_operator"] == "max"
     assert reserve_trim["conditions"]["anchor_operands"] == [
@@ -198,7 +215,7 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
     }
     # advisory keys are echoed with the same version/content_hash stamp as
     # every other section of the response (ROB-932).
-    assert out["version"] == "2026-08-19.2"
+    assert out["version"] == "2026-08-20.1"
     assert out["content_hash"]
 
 

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -8,6 +8,7 @@ import yaml
 from pydantic import ValidationError
 
 import app.schemas.trading_policy as policy_schema
+from app.mcp_server.tick_size import get_tick_size_kr
 from app.schemas.trading_policy import (
     CrashDayNewEntryHoldException,
     PreplannedSupportLadderPolicy,
@@ -28,6 +29,12 @@ _PLAYBOOK = (
     / "docs"
     / "playbooks"
     / "trading-decision-playbook.md"
+)
+
+_ROB1298_ADDITIVE_TIE_BREAK_KEYS = (
+    "breakeven_extension_fallback_order",
+    "breakeven_extension_exclusion_retained",
+    "breakeven_extension_minimum_benefit",
 )
 
 _ROB1292_ALLOWED_POLICY_DELTAS = (
@@ -142,7 +149,7 @@ def _breakeven_reserve_trim_triggered(
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
-    assert doc.version == "2026-08-19.2"
+    assert doc.version == "2026-08-20.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -187,6 +194,7 @@ def test_shipped_config_validates():
         "rsi_confirmed_resistance",
         "ultra_near_resistance",
         "watch_zone",
+        "breakeven_extension_ladder",
     ]
     assert trim_rule.tiers[0].action == "register_watch_instead_of_trim"
     assert trim_rule.tiers[1].sizing == "existing_trim_rule"
@@ -476,6 +484,7 @@ def test_breakeven_reserve_trim_policy_contract_is_machine_readable():
         "rsi_confirmed_resistance",
         "ultra_near_resistance",
         "watch_zone",
+        "breakeven_extension_ladder",
     ]
     assert tier.conditions == {
         "markets": ["kr", "us", "crypto"],
@@ -514,7 +523,8 @@ def test_breakeven_reserve_trim_policy_contract_is_machine_readable():
     assert rule.tie_breaks["tier_priority"] == (
         "de_minimis_trim_watch > sell.breakeven_reserve_trim > "
         "single_share_full_exit_review > momentum_spike_profit_ladder > "
-        "rsi_confirmed_resistance > ultra_near_resistance > watch_zone"
+        "rsi_confirmed_resistance > ultra_near_resistance > watch_zone > "
+        "breakeven_extension_ladder"
     )
     assert _threshold_decimal(doc, "sell.loss_guard_min_multiple") == Decimal("1.01")
     assert _threshold_decimal(doc, "sell.breakeven_near_pct") == Decimal("2")
@@ -956,10 +966,28 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
     baseline["crash_day"]["actions"]["new_entry_hold_exception"] = current_raw[
         "crash_day"
     ]["actions"]["new_entry_hold_exception"]
+    # ROB-1298 KEY_DIFF — the §115차 tier is appended to the current document
+    # only. The schema now requires tie_breaks.tier_priority to match the
+    # declared tier order, so the baseline copy is given the same appended tier
+    # and priority string before parsing; both are then stripped so the
+    # remaining comparison is a closed equivalence over every other key.
+    baseline_trim = baseline["decision_rules"]["sell.trim_preplace"]
+    current_trim = current_raw["decision_rules"]["sell.trim_preplace"]
+    baseline_trim["semantics"] = current_trim["semantics"]
+    baseline_trim["tiers"] = baseline_trim["tiers"] + [current_trim["tiers"][-1]]
+    baseline_trim["tie_breaks"]["tier_priority"] = current_trim["tie_breaks"][
+        "tier_priority"
+    ]
     baseline_dump = TradingPolicyDocument.model_validate(baseline).model_dump()
     current_dump = TradingPolicyDocument.model_validate(current_raw).model_dump()
 
     current_dump["version"] = baseline_dump["version"]
+    # `source` is provenance prose (the machine-readable analogue of a comment).
+    # It may only be *extended*, never rewritten, so the baseline text has to
+    # remain a prefix of it before it is normalized away.
+    assert current_dump["source"].startswith(baseline_dump["source"])
+    assert "ROB-1298" in current_dump["source"]
+    current_dump["source"] = baseline_dump["source"]
     del current_dump["decision_rules"]["buy.preplanned_support_ladder"]
     del current_dump["crash_day"]["actions"]["new_entry_hold_exception"]
     del baseline_dump["decision_rules"]["buy.preplanned_support_ladder"]
@@ -971,9 +999,34 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
         assert _policy_path_get(current_dump, path) == current_value
         _policy_path_set(normalized_current_dump, path, baseline_value)
 
-    # Only the four explicitly enumerated §106차 cap deltas are accepted;
-    # every other pre-existing key/value, including both crypto caps, must
-    # still match the ROB-1289 baseline exactly.
+    # ROB-1298 — the appended tier, the three additive tie_break notes, the
+    # tier_priority string, and the rule semantics prose are the only
+    # sell.trim_preplace deltas; strip exactly those and nothing else.
+    for dump in (normalized_current_dump, baseline_dump):
+        trim = dump["decision_rules"]["sell.trim_preplace"]
+        assert trim["tiers"][-1]["id"] == "breakeven_extension_ladder"
+        del trim["tiers"][-1]
+        assert (
+            trim["tie_breaks"]
+            .pop("tier_priority")
+            .endswith("> watch_zone > breakeven_extension_ladder")
+        )
+        del trim["semantics"]
+    for key in _ROB1298_ADDITIVE_TIE_BREAK_KEYS:
+        assert (
+            key
+            in normalized_current_dump["decision_rules"]["sell.trim_preplace"][
+                "tie_breaks"
+            ]
+        )
+        del normalized_current_dump["decision_rules"]["sell.trim_preplace"][
+            "tie_breaks"
+        ][key]
+
+    # Only the four explicitly enumerated §106차 cap deltas and the enumerated
+    # §115차 additions are accepted; every other pre-existing key/value,
+    # including both crypto caps and the retained exclusions list, must still
+    # match the ROB-1289 baseline exactly.
     assert normalized_current_dump == baseline_dump
 
 
@@ -1071,3 +1124,413 @@ def test_us_notional_usd_range_one_share_exception_missing_required_field_reject
     ]
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)
+
+
+# ---------------------------------------------------------------------------
+# ROB-1298 §115차 — breakeven extension ladder (zero named resistance fallback)
+# ---------------------------------------------------------------------------
+
+_LADDER_TIER_ID = "breakeven_extension_ladder"
+
+# Exact transcription of the Upbit KRW price-unit table documented on
+# ``app.services.brokers.upbit.orders.adjust_price_to_upbit_unit``. Pinned to
+# that production helper by
+# ``test_crypto_krw_tick_transcription_matches_the_production_upbit_grid``.
+_UPBIT_KRW_TICK_BANDS: tuple[tuple[Decimal, Decimal], ...] = (
+    (Decimal("2000000"), Decimal("1000")),
+    (Decimal("1000000"), Decimal("500")),
+    (Decimal("500000"), Decimal("100")),
+    (Decimal("100000"), Decimal("50")),
+    (Decimal("10000"), Decimal("10")),
+    (Decimal("1000"), Decimal("5")),
+    (Decimal("100"), Decimal("1")),
+)
+
+
+def _crypto_krw_tick(price: Decimal) -> Decimal:
+    for lower, tick in _UPBIT_KRW_TICK_BANDS:
+        if price >= lower:
+            return tick
+    raise AssertionError(f"sub-100 KRW crypto price out of scope: {price}")
+
+
+def _market_tick(market: str, price: Decimal) -> Decimal:
+    """Market-native sell-side tick grid the tier's ``tick_grid`` names."""
+
+    if market == "crypto":
+        return _crypto_krw_tick(price)
+    if market == "kr":
+        return Decimal(get_tick_size_kr(float(price)))
+    if market == "us":
+        return Decimal("0.01")
+    raise AssertionError(f"unsupported market: {market!r}")
+
+
+def _breakeven_extension_ladder_tier():
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "sell.trim_preplace"
+    ]
+    return next(tier for tier in rule.tiers if tier.id == _LADDER_TIER_ID)
+
+
+def _breakeven_extension_rungs(
+    tier,
+    *,
+    market: str,
+    average_cost: Decimal,
+) -> list[Decimal]:
+    """Test-only interpreter for the declarative rung contract.
+
+    Nothing here invents policy: the anchor basis, the multiples, the rung
+    count, and the snap direction are all read out of the YAML tier.
+    """
+
+    conditions = tier.conditions
+    assert conditions["anchor_basis"] == "average_cost"
+    rounding = {"ceil": ROUND_CEILING, "floor": ROUND_FLOOR}[
+        str(conditions["tick_snap_direction"])
+    ]
+    multiples = conditions["anchor_average_cost_multiples"]
+    assert len(multiples) == conditions["rungs_max"]
+
+    rungs: list[Decimal] = []
+    for multiple in multiples:
+        raw = average_cost * Decimal(str(multiple))
+        tick = _market_tick(market, raw)
+        rungs.append((raw / tick).to_integral_value(rounding=rounding) * tick)
+    return rungs
+
+
+def _ladder_matches(tier, *, market: str, fresh_named_resistance_count: int) -> bool:
+    """Test-only interpreter for the declarative eligibility contract."""
+
+    conditions = tier.conditions
+    return (
+        market in conditions["markets"]
+        and fresh_named_resistance_count
+        == conditions["fresh_named_resistance_count_eq"]
+    )
+
+
+def test_crypto_krw_tick_transcription_matches_the_production_upbit_grid():
+    from app.services.brokers.upbit.orders import adjust_price_to_upbit_unit
+
+    for probe in (
+        Decimal("3168337"),
+        Decimal("3485170.7"),
+        Decimal("1234567"),
+        Decimal("777777"),
+        Decimal("123456"),
+        Decimal("54321"),
+        Decimal("4321"),
+        Decimal("321"),
+    ):
+        tick = _crypto_krw_tick(probe)
+        snapped = Decimal(str(adjust_price_to_upbit_unit(float(probe))))
+        assert snapped % tick == 0, (probe, tick, snapped)
+        assert abs(snapped - probe) <= tick
+
+
+def test_breakeven_extension_ladder_reproduces_eth_rungs():
+    """AC1 — ETH 실데이터 평단 3,168,337 (crypto/Upbit KRW, tick 1,000).
+
+    🔴 Rung 3 does NOT reproduce the value stated in the issue AC. Under the
+    tier's own declared ``tick_snap_direction: ceil`` the third rung is
+    3,486,000, not 3,485,000. 3,485,000 is the *floor* of 3,168,337 × 1.10 =
+    3,485,170.7, and no tick size on the Upbit KRW grid makes a ceil land on
+    it. Rungs 1 and 2 match the AC exactly and are ceil results, so the AC is
+    internally inconsistent on rung 3 rather than the snap direction being
+    wrong. This test pins the computed values and the delta instead of bending
+    the policy to fit the stated number.
+    """
+
+    tier = _breakeven_extension_ladder_tier()
+    rungs = _breakeven_extension_rungs(
+        tier, market="crypto", average_cost=Decimal("3168337")
+    )
+
+    assert rungs == [
+        Decimal("3201000"),
+        Decimal("3327000"),
+        Decimal("3486000"),
+    ]
+    # AC1 rungs 1-2 reproduce verbatim.
+    assert rungs[:2] == [Decimal("3201000"), Decimal("3327000")]
+    # AC1 rung 3 delta, stated rather than hidden.
+    ac1_stated_third_rung = Decimal("3485000")
+    raw_third_rung = Decimal("3168337") * Decimal("1.10")
+    assert raw_third_rung == Decimal("3485170.70")
+    assert rungs[2] - ac1_stated_third_rung == Decimal("1000")
+    assert ac1_stated_third_rung < raw_third_rung  # i.e. it is a floor, not a ceil
+    # Every rung must clear its own raw anchor after snapping (ceil, never below).
+    for rung, multiple in zip(
+        rungs, tier.conditions["anchor_average_cost_multiples"], strict=True
+    ):
+        assert rung >= Decimal("3168337") * Decimal(str(multiple))
+
+
+def test_breakeven_extension_ladder_lowest_rung_reuses_the_loss_guard_formula():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    tier = _breakeven_extension_ladder_tier()
+    conditions = tier.conditions
+
+    guard_key = str(conditions["anchor_lowest_rung_policy_key"])
+    assert guard_key == "sell.loss_guard_min_multiple"
+    guard = _threshold_decimal(doc, guard_key)
+    multiples = conditions["anchor_average_cost_multiples"]
+
+    # 평단×1.01 = loss_guard 하한과 동일 산식 — the literal is the threshold.
+    assert Decimal(str(multiples[0])) == guard
+    assert [Decimal(str(value)) for value in multiples] == [
+        Decimal("1.01"),
+        Decimal("1.05"),
+        Decimal("1.10"),
+    ]
+    # The guard threshold itself is untouched by this change.
+    assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
+
+
+def test_breakeven_extension_ladder_applies_to_kr_us_and_crypto():
+    tier = _breakeven_extension_ladder_tier()
+    assert tier.conditions["markets"] == ["kr", "us", "crypto"]
+
+    # KR uses the production KRX sell-side grid; US uses the cent grid.
+    kr_rungs = _breakeven_extension_rungs(
+        tier, market="kr", average_cost=Decimal("71300")
+    )
+    assert kr_rungs == [Decimal("72100"), Decimal("74900"), Decimal("78500")]
+    for rung in kr_rungs:
+        assert rung % Decimal(get_tick_size_kr(float(rung))) == 0
+
+    us_rungs = _breakeven_extension_rungs(
+        tier, market="us", average_cost=Decimal("187.42")
+    )
+    assert us_rungs == [Decimal("189.30"), Decimal("196.80"), Decimal("206.17")]
+
+
+def test_breakeven_extension_ladder_never_matches_a_holding_with_named_resistance():
+    """AC2 — BTC-style holding (fresh named resistance present) stays excluded."""
+
+    tier = _breakeven_extension_ladder_tier()
+
+    for market in ("kr", "us", "crypto"):
+        # ETH/LINK case — zero fresh named resistance, the tier is reachable.
+        assert _ladder_matches(tier, market=market, fresh_named_resistance_count=0)
+        # BTC case — any named resistance at all keeps the tier out.
+        for count in (1, 2, 5):
+            assert not _ladder_matches(
+                tier, market=market, fresh_named_resistance_count=count
+            )
+
+    # The tier carries no resistance-proximity condition, so it cannot express
+    # an opinion about a holding that still has a resistance frame.
+    assert not [key for key in tier.conditions if "resistance_near_pct" in key]
+
+
+def test_breakeven_extension_ladder_is_last_so_resistance_tiers_keep_priority():
+    """AC6 — FALLBACK_ORDER pinned in both the tier order and tie_breaks."""
+
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "sell.trim_preplace"
+    ]
+    tier_ids = [tier.id for tier in rule.tiers]
+
+    assert tier_ids[-1] == _LADDER_TIER_ID
+    resistance_tiers = [
+        "single_share_full_exit_review",
+        "momentum_spike_profit_ladder",
+        "rsi_confirmed_resistance",
+        "ultra_near_resistance",
+        "watch_zone",
+    ]
+    for name in resistance_tiers:
+        assert tier_ids.index(name) < tier_ids.index(_LADDER_TIER_ID)
+
+    assert rule.tie_breaks["multiple_tiers_matched"] == "first_matching_tier_wins"
+    assert [part.strip() for part in rule.tie_breaks["tier_priority"].split(">")] == (
+        tier_ids
+    )
+    assert rule.tie_breaks["breakeven_extension_fallback_order"] == (
+        "named_resistance_tiers_first_extension_ladder_only_when_zero_fresh"
+        "_named_resistance"
+    )
+    assert rule.tie_breaks["breakeven_extension_minimum_benefit"] == (
+        "de_minimis_trim_watch_still_preempts"
+    )
+    # D7 minimum-benefit watch still preempts the new tier.
+    assert tier_ids[0] == "de_minimis_trim_watch"
+
+
+def test_breakeven_extension_ladder_keeps_the_no_resistance_reference_exclusion():
+    """AC4 / NO_EXCLUSION_REMOVAL — the exclusion is retained, not deleted."""
+
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "sell.trim_preplace"
+    ]
+    assert rule.exclusions == ["no_resistance_reference", "composite_gates"]
+    assert rule.tie_breaks["breakeven_extension_exclusion_retained"] == (
+        "no_resistance_reference_stays_in_exclusions_dedicated_tier_not"
+        "_exclusion_removal"
+    )
+    assert (
+        _breakeven_extension_ladder_tier().conditions["matched_exclusion_case"]
+        == "no_resistance_reference"
+    )
+
+
+def test_breakeven_extension_ladder_reuses_existing_trim_sizing():
+    """AC7 / SIZING_REUSE — no new quantity rule is introduced."""
+
+    tier = _breakeven_extension_ladder_tier()
+    assert tier.sizing == "existing_trim_rule"
+    assert tier.action == "preplace_resting_breakeven_extension_ladder"
+
+    rule = TradingPolicyDocument.model_validate(_raw()).decision_rules[
+        "sell.trim_preplace"
+    ]
+    # The only sizing token this tier uses is one an existing tier already uses.
+    existing_sizings = {
+        candidate.sizing for candidate in rule.tiers if candidate.id != _LADDER_TIER_ID
+    }
+    assert tier.sizing in existing_sizings
+    # No quantity/percentage key is declared on the tier at all.
+    assert not [
+        key
+        for key in tier.conditions
+        if any(token in key for token in ("quantity", "position_pct", "notional"))
+    ]
+
+
+def _ladder_mutant(mutate) -> dict:
+    raw = _raw()
+    rule = raw["decision_rules"]["sell.trim_preplace"]
+    mutate(rule)
+    return raw
+
+
+def _mutate_drop_exclusion(rule) -> None:
+    rule["exclusions"].remove("no_resistance_reference")
+
+
+def _mutate_move_ladder_ahead_of_resistance_tiers(rule) -> None:
+    ladder = rule["tiers"].pop()
+    rule["tiers"].insert(2, ladder)
+
+
+def _mutate_allow_any_resistance_count(rule) -> None:
+    rule["tiers"][-1]["conditions"]["fresh_named_resistance_count_eq"] = 1
+
+
+def _mutate_add_resistance_proximity_condition(rule) -> None:
+    rule["tiers"][-1]["conditions"]["resistance_near_pct_max"] = 6
+
+
+def _mutate_invent_new_sizing(rule) -> None:
+    rule["tiers"][-1]["sizing"] = "breakeven_extension_third_position"
+
+
+def _mutate_snap_down(rule) -> None:
+    rule["tiers"][-1]["conditions"]["tick_snap_direction"] = "floor"
+
+
+def _mutate_rung_below_average_cost(rule) -> None:
+    rule["tiers"][-1]["conditions"]["anchor_average_cost_multiples"] = [
+        0.99,
+        1.05,
+        1.10,
+    ]
+
+
+def _mutate_unordered_rungs(rule) -> None:
+    rule["tiers"][-1]["conditions"]["anchor_average_cost_multiples"] = [
+        1.05,
+        1.01,
+        1.10,
+    ]
+
+
+def _mutate_rung_count_mismatch(rule) -> None:
+    rule["tiers"][-1]["conditions"]["rungs_max"] = 2
+
+
+def _mutate_detach_from_loss_guard_key(rule) -> None:
+    rule["tiers"][-1]["conditions"]["anchor_lowest_rung_policy_key"] = (
+        "sell.breakeven_near_pct"
+    )
+
+
+def _mutate_stale_tier_priority(rule) -> None:
+    rule["tie_breaks"]["tier_priority"] = rule["tie_breaks"]["tier_priority"].replace(
+        " > breakeven_extension_ladder", ""
+    )
+
+
+def _mutate_drop_fallback_only_flag(rule) -> None:
+    rule["tiers"][-1]["conditions"]["resistance_tier_fallback_only"] = False
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _mutate_drop_exclusion,
+        _mutate_move_ladder_ahead_of_resistance_tiers,
+        _mutate_allow_any_resistance_count,
+        _mutate_add_resistance_proximity_condition,
+        _mutate_invent_new_sizing,
+        _mutate_snap_down,
+        _mutate_rung_below_average_cost,
+        _mutate_unordered_rungs,
+        _mutate_rung_count_mismatch,
+        _mutate_detach_from_loss_guard_key,
+        _mutate_stale_tier_priority,
+        _mutate_drop_fallback_only_flag,
+    ],
+    ids=[
+        "exclusion_removed",
+        "ladder_before_resistance_tiers",
+        "matches_when_resistance_exists",
+        "carries_resistance_proximity_condition",
+        "invents_new_sizing_rule",
+        "snaps_rungs_down",
+        "rung_below_average_cost",
+        "rungs_not_ascending",
+        "rung_count_mismatch",
+        "detached_from_loss_guard_key",
+        "stale_tier_priority",
+        "fallback_only_flag_dropped",
+    ],
+)
+def test_breakeven_extension_ladder_mutants_are_rejected(mutate):
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(_ladder_mutant(mutate))
+
+
+def test_rob_1298_leaves_loss_guard_d7_and_auto_approve_gates_untouched():
+    """AC5 / GATES_UNTOUCHED — asserted against the ROB-1289 baseline document."""
+
+    baseline = yaml.safe_load(_ROB1289_BASELINE.read_text(encoding="utf-8"))
+    current = _raw()
+
+    # Loss guard and D7 minimum-benefit thresholds: byte-identical blocks.
+    for key in (
+        "sell.loss_guard_min_multiple",
+        "sell.loss_cut_max_slip",
+        "sell.breakeven_near_pct",
+        "sell.trim_min_expected_net_realized_gain_krw",
+    ):
+        assert current["thresholds"][key] == baseline["thresholds"][key]
+
+    # Auto-approve gate: only the four §106차 cap deltas already enumerated by
+    # ROB-1292 differ; every other auto-approve key is unchanged by ROB-1298.
+    current_auto = deepcopy(current["order_proposals"]["auto_approve"])
+    baseline_auto = deepcopy(baseline["order_proposals"]["auto_approve"])
+    for path, baseline_value, _current_value in _ROB1292_ALLOWED_POLICY_DELTAS:
+        suffix = path.removeprefix("order_proposals.auto_approve.")
+        _policy_path_set(current_auto, suffix, baseline_value)
+    assert current_auto == baseline_auto
+
+    # The de_minimis (D7) watch tier itself is unchanged.
+    baseline_trim = baseline["decision_rules"]["sell.trim_preplace"]
+    current_trim = current["decision_rules"]["sell.trim_preplace"]
+    assert current_trim["tiers"][0] == baseline_trim["tiers"][0]
+    assert current_trim["tiers"][1] == baseline_trim["tiers"][1]

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -92,6 +92,7 @@ def test_trim_preplace_exposes_d2_d5_d7_advisory_contracts():
         "rsi_confirmed_resistance",
         "ultra_near_resistance",
         "watch_zone",
+        "breakeven_extension_ladder",
     ]
     assert tiers["de_minimis_trim_watch"]["conditions"] == {
         "markets": ["kr", "us", "crypto"],


### PR DESCRIPTION
## 왜

ETH·LINK 가 120일 명명 구조 전체를 상회 → `resistances: []` → 해당 보유가
`sell.trim_preplace.exclusions: ["no_resistance_reference"]` 로 떨어져 **어떤 매도 티어에도
매칭되지 않는다**. 손익분기 돌파 워치(평단×1.01 = 3,200,021)가 발화해도 그물을 깔 앵커가 없다.
강한 랠리 보유일수록 익절 경로가 소멸하는 역설을 닫는다.

## 무엇

`sell.trim_preplace.tiers` 에 전용 폴백 티어 `breakeven_extension_ladder` 신설.

| 항목 | 값 |
|---|---|
| eligibility | `fresh_named_resistance_count_eq: 0` (= 제외 케이스 전용) |
| 순서 | **마지막 선언** — first-match-wins 상 저항 티어가 전부 미매칭이어야 도달 |
| anchors | 평단 × 1.01 / 1.05 / 1.10, 3 rung, 시장별 tick **올림(ceil)** |
| 1.01 출처 | 리터럴이 아니라 기존 `sell.loss_guard_min_multiple` 키 인용 (동일 산식) |
| sizing | `existing_trim_rule` — **신규 수량 규칙 0** |
| markets | `kr`, `us`, `crypto` |

`exclusions` 의 `no_resistance_reference` 는 **그대로 유지**된다. 공백은 제외를 지워서가 아니라
전용 티어를 더해서 닫는다.

## 안 건드린 것

`thresholds` · `order_proposals`(자동승인) · `authority` · `crash_day` 블록은 base 와 **완전 동일**
(파싱 후 dict 등가로 검증). 손실가드·D7 순실현 하한·자동승인 게이트 diff 0.

## 스키마 강제

`PolicyDecisionRule` 에 validator 추가 — 제외 유지 / 마지막 선언 / `tier_priority` 동기 /
zero-resistance eligibility / 저항근접 조건 부재 / 기존 sizing / 오름차순 익절측 rung ×
`rungs_max` 일치 / ceil 스냅. **뮤턴트 12종이 `ValidationError` 로 거부**된다.

## 🔴 AC1 rung 3 불일치 (고치지 않고 보고)

ETH 평단 `3,168,337` 기준:

| rung | 산식 | raw | tick 올림(1,000) | AC1 명시 | 판정 |
|---|---|---|---|---|---|
| 1 | ×1.01 | 3,200,020.37 | **3,201,000** | 3,201,000 | ✅ 일치 |
| 2 | ×1.05 | 3,326,753.85 | **3,327,000** | 3,327,000 | ✅ 일치 |
| 3 | ×1.10 | 3,485,170.70 | **3,486,000** | 3,485,000 | ❌ **+1,000 차이** |

`3,485,000` 은 3,485,170.7 의 **내림**이며, Upbit KRW tick 표 어느 밴드에서도 올림이 그 값에
닿지 않는다(≥2,000,000 → 1,000원 단위). rung 1·2 는 올림 결과로 AC 와 정확히 일치하므로
**스냅 방향이 틀린 것이 아니라 AC1 rung 3 이 내부적으로 불일치**한다. 정책을 숫자에 맞추지 않고
계산값을 박제하고 차이를 테스트에 기록했다
(`test_breakeven_extension_ladder_reproduces_eth_rungs`).

## 검증

- `tests/schemas tests/services tests/mcp_server` — **8,216 passed** (실패 3건은 alembic 바이너리
  부재로 인한 **base `1fb649be4` 에서도 동일 실패**하는 migration 테스트, stash 로 대조 확인)
- `ruff check` / `ruff format --check` / `ty check app/ --error-on-warning` 전부 통과

base = `1fb649be4`

Refs ROB-1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)