### PR TITLE
fix(ci): module-safe call_durations workflow entrypoint (ROB-1308)

### DIFF
--- a/.github/workflows/test-durations-refresh.yml
+++ b/.github/workflows/test-durations-refresh.yml
@@ -224,7 +224,7 @@ jobs:
 
     - name: Build call-phase duration artifact
       run: |
-        python scripts/call_durations.py build \
+        python -m scripts.call_durations build \
           --shard duration-artifacts/call-durations-shard-1.json \
           --shard duration-artifacts/call-durations-shard-2.json \
           --shard duration-artifacts/call-durations-shard-3.json \
@@ -242,7 +242,7 @@ jobs:
       # (ROB-1295). A validate failure here means build_artifact and
       # validate_freshness disagree — treat that as a bug, not driftable.
       run: |
-        python scripts/call_durations.py validate \
+        python -m scripts.call_durations validate \
           --artifact .call_durations.json \
           --collected duration-artifacts/collected-shard-1.txt \
           --collected duration-artifacts/collected-shard-2.txt \

--- a/tests/ci/test_call_durations_workflow_entrypoint.py
+++ b/tests/ci/test_call_durations_workflow_entrypoint.py
@@ -1,0 +1,73 @@
+"""ROB-1308 — module-safe entrypoint contract for `scripts/call_durations.py`.
+
+`scripts/call_durations.py` does ``from scripts.merge_test_durations import
+_load_collected_nodes`` at import time. That only resolves when ``scripts``
+is importable as a package, which requires the invoking process to have the
+repo root on ``sys.path`` (e.g. ``python -m scripts.call_durations``).
+Direct-script invocation (``python scripts/call_durations.py ...``) puts the
+script's own directory on ``sys.path[0]`` instead, so the import raises
+``ModuleNotFoundError: No module named 'scripts'`` — this is exactly what
+broke the "Merge duration shards" job's `build`/`validate` steps in
+https://github.com/mgh3326/auto_trader/actions/runs/32321164500.
+
+This is a static contract on the raw `run:` shell blocks in the ``merge``
+job of ``.github/workflows/test-durations-refresh.yml``: both the
+"Build call-phase duration artifact" and "Validate call-phase duration
+freshness" steps must invoke the module-safe form, and direct-script
+invocation must never reappear.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github/workflows/test-durations-refresh.yml"
+)
+
+MERGE_JOB_ID = "merge"
+BUILD_STEP_NAME = "Build call-phase duration artifact"
+VALIDATE_STEP_NAME = "Validate call-phase duration freshness"
+
+DIRECT_SCRIPT_INVOCATION = "python scripts/call_durations.py"
+MODULE_SAFE_INVOCATION = "python -m scripts.call_durations"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _step(workflow: dict[str, Any], job_id: str, step_name: str) -> dict[str, Any]:
+    job = workflow["jobs"][job_id]
+    for step in job["steps"]:
+        if step.get("name") == step_name:
+            return step
+    raise AssertionError(f"step {step_name!r} not found in job {job_id!r}")
+
+
+@pytest.mark.parametrize("step_name", [BUILD_STEP_NAME, VALIDATE_STEP_NAME])
+def test_call_durations_step_uses_module_safe_invocation(
+    workflow: dict[str, Any], step_name: str
+) -> None:
+    run = _step(workflow, MERGE_JOB_ID, step_name)["run"]
+    assert DIRECT_SCRIPT_INVOCATION not in run, (
+        f"{step_name!r} regressed to direct-script invocation "
+        f"({DIRECT_SCRIPT_INVOCATION!r}), which raises "
+        "ModuleNotFoundError: No module named 'scripts' when scripts/ is "
+        "not installed as an editable package (see ROB-1308)."
+    )
+    assert MODULE_SAFE_INVOCATION in run, (
+        f"{step_name!r} must invoke {MODULE_SAFE_INVOCATION!r} so "
+        "`from scripts.merge_test_durations import ...` resolves without "
+        "relying on an editable install."
+    )
+
+
+def test_no_direct_script_invocation_anywhere_in_workflow() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert DIRECT_SCRIPT_INVOCATION not in text


### PR DESCRIPTION
## Summary
- The `merge` job's "Build call-phase duration artifact" and "Validate call-phase duration freshness" steps in `.github/workflows/test-durations-refresh.yml` invoked `python scripts/call_durations.py ...` directly. That job has no `uv sync`/editable install, so `sys.path` doesn't include the repo root, and the module's top-level `from scripts.merge_test_durations import _load_collected_nodes` fails with `ModuleNotFoundError: No module named 'scripts'`. This blocked ROB-1306's first duration-refresh dispatch (run https://github.com/mgh3326/auto_trader/actions/runs/32321164500).
- Switched both invocations to `python -m scripts.call_durations ...`, which puts cwd (repo root) on `sys.path[0]` regardless of install state.
- Added `tests/ci/test_call_durations_workflow_entrypoint.py`, a static contract test on the workflow YAML that fails if direct-script invocation reappears.

No change to artifact schema, duration computation, source-SHA/collection-hash logic, or fail-closed duplicate/missing/stale semantics.

## Test plan
- [x] Reproduced the exact `ModuleNotFoundError` locally with a plain interpreter (no venv/editable install), matching the CI traceback.
- [x] `uv run python -m scripts.call_durations --help` — exit 0.
- [x] New regression test: red against pre-fix workflow content (verified via `git stash`), green against the fix.
- [x] `uv run pytest scripts/call_durations_test.py tests/test_call_duration_plugin.py tests/ci/test_call_durations_workflow_entrypoint.py -q -ra --no-cov -p no:randomly` — 55 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` on the new test file — clean.
- [x] `actionlint .github/workflows/test-durations-refresh.yml` — clean.
- [x] `git diff --check origin/main...HEAD` — clean.
- [ ] exact-head required CI checks (pending this PR's run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)