### PR TITLE
test(policy-table): cover US averaging levels (ROB-1302)

### DIFF
--- a/tests/scripts/b0x/us/test_guards.py
+++ b/tests/scripts/b0x/us/test_guards.py
@@ -20,7 +20,7 @@ from scripts.b0x.envelope import (
 )
 from scripts.b0x.kill_switch import MissingNavForRatioKill, evaluate
 from scripts.b0x.labels import SHARED_HISTORY_ACCOUNTS, header_labels
-from scripts.b0x.state import LaneAccountState
+from scripts.b0x.state import B0XPosition, LaneAccountState
 from scripts.b0x.table_source import PolicyTable
 from scripts.b0x.us import alpaca
 from scripts.b0x.us.contract import (
@@ -212,6 +212,64 @@ def test_us_table_selected_usd_amount_reaches_generic_derivation() -> None:
     )
     assert len(result.orders) == 1
     assert result.orders[0].notional == Decimal("300")
+
+
+def test_us_table_averaging_levels_reach_generic_derivation() -> None:
+    """US A(k) config is consumed by the shared averaging-down branch."""
+
+    table = PolicyTable(
+        market="us",
+        path=Path("/tmp/latest-us.json"),
+        payload={
+            "config": {
+                "new_entry_notional_usd": "300",
+                "averaging_k_levels": ["0.05", "0.10"],
+                "loss_guard_multiplier": "1",
+            },
+            "sizing": {},
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "insufficient_history": False,
+                    "previous_close": "100",
+                    "A_buy_side": {"buy_l1": {"price": "97"}, "buy_l2": None},
+                    "B_sell_side": {"sell_r1": None, "sell_r2": None},
+                }
+            ],
+        },
+        policy_table_hash="sha256:us",
+        artifact_sha256="sha256:artifact",
+        generated_at=NOW,
+        age=dt.timedelta(0),
+    )
+    state = LaneAccountState(
+        lane=alpaca.LANE,
+        quote_currency="USD",
+        cash=Decimal("10000"),
+        positions=(
+            B0XPosition(
+                symbol="AAPL",
+                quantity=Decimal("1"),
+                average_price=Decimal("110"),
+                invested_notional=Decimal("110"),
+                entry_count=1,
+            ),
+        ),
+        broker_truth=BrokerTruth(position_symbols=("AAPL",), own_pending=()),
+        realized_pnl_today=Decimal("0"),
+        nav=Decimal("10000"),
+    )
+    result = derive_orders(
+        table=table,
+        state=state,
+        envelope=US_ALPACA_PAPER_LAB_ENVELOPE,
+        kill_switch=evaluate(state=state, envelope=US_ALPACA_PAPER_LAB_ENVELOPE),
+    )
+
+    averaging_orders = [order for order in result.orders if order.leg == "averaging"]
+    assert len(averaging_orders) == 1
+    assert averaging_orders[0].detail["rule"] == "b0_averaging_down"
+    assert averaging_orders[0].detail["k"] == "0.05"
 
 
 def test_us_headers_have_exact_three_base_labels_plus_us_extra_but_not_shared_history() -> (

--- a/tests/scripts/test_policy_table_us.py
+++ b/tests/scripts/test_policy_table_us.py
@@ -289,6 +289,39 @@ def test_alpaca_account_mode_is_lab_not_default_paper() -> None:
 
 
 @pytest.mark.unit
+def test_averaging_levels_use_shared_math_only_when_position_inputs_exist() -> None:
+    """A(k) is populated for holdings and explicitly absent without cost inputs."""
+
+    held_payload = us_adapter.compute_policy_table(_sample_raw())
+    held_row = next(row for row in held_payload["rows"] if row["symbol"] == "AAPL")
+    assert held_payload["config"]["averaging_k_levels"] == [
+        Decimal("0.05"),
+        Decimal("0.10"),
+    ]
+    assert set(held_row["A_buy_side"]["averaging_math"]) == {
+        "k_5pct",
+        "k_10pct",
+    }
+
+    raw = _sample_raw()
+    unheld_payload = us_adapter.compute_policy_table(
+        us_adapter.RawInputs(
+            as_of=raw.as_of,
+            holdings=[],
+            watch_alerts=raw.watch_alerts,
+            universe_pool=raw.universe_pool,
+            snapshot_partition_date=raw.snapshot_partition_date,
+            snapshot_breadth=raw.snapshot_breadth,
+            universe_symbols=raw.universe_symbols,
+            candles=raw.candles,
+            market_cap_fill_stats=raw.market_cap_fill_stats,
+        )
+    )
+    unheld_row = next(row for row in unheld_payload["rows"] if row["symbol"] == "AAPL")
+    assert unheld_row["A_buy_side"]["averaging_math"] is None
+
+
+@pytest.mark.unit
 def test_no_order_tool_imports_in_policy_table_tree() -> None:
     """Static AST: scripts/policy_table must not import order placement modules."""
 


### PR DESCRIPTION
## Summary
- lock US policy-table A(k) coverage to the shared KR/crypto averaging math
- prove B0-X generic derivation consumes US `config.averaging_k_levels`
- preserve explicit null A(k) output when holding cost inputs are unavailable

## Verification
- `uv run pytest tests/scripts/test_policy_table_us.py tests/scripts/test_policy_table_halt_suspect.py tests/scripts/b0x/us/test_guards.py tests/scripts/b0x/test_derivation.py -q`
- `make lint`

No broker, gate, scheduler, migration, or production-policy changes.