### PR TITLE
fix(ROB-1305): Sentry whole-event scrubber + PII/prompt defaults off (W0)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -610,9 +610,10 @@ class Settings(BaseSettings):
     SENTRY_ENVIRONMENT: str | None = None
     SENTRY_TRACES_SAMPLE_RATE: float = 1.0
     SENTRY_PROFILES_SAMPLE_RATE: float = 1.0
-    SENTRY_SEND_DEFAULT_PII: bool = True
+    # ROB-1305: default-off. PII/prompt capture is opt-in via env, not repo default.
+    SENTRY_SEND_DEFAULT_PII: bool = False
     SENTRY_ENABLE_LOG_EVENTS: bool = True
-    SENTRY_MCP_INCLUDE_PROMPTS: bool = True
+    SENTRY_MCP_INCLUDE_PROMPTS: bool = False
     SENTRY_DEBUG: bool = False
 
     # Monitoring test route exposure

--- a/app/monitoring/sentry.py
+++ b/app/monitoring/sentry.py
@@ -87,7 +87,7 @@ _URL_BASIC_AUTH_RE = re.compile(
     r"(?P<prefix>https?://)[^\s/@\"']+:[^\s/@\"']+@", flags=re.IGNORECASE
 )
 _SECRET_QUERY_PARAM_RE = re.compile(
-    r"(?P<prefix>[?&](?:api[_-]?key|app[_-]?key|app[_-]?secret|"
+    r"(?P<prefix>(?:^|[?&])(?:api[_-]?key|app[_-]?key|app[_-]?secret|"
     r"access[_-]?key|access[_-]?token|secret|token|password|passwd)=)"
     r"[^&\s\"']+",
     flags=re.IGNORECASE,
@@ -381,28 +381,21 @@ def _before_send_transaction(event: Event, hint: Hint) -> Event | None:
         return event
     is_mcp_transport_transaction = "/mcp" in transaction_name
 
-    request = event.get("request")
-    if isinstance(request, dict):
-        event["request"] = _sanitize_in_place(request)
+    # ROB-1305: one coherent whole-event sanitization boundary, reused by
+    # error events (_before_send), logs (_before_send_log), breadcrumbs
+    # (_before_breadcrumb), and transaction events here. It walks every
+    # nested mapping/sequence on the event — request, contexts, extra, and
+    # every span's description/data alike — filtering by key name and by
+    # secret-value shape (URLs, query strings, JSON-embedded fields).
+    # Structural fields (span/trace ids, timestamps, ops, statuses) are
+    # numeric or hex and never match the secret-shape patterns, so they pass
+    # through unchanged; span descriptions/data for spans of every op (not
+    # just mcp.server) are covered by the same pass.
+    event = _sanitize_in_place(event)
 
     spans = event.get("spans", [])
     if not isinstance(spans, list):
         spans = []
-
-    # ROB-1305: scrub every span's description/data by key-name and by
-    # secret-value shape (e.g. a token embedded in a URL query string or
-    # path) — this covers non-MCP spans (httpx, sqlalchemy, ...) that the
-    # MCP-specific redaction below never touches. Structure (op, status,
-    # timestamps, span_id/trace_id) is left untouched.
-    for span in spans:
-        if not isinstance(span, dict):
-            continue
-        description = span.get("description")
-        if isinstance(description, str):
-            span["description"] = _scrub_secret_shapes_in_string(description)
-        span_data = span.get("data")
-        if isinstance(span_data, dict):
-            span["data"] = _sanitize_in_place(span_data)
 
     found_mcp_span = False
     transaction_renamed = False

--- a/app/monitoring/sentry.py
+++ b/app/monitoring/sentry.py
@@ -58,7 +58,59 @@ _SENSITIVE_KEYWORDS = (
     "passwd",
     "api_key",
     "apikey",
+    "appkey",
+    "app_key",
+    "access_key",
+    "accesskey",
+    "client_secret",
+    "bot_token",
+    "webhook",
+    "credential",
 )
+
+# ROB-1305: value-shape scrubbing for secrets embedded inside strings (URLs,
+# span descriptions) that key-name filtering above cannot reach because the
+# secret is not itself a dict key — e.g. a Telegram bot token in a URL path,
+# or a KIS/broker API key in a query string captured by the httpx integration.
+_TELEGRAM_BOT_URL_RE = re.compile(
+    r"(?P<prefix>https?://api\.telegram\.org/bot)[^/\s\"']+",
+    flags=re.IGNORECASE,
+)
+_TELEGRAM_BOT_PATH_RE = re.compile(
+    r"(?P<prefix>/bot)[^/\s\"']+"
+    r"(?P<suffix>/(?:sendMessage|editMessageText|answerCallbackQuery|"
+    r"sendPhoto|sendDocument|getMe))",
+    flags=re.IGNORECASE,
+)
+_BEARER_TOKEN_RE = re.compile(r"(?P<prefix>\bBearer\s+)\S+", flags=re.IGNORECASE)
+_URL_BASIC_AUTH_RE = re.compile(
+    r"(?P<prefix>https?://)[^\s/@\"']+:[^\s/@\"']+@", flags=re.IGNORECASE
+)
+_SECRET_QUERY_PARAM_RE = re.compile(
+    r"(?P<prefix>[?&](?:api[_-]?key|app[_-]?key|app[_-]?secret|"
+    r"access[_-]?key|access[_-]?token|secret|token|password|passwd)=)"
+    r"[^&\s\"']+",
+    flags=re.IGNORECASE,
+)
+# Matches an exact secret-named field inside a serialized JSON string, e.g.
+# the JSON text captured in an MCP span's `mcp.tool.result.content` data.
+_JSON_SECRET_FIELD_RE = re.compile(
+    r'(?P<prefix>"(?:authorization|cookie|set-cookie|x-api-key|token|secret|'
+    r"password|passwd|api[_-]?key|app[_-]?key|access[_-]?key|access[_-]?token|"
+    r'client[_-]?secret|bot[_-]?token|webhook|credential)"\s*:\s*")[^"]*(?P<suffix>")',
+    flags=re.IGNORECASE,
+)
+
+
+def _scrub_secret_shapes_in_string(value: str) -> str:
+    """Redact secret-bearing substrings without deleting the surrounding text."""
+    scrubbed = _TELEGRAM_BOT_URL_RE.sub(r"\g<prefix>[REDACTED]", value)
+    scrubbed = _TELEGRAM_BOT_PATH_RE.sub(r"\g<prefix>[REDACTED]\g<suffix>", scrubbed)
+    scrubbed = _BEARER_TOKEN_RE.sub(r"\g<prefix>[REDACTED]", scrubbed)
+    scrubbed = _URL_BASIC_AUTH_RE.sub(r"\g<prefix>[REDACTED]@", scrubbed)
+    scrubbed = _SECRET_QUERY_PARAM_RE.sub(r"\g<prefix>[REDACTED]", scrubbed)
+    scrubbed = _JSON_SECRET_FIELD_RE.sub(r"\g<prefix>[Filtered]\g<suffix>", scrubbed)
+    return scrubbed
 
 
 def _is_healthcheck_access_log(logger_name: str | None, message: str | None) -> bool:
@@ -275,6 +327,9 @@ def _sanitize_in_place(value: Any, parent_key: str | None = None) -> Any:
     if isinstance(value, tuple):
         return tuple(_sanitize_in_place(item, parent_key) for item in value)
 
+    if isinstance(value, str):
+        return _scrub_secret_shapes_in_string(value)
+
     return value
 
 
@@ -326,9 +381,28 @@ def _before_send_transaction(event: Event, hint: Hint) -> Event | None:
         return event
     is_mcp_transport_transaction = "/mcp" in transaction_name
 
+    request = event.get("request")
+    if isinstance(request, dict):
+        event["request"] = _sanitize_in_place(request)
+
     spans = event.get("spans", [])
     if not isinstance(spans, list):
         spans = []
+
+    # ROB-1305: scrub every span's description/data by key-name and by
+    # secret-value shape (e.g. a token embedded in a URL query string or
+    # path) — this covers non-MCP spans (httpx, sqlalchemy, ...) that the
+    # MCP-specific redaction below never touches. Structure (op, status,
+    # timestamps, span_id/trace_id) is left untouched.
+    for span in spans:
+        if not isinstance(span, dict):
+            continue
+        description = span.get("description")
+        if isinstance(description, str):
+            span["description"] = _scrub_secret_shapes_in_string(description)
+        span_data = span.get("data")
+        if isinstance(span_data, dict):
+            span["data"] = _sanitize_in_place(span_data)
 
     found_mcp_span = False
     transaction_renamed = False

--- a/app/monitoring/sentry.py
+++ b/app/monitoring/sentry.py
@@ -66,6 +66,7 @@ _SENSITIVE_KEYWORDS = (
     "bot_token",
     "webhook",
     "credential",
+    "signature",
 )
 
 # ROB-1305: value-shape scrubbing for secrets embedded inside strings (URLs,
@@ -76,28 +77,39 @@ _TELEGRAM_BOT_URL_RE = re.compile(
     r"(?P<prefix>https?://api\.telegram\.org/bot)[^/\s\"']+",
     flags=re.IGNORECASE,
 )
+# ROB-1305 follow-up: match by credential *shape* (digits:token), not by
+# enumerating known Telegram method names — a relative (no-host) bot path
+# using an unlisted method must not defeat redaction.
 _TELEGRAM_BOT_PATH_RE = re.compile(
-    r"(?P<prefix>/bot)[^/\s\"']+"
-    r"(?P<suffix>/(?:sendMessage|editMessageText|answerCallbackQuery|"
-    r"sendPhoto|sendDocument|getMe))",
+    r"(?P<prefix>/bot)\d+:[A-Za-z0-9_-]+",
     flags=re.IGNORECASE,
 )
 _BEARER_TOKEN_RE = re.compile(r"(?P<prefix>\bBearer\s+)\S+", flags=re.IGNORECASE)
 _URL_BASIC_AUTH_RE = re.compile(
     r"(?P<prefix>https?://)[^\s/@\"']+:[^\s/@\"']+@", flags=re.IGNORECASE
 )
+# ROB-1305 follow-up: both the query-string and JSON-field value-shape
+# matchers below are built from the same _SENSITIVE_KEYWORDS list the
+# dict-key sanitizer (_is_sensitive_key) uses, and match a keyword as a
+# *substring* of the key (not only an exact key), matching that sanitizer's
+# semantics — this closes the earlier drift where e.g. "client_secret" or
+# "signature"-shaped query/JSON keys were only caught for dict keys, not for
+# the same keyword embedded in a serialized query string or JSON blob.
+_SENSITIVE_KEY_SUBSTRING_RE = "|".join(
+    re.escape(keyword) for keyword in _SENSITIVE_KEYWORDS
+)
 _SECRET_QUERY_PARAM_RE = re.compile(
-    r"(?P<prefix>(?:^|[?&])(?:api[_-]?key|app[_-]?key|app[_-]?secret|"
-    r"access[_-]?key|access[_-]?token|secret|token|password|passwd)=)"
-    r"[^&\s\"']+",
+    r"(?P<prefix>(?:^|[?&])[A-Za-z0-9_-]*(?:"
+    + _SENSITIVE_KEY_SUBSTRING_RE
+    + r")[A-Za-z0-9_-]*=)[^&\s\"']+",
     flags=re.IGNORECASE,
 )
-# Matches an exact secret-named field inside a serialized JSON string, e.g.
-# the JSON text captured in an MCP span's `mcp.tool.result.content` data.
+# Matches a secret-named field inside a serialized JSON string, e.g. the JSON
+# text captured in an MCP span's `mcp.tool.result.content` data.
 _JSON_SECRET_FIELD_RE = re.compile(
-    r'(?P<prefix>"(?:authorization|cookie|set-cookie|x-api-key|token|secret|'
-    r"password|passwd|api[_-]?key|app[_-]?key|access[_-]?key|access[_-]?token|"
-    r'client[_-]?secret|bot[_-]?token|webhook|credential)"\s*:\s*")[^"]*(?P<suffix>")',
+    r'(?P<prefix>"[A-Za-z0-9_-]*(?:'
+    + _SENSITIVE_KEY_SUBSTRING_RE
+    + r')[A-Za-z0-9_-]*"\s*:\s*")[^"]*(?P<suffix>")',
     flags=re.IGNORECASE,
 )
 
@@ -105,7 +117,7 @@ _JSON_SECRET_FIELD_RE = re.compile(
 def _scrub_secret_shapes_in_string(value: str) -> str:
     """Redact secret-bearing substrings without deleting the surrounding text."""
     scrubbed = _TELEGRAM_BOT_URL_RE.sub(r"\g<prefix>[REDACTED]", value)
-    scrubbed = _TELEGRAM_BOT_PATH_RE.sub(r"\g<prefix>[REDACTED]\g<suffix>", scrubbed)
+    scrubbed = _TELEGRAM_BOT_PATH_RE.sub(r"\g<prefix>[REDACTED]", scrubbed)
     scrubbed = _BEARER_TOKEN_RE.sub(r"\g<prefix>[REDACTED]", scrubbed)
     scrubbed = _URL_BASIC_AUTH_RE.sub(r"\g<prefix>[REDACTED]@", scrubbed)
     scrubbed = _SECRET_QUERY_PARAM_RE.sub(r"\g<prefix>[REDACTED]", scrubbed)

--- a/docs/runbooks/sentry-credential-rotation.md
+++ b/docs/runbooks/sentry-credential-rotation.md
@@ -1,0 +1,109 @@
+# Credential rotation runbook — Sentry leak follow-up (ROB-1305)
+
+> **This document is procedure only. No rotation, revocation, regeneration,
+> Sentry data deletion, deploy, or restart is performed by writing or reading
+> this file.** Every step below is an **operator-owned decision**: whether to
+> rotate at all, which credentials, on what schedule, and how to sequence
+> deploys around it. ROB-1305 R1 (W0) scope ends at documenting this
+> procedure; see `sentry-pii-leak-evidence-rob1305.md` for the evidence that
+> motivates it.
+
+## 1. Why this exists
+
+The evidence inventory in `sentry-pii-leak-evidence-rob1305.md` shows the
+Telegram bot token reached Sentry unredacted in span descriptions, error
+messages, and log entries before the ROB-1305 scrubber fix. KIS `appkey`/
+`appsecret` header-path exposure is unconfirmed but flagged suspect. This
+runbook exists so that **if the operator decides to rotate**, the steps are
+known in advance rather than improvised during an incident.
+
+## 2. Candidate credentials and dependency map
+
+| Credential | Env var(s) | Used by | Blast radius if rotated without coordination |
+|---|---|---|---|
+| Telegram bot token | `TELEGRAM_TOKEN` | `app/monitoring/trade_notifier/transports.py` (all Telegram send/edit/callback calls); any deployed process that sends trade notifications | Old token stops working immediately at Telegram's API the moment it is revoked in BotFather — all in-flight and future notification sends fail until every deployed process picks up the new value |
+| KIS live app key/secret | `KIS_APP_KEY`, `KIS_APP_SECRET` | `app/services/brokers/kis/*` (live order placement, account reads, market data) | Regenerating invalidates the current OAuth token immediately; any in-flight KIS order/reconcile call using the old token fails until the process restarts with the new credential and re-authenticates |
+| KIS mock app key/secret | `KIS_MOCK_APP_KEY`, `KIS_MOCK_APP_SECRET` (naming per `settings.kis_mock_app_key`) | `app/services/brokers/kis/*` mock-mode paths | Same failure mode as live, scoped to `kis_mock` account-mode traffic only |
+
+Do not assume this table is exhaustive — before executing any rotation, the
+operator should re-derive the current credential surface from
+`app/core/config.py` and the relevant broker client, since env var names and
+call sites drift over time.
+
+## 3. Safe sequencing (per credential, operator-executed)
+
+This is the general shape; the operator adapts per credential based on the
+dependency map above.
+
+1. **Freeze intake for the affected surface.** For Telegram: pause any
+   scheduled job that sends Telegram notifications, or accept a short gap in
+   notifications during the rotation window. For KIS: avoid rotating during
+   an active order/reconcile window; prefer a quiet period (e.g. outside KRX
+   trading hours for KR live).
+2. **Generate the new credential** at the provider (BotFather for Telegram;
+   KIS developer portal for KIS app key/secret) **without revoking the old one
+   yet**, if the provider supports having two valid credentials briefly.
+3. **Stage the new value** in the deployment's secret manager / env file
+   (never committed to the repo — see `CLAUDE.md` env variable conventions).
+   Do not print or log the new value; do not paste it into Linear, Slack, or
+   this runbook.
+4. **Roll the new credential to every process that reads it** — this is a
+   config/env change, which for this repo's blue/green deploy means a
+   redeploy or restart of the affected service color (see
+   `docs/runbooks/` native deploy docs for the current mechanism). A stale
+   process holding the old credential in memory will keep failing after the
+   old credential is revoked in step 5, so confirm the new value is live
+   everywhere before proceeding.
+5. **Revoke the old credential** at the provider once every deployed process
+   has confirmed use of the new one (see verification in §4).
+6. **Roll back path**: if verification in §4 fails after revocation, the only
+   recovery is re-issuing another new credential and repeating steps 2-5 — a
+   revoked provider credential cannot be un-revoked. This is why step 2
+   deliberately avoids revoking the old credential until the new one is
+   confirmed live everywhere.
+
+## 4. Post-rotation verification (operator-executed, read-only where possible)
+
+- **Telegram**: confirm a real notification send succeeds end-to-end after
+  the new token is deployed (this repo's existing `send_telegram_message`
+  path returns a typed `TelegramMethodResult`; a non-`ok` result with
+  `error_code=401` after rotation means a process is still holding the old
+  token).
+- **KIS**: confirm a read-only KIS call (e.g. account balance / orderable
+  cash) succeeds with the new credential before allowing order-mutation
+  traffic to resume.
+- **Sentry**: confirm the ROB-1305 scrubber fix is deployed and active
+  *before* generating any new credential, so the new credential's traffic
+  does not repeat the same exposure. This is verifiable by the regression
+  tests in `tests/test_sentry_init.py` (`test_before_send_transaction_scrubs_*`)
+  passing in CI on the deployed release.
+
+## 5. Historical Sentry data — retention and purge decision
+
+The events counted in `sentry-pii-leak-evidence-rob1305.md` already exist in
+Sentry (as of the query date) and contain the pre-fix unredacted values. This
+runbook does **not** delete them. The operator has three options, in
+increasing order of intrusiveness:
+
+1. **Do nothing** and rely on Sentry's normal data retention window to age the
+   events out naturally. Check the org's configured retention period in
+   Sentry project settings before assuming a specific timeline.
+2. **Manually delete the specific issues/events** via the Sentry web UI
+   (Sentry's issue-delete action, not an API call from this repo or an
+   MCP tool) — scoped to the affected date range, after confirming the
+   scrubber fix is deployed so newly-ingested events are already clean.
+3. **Rotate the credential regardless of retention**, treating any residual
+   Sentry-side copy as a reason to rotate rather than a reason to purge — this
+   is likely the higher-leverage action since Telegram/KIS access, not Sentry
+   read access, is the actual attack surface.
+
+No Sentry deletion API call, secret-store call, or deploy tool call was made
+while producing this document or the evidence inventory it references.
+
+## 6. Explicit non-actions
+
+Nothing in this document or in the ROB-1305 R1 (W0) PR performed: credential
+rotation, revocation, regeneration, a Sentry data-deletion API call, a
+production deploy, a service restart, or a broker/order/DB mutation. Rotation
+scope and timing are operator decisions, to be made after reading this runbook
+and the evidence inventory, separately from this PR's merge.

--- a/docs/runbooks/sentry-pii-leak-evidence-rob1305.md
+++ b/docs/runbooks/sentry-pii-leak-evidence-rob1305.md
@@ -4,74 +4,40 @@
 
 This inventory documents what the **pre-fix** Sentry scrubbing gap (ROB-1305 W0)
 allowed into Sentry, using **aggregate-only** Sentry search queries against the
-`auto_trader` project (org `mgh3326-daum`). No row below contains a credential
-value, a masked fragment, a hash, a URL, a header, or a screenshot — every row
-is limited to: credential category, a bounded observation period, an event or
-span count, and an optional safe source-class label. This matches ROB-1305 D6/
-AC-D6 exactly; do not add columns beyond these when updating this table.
+project this repository's Sentry integration writes to. No row below contains
+a credential value, a masked or partial value, a URL, a URL template, a query
+or header parameter name, an environment variable name, or a screenshot —
+every row is limited to: leak category (high-level), a bounded observation
+period, an event/span/log count with its unit, and an optional safe source
+class. This matches ROB-1305's hard invariant on the evidence table exactly;
+do not add columns or reintroduce identifying detail when updating this table.
 
-Queries were run 2026-08-20 via the Sentry MCP `search_events` tool
-(`dataset=spans|errors|logs`, aggregate `count()` only — no individual event
-bodies were opened or copied).
+Queries were run 2026-08-20 using aggregate-count-only searches — no
+individual event body was opened or copied.
 
 ## Evidence table
 
-| Credential category | Observation period | Count | Source class |
+| Leak category | Observation period | Count | Source class |
 |---|---|---|---|
-| Telegram bot API token (embedded in URL path, e.g. `.../bot<token>/sendMessage`) | 2026-08-06 → 2026-08-20 (14d) | 548 | transaction span (`span.description`, httpx spans) |
-| Telegram bot API token (embedded in URL path) | 2026-08-06 → 2026-08-20 (14d) | 20 | error event message |
-| Telegram bot API token (embedded in URL path) | 2026-08-06 → 2026-08-20 (14d) | 20 | log entry message |
-| Broker/KIS API key or app-secret in a URL query string (`app_key=`, `app_secret=`, `api_key=`, `access_token=`) | 2026-08-06 → 2026-08-20 (14d) | 0 | transaction span (`span.description`) |
+| Messaging-bot credential embedded in an outbound notification URL | 2026-08-06 → 2026-08-20 (14d) | 548 spans | transaction span |
+| Messaging-bot credential embedded in an outbound notification URL | 2026-08-06 → 2026-08-20 (14d) | 20 events | error event |
+| Messaging-bot credential embedded in an outbound notification URL | 2026-08-06 → 2026-08-20 (14d) | 20 entries | log entry |
+| Broker API credential in a URL query string | 2026-08-06 → 2026-08-20 (14d) | 0 spans | transaction span |
+| Broker API credential attached as an HTTP request header on a span | 2026-08-06 → 2026-08-20 | 집계 불가/미확인 (not aggregated / undetermined) | — |
 
-## Blocked / undetermined rows
+The last row's reason is limited to: no safe aggregate query available for
+this shape without risking exposure of the underlying attribute. It is
+reported as undetermined rather than assigned a fabricated count of zero.
 
-- **Broker/KIS `appkey`/`appsecret` exposure via HTTP request headers on httpx
-  spans** (as opposed to URL query strings, which are ruled out above at 0):
-  KIS sends these as headers (`app/services/brokers/kis/base.py`), and Sentry's
-  httpx integration can attach request headers as span *data* attributes when
-  `SENTRY_SEND_DEFAULT_PII` is true (the pre-fix repo default). No safe
-  aggregate query was found that counts spans by a specific header-attribute
-  key without a per-project schema lookup that risks surfacing raw attribute
-  values. This row is reported as **blocked**, not fabricated as zero.
-  Consequence: treat KIS `appkey`/`appsecret` as **suspect for header-path
-  exposure** in the rotation runbook even though this specific count is
-  unresolved.
-- Only the `auto_trader` Sentry project was queried (the only project this
-  repository's Sentry integration writes to). `brewdial-node` /
-  `brewdial-react` are unrelated projects and were not queried.
-- 14 days was chosen as the longest single bounded window the Sentry MCP
-  `search_events` tool accepts in one call (`period` enum tops out at `90d`;
-  14d was used to match the ROB-1305 investigation's original observation
-  window cited in Linear). A longer-window re-run is safe to do later with the
-  same aggregate-only method.
+## Notes
 
-## What this evidence means (context, not a value)
-
-- The counts above are **consistent with the code-level root cause fixed in
-  this PR**: `before_send_transaction` did not scrub non-`mcp.server` span
-  descriptions/data before this change, so any httpx span whose URL embedded a
-  Telegram bot token (`app/monitoring/trade_notifier/transports.py` builds
-  URLs as `https://api.telegram.org/bot{bot_token}/sendMessage`) reached
-  Sentry unredacted. The fix in `app/monitoring/sentry.py`
-  (`_scrub_secret_shapes_in_string`, applied to every span and to the
-  transaction `request` block) closes this specific path going forward.
-- The KIS query-string count of 0 is consistent with KIS sending its
-  `appkey`/`appsecret` as HTTP headers, not query parameters — this is why the
-  blocked header-path row above is flagged as suspect rather than cleared.
-- This table does **not** state whether the exposed events still exist in
+- Only this repository's own Sentry project was queried. Unrelated projects
+  in the same organization were not queried.
+- 14 days was the observation window used; a longer-window re-run with the
+  same aggregate-only method is safe to do later.
+- This table does not state whether the counted events still exist in
   Sentry, whether the org's data retention window has already aged them out,
-  or whether any external party accessed them. That determination and any
-  purge/retention decision is out of scope for this document (see the
-  companion rotation runbook, `sentry-credential-rotation.md`).
-
-## Credentials that should be treated as rotation candidates
-
-Derived from the evidence above — see `sentry-credential-rotation.md` for the
-runbook. Rotation scope, timing, and execution remain **operator decisions**;
-nothing in this document performs or schedules a rotation.
-
-1. Telegram bot token (`TELEGRAM_TOKEN`) — **confirmed** exposure (548 span +
-   20 error + 20 log occurrences, 14d window).
-2. KIS `app_key` / `app_secret` (`KIS_APP_KEY`, `KIS_APP_SECRET`, and mock
-   variants) — **suspect, unconfirmed** (header-path query blocked; ruled out
-   via query string).
+  or whether any external party accessed them. Retention/purge decisions and
+  rotation candidates, dependency mapping, and environment-variable-level
+  detail belong only in the companion rotation runbook
+  (`sentry-credential-rotation.md`), not in this evidence document.

--- a/docs/runbooks/sentry-pii-leak-evidence-rob1305.md
+++ b/docs/runbooks/sentry-pii-leak-evidence-rob1305.md
@@ -1,0 +1,77 @@
+# Sentry leak-evidence inventory (ROB-1305)
+
+## Scope and method
+
+This inventory documents what the **pre-fix** Sentry scrubbing gap (ROB-1305 W0)
+allowed into Sentry, using **aggregate-only** Sentry search queries against the
+`auto_trader` project (org `mgh3326-daum`). No row below contains a credential
+value, a masked fragment, a hash, a URL, a header, or a screenshot — every row
+is limited to: credential category, a bounded observation period, an event or
+span count, and an optional safe source-class label. This matches ROB-1305 D6/
+AC-D6 exactly; do not add columns beyond these when updating this table.
+
+Queries were run 2026-08-20 via the Sentry MCP `search_events` tool
+(`dataset=spans|errors|logs`, aggregate `count()` only — no individual event
+bodies were opened or copied).
+
+## Evidence table
+
+| Credential category | Observation period | Count | Source class |
+|---|---|---|---|
+| Telegram bot API token (embedded in URL path, e.g. `.../bot<token>/sendMessage`) | 2026-08-06 → 2026-08-20 (14d) | 548 | transaction span (`span.description`, httpx spans) |
+| Telegram bot API token (embedded in URL path) | 2026-08-06 → 2026-08-20 (14d) | 20 | error event message |
+| Telegram bot API token (embedded in URL path) | 2026-08-06 → 2026-08-20 (14d) | 20 | log entry message |
+| Broker/KIS API key or app-secret in a URL query string (`app_key=`, `app_secret=`, `api_key=`, `access_token=`) | 2026-08-06 → 2026-08-20 (14d) | 0 | transaction span (`span.description`) |
+
+## Blocked / undetermined rows
+
+- **Broker/KIS `appkey`/`appsecret` exposure via HTTP request headers on httpx
+  spans** (as opposed to URL query strings, which are ruled out above at 0):
+  KIS sends these as headers (`app/services/brokers/kis/base.py`), and Sentry's
+  httpx integration can attach request headers as span *data* attributes when
+  `SENTRY_SEND_DEFAULT_PII` is true (the pre-fix repo default). No safe
+  aggregate query was found that counts spans by a specific header-attribute
+  key without a per-project schema lookup that risks surfacing raw attribute
+  values. This row is reported as **blocked**, not fabricated as zero.
+  Consequence: treat KIS `appkey`/`appsecret` as **suspect for header-path
+  exposure** in the rotation runbook even though this specific count is
+  unresolved.
+- Only the `auto_trader` Sentry project was queried (the only project this
+  repository's Sentry integration writes to). `brewdial-node` /
+  `brewdial-react` are unrelated projects and were not queried.
+- 14 days was chosen as the longest single bounded window the Sentry MCP
+  `search_events` tool accepts in one call (`period` enum tops out at `90d`;
+  14d was used to match the ROB-1305 investigation's original observation
+  window cited in Linear). A longer-window re-run is safe to do later with the
+  same aggregate-only method.
+
+## What this evidence means (context, not a value)
+
+- The counts above are **consistent with the code-level root cause fixed in
+  this PR**: `before_send_transaction` did not scrub non-`mcp.server` span
+  descriptions/data before this change, so any httpx span whose URL embedded a
+  Telegram bot token (`app/monitoring/trade_notifier/transports.py` builds
+  URLs as `https://api.telegram.org/bot{bot_token}/sendMessage`) reached
+  Sentry unredacted. The fix in `app/monitoring/sentry.py`
+  (`_scrub_secret_shapes_in_string`, applied to every span and to the
+  transaction `request` block) closes this specific path going forward.
+- The KIS query-string count of 0 is consistent with KIS sending its
+  `appkey`/`appsecret` as HTTP headers, not query parameters — this is why the
+  blocked header-path row above is flagged as suspect rather than cleared.
+- This table does **not** state whether the exposed events still exist in
+  Sentry, whether the org's data retention window has already aged them out,
+  or whether any external party accessed them. That determination and any
+  purge/retention decision is out of scope for this document (see the
+  companion rotation runbook, `sentry-credential-rotation.md`).
+
+## Credentials that should be treated as rotation candidates
+
+Derived from the evidence above — see `sentry-credential-rotation.md` for the
+runbook. Rotation scope, timing, and execution remain **operator decisions**;
+nothing in this document performs or schedules a rotation.
+
+1. Telegram bot token (`TELEGRAM_TOKEN`) — **confirmed** exposure (548 span +
+   20 error + 20 log occurrences, 14d window).
+2. KIS `app_key` / `app_secret` (`KIS_APP_KEY`, `KIS_APP_SECRET`, and mock
+   variants) — **suspect, unconfirmed** (header-path query blocked; ruled out
+   via query string).

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-from sentry_sdk.types import Event, Log
+from sentry_sdk.types import Breadcrumb, Event, Log
 
 import app.monitoring.sentry as sentry_module
 
@@ -589,6 +589,236 @@ def test_before_send_transaction_keeps_non_mcp_transactions():
     assert kept is event
     assert kept is not None
     assert kept.get("transaction") == "GET /api/v1/orders"
+
+
+@pytest.mark.unit
+def test_sentry_pii_and_mcp_prompts_default_off():
+    """ROB-1305: repo defaults must not opt into PII/prompt capture."""
+    pii_field = sentry_module.settings.__class__.model_fields["SENTRY_SEND_DEFAULT_PII"]
+    prompts_field = sentry_module.settings.__class__.model_fields[
+        "SENTRY_MCP_INCLUDE_PROMPTS"
+    ]
+    assert pii_field.default is False
+    assert prompts_field.default is False
+
+
+@pytest.mark.unit
+def test_init_sentry_threads_explicit_pii_and_prompt_config(monkeypatch):
+    """Explicit env/config values must still reach sentry_sdk.init/MCPIntegration."""
+    monkeypatch.setattr(sentry_module.settings, "SENTRY_DSN", "https://key@sentry/1")
+    monkeypatch.setattr(sentry_module.settings, "SENTRY_SEND_DEFAULT_PII", True)
+    monkeypatch.setattr(sentry_module.settings, "SENTRY_MCP_INCLUDE_PROMPTS", True)
+    mock_init = Mock()
+    monkeypatch.setattr(sentry_module.sentry_sdk, "init", mock_init)
+
+    result = sentry_module.init_sentry("test-service", enable_mcp=True)
+
+    assert result is True
+    _, kwargs = mock_init.call_args
+    assert kwargs["send_default_pii"] is True
+    mcp_integrations = [
+        integration
+        for integration in kwargs["integrations"]
+        if type(integration).__name__ == "MCPIntegration"
+    ]
+    assert len(mcp_integrations) == 1
+    assert mcp_integrations[0].include_prompts is True
+
+
+@pytest.mark.unit
+def test_before_send_scrubs_query_secret_and_stack_frame_locals():
+    """ROB-1305: nested headers/query/locals with fake secrets must be filtered."""
+    event: Event = {
+        "request": {
+            "url": "https://broker.example/api?app_key=FAKE_APP_KEY_123&symbol=AAPL",
+            "headers": {"Authorization": "Bearer FAKE.BEARER.TOKEN"},
+        },
+        "exception": {
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": "boom",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "filename": "client.py",
+                                "vars": {
+                                    "app_secret": "FAKE_SECRET_VALUE",
+                                    "url": (
+                                        "https://broker.example/x?"
+                                        "access_token=FAKE_ACCESS_TOKEN_XYZ"
+                                    ),
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+    }
+
+    sanitized = sentry_module._before_send(event, {})
+
+    assert sanitized is not None
+    request = sanitized["request"]
+    assert "FAKE_APP_KEY_123" not in request["url"]
+    assert request["headers"]["Authorization"] == "[Filtered]"
+
+    frame_vars = sanitized["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]
+    assert frame_vars["app_secret"] == "[Filtered]"
+    assert "FAKE_ACCESS_TOKEN_XYZ" not in frame_vars["url"]
+
+
+@pytest.mark.unit
+def test_before_send_scrubs_telegram_bot_token_in_log_message():
+    event: Event = {
+        "logger": "httpx",
+        "message": (
+            "HTTP Request: POST https://api.telegram.org/bot"
+            "111111111:FAKE-TEST-TOKEN-NOT-REAL/sendMessage"
+        ),
+    }
+
+    sanitized = sentry_module._before_send(event, {})
+
+    assert sanitized is not None
+    assert "FAKE-TEST-TOKEN-NOT-REAL" not in sanitized["message"]
+    assert "api.telegram.org/bot[REDACTED]" in sanitized["message"]
+
+
+@pytest.mark.unit
+def test_before_breadcrumb_scrubs_telegram_bot_token_in_url():
+    crumb: Breadcrumb = {
+        "category": "httplib",
+        "message": (
+            "https://api.telegram.org/bot222222222:ANOTHER-FAKE-TOKEN/sendMessage"
+        ),
+        "data": {"url": "https://api.telegram.org/bot222222222:ANOTHER-FAKE-TOKEN/sendMessage"},
+    }
+
+    sanitized = sentry_module._before_breadcrumb(crumb, {})
+
+    assert sanitized is not None
+    assert "ANOTHER-FAKE-TOKEN" not in sanitized["message"]
+    assert "ANOTHER-FAKE-TOKEN" not in sanitized["data"]["url"]
+
+
+@pytest.mark.unit
+def test_before_send_transaction_scrubs_non_mcp_span_description_and_data():
+    """ROB-1305: httpx/other spans (not just mcp.server) must be scrubbed."""
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "contexts": {
+            "trace": {
+                "trace_id": "abc123def456abc123def456abc123d",
+                "span_id": "1122334455667788",
+                "op": "http.server",
+                "status": "ok",
+            }
+        },
+        "start_timestamp": 1000.0,
+        "timestamp": 1000.5,
+        "spans": [
+            {
+                "op": "http.client",
+                "description": (
+                    "GET https://broker.example/v1/quote?"
+                    "api_key=FAKE_QUOTE_API_KEY_9999&symbol=AAPL"
+                ),
+                "span_id": "aaaa1111bbbb2222",
+                "trace_id": "abc123def456abc123def456abc123d",
+                "start_timestamp": 1000.1,
+                "timestamp": 1000.2,
+                "status": "ok",
+                "data": {
+                    "http.request.header.authorization": "Bearer FAKE_HTTPX_TOKEN",
+                    "nested": {"app_secret": "FAKE_NESTED_SECRET"},
+                },
+            }
+        ],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    span = kept["spans"][0]
+    assert "FAKE_QUOTE_API_KEY_9999" not in span["description"]
+    assert "symbol=AAPL" in span["description"]
+    assert span["data"]["http.request.header.authorization"] == "[Filtered]"
+    assert span["data"]["nested"]["app_secret"] == "[Filtered]"
+
+    # Structure — trace/span identity, timing, op, status — must be preserved.
+    assert span["op"] == "http.client"
+    assert span["span_id"] == "aaaa1111bbbb2222"
+    assert span["trace_id"] == "abc123def456abc123def456abc123d"
+    assert span["start_timestamp"] == 1000.1
+    assert span["timestamp"] == 1000.2
+    assert span["status"] == "ok"
+    assert kept["contexts"]["trace"]["trace_id"] == "abc123def456abc123def456abc123d"
+    assert kept["start_timestamp"] == 1000.0
+    assert kept["timestamp"] == 1000.5
+
+
+@pytest.mark.unit
+def test_before_send_transaction_scrubs_request_headers_and_query():
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "request": {
+            "url": "https://internal.example/api?token=FAKE_REQUEST_TOKEN_555",
+            "headers": {"Cookie": "session=FAKE_SESSION_COOKIE"},
+        },
+        "spans": [],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    assert "FAKE_REQUEST_TOKEN_555" not in kept["request"]["url"]
+    assert kept["request"]["headers"]["Cookie"] == "[Filtered]"
+
+
+@pytest.mark.unit
+def test_before_send_transaction_preserves_tools_call_span_while_scrubbing_payload():
+    """ROB-1305/D5: mcp.server span + tools/call rename must survive scrubbing
+    alongside an unrelated performance span, with sensitive payload removed."""
+    event: Event = {
+        "transaction": "POST http://127.0.0.1:8765/mcp",
+        "spans": [
+            {
+                "op": "mcp.server",
+                "span_id": "cccc3333dddd4444",
+                "data": {
+                    "mcp.tool.name": "get_news",
+                    "mcp.method.name": "tools/call",
+                    "mcp.request.argument.api_key": "FAKE_MCP_API_KEY_777",
+                    "mcp.tool.result.content": (
+                        '{"success":true,"token":"FAKE_RESULT_TOKEN_888"}'
+                    ),
+                },
+            },
+            {
+                "op": "db.sql.query",
+                "description": "SELECT 1",
+                "span_id": "eeee5555ffff6666",
+                "status": "ok",
+            },
+        ],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    assert kept["transaction"] == "tools/call get_news"
+    spans = kept["spans"]
+    mcp_span = next(s for s in spans if s["op"] == "mcp.server")
+    assert mcp_span["span_id"] == "cccc3333dddd4444"
+    assert mcp_span["data"]["mcp.request.argument.api_key"] == "[Filtered]"
+    assert "FAKE_RESULT_TOKEN_888" not in mcp_span["data"]["mcp.tool.result.content"]
+
+    other_span = next(s for s in spans if s["op"] == "db.sql.query")
+    assert other_span["span_id"] == "eeee5555ffff6666"
+    assert other_span["status"] == "ok"
+    assert other_span["description"] == "SELECT 1"
 
 
 @pytest.mark.unit

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -693,7 +693,9 @@ def test_before_breadcrumb_scrubs_telegram_bot_token_in_url():
         "message": (
             "https://api.telegram.org/bot222222222:ANOTHER-FAKE-TOKEN/sendMessage"
         ),
-        "data": {"url": "https://api.telegram.org/bot222222222:ANOTHER-FAKE-TOKEN/sendMessage"},
+        "data": {
+            "url": "https://api.telegram.org/bot222222222:ANOTHER-FAKE-TOKEN/sendMessage"
+        },
     }
 
     sanitized = sentry_module._before_breadcrumb(crumb, {})

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -892,6 +892,82 @@ def test_before_send_transaction_scrubs_leading_query_string_secret():
 
 
 @pytest.mark.unit
+def test_before_send_transaction_scrubs_relative_bot_path_regardless_of_method():
+    """ROB-1305 follow-up 04: a relative (no-host) bot credential path must be
+    scrubbed by credential *shape* (digits:token), not by enumerating known
+    Telegram method names — an unlisted method must not defeat redaction."""
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "request": {
+            "url": "/bot123456789:FAKE-REL-PATH-TOKEN-AAA/deleteMessage",
+        },
+        "spans": [],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    url = kept["request"]["url"]
+    assert "FAKE-REL-PATH-TOKEN-AAA" not in url
+    assert url.startswith("/bot")
+    assert "deleteMessage" in url
+
+
+@pytest.mark.unit
+def test_before_send_transaction_scrubs_leading_authorization_query_param():
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "request": {
+            "query_string": "authorization=FAKE_AUTH_QS_VALUE_1&symbol=AAPL",
+        },
+        "spans": [],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    query_string = kept["request"]["query_string"]
+    assert "FAKE_AUTH_QS_VALUE_1" not in query_string
+    assert "symbol=AAPL" in query_string
+
+
+@pytest.mark.unit
+def test_before_send_transaction_scrubs_leading_client_secret_query_param():
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "request": {
+            "query_string": "client_secret=FAKE_CLIENT_SECRET_VALUE_2&symbol=AAPL",
+        },
+        "spans": [],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    query_string = kept["request"]["query_string"]
+    assert "FAKE_CLIENT_SECRET_VALUE_2" not in query_string
+    assert "symbol=AAPL" in query_string
+
+
+@pytest.mark.unit
+def test_before_send_transaction_scrubs_leading_signature_query_param():
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "request": {
+            "query_string": "signature=FAKE_REQUEST_SIGNATURE_VALUE_3&symbol=AAPL",
+        },
+        "spans": [],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    query_string = kept["request"]["query_string"]
+    assert "FAKE_REQUEST_SIGNATURE_VALUE_3" not in query_string
+    assert "symbol=AAPL" in query_string
+
+
+@pytest.mark.unit
 def test_capture_exception_adds_masked_context(monkeypatch):
     scope_mock = Mock()
     context_manager = Mock()

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -824,6 +824,74 @@ def test_before_send_transaction_preserves_tools_call_span_while_scrubbing_paylo
 
 
 @pytest.mark.unit
+def test_before_send_transaction_scrubs_nested_contexts_and_extra():
+    """ROB-1305 follow-up: the scrub boundary must reach every nested
+    transaction payload location (contexts/extra), not just request/spans."""
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "contexts": {
+            "trace": {
+                "trace_id": "abc123def456abc123def456abc123d",
+                "span_id": "1122334455667788",
+                "op": "http.server",
+                "status": "ok",
+            },
+            "response": {
+                "headers": {"Authorization": "Bearer FAKE_CTX_RESPONSE_TOKEN"},
+            },
+            "custom": {"nested": {"api_key": "FAKE_CTX_CUSTOM_SECRET"}},
+        },
+        "extra": {
+            "debug_headers": {"Authorization": "Bearer FAKE_EXTRA_TOKEN_123"},
+        },
+        "start_timestamp": 1000.0,
+        "timestamp": 1000.5,
+        "spans": [
+            {"op": "db.sql.query", "description": "SELECT 1", "status": "ok"},
+        ],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    assert kept["contexts"]["response"]["headers"]["Authorization"] == "[Filtered]"
+    assert kept["contexts"]["custom"]["nested"]["api_key"] == "[Filtered]"
+    assert kept["extra"]["debug_headers"]["Authorization"] == "[Filtered]"
+
+    # Structure — trace context, span count, timing — must be preserved.
+    trace = kept["contexts"]["trace"]
+    assert trace["trace_id"] == "abc123def456abc123def456abc123d"
+    assert trace["span_id"] == "1122334455667788"
+    assert trace["op"] == "http.server"
+    assert trace["status"] == "ok"
+    assert len(kept["spans"]) == 1
+    assert kept["spans"][0]["description"] == "SELECT 1"
+    assert kept["start_timestamp"] == 1000.0
+    assert kept["timestamp"] == 1000.5
+
+
+@pytest.mark.unit
+def test_before_send_transaction_scrubs_leading_query_string_secret():
+    """ROB-1305 follow-up: a query_string serialized without a leading '?'
+    (Sentry's own request.query_string shape) must still be scrubbed when
+    the very first parameter is the sensitive one."""
+    event: Event = {
+        "transaction": "GET /api/v1/orders",
+        "request": {
+            "query_string": "token=FAKE_LEADING_QS_TOKEN_999&symbol=AAPL",
+        },
+        "spans": [],
+    }
+
+    kept = sentry_module._before_send_transaction(event, {})
+
+    assert kept is not None
+    query_string = kept["request"]["query_string"]
+    assert "FAKE_LEADING_QS_TOKEN_999" not in query_string
+    assert "symbol=AAPL" in query_string
+
+
+@pytest.mark.unit
 def test_capture_exception_adds_masked_context(monkeypatch):
     scope_mock = Mock()
     context_manager = Mock()


### PR DESCRIPTION
## Summary

ROB-1305 R1 — **W0 scope only** (approved by operator decision in the issue; W1-W5, profiling, and credential rotation are explicitly out of scope for this PR).

- Extends `app/monitoring/sentry.py`'s existing key-name-based sanitizer with **value-shape** scrubbing (Telegram bot tokens by shape rather than a method-name allowlist, Bearer tokens, basic-auth URLs, secret-named query params — synced with the same keyword list the dict-key sanitizer uses, including a leading no-`?` query_string — and secret-named JSON fields, same shared keyword list).
- `before_send_transaction` applies **one coherent whole-event sanitization boundary** (`_sanitize_in_place(event)`) — the same boundary already used by `before_send`/`before_send_log`/`before_breadcrumb` — covering request, contexts, extra, and every span's description/data uniformly (not just `mcp.server` spans, and not just `request`).
- Flips `SENTRY_SEND_DEFAULT_PII` and `SENTRY_MCP_INCLUDE_PROMPTS` repo defaults to `False`; explicit env/config values still thread through to `sentry_sdk.init`/`MCPIntegration`.
- Fake-credential-only regression tests covering: nested headers/query/stack-frame locals, non-mcp span description/data, transaction request, nested `contexts`/`extra` payloads, a leading (no `?`) sensitive query-string parameter, a relative (no-host) bot-credential path with an unlisted method, and standalone leading `authorization`/`client_secret`/`signature` query parameters — all fail against the pre-fix code at each stage and pass after.
- Explicit regression proving `mcp.server` spans and the `tools/call <tool>` transaction rename survive scrubbing while sensitive payload content is removed (MCP `tools/call` span is the production source of truth for tool-use frequency — must not be deleted).
- Adds an aggregate-only Sentry leak-evidence inventory (`docs/runbooks/sentry-pii-leak-evidence-rob1305.md` — leak category/period/count/source-class only, no values/URLs/parameter or env names) and a rotation-procedure-only runbook (`docs/runbooks/sentry-credential-rotation.md`) — no rotation performed.

## Investigated and not forced

Checked whether Sentry's installed `HttpxIntegration` ever serializes request headers as a list-of-pairs sequence (vs. dict) on spans: it does not — this version only calls `span.set_data` for `url`/`http.query`/`http.fragment`/`http.method`/`reason`, never headers. No test or implementation was added for that shape; documented in `final.md` rather than forced.

## Not in scope / not performed

W1 (`screen_stocks_snapshot` contract), W2-W4 (perf refactors), W5 (durable worker/scheduler), profiling collection-path work, credential rotation/revocation/regeneration, Sentry data deletion, deploy, restart, merge, or any broker/order/DB mutation.

## Commits (unsquashed, tests-first, appended per review round)

1. `test(ROB-1305): add failing Sentry scrub regressions`
2. `fix(ROB-1305): scrub Sentry payloads by default`
3. `docs(ROB-1305): add leak inventory and rotation runbook`
4. `docs(ROB-1305): tighten evidence table to category/period/count/source-class only` — removed URL templates/parameter/env names from the evidence doc.
5. `test(ROB-1305): add failing whole-transaction scrub-boundary regressions`
6. `fix(ROB-1305): unify transaction scrubbing into one whole-event boundary`
7. `test(ROB-1305): add failing adversarial credential-shape regressions`
8. `fix(ROB-1305): close adversarial credential-shape gaps in the scrubber`

Each test-first commit was verified failing (real assertion errors, not import/setup errors) at its own exact clean commit SHA before the paired fix commit was written. Reverting any of the three fix commits (2, 6, 8) alone on a throwaway branch reproduces that round's failures (verified locally, branches deleted after verification).

## Test plan

- [x] `uv run pytest tests/test_sentry_init.py tests/test_mcp_sentry_middleware.py -q` — 137 passed
- [x] `uv run pytest tests/test_mcp_server_main.py tests/test_main_sentry.py -q` — 40 passed
- [x] `make lint` — ruff check/format + ty all pass
- [x] `git diff --check` — clean
- [x] fails-before-fix raw output captured for all three tests-first commits, at each commit's exact clean SHA
- [x] fix-commit-alone-revert reproduces the pre-fix failures for all three fix commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)