### PR TITLE
feat(ROB-1283): structured negative-class recording + run-start stall guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,34 @@ set-difference upsert하고 DB 상태로 응답한다 (excluded만 제외, pendi
   `FINNHUB_NEWS_TIMEOUT_S`×`FINNHUB_NEWS_MAX_ATTEMPTS` 재시도, 전 실패 시
   degraded + DB stale 폴백.
 
+### Negative-class(기각 코호트) 기록 — `decision_bucket` (ROB-1283)
+
+"매수 후보가 정말 없었나"에 정본 데이터로 답하기 위한 기각 기록 경로. 🔴 **관측 전용**
+(주문·승인 경로 영향 0).
+
+- **어휘 정본**: `app/models/decision_vocabulary.DECISION_BUCKETS` — 리포트 아이템 CHECK ·
+  Pydantic 스키마 · `review.trade_forecasts` CHECK 가 **같은 튜플**에서 생성됨(3층 드리프트 불가)
+- **기록**: `forecast_save(decision_bucket="deferred_no_action", ...)` — 세션이 실제로 부르는
+  표면. bucket + resolvable target + review_date + outcome/brier 가 한 행이라 리포트 아이템이
+  없어도 **채점 가능**(고아 아님)
+- **조회**: `get_forecasts(decision_bucket=...)`; `summary.by_decision_bucket` 의
+  `unclassified` 는 **사각지대 크기**이지 0 이 아님
+- **가드**: `get_operating_briefing` → `negative_class_recording` 섹션. route-stamp
+  (`operator-compliance/v1`)가 브리핑 응답을 통째로 박제하므로 **운영자 레포 변경 0으로**
+  세션 준수 스탬프에 도달
+- **진단**: `scripts/diagnose_negative_class_recording.py` (SELECT only, exit 1 = stalled)
+- **런북**: `docs/runbooks/negative-class-recording.md`
+
+**주의**:
+- 🔴 2026-06-15~ 결손 구간은 **메우지 않는다**. `gap.backfilled=false` 로 명시 보고 —
+  가짜 연속성 금지. 이 구간을 가로지르는 코호트는 정확히 그만큼 불완전
+- 🔴 원인은 핸들러 파손이 아니라 **호출 지점 부재**(라이브 프롬프트 5종이 `deferred_no_action`
+  어휘만 쓰고 그걸 기록하는 도구 이름을 대지 않음). 기록 재개는 **운영자 레포 프롬프트 수정**이
+  선행돼야 함 — 이 레포 변경만으로는 완결되지 않는다
+- 🔴 bucket 없는 일반 forecast 는 카운트 안 됨. 실제 정지가 숨은 방식이 정확히 이것
+  (`trade_forecasts` 는 66일 내내 바빴다)
+- `decision_bucket=NULL` = "미분류"이지 "기각 아님"이 아니다. 오타는 fail-closed(거부)
+
 ### 정지 종목 오염 차단 — `halted_suspect` (ROB-1236)
 
 일봉이 **3거래일 연속 죽어 있으면**(`volume=0` **또는** `high==low==close` 이면서

--- a/alembic/versions/20260820_rob1283_forecast_decision_bucket.py
+++ b/alembic/versions/20260820_rob1283_forecast_decision_bucket.py
@@ -1,0 +1,83 @@
+"""ROB-1283 negative-class decision_bucket on trade_forecasts (additive)
+
+Revision ID: 20260820_rob1283_bucket
+Revises: 20260819_rob1286_claims
+Create Date: 2026-08-20
+
+Additive: one nullable column, one CHECK, one index on
+``review.trade_forecasts``. No existing column, constraint or index is
+altered, no row is rewritten, and no other table is touched.
+
+Why this column exists (see ROB-1283 root cause): the report-item path that
+used to carry ``decision_bucket`` stopped being called on 2026-06-15, while
+``trade_forecasts`` has recorded continuously since 2026-07-03. The two
+surfaces never overlapped, which is why every ``report_uuid`` link is NULL.
+Putting the vocabulary on the surface sessions actually call makes a rejected
+buy candidate a structured, scorable row in one call instead of a regex proxy
+over free text.
+
+NULL is the pre-existing state for every historical row and means "not
+classified" -- never "not a rejection". This migration deliberately does NOT
+backfill: the 06-15 -> 07-03 gap is reported as a gap by
+``scripts/diagnose_negative_class_recording.py`` rather than papered over with
+inferred values.
+
+The CHECK is emitted as explicit DDL rather than via
+``op.create_check_constraint``. That helper re-applies the metadata naming
+convention to whatever name it is handed, so passing the ORM's rendered name
+yields a doubly-mangled, hash-truncated
+``ck_trade_forecasts_ck_trade_forecasts_ck_trade_forecast_54f4`` -- which then
+does not match the ORM and cannot be found by ``downgrade``. Writing the SQL
+directly pins the exact name the ORM renders
+(``ck_%(table_name)s_%(constraint_name)s`` applied to a constraint already
+named ``ck_trade_forecasts_...``, hence the doubled prefix). The four
+constraints already deployed on this table carry that same doubled prefix, so
+this matches the table it is altering instead of introducing drift.
+
+Provenance: hand-written against the deployed schema, then verified by a full
+``upgrade head`` / ``downgrade -1`` / ``upgrade head`` round trip on a
+run-owned scratch database.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from app.models.decision_vocabulary import DECISION_BUCKETS, sql_in_list
+
+# revision identifiers, used by Alembic.
+revision: str = "20260820_rob1283_bucket"
+down_revision: str | Sequence[str] | None = "20260819_rob1286_claims"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CHECK_NAME = "ck_trade_forecasts_ck_trade_forecasts_decision_bucket"
+_INDEX_NAME = "ix_trade_forecasts_decision_bucket"
+_IN_LIST = sql_in_list(DECISION_BUCKETS)
+
+
+def upgrade() -> None:
+    """Add review.trade_forecasts.decision_bucket (nullable, CHECKed, indexed)."""
+    op.add_column(
+        "trade_forecasts",
+        sa.Column("decision_bucket", sa.Text(), nullable=True),
+        schema="review",
+    )
+    op.execute(
+        f"ALTER TABLE review.trade_forecasts ADD CONSTRAINT {_CHECK_NAME} "
+        f"CHECK (decision_bucket IS NULL OR decision_bucket IN ({_IN_LIST}))"
+    )
+    op.create_index(
+        _INDEX_NAME,
+        "trade_forecasts",
+        ["decision_bucket"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    """Drop the column and everything created with it."""
+    op.drop_index(_INDEX_NAME, table_name="trade_forecasts", schema="review")
+    op.execute(f"ALTER TABLE review.trade_forecasts DROP CONSTRAINT {_CHECK_NAME}")
+    op.drop_column("trade_forecasts", "decision_bucket", schema="review")

--- a/app/mcp_server/tooling/forecast_registration.py
+++ b/app/mcp_server/tooling/forecast_registration.py
@@ -41,7 +41,19 @@ def register_forecast_tools(mcp: Any) -> None:
             "links, and session_label/model_label/policy_version for calibration. "
             "Idempotent per forecast_id (omit to create; supply to update while "
             "open — a closed/resolved forecast is immutable). Composition is the "
-            "caller's judgment; storage/scoring is deterministic."
+            "caller's judgment; storage/scoring is deterministic. "
+            "NEGATIVE CLASS (ROB-1283): when this forecast records a candidate "
+            "you evaluated and did NOT act on, pass "
+            "decision_bucket='deferred_no_action' — that is what makes the "
+            "rejected cohort queryable instead of reconstructable only by "
+            "regex over prose. decision_bucket accepts the shared vocabulary "
+            "{new_buy_candidate, open_action, completed_or_existing, "
+            "deferred_no_action, risk_watch}; an unknown value is rejected. "
+            "A bucketed forecast is self-sufficient for scoring, so recording "
+            "one is worthwhile even when no report item exists; if you did "
+            "create a report item, also pass its item_uuid as report_item_uuid "
+            "so both halves join. The response carries a 'warnings' list when "
+            "the bucket or the link is missing."
         ),
     )(forecast_save)
     _ = mcp.tool(
@@ -81,7 +93,11 @@ def register_forecast_tools(mcp: Any) -> None:
         name="get_forecasts",
         description=(
             "List forecasts with filters (status open/closed/closed_no_claim, symbol, "
-            "created_by, correlation_id). Read-only."
+            "created_by, correlation_id, decision_bucket). Read-only. "
+            "decision_bucket='deferred_no_action' returns the rejected-candidate "
+            "(negative class) cohort; an unknown bucket is an error, not an empty "
+            "result. summary.by_decision_bucket counts 'unclassified' separately — "
+            "that count is the blind spot, not a zero (ROB-1283)."
         ),
     )(get_forecasts)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/forecast_tools.py
+++ b/app/mcp_server/tooling/forecast_tools.py
@@ -23,6 +23,7 @@ from app.services.trade_journal.forecast_service import (
     save_forecast,
     serialize_forecast,
 )
+from app.services.trade_journal.negative_class import negative_class_warnings
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ async def forecast_save(
     report_uuid: str | None = None,
     report_item_uuid: str | None = None,
     correlation_id: str | None = None,
+    decision_bucket: str | None = None,
 ) -> dict[str, Any]:
     symbol = (symbol or "").strip()
     if not symbol:
@@ -84,13 +86,16 @@ async def forecast_save(
                 report_uuid=report_uuid,
                 report_item_uuid=report_item_uuid,
                 correlation_id=correlation_id,
+                decision_bucket=decision_bucket,
             )
             await db.commit()
             await db.refresh(row)
+            data = serialize_forecast(row)
             return {
                 "success": True,
                 "action": action,
-                "data": serialize_forecast(row),
+                "data": data,
+                "warnings": negative_class_warnings(data),
             }
     except ForecastValidationError as exc:
         return {"success": False, "error": str(exc)}
@@ -185,6 +190,7 @@ async def get_forecasts(
     created_by: str | None = None,
     correlation_id: str | None = None,
     limit: int = 50,
+    decision_bucket: str | None = None,
 ) -> dict[str, Any]:
     try:
         async with _session_factory()() as db:
@@ -195,8 +201,11 @@ async def get_forecasts(
                 created_by=created_by,
                 correlation_id=correlation_id,
                 limit=limit,
+                decision_bucket=decision_bucket,
             )
         return {"success": True, **result}
+    except ForecastValidationError as exc:
+        return {"success": False, "error": str(exc)}
     except Exception as exc:  # noqa: BLE001
         logger.exception("get_forecasts failed")
         return {"success": False, "error": f"get_forecasts failed: {exc}"}

--- a/app/mcp_server/tooling/operating_briefing.py
+++ b/app/mcp_server/tooling/operating_briefing.py
@@ -27,6 +27,9 @@ from app.services.investment_reports.query_service import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.session_context import SessionContextService
+from app.services.trade_journal.negative_class import (
+    load_negative_class_health,
+)
 from app.services.trading_policy_service import policy_version_stamp
 
 
@@ -347,6 +350,22 @@ async def get_operating_briefing_impl(
                 "unavailable_reason": reason,
             }
 
+        # ROB-1283 — negative-class recording health. Fail-open: the briefing is
+        # the run-start surface and must still return if this probe errors, but
+        # a failure is reported as such rather than as a clean "ok".
+        try:
+            negative_class_recording = (
+                await load_negative_class_health(db, market=market, now=as_of)
+            ).to_dict()
+        except Exception as exc:  # noqa: BLE001
+            negative_class_recording = {
+                "status": "unavailable",
+                "market": market,
+                "unavailable_reason": _section_unavailable_reason(
+                    "negative_class_recording", exc
+                ),
+            }
+
         try:
             from app.services.trade_journal.aggregates import (
                 build_counterfactual_delta_scoreboard,
@@ -455,6 +474,7 @@ async def get_operating_briefing_impl(
         "analysis_artifacts": analysis_artifacts,
         "policy_version": policy_version,
         "trading_scoreboards": trading_scoreboards,
+        "negative_class_recording": negative_class_recording,
     }
     return OperatingBriefingResponse.model_validate(response).model_dump(mode="json")
 

--- a/app/models/decision_vocabulary.py
+++ b/app/models/decision_vocabulary.py
@@ -1,0 +1,44 @@
+"""Controlled vocabulary for decision buckets — the one place it is spelled.
+
+Extracted here by ROB-1283 so more than one table can carry the vocabulary
+without the importers being coupled to each other's mapper graphs. It
+previously lived in ``investment_symbol_intermediate_reports``, whose module
+also defines a mapper with a ``review.investment_stage_runs`` foreign key;
+importing it from ``app.models.review`` to reuse the tuple would have forced
+that unrelated mapper (and its FK target) to be configured for every consumer
+of the review models.
+
+This module deliberately imports nothing from ``app`` — it is a leaf, so any
+table, schema, or service can build a CHECK constraint or a validator from the
+same source without dragging a mapper along.
+
+``investment_symbol_intermediate_reports`` re-exports these names, so existing
+``from app.models.investment_symbol_intermediate_reports import
+DECISION_BUCKETS`` imports keep working unchanged.
+"""
+
+from __future__ import annotations
+
+# ``deferred_no_action`` is the negative class: a candidate that was evaluated
+# and deliberately not acted on. ROB-1283 records it on ``review.trade_forecasts``
+# as well as on report items, so the rejected cohort is queryable rather than
+# reconstructable only by regex over prose.
+DECISION_BUCKETS: tuple[str, ...] = (
+    "new_buy_candidate",
+    "open_action",
+    "completed_or_existing",
+    "deferred_no_action",
+    "risk_watch",
+)
+
+
+def sql_in_list(values: tuple[str, ...]) -> str:
+    """Render a tuple as a SQL IN-list literal: ``'a', 'b'``.
+
+    Used to build CHECK constraints from the tuple above, so the DB constraint
+    and the Python vocabulary cannot drift.
+    """
+    return ", ".join(f"'{v}'" for v in values)
+
+
+__all__ = ["DECISION_BUCKETS", "sql_in_list"]

--- a/app/models/investment_symbol_intermediate_reports.py
+++ b/app/models/investment_symbol_intermediate_reports.py
@@ -41,19 +41,23 @@ from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
+from app.models.decision_vocabulary import (
+    DECISION_BUCKETS as _DECISION_BUCKETS,
+)
+from app.models.decision_vocabulary import (
+    sql_in_list,
+)
 
 # --- Single source of truth for the controlled vocabularies (ROB-301 D5). ---
 # The DB CHECK constraints below are BUILT from these tuples, and the Pydantic
 # schema Literals (PR T2) import the same tuples. The three layers therefore
 # cannot drift; ``tests/models/test_investment_symbol_intermediate_reports_model.py``
 # asserts the model CHECK reflects each tuple value.
-DECISION_BUCKETS: tuple[str, ...] = (
-    "new_buy_candidate",
-    "open_action",
-    "completed_or_existing",
-    "deferred_no_action",
-    "risk_watch",
-)
+# ROB-1283 moved this tuple to the leaf module ``app.models.decision_vocabulary``
+# so ``review.trade_forecasts`` can build its CHECK from the same source without
+# importing this module (and thus configuring its investment_stage_runs FK).
+# Re-exported here so existing importers of this name are unaffected.
+DECISION_BUCKETS = _DECISION_BUCKETS
 VERDICTS: tuple[str, ...] = ("buy", "sell", "hold", "risk", "unavailable")
 UNAVAILABLE_REASONS: tuple[str, ...] = ("hermes_omitted", "data_unavailable")
 REPORT_KINDS: tuple[str, ...] = ("final_report_symbol",)
@@ -66,9 +70,9 @@ ACCOUNT_SCOPES: tuple[str, ...] = (
 )
 
 
-def _sql_in(values: tuple[str, ...]) -> str:
-    """Render a tuple as a SQL IN-list literal: ('a','b')."""
-    return ", ".join(f"'{v}'" for v in values)
+# ROB-1283: the renderer moved next to the vocabulary it renders, so a CHECK
+# built here and one built on review.trade_forecasts are produced identically.
+_sql_in = sql_in_list
 
 
 class InvestmentSymbolIntermediateReport(Base):

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func, text
 
 from app.models.base import Base
+from app.models.decision_vocabulary import DECISION_BUCKETS, sql_in_list
 from app.models.trading import InstrumentType
 
 
@@ -1462,6 +1463,17 @@ class TradeForecast(Base):
         Index("ix_trade_forecasts_created_by", "created_by"),
         Index("ix_trade_forecasts_correlation_id", "correlation_id"),
         Index("ix_trade_forecasts_report_item_uuid", "report_item_uuid"),
+        # ROB-1283 — the negative class is scored from this column, so the
+        # vocabulary is a DB property, not a convention. Built from the same
+        # DECISION_BUCKETS tuple the report-item CHECK and the Pydantic
+        # schemas use, so the three layers cannot drift.
+        CheckConstraint(
+            "decision_bucket IS NULL OR decision_bucket IN ("
+            + sql_in_list(DECISION_BUCKETS)
+            + ")",
+            name="ck_trade_forecasts_decision_bucket",
+        ),
+        Index("ix_trade_forecasts_decision_bucket", "decision_bucket"),
         {"schema": "review"},
     )
 
@@ -1480,6 +1492,14 @@ class TradeForecast(Base):
     report_uuid: Mapped[str | None] = mapped_column(Text)
     report_item_uuid: Mapped[str | None] = mapped_column(Text)
     correlation_id: Mapped[str | None] = mapped_column(Text)
+
+    # ROB-1283 — the negative class ("we looked and did NOT buy") recorded on
+    # the surface sessions actually call. Report items carry the same
+    # vocabulary, but a forecast row is self-sufficient for scoring: bucket +
+    # resolvable target + review_date + outcome/brier live together, so a
+    # rejected candidate is gradeable even when no report item was created.
+    # NULL means "not classified", never "not a rejection".
+    decision_bucket: Mapped[str | None] = mapped_column(Text)
 
     # Attribution (calibration groups by these labels).
     created_by: Mapped[str] = mapped_column(Text, nullable=False)

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -1240,6 +1240,12 @@ class OperatingBriefingResponse(BaseModel):
     policy_version: dict[str, Any] | None = None
     # ROB-734 — realized trading scoreboards/delta. Defaulted for back-compat.
     trading_scoreboards: dict[str, Any] | None = None
+    # ROB-1283 — negative-class (rejected-candidate) recording health, so a
+    # stalled recording contract is visible at run start instead of being
+    # discovered 66 days later. The operator compliance stamp captures this
+    # response verbatim, which is how the guard reaches the stamp. Defaulted
+    # for back-compat.
+    negative_class_recording: dict[str, Any] | None = None
 
 
 class InvestmentReportCreateResponse(BaseModel):

--- a/app/services/live_place_provenance.py
+++ b/app/services/live_place_provenance.py
@@ -18,7 +18,11 @@ from decimal import Decimal
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
-from app.services.trade_journal.forecast_service import save_forecast
+from app.services.trade_journal.forecast_service import (
+    ForecastValidationError,
+    normalize_report_link,
+    save_forecast,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +49,22 @@ async def publish_place_time_forecast(
         else _DEFAULT_HORIZON_DAYS
     )
     review_date = (now_kst().date() + timedelta(days=horizon_days)).isoformat()
+    # ROB-1283 — ROB-473 fixed the policy for this link on the order path: it is
+    # audit metadata and must never cost anything upstream. save_forecast is
+    # deliberately strict (a session that typos a link gets a loud error), so
+    # coerce here instead: an unusable link is dropped and the forecast is still
+    # published. Losing the forecast — the actual scoring record — over a bad
+    # audit pointer would be the worse trade.
+    try:
+        linked_item_uuid = normalize_report_link(report_item_uuid, "report_item_uuid")
+    except ForecastValidationError:
+        logger.warning(
+            "live place: dropping unusable report_item_uuid=%r for "
+            "correlation_id=%s; forecast is still published without the link",
+            report_item_uuid,
+            correlation_id,
+        )
+        linked_item_uuid = None
     try:
         async with AsyncSessionLocal() as fdb:
             _action, fc = await save_forecast(
@@ -64,7 +84,7 @@ async def publish_place_time_forecast(
                 horizon=f"P{horizon_days}D",
                 model_label=None,
                 session_label=session_label,
-                report_item_uuid=report_item_uuid,
+                report_item_uuid=linked_item_uuid,
             )
             fid = getattr(fc, "forecast_id", None)
             await fdb.commit()

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import defer
 
 from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
+from app.models.decision_vocabulary import DECISION_BUCKETS
 from app.models.invalid_sample_eligibility import SampleEligibilityDecision
 from app.models.review import TradeForecast
 from app.models.trading import InstrumentType
@@ -314,6 +315,48 @@ def _parse_date(value: str | date, field: str) -> date:
         raise ForecastValidationError(f"{field} must be YYYY-MM-DD: {value!r}") from exc
 
 
+def _validate_decision_bucket(value: str | None) -> str | None:
+    """ROB-1283 — normalise/validate the negative-class label.
+
+    Fail-closed on an unknown label: a typo'd bucket would silently vanish from
+    the rejected cohort at scoring time, which is exactly the failure this
+    issue exists to end. None stays None ("not classified").
+    """
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    if not cleaned:
+        return None
+    if cleaned not in DECISION_BUCKETS:
+        raise ForecastValidationError(
+            f"invalid decision_bucket: {value!r} (expected one of "
+            f"{', '.join(DECISION_BUCKETS)})"
+        )
+    return cleaned
+
+
+def normalize_report_link(value: str | None, field: str) -> str | None:
+    """ROB-1283 — a link that cannot join is worse than no link.
+
+    ``report_uuid`` / ``report_item_uuid`` are Text columns joined against
+    ``investment_report*.*_uuid``. Storing a non-UUID string there produces a
+    row that looks linked and never joins, so reject it at write time instead
+    of discovering it at scoring time. The canonical (lowercase, hyphenated)
+    form is stored so string equality joins hold.
+    """
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    if not cleaned:
+        return None
+    try:
+        return str(uuid.UUID(cleaned))
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise ForecastValidationError(
+            f"{field} must be a UUID string, got {value!r}"
+        ) from exc
+
+
 def _validate_forecast_target(
     target: Any,
     *,
@@ -398,6 +441,7 @@ def serialize_forecast(r: TradeForecast) -> dict[str, Any]:
         "report_uuid": r.report_uuid,
         "report_item_uuid": r.report_item_uuid,
         "correlation_id": r.correlation_id,
+        "decision_bucket": r.decision_bucket,
         "created_by": r.created_by,
         "session_label": r.session_label,
         "model_label": r.model_label,
@@ -511,6 +555,7 @@ async def save_forecast(
     report_uuid: str | None = None,
     report_item_uuid: str | None = None,
     correlation_id: str | None = None,
+    decision_bucket: str | None = None,
 ) -> tuple[str, TradeForecast]:
     if not (created_by or "").strip():
         raise ForecastValidationError("created_by is required")
@@ -554,6 +599,7 @@ async def save_forecast(
     )
     if start is not None and start > review:
         raise ForecastValidationError("forecast_start_date must be <= review_date")
+    bucket = _validate_decision_bucket(decision_bucket)
 
     payload: dict[str, Any] = {
         "forecast_id": _coerce_forecast_id(forecast_id),
@@ -575,9 +621,12 @@ async def save_forecast(
         "policy_version": policy_version or _default_policy_version(),
         "artifact_uuid": artifact_uuid,
         "journal_id": journal_id,
-        "report_uuid": report_uuid,
-        "report_item_uuid": report_item_uuid,
+        "report_uuid": normalize_report_link(report_uuid, "report_uuid"),
+        "report_item_uuid": normalize_report_link(report_item_uuid, "report_item_uuid"),
         "correlation_id": correlation_id,
+        # ROB-1283 — validated above; an unknown label raises rather than
+        # writing a row that would drop out of the rejected cohort silently.
+        "decision_bucket": bucket,
         "status": "open",
     }
     return await ForecastRepository(db).upsert(payload)
@@ -702,6 +751,29 @@ async def list_due_quarantined_forecasts(
     return list((await db.execute(stmt)).scalars().all())
 
 
+def _forecast_listing_payload(rows: Sequence[TradeForecast]) -> dict[str, Any]:
+    """Shared listing shape for the forecast list endpoints.
+
+    ROB-1283 adds ``by_decision_bucket``. ``unclassified`` is counted as its own
+    bucket on purpose: it is the size of the blind spot, and collapsing it into
+    zero would say "nothing was rejected" when the truth is "nobody said".
+    """
+    by_status: dict[str, int] = {}
+    by_bucket: dict[str, int] = {}
+    for r in rows:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+        key = r.decision_bucket or "unclassified"
+        by_bucket[key] = by_bucket.get(key, 0) + 1
+    return {
+        "entries": [serialize_forecast(r) for r in rows],
+        "summary": {
+            "count": len(rows),
+            "by_status": by_status,
+            "by_decision_bucket": by_bucket,
+        },
+    }
+
+
 async def list_forecasts(
     db: AsyncSession,
     *,
@@ -710,6 +782,7 @@ async def list_forecasts(
     created_by: str | None = None,
     correlation_id: str | None = None,
     limit: int = 50,
+    decision_bucket: str | None = None,
 ) -> dict[str, Any]:
     filters = []
     if status is not None:
@@ -720,6 +793,13 @@ async def list_forecasts(
         filters.append(TradeForecast.created_by == created_by)
     if correlation_id is not None:
         filters.append(TradeForecast.correlation_id == correlation_id)
+    if decision_bucket is not None:
+        # ROB-1283 — the query path the rejected-candidate cohort is pulled
+        # through. Validated, so a typo raises instead of returning an empty
+        # cohort that would read as "nothing was rejected".
+        filters.append(
+            TradeForecast.decision_bucket == _validate_decision_bucket(decision_bucket)
+        )
     stmt = (
         select(TradeForecast)
         .where(*filters)
@@ -727,13 +807,7 @@ async def list_forecasts(
         .limit(limit)
     )
     rows = (await db.execute(stmt)).scalars().all()
-    by_status: dict[str, int] = {}
-    for r in rows:
-        by_status[r.status] = by_status.get(r.status, 0) + 1
-    return {
-        "entries": [serialize_forecast(r) for r in rows],
-        "summary": {"count": len(rows), "by_status": by_status},
-    }
+    return _forecast_listing_payload(rows)
 
 
 def _forecast_scope_filters(
@@ -763,13 +837,7 @@ async def _run_forecast_listing(
 ) -> dict[str, Any]:
     stmt = select(TradeForecast).where(*filters).order_by(order_by).limit(limit)
     rows = (await db.execute(stmt)).scalars().all()
-    by_status: dict[str, int] = {}
-    for r in rows:
-        by_status[r.status] = by_status.get(r.status, 0) + 1
-    return {
-        "entries": [serialize_forecast(r) for r in rows],
-        "summary": {"count": len(rows), "by_status": by_status},
-    }
+    return _forecast_listing_payload(rows)
 
 
 async def list_open_forecasts(

--- a/app/services/trade_journal/negative_class.py
+++ b/app/services/trade_journal/negative_class.py
@@ -1,0 +1,312 @@
+"""ROB-1283 — negative-class ("we looked and did NOT buy") recording health.
+
+Why this module exists
+----------------------
+The rejected-buy cohort used to live in ``review.investment_report_items``
+under ``decision_bucket='deferred_no_action'``. That path stopped being
+called on 2026-06-15 and nothing noticed for 66 days, because nothing ever
+*looked*. The gate-calibration diagnostic that eventually noticed had to
+reconstruct the cohort from free text with a regex, and a single Korean verb
+ending moved its headline figure by 73% -- a proxy biased by prose style.
+
+So this module does two things and deliberately not a third:
+
+* ``negative_class_warnings`` -- per-record advisory attached to a
+  ``forecast_save`` response, so a session that records a rejection without a
+  bucket (or without a report link) is told so at the moment it happens.
+* ``assess_negative_class_health`` / ``load_negative_class_health`` -- the
+  run-start regression guard. ``get_operating_briefing`` embeds the result,
+  and because the operator compliance stamp (``operator-compliance/v1``)
+  captures the whole briefing response verbatim, the guard reaches the
+  session compliance stamp with no operator-repo change.
+* It does NOT infer, impute, or backfill. A stretch of time with no records
+  is reported as a gap with its real endpoints. Fake continuity is the one
+  outcome worse than a visible hole, because it would be believed.
+
+Read-only and side-effect free: no broker, order, watch, approval, or
+order-intent path is reachable from here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentReport, InvestmentReportItem
+from app.models.review import TradeForecast
+
+# The one bucket that means "considered and rejected". Other buckets are
+# recorded too, but this is the one the gate-calibration cohort is built from.
+NEGATIVE_CLASS_BUCKET = "deferred_no_action"
+
+# A week with zero recorded rejections, across every session in a market, is
+# not a quiet week -- the KR/US/crypto prompts each run multiple times a day
+# and every one of them evaluates candidates it does not buy. Chosen to be
+# loose enough that a holiday stretch does not cry wolf.
+STALL_THRESHOLD_DAYS = 7
+
+# briefing market -> instrument_type stored on trade_forecasts.
+_MARKET_TO_INSTRUMENT: dict[str, str] = {
+    "kr": "equity_kr",
+    "us": "equity_us",
+    "crypto": "crypto",
+}
+
+
+@dataclass(frozen=True)
+class NegativeClassHealth:
+    """Assessment result. ``status`` is the single field worth alerting on."""
+
+    status: str  # ok | stalled | never_recorded
+    market: str
+    last_recorded_at: str | None
+    last_source: str | None  # forecast | report_item
+    stale_days: int | None
+    stall_threshold_days: int
+    forecast_last_at: str | None
+    report_item_last_at: str | None
+    gap: dict[str, Any] | None
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "market": self.market,
+            "last_recorded_at": self.last_recorded_at,
+            "last_source": self.last_source,
+            "stale_days": self.stale_days,
+            "stall_threshold_days": self.stall_threshold_days,
+            "forecast_last_at": self.forecast_last_at,
+            "report_item_last_at": self.report_item_last_at,
+            "gap": self.gap,
+            "notes": self.notes,
+        }
+
+
+def negative_class_warnings(forecast: dict[str, Any]) -> list[str]:
+    """Advisory strings for one saved forecast. Never raises, never blocks.
+
+    A warning here is not an error: the forecast is already stored. It exists
+    so a session learns at call time that the row it just wrote will not be
+    findable as a rejection later.
+    """
+    try:
+        out: list[str] = []
+        bucket = forecast.get("decision_bucket")
+        if bucket is None:
+            out.append(
+                "decision_bucket is unset — this forecast will not appear in the "
+                "rejected-candidate (negative class) cohort. If this call records "
+                "a candidate you evaluated and did NOT buy, pass "
+                f"decision_bucket='{NEGATIVE_CLASS_BUCKET}' (ROB-1283)."
+            )
+            return out
+        if bucket == NEGATIVE_CLASS_BUCKET and not forecast.get("report_item_uuid"):
+            out.append(
+                "negative-class forecast recorded without report_item_uuid — the "
+                "forecast alone is scorable, but the rationale/evidence half "
+                "lives on the report item. If you created one via "
+                "investment_report_create / investment_report_add_items, pass its "
+                "item_uuid as report_item_uuid so the two halves join (ROB-1283)."
+            )
+        return out
+    except Exception:  # noqa: BLE001 — advisory must never break forecast_save
+        return []
+
+
+def assess_negative_class_health(
+    *,
+    now: datetime,
+    market: str,
+    forecast_last_at: datetime | None,
+    report_item_last_at: datetime | None,
+    first_bucketed_forecast_at: datetime | None,
+    stall_threshold_days: int = STALL_THRESHOLD_DAYS,
+) -> NegativeClassHealth:
+    """Pure assessment — no DB, no clock, no network. All inputs are given.
+
+    ``forecast_last_at`` is the newest bucketed forecast, ``report_item_last_at``
+    the newest ``deferred_no_action`` report item. Either surface counts as a
+    record; the cohort is the union, because the two are the same claim written
+    in two places.
+    """
+    notes: list[str] = []
+    candidates: list[tuple[datetime, str]] = []
+    if forecast_last_at is not None:
+        candidates.append((forecast_last_at, "forecast"))
+    if report_item_last_at is not None:
+        candidates.append((report_item_last_at, "report_item"))
+
+    gap = _describe_gap(
+        report_item_last_at=report_item_last_at,
+        first_bucketed_forecast_at=first_bucketed_forecast_at,
+        now=now,
+    )
+    if gap is not None:
+        notes.append(
+            "A stretch of time carries no structured negative-class record. It is "
+            "reported as a gap and is NOT backfilled — any cohort built across it "
+            "is incomplete by exactly this window (ROB-1283)."
+        )
+
+    if not candidates:
+        return NegativeClassHealth(
+            status="never_recorded",
+            market=market,
+            last_recorded_at=None,
+            last_source=None,
+            stale_days=None,
+            stall_threshold_days=stall_threshold_days,
+            forecast_last_at=None,
+            report_item_last_at=None,
+            gap=gap,
+            notes=[
+                *notes,
+                "No negative-class record has ever been observed for this market. "
+                "Record rejected candidates with "
+                f"forecast_save(decision_bucket='{NEGATIVE_CLASS_BUCKET}', ...).",
+            ],
+        )
+
+    last_at, last_source = max(candidates, key=lambda c: c[0])
+    stale_days = max(0, (now - last_at).days)
+    stalled = stale_days >= stall_threshold_days
+    if stalled:
+        notes.append(
+            f"No negative-class record in {stale_days} days (threshold "
+            f"{stall_threshold_days}). Sessions evaluate candidates they do not "
+            "buy every run, so silence here means the recording contract is not "
+            "being honoured — not that nothing was rejected. Record with "
+            f"forecast_save(decision_bucket='{NEGATIVE_CLASS_BUCKET}', ...)."
+        )
+    return NegativeClassHealth(
+        status="stalled" if stalled else "ok",
+        market=market,
+        last_recorded_at=last_at.isoformat(),
+        last_source=last_source,
+        stale_days=stale_days,
+        stall_threshold_days=stall_threshold_days,
+        forecast_last_at=(
+            forecast_last_at.isoformat() if forecast_last_at is not None else None
+        ),
+        report_item_last_at=(
+            report_item_last_at.isoformat() if report_item_last_at is not None else None
+        ),
+        gap=gap,
+        notes=notes,
+    )
+
+
+def _describe_gap(
+    *,
+    report_item_last_at: datetime | None,
+    first_bucketed_forecast_at: datetime | None,
+    now: datetime,
+) -> dict[str, Any] | None:
+    """Describe the hole between the old surface dying and the new one starting.
+
+    Endpoints are derived from data, never hardcoded, so the description stays
+    true as the gap closes. ``ends_at=None`` means the gap is still open.
+    """
+    if report_item_last_at is None:
+        return None
+    end = first_bucketed_forecast_at
+    if end is not None and end <= report_item_last_at:
+        return None  # the surfaces overlap; there is no hole
+    boundary = end if end is not None else now
+    days = max(0, (boundary - report_item_last_at).days)
+    if days < STALL_THRESHOLD_DAYS:
+        return None
+    return {
+        "starts_at": report_item_last_at.isoformat(),
+        "ends_at": end.isoformat() if end is not None else None,
+        "open": end is None,
+        "days": days,
+        "reason": (
+            "report-item recording stopped and no bucketed forecast had taken over yet"
+        ),
+        "backfilled": False,
+    }
+
+
+async def load_negative_class_health(
+    db: AsyncSession,
+    *,
+    market: str,
+    now: datetime,
+    stall_threshold_days: int = STALL_THRESHOLD_DAYS,
+) -> NegativeClassHealth:
+    """Read the three timestamps the assessment needs. Read-only."""
+    instrument = _MARKET_TO_INSTRUMENT.get(market)
+
+    forecast_filters = [TradeForecast.decision_bucket == NEGATIVE_CLASS_BUCKET]
+    if instrument is not None:
+        forecast_filters.append(TradeForecast.instrument_type == instrument)
+
+    forecast_last_at = (
+        await db.execute(
+            select(func.max(TradeForecast.created_at)).where(*forecast_filters)
+        )
+    ).scalar_one_or_none()
+
+    # ``first_bucketed`` anchors the far edge of the historical gap. It uses the
+    # same filters so the gap is described in the same scope it is measured.
+    first_bucketed = (
+        await db.execute(
+            select(func.min(TradeForecast.created_at)).where(*forecast_filters)
+        )
+    ).scalar_one_or_none()
+
+    item_stmt = (
+        select(func.max(InvestmentReportItem.created_at))
+        .join(InvestmentReport, InvestmentReportItem.report_id == InvestmentReport.id)
+        .where(InvestmentReportItem.decision_bucket == NEGATIVE_CLASS_BUCKET)
+    )
+    if market:
+        item_stmt = item_stmt.where(InvestmentReport.market == market)
+    report_item_last_at = (await db.execute(item_stmt)).scalar_one_or_none()
+
+    return assess_negative_class_health(
+        now=now,
+        market=market,
+        forecast_last_at=_aware(forecast_last_at, now),
+        report_item_last_at=_aware(report_item_last_at, now),
+        first_bucketed_forecast_at=_aware(first_bucketed, now),
+        stall_threshold_days=stall_threshold_days,
+    )
+
+
+def _aware(value: datetime | None, reference: datetime) -> datetime | None:
+    """Match tz-awareness to ``reference`` so subtraction never raises.
+
+    The columns are ``TIMESTAMP WITH TIME ZONE``, but a SQLite-backed test
+    harness hands back naive datetimes; normalising here keeps the pure
+    assessment free of driver trivia.
+    """
+    if value is None:
+        return None
+    if (value.tzinfo is None) == (reference.tzinfo is None):
+        return value
+    if reference.tzinfo is None:
+        return value.replace(tzinfo=None)
+    return value.replace(tzinfo=reference.tzinfo)
+
+
+def market_stall_window(now: datetime, days: int = STALL_THRESHOLD_DAYS) -> datetime:
+    """Convenience for callers that want the cutoff instant itself."""
+    return now - timedelta(days=days)
+
+
+__all__ = [
+    "NEGATIVE_CLASS_BUCKET",
+    "STALL_THRESHOLD_DAYS",
+    "NegativeClassHealth",
+    "assess_negative_class_health",
+    "load_negative_class_health",
+    "market_stall_window",
+    "negative_class_warnings",
+]

--- a/docs/runbooks/negative-class-recording.md
+++ b/docs/runbooks/negative-class-recording.md
@@ -1,0 +1,179 @@
+# Negative-class (rejected-candidate) recording — ROB-1283
+
+**한 줄**: "매수 후보가 정말 없었나"에 정본 데이터로 답하기 위한 기각 코호트 기록 경로.
+🔴 **관측 전용** — 주문·승인 경로에 영향 0.
+
+---
+
+## 1. 근본 원인 (AC1) — 실측 확정
+
+### 관측 (prod DB, 2026-08-20 read-only SELECT)
+
+| 관측 | 값 |
+|---|---|
+| `investment_report_items[deferred_no_action]` 마지막 | **2026-06-15** (77건 전부 05-26~06-15) |
+| `investment_report_items` 테이블 전체 마지막 | 2026-07-28 (1건) |
+| 아이템 생산 프로파일(CLAUDE_ADVISOR/HERMES_*/claude_crypto_operator) 마지막 | **2026-06-15** |
+| 그 이후 리포트 | claude_ops 3건(06-23/27/29, deferred **0**) + CLAUDE_ADVISOR 1건(07-28, 아이템 1) |
+| `trade_forecasts` **첫** 행 | **2026-07-03** |
+| `trade_forecasts` 마지막 | 2026-08-20 (정상 가동, 410건) |
+| `report_uuid` / `report_item_uuid` | **전건 NULL** |
+
+### 판정: **핸들러 파손 아님 — 플레이북 드리프트(호출 지점 부재)**
+
+근거 3가지:
+
+1. **핸들러는 살아 있다.** 07-28 CLAUDE_ADVISOR 리포트가 아이템까지 정상 생성됐다.
+   `register_investment_report_tools`는 프로파일 분기 없이 **무조건 등록**되므로
+   도구 자체는 세션에 노출돼 있다.
+
+2. **두 표면은 겹친 적이 없다.** 아이템은 06-15에 죽고 forecast는 **07-03에 시작**했다.
+   → `report_uuid` 100% NULL은 "링크 배선이 끊긴 것"이 아니라 **연결할 리포트가 애초에
+   존재한 적이 없는 것**이다. 🔴 이 구분이 중요하다: 링크 배선만 고쳐도 아무것도 안 채워진다.
+
+3. **라이브 프롬프트 5개 전부에 호출 지점이 없다.** (`auto_trader-operator/prompts/`)
+
+   | 프롬프트 | `deferred_no_action` 언급 | `investment_report_create`/`add_items` 언급 |
+   |---|---|---|
+   | kr-open-trade.md | O (L77) | **0** |
+   | us-open-trade.md | O (L46) | **0** |
+   | crypto-session-trade.md | O (L49) | **0** |
+   | kr-nxt-prep.md | O (L38) | **0** |
+   | kr-nxt-preopen-trade.md | O (L87) | **0** |
+
+   전부 `forecast_save`는 이름을 대고, `decision_bucket`을 **쓸 수 있는 유일한 도구**는
+   이름을 대지 않는다. 세션은 계약의 forecast 절반만 이행할 수 있었고, 그것을 성실히 했다.
+
+**즉 결함은 세션에도 핸들러에도 없다. 어휘만 있고 호출 지점이 없는 계약에 있었다.**
+그리고 아무도 보지 않았기 때문에 **66일간 침묵**했다.
+
+### 재현
+
+```bash
+ENV_FILE=... uv run python -m scripts.diagnose_negative_class_recording        # 사람용
+ENV_FILE=... uv run python -m scripts.diagnose_negative_class_recording --json # 기계용
+```
+읽기 전용(SELECT만). exit 0 = 기록 정상, exit 1 = stalled/never_recorded.
+
+---
+
+## 2. 복구 (AC2) — 세션이 실제로 부르는 표면에 negative class를 얹는다
+
+`forecast_save`가 라이브 표면이므로 어휘를 그쪽으로 가져왔다.
+
+```python
+forecast_save(
+    created_by="kr-open-trade",
+    symbol="005930",
+    instrument_type="equity_kr",
+    forecast_target={...},         # resolvable target
+    probability=0.30,
+    review_date="2026-09-01",
+    decision_bucket="deferred_no_action",   # ← 기각 코호트
+    report_item_uuid="<item_uuid>",         # ← 리포트 아이템이 있으면 함께
+)
+```
+
+- 컬럼: `review.trade_forecasts.decision_bucket` (nullable Text + CHECK + index)
+- 어휘 정본: `app/models/decision_vocabulary.DECISION_BUCKETS` — 리포트 아이템 CHECK,
+  Pydantic 스키마, forecast CHECK가 **같은 튜플**에서 생성돼 3층이 드리프트할 수 없다
+- 🔴 오타는 **거부**된다(`ForecastValidationError` + DB CHECK 이중). 조용히 저장돼서
+  코호트에서 사라지는 경로가 없다 — 그게 이 이슈의 원래 실패 형태다
+- `NULL` = "미분류"이지 **"기각 아님"이 아니다**
+
+### 왜 forecast 한 건만으로도 가치가 있나 (고아 기록 금지)
+
+bucket + resolvable target + review_date + outcome/brier가 **한 행에** 있다.
+그래서 기각 forecast는 실행한 판단과 **동일한 경로로** resolve·채점된다.
+리포트 아이템이 없어도 고아가 아니다. (`tests/test_rob1283_negative_class_db.py::
+test_negative_class_forecast_is_gradeable_like_any_other`가 기계 증명)
+
+ROB-1301 A/B 채점기가 필요로 하는 (코호트, 결과, 귀속)은 전부 이 한 테이블에서 나온다:
+`decision_bucket` × `session_label`/`created_by` × `outcome`/`brier_score`.
+
+---
+
+## 3. 링크 (AC3)
+
+- `report_uuid` / `report_item_uuid`는 **UUID 문자열로 검증·정규화**된다.
+  조인 불가능한 값은 **쓰기 시점에 거부** — 링크된 것처럼 보이면서 영원히 조인 안 되는
+  행을 만들지 않는다(그건 링크 없음보다 나쁘다).
+- 🔴 **기존 351건 백필은 하지 않았다.** 연결 대상 리포트 아이템이 존재하지 않으므로
+  백필할 진실이 없다. 별건이 아니라 **불가능**이다 — §1 판정 참조.
+- negative class인데 `report_item_uuid`가 없으면 `forecast_save` 응답의 `warnings`가
+  알려준다(차단 아님, 조언).
+
+### 조회
+
+```
+get_forecasts(decision_bucket="deferred_no_action")   # 기각 코호트
+```
+`summary.by_decision_bucket`은 `unclassified`를 **별도 카운트**한다 — 그 숫자가
+사각지대의 크기이지 0이 아니다.
+
+---
+
+## 4. 회귀 가드 (AC4) — 런스타트에서 보인다
+
+`get_operating_briefing` 응답에 `negative_class_recording` 섹션이 추가됐다.
+
+```json
+{
+  "status": "stalled",           // ok | stalled | never_recorded | unavailable
+  "market": "kr",
+  "last_recorded_at": "2026-06-15T00:00:00+00:00",
+  "last_source": "report_item",  // forecast | report_item
+  "stale_days": 66,
+  "stall_threshold_days": 7,
+  "gap": { "starts_at": "...", "ends_at": null, "open": true,
+           "days": 66, "backfilled": false },
+  "notes": ["..."]
+}
+```
+
+🔵 **운영자 레포 변경 0으로 세션 준수 스탬프에 도달한다.**
+route-stamp(`operator-compliance/v1`)가 `briefing_capture.response`에 브리핑 응답을
+**통째로 박제**하므로, 이 섹션은 자동으로 스탬프에 들어간다.
+
+주의:
+- 🔴 임계 7일은 **판단값**이다. 시장별 세션이 하루 여러 번 돌고 매 회차가 사지 않은
+  후보를 평가하므로, 일주일 침묵은 조용한 주가 아니라 계약 미이행이다.
+  연휴로 우는 늑대가 되지 않을 만큼은 느슨하게 잡았다.
+- 🔴 **buckets 없는 일반 forecast는 카운트되지 않는다.** 실제 정지가 숨은 방식이
+  정확히 이거다 — `trade_forecasts`는 66일 내내 바빴다. "forecast 쓰이고 있나?"라고
+  물었으면 66일 동안 "예"라고 답했을 것이다.
+- 프로브 실패는 `status="unavailable"` + 사유. 🔴 **fail-open이지 fail-silent가 아니다** —
+  깨진 프로브가 깨끗한 `ok`로 세탁되지 않는다.
+
+---
+
+## 5. 결손 구간 — 🔴 메우지 않는다
+
+06-15 → (첫 bucketed forecast) 구간에는 구조화된 기각 기록이 **없다**.
+
+- `gap`으로 **명시 보고**된다. 끝점은 하드코딩이 아니라 데이터에서 파생되므로
+  구멍이 닫히면 설명도 따라 닫힌다.
+- `backfilled: false` 고정. 🔴 **추론 백필 금지** — 가짜 연속성은 눈에 보이는 구멍보다
+  나쁘다. 믿어지기 때문이다.
+- 이 구간을 가로지르는 코호트 분석은 **정확히 이 창만큼 불완전**하다. 인용 시 명시할 것.
+- §89차 gatecal(N=17)이 프록시 한정이었던 이유가 이 구간이다. 🔴 그 숫자로 게이트
+  완화/유지를 결정하지 말 것 — 자료이지 결론이 아니다.
+
+---
+
+## 6. 남은 일 (이 PR 범위 밖)
+
+1. 🔴 **운영자 레포 프롬프트 5종에 `decision_bucket` 인자를 명시**해야 실제 기록이 재개된다.
+   이 PR은 기록을 *가능·가시*하게 만들었을 뿐, 아웃오브프로세스 세션의 호출을 강제할 수 없다.
+   §1의 판정이 정확하다면 **이것이 유일한 잔여 차단 요인**이다.
+   (auto_trader-operator는 별도 repo·PR 관할)
+2. 마이그레이션 적용: `alembic upgrade head` — 운영자 소유 작업. 이 PR은 실행하지 않았다.
+3. 임계 7일은 실측 후 조정 가능(`STALL_THRESHOLD_DAYS`).
+
+## 7. 안전 경계
+
+- 브로커/주문/watch/승인/order-intent mutation **도달 불가**. 관측 전용.
+- 스케줄러 등록 **0**. 진단 스크립트는 수동 실행만.
+- 마이그레이션은 additive(1 컬럼 + 1 CHECK + 1 인덱스). 기존 컬럼·제약·인덱스 무변경,
+  행 재작성 없음. downgrade 왕복 검증 완료.
+- 진단 스크립트는 SELECT만 발행한다.

--- a/scripts/diagnose_negative_class_recording.py
+++ b/scripts/diagnose_negative_class_recording.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+"""ROB-1283 — reproduce the negative-class recording diagnosis. Read-only.
+
+The 2026-06-15 stall was found once, by hand, 66 days late. This script exists
+so the same measurement is a command rather than an archaeology session:
+
+    ENV_FILE=... uv run python -m scripts.diagnose_negative_class_recording
+
+It issues SELECTs only -- no INSERT/UPDATE/DELETE, no DDL, no broker call, no
+scheduler registration. It never backfills and never infers: a stretch of time
+with no records is printed as a gap with its real endpoints.
+
+Exit code is 0 when the negative class is recording, 1 when it is stalled or
+has never recorded, so a future check can gate on it. ``--json`` prints the
+machine-readable payload (the same shape ``get_operating_briefing`` embeds
+under ``negative_class_recording``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select
+
+from app.core.db import AsyncSessionLocal
+from app.models.investment_reports import InvestmentReport, InvestmentReportItem
+from app.models.review import TradeForecast
+from app.services.trade_journal.negative_class import (
+    NEGATIVE_CLASS_BUCKET,
+    STALL_THRESHOLD_DAYS,
+    load_negative_class_health,
+)
+
+MARKETS = ("kr", "us", "crypto")
+
+
+async def _surface_timeline(db: Any) -> dict[str, Any]:
+    """Per-month counts on both surfaces — the evidence the root cause rests on."""
+    # Truncate in UTC explicitly: date_trunc on a timestamptz uses the session
+    # TimeZone, which silently shifts a month boundary (a 08-01T00:20Z row
+    # reports as 2026-07 under a negative-offset session) — exactly the kind of
+    # off-by-one that made this stall hard to date in the first place.
+    item_month = func.date_trunc(
+        "month", func.timezone("UTC", InvestmentReportItem.created_at)
+    )
+    items = (
+        await db.execute(
+            select(
+                item_month.label("month"),
+                func.count().label("n"),
+                func.count(InvestmentReportItem.decision_bucket).label("bucketed"),
+            )
+            .group_by(item_month)
+            .order_by(item_month)
+        )
+    ).all()
+
+    fc_month = func.date_trunc("month", func.timezone("UTC", TradeForecast.created_at))
+    forecasts = (
+        await db.execute(
+            select(
+                fc_month.label("month"),
+                func.count().label("n"),
+                func.count(TradeForecast.decision_bucket).label("bucketed"),
+                func.count(TradeForecast.report_item_uuid).label("linked"),
+            )
+            .group_by(fc_month)
+            .order_by(fc_month)
+        )
+    ).all()
+    return {
+        "report_items_by_month": [
+            {"month": r.month.strftime("%Y-%m"), "items": r.n, "bucketed": r.bucketed}
+            for r in items
+        ],
+        "forecasts_by_month": [
+            {
+                "month": r.month.strftime("%Y-%m"),
+                "forecasts": r.n,
+                "bucketed": r.bucketed,
+                "linked_to_report_item": r.linked,
+            }
+            for r in forecasts
+        ],
+    }
+
+
+async def _bucket_spans(db: Any) -> list[dict[str, Any]]:
+    """First/last timestamp per decision_bucket on the report-item surface."""
+    rows = (
+        await db.execute(
+            select(
+                InvestmentReportItem.decision_bucket,
+                func.count().label("n"),
+                func.min(InvestmentReportItem.created_at).label("first"),
+                func.max(InvestmentReportItem.created_at).label("last"),
+            )
+            .join(
+                InvestmentReport,
+                InvestmentReportItem.report_id == InvestmentReport.id,
+            )
+            .group_by(InvestmentReportItem.decision_bucket)
+            .order_by(func.count().desc())
+        )
+    ).all()
+    return [
+        {
+            "decision_bucket": r.decision_bucket or "unclassified",
+            "count": r.n,
+            "first": r.first.isoformat() if r.first else None,
+            "last": r.last.isoformat() if r.last else None,
+        }
+        for r in rows
+    ]
+
+
+async def run(as_json: bool) -> int:
+    now = datetime.now(UTC)
+    async with AsyncSessionLocal() as db:
+        health = {
+            market: (
+                await load_negative_class_health(db, market=market, now=now)
+            ).to_dict()
+            for market in MARKETS
+        }
+        payload = {
+            "as_of": now.isoformat(),
+            "negative_class_bucket": NEGATIVE_CLASS_BUCKET,
+            "stall_threshold_days": STALL_THRESHOLD_DAYS,
+            "health_by_market": health,
+            "report_item_bucket_spans": await _bucket_spans(db),
+            **await _surface_timeline(db),
+        }
+
+    stalled = [m for m, h in health.items() if h["status"] != "ok"]
+    payload["stalled_markets"] = stalled
+
+    if as_json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 1 if stalled else 0
+
+    print(f"ROB-1283 negative-class recording — as of {payload['as_of']}")
+    print(f"bucket={NEGATIVE_CLASS_BUCKET} stall_threshold={STALL_THRESHOLD_DAYS}d\n")
+
+    print("per-market health")
+    for market, h in health.items():
+        print(
+            f"  {market:<7} status={h['status']:<15} "
+            f"last={h['last_recorded_at'] or '-'} "
+            f"source={h['last_source'] or '-'} stale_days={h['stale_days']}"
+        )
+        gap = h.get("gap")
+        if gap:
+            end = gap["ends_at"] or "OPEN (still no replacement record)"
+            print(
+                f"          GAP {gap['days']}d  {gap['starts_at']} -> {end}"
+                f"  backfilled={gap['backfilled']}"
+            )
+
+    print("\nreport-item decision_bucket spans")
+    for row in payload["report_item_bucket_spans"]:
+        print(
+            f"  {row['decision_bucket']:<24} n={row['count']:<5} "
+            f"{row['first']} .. {row['last']}"
+        )
+
+    print("\nreport items by month (surface A)")
+    for row in payload["report_items_by_month"]:
+        print(f"  {row['month']}  items={row['items']:<5} bucketed={row['bucketed']}")
+
+    print("\nforecasts by month (surface B)")
+    for row in payload["forecasts_by_month"]:
+        print(
+            f"  {row['month']}  forecasts={row['forecasts']:<5} "
+            f"bucketed={row['bucketed']:<5} "
+            f"linked_to_report_item={row['linked_to_report_item']}"
+        )
+
+    if stalled:
+        print(
+            "\nSTALLED: " + ", ".join(stalled) + " — see "
+            "docs/runbooks/negative-class-recording.md"
+        )
+    else:
+        print("\nOK — every market has a recent negative-class record.")
+    return 1 if stalled else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json", action="store_true", help="emit the machine-readable payload"
+    )
+    args = parser.parse_args()
+    return asyncio.run(run(args.json))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -74,7 +74,10 @@ from sqlalchemy import text
 # migration is deliberately not run by tests; create_all owns the test copy.
 # v37 (ROB-1292): review.external_cash_declarations append-only + correction
 # scope triggers (non-ORM DDL; table itself comes from create_all).
-SCHEMA_BOOTSTRAP_VERSION = 37
+# v38 (ROB-1283): review.trade_forecasts.decision_bucket (nullable Text + CHECK
+# + index). create_all builds it on a fresh DB; this bump forces a persistent
+# local test DB to re-bootstrap once so the column exists there too.
+SCHEMA_BOOTSTRAP_VERSION = 38
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"

--- a/tests/mcp_server/test_operating_briefing_negative_class.py
+++ b/tests/mcp_server/test_operating_briefing_negative_class.py
@@ -1,0 +1,148 @@
+"""ROB-1283 — the stall guard must reach the run-start briefing.
+
+Why this test matters more than it looks: the operator compliance stamp
+(``operator-compliance/v1``) embeds the whole ``get_operating_briefing``
+response verbatim under ``briefing_capture.response``. That embedding is the
+entire delivery mechanism for AC4 — it is how a stalled recording contract
+lands in the session compliance stamp without any operator-repo change. If this
+key silently stops being emitted, the guard is gone and nothing else fails.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.mcp_server.tooling import operating_briefing as ob
+from app.services.trade_journal.negative_class import NegativeClassHealth
+
+
+def _patch_briefing_sections(monkeypatch):
+    """Stub every section except the one under test."""
+
+    async def fake_holdings(**kwargs):
+        return {
+            "total_positions": 0,
+            "summary": {"total_value": 0},
+            "accounts": [],
+            "errors": [],
+        }
+
+    class FakePendingSnapshot:
+        orders = []
+        as_of = "2026-08-20T09:00:00+09:00"
+        freshness_status = "fresh"
+        unavailable_reason = None
+        account_scope = "kis_live"
+
+    async def fake_pending(db, *, market, account_scope):
+        return FakePendingSnapshot()
+
+    async def fake_active_watches(**kwargs):
+        return {
+            "success": True,
+            "count": 0,
+            "as_of": datetime.now(tz=UTC).isoformat(),
+            "active_watches": [],
+        }
+
+    async def fake_latest_report(db, *, market, account_scope):
+        return None
+
+    async def fake_recent_session(db, *, market, account_scope, limit):
+        return {"count": 0, "entries": []}
+
+    async def fake_recent_analysis(db, *, market):
+        return {"count": 0, "artifacts": []}
+
+    monkeypatch.setattr(ob, "_get_holdings_impl", fake_holdings)
+    monkeypatch.setattr(ob, "collect_pending_orders_snapshot", fake_pending)
+    monkeypatch.setattr(ob, "list_active_watches_impl", fake_active_watches)
+    monkeypatch.setattr(ob, "_latest_report_summary", fake_latest_report)
+    monkeypatch.setattr(ob, "_recent_session_context", fake_recent_session)
+    monkeypatch.setattr(ob, "_recent_analysis_artifacts", fake_recent_analysis)
+
+
+@pytest.mark.asyncio
+async def test_stalled_recording_is_visible_at_run_start(monkeypatch):
+    _patch_briefing_sections(monkeypatch)
+
+    async def fake_health(db, *, market, now):
+        return NegativeClassHealth(
+            status="stalled",
+            market=market,
+            last_recorded_at="2026-06-15T00:00:00+00:00",
+            last_source="report_item",
+            stale_days=66,
+            stall_threshold_days=7,
+            forecast_last_at=None,
+            report_item_last_at="2026-06-15T00:00:00+00:00",
+            gap={
+                "starts_at": "2026-06-15T00:00:00+00:00",
+                "ends_at": None,
+                "open": True,
+                "days": 66,
+                "reason": "test",
+                "backfilled": False,
+            },
+            notes=["stalled"],
+        )
+
+    monkeypatch.setattr(ob, "load_negative_class_health", fake_health)
+
+    resp = await ob.get_operating_briefing_impl(market="kr")
+
+    section = resp["negative_class_recording"]
+    assert section["status"] == "stalled"
+    assert section["stale_days"] == 66
+    # The gap travels with it and is never presented as backfilled.
+    assert section["gap"]["open"] is True
+    assert section["gap"]["backfilled"] is False
+
+
+@pytest.mark.asyncio
+async def test_healthy_recording_is_reported_as_ok(monkeypatch):
+    _patch_briefing_sections(monkeypatch)
+
+    async def fake_health(db, *, market, now):
+        return NegativeClassHealth(
+            status="ok",
+            market=market,
+            last_recorded_at="2026-08-20T00:00:00+00:00",
+            last_source="forecast",
+            stale_days=0,
+            stall_threshold_days=7,
+            forecast_last_at="2026-08-20T00:00:00+00:00",
+            report_item_last_at=None,
+            gap=None,
+        )
+
+    monkeypatch.setattr(ob, "load_negative_class_health", fake_health)
+
+    resp = await ob.get_operating_briefing_impl(market="kr")
+    assert resp["negative_class_recording"]["status"] == "ok"
+    assert resp["negative_class_recording"]["gap"] is None
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_is_reported_not_swallowed_into_ok(monkeypatch):
+    """Fail-open must not mean fail-silent.
+
+    The briefing still returns (it is the run-start surface), but a broken probe
+    reports ``unavailable`` with a reason — never a clean ``ok`` that would be
+    read as "recording is fine".
+    """
+    _patch_briefing_sections(monkeypatch)
+
+    async def boom(db, *, market, now):
+        raise RuntimeError("column missing")
+
+    monkeypatch.setattr(ob, "load_negative_class_health", boom)
+
+    resp = await ob.get_operating_briefing_impl(market="kr")
+
+    section = resp["negative_class_recording"]
+    assert section["status"] == "unavailable"
+    assert section["status"] != "ok"
+    assert "negative_class_recording_failed" in section["unavailable_reason"]
+    # The rest of the briefing is unaffected.
+    assert resp["success"] is True

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -164,6 +164,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             await connection.execute(
                 text("DROP TABLE review.watch_event_repricing_claims")
             )
+            # ROB-1283's decision_bucket column is later than this boundary and
+            # is already materialized by create_all, so drop it (its CHECK and
+            # index go with it) and let the migration add it back.
+            await connection.execute(
+                text("ALTER TABLE review.trade_forecasts DROP COLUMN decision_bucket")
+            )
             # B1 loss-cut approval is later than this reconstructed boundary.
             # Remove its current-head tables and additive columns so the head
             # upgrade exercises the migration instead of colliding with

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -151,6 +151,12 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             await connection.execute(
                 text("DROP TABLE review.watch_event_repricing_claims")
             )
+            # ROB-1283's decision_bucket column is later than this boundary and
+            # is already materialized by create_all, so drop it (its CHECK and
+            # index go with it) and let the migration add it back.
+            await connection.execute(
+                text("ALTER TABLE review.trade_forecasts DROP COLUMN decision_bucket")
+            )
             # B1 loss-cut approval is later than this reconstructed boundary.
             # Remove its current-head tables and additive columns so the head
             # upgrade exercises the migration instead of colliding with

--- a/tests/test_rob1283_negative_class_db.py
+++ b/tests/test_rob1283_negative_class_db.py
@@ -1,0 +1,256 @@
+# tests/test_rob1283_negative_class_db.py
+"""ROB-1283 — DB-level proof that the negative class records, queries, and scores.
+
+The point of the column is not that it stores a string. It is that a rejected
+candidate recorded through ``forecast_save`` is later *findable* and *gradeable*
+by the same machinery that grades acted-on calls — otherwise ROB-1301's A/B
+comparison inherits a cohort it cannot score, which is the orphan-record failure
+this issue exists to prevent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast
+from app.services.trade_journal import forecast_service as svc
+from app.services.trade_journal.negative_class import (
+    NEGATIVE_CLASS_BUCKET,
+    load_negative_class_health,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+_TOUCH_RULE_VERSION = "window-touch-v1-high-gte-low-lte"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
+    await db_session.execute(delete(TradeForecast))
+    await db_session.commit()
+
+
+def _target(target_price: float = 130.0) -> dict:
+    return {
+        "kind": "price_target",
+        "direction": "at_or_above",
+        "target_price": target_price,
+        "outcome_rule_version": _TOUCH_RULE_VERSION,
+    }
+
+
+async def _save(db: AsyncSession, **overrides):
+    kwargs = {
+        "created_by": "kr-open-trade",
+        "symbol": "005930",
+        "instrument_type": "equity_kr",
+        "forecast_target": _target(),
+        "probability": 0.3,
+        "review_date": "2026-09-01",
+    }
+    kwargs.update(overrides)
+    action, row = await svc.save_forecast(db, **kwargs)
+    await db.commit()
+    await db.refresh(row)
+    return action, row
+
+
+async def test_negative_class_forecast_persists_and_serialises(
+    db_session: AsyncSession,
+) -> None:
+    _, row = await _save(db_session, decision_bucket=NEGATIVE_CLASS_BUCKET)
+    assert row.decision_bucket == NEGATIVE_CLASS_BUCKET
+    assert svc.serialize_forecast(row)["decision_bucket"] == NEGATIVE_CLASS_BUCKET
+
+
+async def test_bucket_defaults_to_null_so_existing_callers_are_unaffected(
+    db_session: AsyncSession,
+) -> None:
+    """Back-compat: every pre-existing forecast_save call keeps working."""
+    _, row = await _save(db_session)
+    assert row.decision_bucket is None
+
+
+async def test_unknown_bucket_is_rejected_before_the_write(
+    db_session: AsyncSession,
+) -> None:
+    with pytest.raises(svc.ForecastValidationError):
+        await _save(db_session, decision_bucket="defered_no_action")
+    await db_session.rollback()
+    remaining = (await db_session.execute(select(TradeForecast))).scalars().all()
+    assert remaining == []
+
+
+async def test_unjoinable_report_link_is_rejected_before_the_write(
+    db_session: AsyncSession,
+) -> None:
+    with pytest.raises(svc.ForecastValidationError):
+        await _save(db_session, report_item_uuid="not-a-uuid")
+    await db_session.rollback()
+    assert (await db_session.execute(select(TradeForecast))).scalars().all() == []
+
+
+async def test_report_link_survives_the_round_trip_and_can_join(
+    db_session: AsyncSession,
+) -> None:
+    item_uuid = str(uuid.uuid4())
+    _, row = await _save(
+        db_session,
+        decision_bucket=NEGATIVE_CLASS_BUCKET,
+        report_item_uuid=item_uuid.upper(),
+    )
+    # Stored canonically, so a string-equality join against the item table holds.
+    assert row.report_item_uuid == item_uuid
+    found = (
+        (
+            await db_session.execute(
+                select(TradeForecast).where(TradeForecast.report_item_uuid == item_uuid)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(found) == 1
+
+
+async def test_cohort_is_queryable_by_bucket(db_session: AsyncSession) -> None:
+    await _save(
+        db_session, decision_bucket=NEGATIVE_CLASS_BUCKET, forecast_id=uuid.uuid4()
+    )
+    await _save(
+        db_session, decision_bucket="new_buy_candidate", forecast_id=uuid.uuid4()
+    )
+    await _save(db_session, forecast_id=uuid.uuid4())  # unclassified
+
+    cohort = await svc.list_forecasts(db_session, decision_bucket=NEGATIVE_CLASS_BUCKET)
+    assert cohort["summary"]["count"] == 1
+    assert cohort["entries"][0]["decision_bucket"] == NEGATIVE_CLASS_BUCKET
+
+    everything = await svc.list_forecasts(db_session)
+    breakdown = everything["summary"]["by_decision_bucket"]
+    # "unclassified" is counted, not collapsed: it is the size of the blind spot.
+    assert breakdown[NEGATIVE_CLASS_BUCKET] == 1
+    assert breakdown["new_buy_candidate"] == 1
+    assert breakdown["unclassified"] == 1
+
+
+async def test_typo_in_the_cohort_query_errors_instead_of_returning_empty(
+    db_session: AsyncSession,
+) -> None:
+    """An empty result would read as "nothing was rejected". It must raise."""
+    await _save(db_session, decision_bucket=NEGATIVE_CLASS_BUCKET)
+    with pytest.raises(svc.ForecastValidationError):
+        await svc.list_forecasts(db_session, decision_bucket="deferred")
+
+
+async def test_negative_class_forecast_is_gradeable_like_any_other(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The anti-orphan guarantee ROB-1301's scoring depends on.
+
+    A bucketed forecast must resolve and score through the *same* path as an
+    unbucketed one — the bucket is a label on the cohort, never a side channel
+    that diverts the row out of scoring.
+    """
+    from app.services.daily_candles.repository import DailyCandleRow
+
+    async def _fake_window(*args, **kwargs):
+        return [
+            DailyCandleRow(
+                time_utc=datetime(2026, 8, 25, tzinfo=UTC),
+                symbol="005930",
+                partition="KRX",
+                open=125.0,
+                high=131.0,
+                low=124.0,
+                close=130.5,
+                adj_close=None,
+                volume=1000.0,
+                value=130000.0,
+                source="kis",
+            )
+        ]
+
+    monkeypatch.setattr(svc, "_read_window_candles", _fake_window)
+
+    _, row = await _save(
+        db_session,
+        decision_bucket=NEGATIVE_CLASS_BUCKET,
+        review_date="2026-08-25",
+        probability=0.3,
+    )
+    result = await svc.resolve_forecast(
+        db_session, forecast_id=row.forecast_id, persist=True, backfill_missing=False
+    )
+    await db_session.commit()
+    await db_session.refresh(row)
+
+    assert result["status"] == "resolved", result
+    assert result["computed"]["brier_score"] is not None
+    assert row.status == "closed"
+    assert row.outcome is True  # high 131 >= target 130
+    assert row.brier_score is not None
+    # The label survives scoring, so the cohort stays identifiable afterwards.
+    assert row.decision_bucket == NEGATIVE_CLASS_BUCKET
+
+
+async def test_health_reads_the_live_surface(db_session: AsyncSession) -> None:
+    now = datetime.now(UTC)
+    health = await load_negative_class_health(db_session, market="kr", now=now)
+    assert health.status == "never_recorded"
+
+    await _save(db_session, decision_bucket=NEGATIVE_CLASS_BUCKET)
+    health = await load_negative_class_health(db_session, market="kr", now=now)
+    assert health.status == "ok"
+    assert health.last_source == "forecast"
+
+
+async def test_health_is_scoped_per_market(db_session: AsyncSession) -> None:
+    """A KR rejection must not make US look healthy."""
+    now = datetime.now(UTC)
+    await _save(db_session, decision_bucket=NEGATIVE_CLASS_BUCKET)
+    assert (
+        await load_negative_class_health(db_session, market="kr", now=now)
+    ).status == "ok"
+    assert (
+        await load_negative_class_health(db_session, market="us", now=now)
+    ).status == "never_recorded"
+
+
+async def test_unbucketed_forecasts_do_not_count_as_negative_class(
+    db_session: AsyncSession,
+) -> None:
+    """The stall must not be masked by ordinary forecast traffic.
+
+    This is precisely how the real stall hid: ``trade_forecasts`` was busy the
+    whole time, so any check that merely asked "are forecasts being written?"
+    would have answered yes for 66 days.
+    """
+    await _save(db_session)
+    health = await load_negative_class_health(
+        db_session, market="kr", now=datetime.now(UTC)
+    )
+    assert health.status == "never_recorded"
+
+
+async def test_stale_bucketed_forecast_reports_stalled(
+    db_session: AsyncSession,
+) -> None:
+    _, row = await _save(db_session, decision_bucket=NEGATIVE_CLASS_BUCKET)
+    far_future = datetime.now(UTC).replace(year=datetime.now(UTC).year + 1)
+    health = await load_negative_class_health(db_session, market="kr", now=far_future)
+    assert health.status == "stalled"
+    assert health.stale_days >= 365
+    assert date.today() is not None  # sanity: no clock freezing in this module

--- a/tests/test_rob1283_negative_class_recording.py
+++ b/tests/test_rob1283_negative_class_recording.py
@@ -1,0 +1,336 @@
+# tests/test_rob1283_negative_class_recording.py
+"""ROB-1283 — negative-class recording: vocabulary, links, and the stall guard.
+
+The failure this guards against is not a crash. It is 66 days of silence that
+everything downstream read as "nothing was rejected". So the assertions below
+care most about the cases where a wrong answer would still *look* fine:
+
+* a mistyped bucket must raise, not vanish into an empty cohort;
+* an unlinkable report link must raise, not persist as a row that never joins;
+* a stalled market must report ``stalled``, not ``ok`` with a stale timestamp;
+* a gap must be reported as a gap, never smoothed into continuity.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.trade_journal.forecast_service import (
+    ForecastValidationError,
+    _validate_decision_bucket,
+    normalize_report_link,
+)
+from app.services.trade_journal.negative_class import (
+    NEGATIVE_CLASS_BUCKET,
+    STALL_THRESHOLD_DAYS,
+    assess_negative_class_health,
+    negative_class_warnings,
+)
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 8, 20, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------- #
+# vocabulary — a typo must be loud                                            #
+# --------------------------------------------------------------------------- #
+def test_valid_bucket_passes_through() -> None:
+    assert _validate_decision_bucket("deferred_no_action") == "deferred_no_action"
+    assert _validate_decision_bucket("  risk_watch  ") == "risk_watch"
+
+
+def test_none_and_blank_mean_not_classified() -> None:
+    assert _validate_decision_bucket(None) is None
+    assert _validate_decision_bucket("   ") is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "defered_no_action",  # single-letter typo
+        "deferred",  # truncated
+        "DEFERRED_NO_ACTION",  # wrong case
+        "no_action",  # plausible synonym
+    ],
+)
+def test_unknown_bucket_raises_rather_than_silently_dropping(bad: str) -> None:
+    """A typo'd bucket that stored as-is would be invisible to the cohort query.
+
+    That is the exact shape of this issue's original failure, so it must fail
+    at write time and name the accepted vocabulary.
+    """
+    with pytest.raises(ForecastValidationError) as exc:
+        _validate_decision_bucket(bad)
+    assert "decision_bucket" in str(exc.value)
+    assert NEGATIVE_CLASS_BUCKET in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# links — a link that cannot join is worse than no link                       #
+# --------------------------------------------------------------------------- #
+def test_report_link_normalised_to_canonical_uuid() -> None:
+    upper = "3F2504E0-4F89-11D3-9A0C-0305E82C3301"
+    assert normalize_report_link(upper, "report_uuid") == upper.lower()
+
+
+def test_blank_report_link_is_none_not_empty_string() -> None:
+    assert normalize_report_link("  ", "report_uuid") is None
+    assert normalize_report_link(None, "report_uuid") is None
+
+
+@pytest.mark.parametrize("bad", ["not-a-uuid", "12345", "item_uuid=abc"])
+def test_non_uuid_report_link_raises(bad: str) -> None:
+    with pytest.raises(ForecastValidationError) as exc:
+        normalize_report_link(bad, "report_item_uuid")
+    assert "report_item_uuid" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# per-record advisory                                                         #
+# --------------------------------------------------------------------------- #
+def test_missing_bucket_warns_about_cohort_invisibility() -> None:
+    warnings = negative_class_warnings({"decision_bucket": None})
+    assert len(warnings) == 1
+    assert NEGATIVE_CLASS_BUCKET in warnings[0]
+
+
+def test_negative_class_without_item_link_warns() -> None:
+    warnings = negative_class_warnings(
+        {"decision_bucket": NEGATIVE_CLASS_BUCKET, "report_item_uuid": None}
+    )
+    assert len(warnings) == 1
+    assert "report_item_uuid" in warnings[0]
+
+
+def test_fully_recorded_negative_class_is_silent() -> None:
+    assert (
+        negative_class_warnings(
+            {
+                "decision_bucket": NEGATIVE_CLASS_BUCKET,
+                "report_item_uuid": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+            }
+        )
+        == []
+    )
+
+
+def test_positive_bucket_does_not_demand_a_link() -> None:
+    assert (
+        negative_class_warnings(
+            {"decision_bucket": "new_buy_candidate", "report_item_uuid": None}
+        )
+        == []
+    )
+
+
+def test_warnings_never_raise_on_a_malformed_payload() -> None:
+    """Advisory output must never be able to break a forecast that already saved."""
+    assert negative_class_warnings({}) != []  # missing bucket -> warns
+    assert negative_class_warnings(None) == []  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# the stall guard                                                             #
+# --------------------------------------------------------------------------- #
+def _assess(**kw):
+    base = {
+        "now": NOW,
+        "market": "kr",
+        "forecast_last_at": None,
+        "report_item_last_at": None,
+        "first_bucketed_forecast_at": None,
+    }
+    base.update(kw)
+    return assess_negative_class_health(**base)
+
+
+def test_recent_forecast_is_ok() -> None:
+    health = _assess(forecast_last_at=datetime(2026, 8, 19, tzinfo=UTC))
+    assert health.status == "ok"
+    assert health.last_source == "forecast"
+    assert health.stale_days == 1
+
+
+def test_the_actual_rob1283_stall_reports_stalled_not_ok() -> None:
+    """The measured production state: items died 06-15, nothing replaced them."""
+    health = _assess(report_item_last_at=datetime(2026, 6, 15, tzinfo=UTC))
+    assert health.status == "stalled"
+    assert health.stale_days == 66
+    assert health.last_source == "report_item"
+
+
+def test_no_records_at_all_is_distinct_from_stalled() -> None:
+    """ "Never recorded" and "stopped recording" need different operator responses."""
+    health = _assess()
+    assert health.status == "never_recorded"
+    assert health.stale_days is None
+    assert health.last_recorded_at is None
+
+
+def test_either_surface_counts_and_the_newer_one_wins() -> None:
+    health = _assess(
+        report_item_last_at=datetime(2026, 6, 15, tzinfo=UTC),
+        forecast_last_at=datetime(2026, 8, 18, tzinfo=UTC),
+    )
+    assert health.status == "ok"
+    assert health.last_source == "forecast"
+
+
+def test_threshold_boundary_is_inclusive() -> None:
+    exactly = NOW.replace(day=NOW.day - STALL_THRESHOLD_DAYS)
+    assert _assess(forecast_last_at=exactly).status == "stalled"
+    just_inside = NOW.replace(day=NOW.day - STALL_THRESHOLD_DAYS + 1)
+    assert _assess(forecast_last_at=just_inside).status == "ok"
+
+
+# --------------------------------------------------------------------------- #
+# gaps are reported, never smoothed                                           #
+# --------------------------------------------------------------------------- #
+def test_open_gap_is_marked_open_and_not_backfilled() -> None:
+    health = _assess(report_item_last_at=datetime(2026, 6, 15, tzinfo=UTC))
+    assert health.gap is not None
+    assert health.gap["open"] is True
+    assert health.gap["ends_at"] is None
+    assert health.gap["backfilled"] is False
+    assert health.gap["days"] == 66
+
+
+def test_closed_gap_keeps_its_real_endpoints() -> None:
+    """Once a bucketed forecast takes over, the hole is bounded — not erased."""
+    health = _assess(
+        report_item_last_at=datetime(2026, 6, 15, tzinfo=UTC),
+        first_bucketed_forecast_at=datetime(2026, 8, 20, tzinfo=UTC),
+        forecast_last_at=datetime(2026, 8, 20, tzinfo=UTC),
+    )
+    assert health.status == "ok"
+    assert health.gap is not None
+    assert health.gap["open"] is False
+    assert health.gap["starts_at"].startswith("2026-06-15")
+    assert health.gap["ends_at"].startswith("2026-08-20")
+    assert health.gap["days"] == 66
+
+
+def test_overlapping_surfaces_report_no_gap() -> None:
+    health = _assess(
+        report_item_last_at=datetime(2026, 8, 19, tzinfo=UTC),
+        first_bucketed_forecast_at=datetime(2026, 7, 1, tzinfo=UTC),
+        forecast_last_at=datetime(2026, 8, 19, tzinfo=UTC),
+    )
+    assert health.gap is None
+
+
+def test_a_short_quiet_stretch_is_not_called_a_gap() -> None:
+    health = _assess(
+        report_item_last_at=datetime(2026, 8, 18, tzinfo=UTC),
+        first_bucketed_forecast_at=datetime(2026, 8, 20, tzinfo=UTC),
+        forecast_last_at=datetime(2026, 8, 20, tzinfo=UTC),
+    )
+    assert health.gap is None
+
+
+def test_health_payload_is_json_serialisable_for_the_compliance_stamp() -> None:
+    """The operator stamp embeds this verbatim, so it must survive json.dumps."""
+    import json
+
+    payload = _assess(report_item_last_at=datetime(2026, 6, 15, tzinfo=UTC)).to_dict()
+    round_tripped = json.loads(json.dumps(payload))
+    assert round_tripped["status"] == "stalled"
+    assert round_tripped["gap"]["backfilled"] is False
+
+
+# --------------------------------------------------------------------------- #
+# order path — a bad audit link must not cost the forecast                    #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_order_path_drops_a_bad_link_but_still_publishes_the_forecast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-473 policy preserved: this link is audit metadata on the order path.
+
+    ``save_forecast`` is strict so a session gets a loud error, but the
+    automatic place-time publish must degrade to "no link", never to "no
+    forecast" — the forecast is the scoring record.
+    """
+    from app.services import live_place_provenance as lpp
+
+    captured: dict[str, object] = {}
+
+    class _FakeForecast:
+        forecast_id = "11111111-1111-1111-1111-111111111111"
+
+    async def fake_save(db, **kwargs):
+        captured.update(kwargs)
+        return "created", _FakeForecast()
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def commit(self):
+            return None
+
+    monkeypatch.setattr(lpp, "save_forecast", fake_save)
+    monkeypatch.setattr(lpp, "AsyncSessionLocal", lambda: _FakeSession())
+
+    result = await lpp.publish_place_time_forecast(
+        correlation_id="corr-1",
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        target_price=130.0,
+        min_hold_days=5,
+        session_label="kr-open-trade",
+        created_by="kr-open-trade",
+        report_item_uuid="definitely-not-a-uuid",
+    )
+
+    assert result == _FakeForecast.forecast_id  # the forecast still published
+    assert captured["report_item_uuid"] is None  # the unusable link was dropped
+
+
+@pytest.mark.asyncio
+async def test_order_path_keeps_a_valid_link(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.services import live_place_provenance as lpp
+
+    captured: dict[str, object] = {}
+    item_uuid = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+
+    class _FakeForecast:
+        forecast_id = "22222222-2222-2222-2222-222222222222"
+
+    async def fake_save(db, **kwargs):
+        captured.update(kwargs)
+        return "created", _FakeForecast()
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def commit(self):
+            return None
+
+    monkeypatch.setattr(lpp, "save_forecast", fake_save)
+    monkeypatch.setattr(lpp, "AsyncSessionLocal", lambda: _FakeSession())
+
+    await lpp.publish_place_time_forecast(
+        correlation_id="corr-2",
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        target_price=130.0,
+        min_hold_days=5,
+        session_label="kr-open-trade",
+        created_by="kr-open-trade",
+        report_item_uuid=item_uuid.upper(),
+    )
+
+    assert captured["report_item_uuid"] == item_uuid


### PR DESCRIPTION
## 🔴 정지점 = draft. 자가 merge/ready/배포 0. 검증자 대기.

## AC1 — 근본 원인: **핸들러 파손 아님, 호출 지점 부재**

06-15 경계 실측(prod read-only SELECT):

| 관측 | 값 |
|---|---|
| `investment_report_items[deferred_no_action]` 마지막 | **2026-06-15** (77건) |
| 아이템 생산 프로파일 마지막 | **2026-06-15** |
| 이후 리포트 | claude_ops 3건(deferred **0**) + CLAUDE_ADVISOR 1건(07-28, 아이템 1 **정상 생성**) |
| `trade_forecasts` **첫** 행 | **2026-07-03** |
| `report_uuid`/`report_item_uuid` | 전건 NULL |

판정 근거 3가지:

1. **핸들러는 살아 있다** — 07-28 리포트가 아이템까지 정상 생성. `register_investment_report_tools`는 프로파일 분기 없이 무조건 등록.
2. **두 표면은 겹친 적이 없다** — 아이템 사망(06-15) 후 forecast 시작(07-03). 🔴 `report_uuid` 100% NULL은 배선 파손이 아니라 **연결할 리포트가 존재한 적이 없는 것**. 링크만 고쳐도 아무것도 안 채워진다.
3. **라이브 프롬프트 5종 전부 호출 지점 0** — `deferred_no_action` 어휘는 5/5 인용하면서, 그걸 쓸 수 있는 유일한 도구(`investment_report_create`/`add_items`)는 **0/5** 언급. 전부 `forecast_save`만 호명.

→ 세션은 계약의 forecast 절반만 이행 가능했고 성실히 했다. 결함은 세션에도 핸들러에도 없고 **어휘만 있고 호출 지점 없는 계약**에 있었다. 그리고 아무도 보지 않아 66일 침묵했다.

## AC2 — 세션이 실제로 부르는 표면에 negative class

- `review.trade_forecasts.decision_bucket` (nullable Text + CHECK + index, additive)
- `forecast_save(decision_bucket="deferred_no_action", ...)` — 한 번의 호출로 구조화 기록
- 어휘 정본 = `app/models/decision_vocabulary` (leaf). forecast CHECK · 아이템 CHECK · Pydantic이 **같은 튜플**에서 생성
- 🔴 오타 fail-closed (서비스 + DB CHECK 이중). 조용히 코호트에서 사라지는 경로 없음

**고아 기록 금지**: bucket + resolvable target + review_date + outcome/brier가 한 행 → 리포트 아이템 없어도 **동일 경로로 채점**된다. `test_negative_class_forecast_is_gradeable_like_any_other`가 기계 증명(resolve → closed, brier 산출, bucket 보존).

ROB-1301 채점기가 필요한 (코호트 × 귀속 × 결과)이 전부 이 한 테이블에서 나온다.

## AC3 — 링크

- `report_uuid`/`report_item_uuid` UUID 검증·정규화. 조인 불가 값은 **쓰기 시점 거부**
- 🔴 기존 351건 백필 안 함 — 연결 대상이 존재한 적 없어 **백필할 진실이 없다**(별건이 아니라 불가능)
- 미링크 negative class는 `warnings`로 조언(차단 아님)
- `get_forecasts(decision_bucket=...)` = 코호트 조회. `by_decision_bucket`의 `unclassified`는 **사각지대 크기**이지 0 아님

## AC4 — 런스타트 가드

`get_operating_briefing` → `negative_class_recording` 섹션 (status/stale_days/gap/notes).

🔵 **운영자 레포 변경 0으로 세션 준수 스탬프 도달** — route-stamp(`operator-compliance/v1`)가 `briefing_capture.response`에 브리핑을 통째로 박제하므로 자동 편입.

- 🔴 **bucket 없는 일반 forecast는 카운트 안 됨** — 실제 정지가 숨은 방식이 정확히 이것(`trade_forecasts`는 66일 내내 바빴다). "forecast 쓰이나?"라고 물었으면 66일간 "예"였다.
- 프로브 실패 = `unavailable` + 사유. fail-open이지 **fail-silent 아님**

## 결손 = 명시 보고, 메우지 않음

`gap.backfilled=false` 고정, 끝점은 데이터 파생(하드코딩 아님), 열린 구간은 `open=true`. 🔴 가짜 연속성은 눈에 보이는 구멍보다 나쁘다 — 믿어지기 때문이다.

## 부수 발견 및 처리

`live_place_provenance`: 링크 검증을 엄격하게 하면 주문 hot path에서 **malformed 링크 때문에 forecast 자체를 잃는** 회귀가 생긴다. ROB-473이 이미 "이 링크는 audit metadata, 절대 상위를 막지 않는다"로 정책을 정해뒀으므로, 그 경로만 fail-open 강제(링크만 버리고 forecast는 발행). 세션 대면 `save_forecast`는 엄격 유지 — 두 불변식 모두 보존.

## 검증

- 신규 테스트 43 (unit 28 + DB 12 + briefing 3) — 전부 통과
- 회귀: forecast/provenance/briefing/vocabulary 346 · ledger/order 1438 · **전체 unit 6709 passed, 3 skipped**
- `ruff check` clean · `ty check` clean
- 마이그레이션: run-owned scratch DB에서 `upgrade head` → `downgrade -1` → `upgrade head` 왕복 검증. CHECK가 오타를 실제로 거부하는 것까지 확인
- 🔴 **prod 미적용 확인**: `decision_bucket=None`, alembic version = `20260819_rob1286_claims` (변경 없음)

## 안전 경계

- 브로커/주문/watch/승인/order-intent mutation **도달 불가**. 관측 전용
- 스케줄러 등록 **0**. 진단 스크립트 수동 실행만, SELECT만 발행
- 마이그레이션 additive(1 컬럼 + 1 CHECK + 1 인덱스). 기존 컬럼·제약·인덱스 무변경, 행 재작성 없음
- 🔴 prod `alembic upgrade head`는 **운영자 소유**. 이 PR은 실행하지 않았다

## 🔴 잔여 차단 요인 (이 레포 밖)

기록이 실제로 재개되려면 **운영자 레포 프롬프트 5종에 `decision_bucket` 인자 명시**가 필요하다. 이 PR은 기록을 *가능·가시*하게 만들었을 뿐, 아웃오브프로세스 세션의 호출을 코드로 강제할 수 없다. §1 판정이 맞다면 이것이 유일한 남은 차단 요인이다. (auto_trader-operator = 별도 repo/PR 관할)

런북: `docs/runbooks/negative-class-recording.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
