### PR TITLE
feat(ROB-1304): extend watch repricing to US and crypto

### DIFF
--- a/app/services/watch_trigger_repricing/event_source.py
+++ b/app/services/watch_trigger_repricing/event_source.py
@@ -47,6 +47,13 @@ class WatchEventRow(Protocol):
     outcome: str
     delivery_status: str
     delivered_at: datetime | None
+    metric: str
+    operator: str
+    threshold: Any
+    threshold_high: Any
+    threshold_key: str
+    current_value: Any
+    created_at: datetime
 
 
 class WatchEventSource(Protocol):

--- a/app/services/watch_trigger_repricing/gate.py
+++ b/app/services/watch_trigger_repricing/gate.py
@@ -1,4 +1,4 @@
-"""ROB-1286 §5 / AC3 — trading-session and intraday-window gate (KR only).
+"""ROB-1286 / ROB-1304 — market-specific session gate.
 
 Which calendar, and why not the other one
 -----------------------------------------
@@ -39,9 +39,13 @@ up as a reason on the tick rather than as silence.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
 
-from app.services.market_events.session_calendar import trading_session_status
+from app.services.market_events.session_calendar import (
+    regular_session_bounds,
+    trading_session_status,
+)
 
 __all__ = [
     "KST",
@@ -52,6 +56,7 @@ __all__ = [
 ]
 
 KST = timezone(timedelta(hours=9))
+ET = ZoneInfo("America/New_York")
 
 # KR regular session (ROB-1286 설계 1항: 09:00~15:30 KST). End is exclusive.
 SESSION_START_KST = time(9, 0)
@@ -66,9 +71,10 @@ class GateDecision:
     reason: str
     session_status: str
     kst_date: str
+    market_date: str
 
 
-def evaluate_gate(*, now: datetime) -> GateDecision:
+def evaluate_gate(*, now: datetime, market: str = "kr") -> GateDecision:
     """Decide whether a repricing tick may run at ``now``.
 
     ``now`` must be timezone-aware; a naive value is a caller bug and is
@@ -78,9 +84,24 @@ def evaluate_gate(*, now: datetime) -> GateDecision:
     if now.tzinfo is None:
         raise ValueError("evaluate_gate requires a timezone-aware 'now'")
 
-    local = now.astimezone(KST)
-    kst_date = local.date().isoformat()
-    status = trading_session_status("kr", local.date())
+    kst_date = now.astimezone(KST).date().isoformat()
+    if market == "crypto":
+        # Crypto is 24/7. Applying an equity holiday calendar here would
+        # silently strand a valid fire every weekend and US/KR holiday.
+        return GateDecision(
+            should_run=True,
+            reason="ok_24x7",
+            session_status="open_24x7",
+            kst_date=kst_date,
+            market_date=now.astimezone(UTC).date().isoformat(),
+        )
+
+    if market not in {"kr", "us"}:
+        raise ValueError(f"unsupported watch repricing market {market!r}")
+
+    local = now.astimezone(KST if market == "kr" else ET)
+    market_date = local.date().isoformat()
+    status = trading_session_status(market, local.date())
 
     if status == "closed":
         return GateDecision(
@@ -88,6 +109,7 @@ def evaluate_gate(*, now: datetime) -> GateDecision:
             reason="market_closed",
             session_status=status,
             kst_date=kst_date,
+            market_date=market_date,
         )
     if status != "open":
         # Fail-closed on an unclassifiable date -- see the module docstring.
@@ -96,6 +118,34 @@ def evaluate_gate(*, now: datetime) -> GateDecision:
             reason="session_status_indeterminate",
             session_status=status,
             kst_date=kst_date,
+            market_date=market_date,
+        )
+
+    if market == "us":
+        bounds = regular_session_bounds("us", local.date())
+        if bounds is None:
+            return GateDecision(
+                should_run=False,
+                reason="session_bounds_indeterminate",
+                session_status="unknown",
+                kst_date=kst_date,
+                market_date=market_date,
+            )
+        opened_at, closed_at = bounds
+        if not opened_at <= now.astimezone(UTC) < closed_at:
+            return GateDecision(
+                should_run=False,
+                reason="outside_regular_session",
+                session_status=status,
+                kst_date=kst_date,
+                market_date=market_date,
+            )
+        return GateDecision(
+            should_run=True,
+            reason="ok",
+            session_status=status,
+            kst_date=kst_date,
+            market_date=market_date,
         )
 
     clock = local.timetz().replace(tzinfo=None)
@@ -105,6 +155,7 @@ def evaluate_gate(*, now: datetime) -> GateDecision:
             reason="outside_intraday_window",
             session_status=status,
             kst_date=kst_date,
+            market_date=market_date,
         )
 
     return GateDecision(
@@ -112,4 +163,5 @@ def evaluate_gate(*, now: datetime) -> GateDecision:
         reason="ok",
         session_status=status,
         kst_date=kst_date,
+        market_date=market_date,
     )

--- a/app/services/watch_trigger_repricing/orchestrator.py
+++ b/app/services/watch_trigger_repricing/orchestrator.py
@@ -173,6 +173,7 @@ class TickResult:
             "gateReason": self.gate.reason,
             "sessionStatus": self.gate.session_status,
             "kstDate": self.gate.kst_date,
+            "marketDate": self.gate.market_date,
             "spawned": [
                 {
                     "eventUuid": o.request.event_uuid,
@@ -277,7 +278,7 @@ async def run_repricing_tick(
     """Run one tick. Starts no session unless a live spawner is injected."""
     spawner = spawner if spawner is not None else DrySessionSpawner()
 
-    gate = evaluate_gate(now=now)
+    gate = evaluate_gate(now=now, market=market)
     if not gate.should_run:
         logger.info(
             "watch_trigger_repricing: tick skipped (reason=%s, session=%s, date=%s)",
@@ -342,7 +343,9 @@ async def run_repricing_tick(
             symbol=event.symbol,
             market=event.market,
             kst_date=gate.kst_date,
+            market_date=gate.market_date,
             label=session_label(event.symbol, now=now),
+            trigger_evidence=dict(event.trigger_evidence),
         )
 
         disposition, detail = await _attempt_spawn(spawner=spawner, request=request)

--- a/app/services/watch_trigger_repricing/poller.py
+++ b/app/services/watch_trigger_repricing/poller.py
@@ -27,7 +27,9 @@ unhandled fire is the one that has been waiting longest.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
 
 from app.services.watch_trigger_repricing.event_source import (
     WatchEventRow,
@@ -56,7 +58,49 @@ def to_candidate_event(row: WatchEventRow) -> CandidateEvent:
         outcome=row.outcome,
         delivery_status=row.delivery_status,
         delivered_at=row.delivered_at,
+        trigger_evidence=_trigger_evidence(row),
     )
+
+
+def _json_value(value: Any) -> str | float | int | None:
+    """Keep durable evidence JSON-safe without rounding price values."""
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (str, float, int)):
+        return value
+    return str(value)
+
+
+def _timestamp(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        # ORM timestamps are timezone-aware. Do not invent a zone if a
+        # fixture or an unexpected source violates that contract.
+        return None
+    return value.astimezone(UTC).isoformat()
+
+
+def _trigger_evidence(row: WatchEventRow) -> dict[str, object]:
+    """The durable counterpart to a compact operator notification.
+
+    The operator repo may render one line, but it must retain this snapshot
+    (and the source event does too): condition, observed value, and fire time
+    are not presentation-only fields.
+    """
+    return {
+        "market": row.market,
+        "symbol": row.symbol,
+        "metric": row.metric,
+        "operator": row.operator,
+        "threshold": _json_value(row.threshold),
+        "thresholdHigh": _json_value(row.threshold_high),
+        "thresholdKey": row.threshold_key,
+        "currentValue": _json_value(row.current_value),
+        "firedAt": _timestamp(row.delivered_at or row.created_at),
+    }
 
 
 def dedupe_candidates(

--- a/app/services/watch_trigger_repricing/proposal_chain.py
+++ b/app/services/watch_trigger_repricing/proposal_chain.py
@@ -222,7 +222,9 @@ async def create_proposal_for_fire(
                 "event_uuid": request.event_uuid,
                 "spawn_key": request.spawn_key,
                 "kst_date": request.kst_date,
+                "market_date": request.market_date,
                 "session_label": request.label,
+                "trigger_evidence": dict(request.trigger_evidence),
             },
         )
     except Exception as exc:  # noqa: BLE001 - unknown is not "no"

--- a/app/services/watch_trigger_repricing/selection.py
+++ b/app/services/watch_trigger_repricing/selection.py
@@ -28,7 +28,7 @@ fix.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 from app.services.watch_trigger_repricing.claims import (
@@ -79,6 +79,7 @@ class CandidateEvent:
     outcome: str
     delivery_status: str
     delivered_at: datetime | None
+    trigger_evidence: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/app/services/watch_trigger_repricing/spawn.py
+++ b/app/services/watch_trigger_repricing/spawn.py
@@ -139,6 +139,8 @@ class SpawnRequest:
     market: str
     kst_date: str
     label: str
+    market_date: str = ""
+    trigger_evidence: dict[str, object] = field(default_factory=dict)
     spawn_key: str = ""
     execution_boundary: str = EXECUTION_BOUNDARY
     capability_profile: CapabilityProfile = PROPOSAL_ONLY_PROFILE

--- a/ci_shards/shard-1.txt
+++ b/ci_shards/shard-1.txt
@@ -225,6 +225,7 @@ tests/services/us_dual_paper/test_capability_matrix.py
 tests/services/us_dual_paper/test_config_flag.py
 tests/services/us_dual_paper/test_kis_mock_preview.py
 tests/services/watch_trigger_repricing/test_db_claim_store.py
+tests/services/watch_trigger_repricing/test_us_crypto_extension.py
 tests/tasks/test_news_relevance_judgment_tasks.py
 tests/test_agent_gateway.py
 tests/test_alembic_revision_ids.py

--- a/docs/runbooks/watch-trigger-repricing.md
+++ b/docs/runbooks/watch-trigger-repricing.md
@@ -1,6 +1,6 @@
-# 워치 발화 트리거 구동 재판정 (ROB-1286 / §93차 A안)
+# 워치 발화 트리거 구동 재판정 (ROB-1286 / ROB-1304)
 
-워치 발화(`review.investment_watch_events`)를 장중에 폴링해, 미소비
+워치 발화(`review.investment_watch_events`)를 시장별 거래 가능 시간에 폴링해, 미소비
 `review_required` 이벤트를 종목 한정 재판정 세션으로 전환한다. 목적은 **제안
 생성 지연 단축**이다.
 
@@ -189,6 +189,80 @@ needs_reconcile` + 응답 `needsReconcile[]` 로 **운영자 과제로 표면화
 
 `prefect` 는 프로젝트 의존성이 아니므로 로직은 prefect 없이 import·테스트된다
 (`test_prefect_is_not_imported_anywhere_in_the_package`).
+
+### 5.1 시장별 게이트 (ROB-1304)
+
+이 체인은 `market` 한 값으로 시장을 구분한다. KR 규칙을 US·crypto에 복사하지 않는다.
+
+| 시장 | 발화 가능 시간 | 거래일/세션 근거 | 심볼·통화 주의 |
+|---|---|---|---|
+| `kr` | XKRX 정규장 09:00–15:30 KST | 기존 XKRX offline calendar | DB KR 심볼, KRW 가격 |
+| `us` | XNYS regular session의 실제 open~close, close 배타 | `exchange_calendars` XNYS; early close 포함 | DB 기준 `BRK.B` 유지(`app/core/symbol.py` 전용 변환), USD 가격 |
+| `crypto` | 24/7 | equity calendar을 적용하지 않음 | `KRW-BTC` 같은 거래쌍 유지, quote currency는 쌍에서 읽음 |
+
+US가 KST 23:00에도 실행될 수 있는 것은 XNYS가 열려 있기 때문이다. 반대로 US
+after-hours는 이 체인의 범위 밖이다. crypto는 주말·공휴일에도 유효하며
+`ok_24x7`로 명시된다. 미지의 market은 fail-closed (`ValueError`)다.
+
+`kstDate`는 기존 감사 호환 필드다. 새 `marketDate`는 KR은 KST, US는 ET,
+crypto는 UTC 날짜를 기록하므로 이를 거래일 판단에 혼용하지 않는다.
+
+### 5.2 짧은 알림과 증거 보존
+
+operator/운영 레포는 알림을 한 줄로 렌더링할 수 있다. 그러나 auto_trader가
+보존하는 원문 증거를 축약하거나 재계산해 덮어써서는 안 된다. poller는 이벤트의
+`market`, `symbol`, `metric`, `operator`, `threshold`, `thresholdHigh`,
+`thresholdKey`, `currentValue`, `firedAt`를 `triggerEvidence`로 snapshot한다.
+원본은 `review.investment_watch_events`에 남고, proposal 생성 시 같은 snapshot이
+`review.order_proposals.rationale.trigger_evidence`에 남는다. 즉 표시 축소와
+기록 축소는 별개다.
+
+이 PR은 auto_trader만 바꾼다. 운영 레포에는 다음 후속 변경이 필요하지만 여기서
+커밋하거나 적용하지 않는다.
+
+- market별 tick 호출(`market=kr|us|crypto`)과 배포 시 arm 절차
+- 한 줄 renderer 및 원본 `triggerEvidence` 열람 링크/첨부
+- `eventUuid`/`spawnKey`를 키로 하는 cross-path delivery dedupe와 관측 대시보드
+
+### 5.3 §110차 배포 전환 계획: 기존 watch-alert triage 대체
+
+이 절은 **머지 절차가 아니라 배포 절차**다. 이 PR이 머지되어도 기존
+watch-alert triage poller/launchd는 계속 동작한다. 스케줄러·cron·TaskIQ·Prefect
+등록과 env arm은 이 PR에 없다.
+
+#### 배포 순서 — 무엇을 언제 끄는가
+
+1. 운영 레포에서 새 market별 consumer와 dedupe 관측을 배포하되, 새 consumer는
+   delivery를 기록만 하고 발송은 하지 않는 shadow 상태로 둔다. 기존 triage는 그대로
+   실행한다.
+2. KR·US·crypto 각각에서 source event, `triggerEvidence`, proposal/decline
+   completion, dedupe key가 관측되는지 확인한다. 오류·quarantine·unmapped가 0인지
+   확인한다.
+3. 동일한 배포 변경에서 기존 watch-alert triage poller/launchd를 **중지**하고,
+   새 consumer의 실제 발송을 **활성화**한다. 둘의 순서는 중지 → activation이며,
+   activation 전 기존 프로세스의 단일 인스턴스 종료를 확인한다.
+4. 전환 뒤 첫 시장 세션(KR/US)과 crypto 24시간 구간을 관측한다. auto_trader의
+   `WATCH_TRIGGER_REPRICING_ENABLED`는 운영 승인 전까지 default-off를 유지한다.
+
+#### 롤백 조건과 방법
+
+다음 중 하나면 즉시 새 consumer 발송을 끄고 기존 triage를 재가동한다: 중복
+`eventUuid` 발송, 발화 대비 completion 누락/unmapped, `spawn_ambiguous` 또는
+quarantine 미화해결, US 세션 밖 실행, crypto 주말 fire 누락, `triggerEvidence`의
+조건·값·시각 누락/불일치, 혹은 새 consumer의 전송 실패가 기존 경로보다 지속된다.
+
+롤백은 주문/승인 정책 변경이 아니다. 새 consumer의 send arm을 끄고, 기존 poller를
+단일 인스턴스로 복구하고, watermark를 되돌리지 않은 채 `eventUuid` dedupe 상태를
+보존한다. 누락/중복 후보는 source event에서 재조사한다.
+
+#### 동시 구간과 중복 방지
+
+shadow 단계에서는 두 경로가 동시에 실행될 수 있지만 **기존 triage만 발송**한다.
+새 경로는 `eventUuid`와 결정적 `spawnKey`를 저장해 would-send만 기록한다. 실제
+발송 단계에는 동시 구간을 만들지 않는다. 불가피한 겹침(프로세스 종료 지연 등)은
+공유 durable dedupe key `eventUuid`를 send 전에 원자적으로 claim하고, 성공 후에만
+delivery를 기록해 막는다. 메모리 watermark·표시 텍스트·심볼만을 키로 dedupe하면
+재시작·문구 축소·동일 심볼 다중 threshold에서 중복을 막지 못하므로 사용하지 않는다.
 
 ---
 

--- a/tests/services/watch_trigger_repricing/test_invariants.py
+++ b/tests/services/watch_trigger_repricing/test_invariants.py
@@ -336,8 +336,8 @@ def test_prefect_is_not_imported_anywhere_in_the_package() -> None:
 # ---------------------------------------------------------------------------
 # Scope
 # ---------------------------------------------------------------------------
-def test_market_scope_stays_kr() -> None:
-    """US/crypto expansion is explicitly a separate issue."""
+def test_market_scope_includes_all_supported_watch_markets() -> None:
+    """ROB-1304: each market is selected only by its explicit lane."""
     import asyncio
 
     from app.services.watch_trigger_repricing.claims import InMemoryClaimStore
@@ -345,20 +345,25 @@ def test_market_scope_stays_kr() -> None:
 
     from .conftest import INCIDENT_TICK, make_event
 
-    result = asyncio.run(
-        select_candidates(
-            [
-                make_event(event_uuid="evt-us", symbol="AAPL", market="us"),
-                make_event(event_uuid="evt-crypto", symbol="KRW-BTC", market="crypto"),
-                make_event(event_uuid="evt-kr", symbol="005930", market="kr"),
-            ],
-            store=InMemoryClaimStore(),
-            now=INCIDENT_TICK,
+    events = [
+        make_event(event_uuid="evt-us", symbol="AAPL", market="us"),
+        make_event(event_uuid="evt-crypto", symbol="KRW-BTC", market="crypto"),
+        make_event(event_uuid="evt-kr", symbol="005930", market="kr"),
+    ]
+    for market, expected in (
+        ("kr", "evt-kr"),
+        ("us", "evt-us"),
+        ("crypto", "evt-crypto"),
+    ):
+        result = asyncio.run(
+            select_candidates(
+                events,
+                store=InMemoryClaimStore(),
+                now=INCIDENT_TICK,
+                market=market,
+            )
         )
-    )
-
-    assert [e.event_uuid for e in result.selected] == ["evt-kr"]
-    assert {s.reason for s in result.skipped} == {"market_out_of_scope"}
+        assert [e.event_uuid for e in result.selected] == [expected]
 
 
 def test_settings_gate_defaults_off() -> None:

--- a/tests/services/watch_trigger_repricing/test_us_crypto_extension.py
+++ b/tests/services/watch_trigger_repricing/test_us_crypto_extension.py
@@ -1,0 +1,108 @@
+"""ROB-1304 — fixed-fixture US/crypto watch-fire paths.
+
+These are deliberately fixed fixtures, not a production arm: the feature
+remains scheduleless and ``WATCH_TRIGGER_REPRICING_ENABLED`` defaults off.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from app.services.watch_trigger_repricing.claims import InMemoryClaimStore
+from app.services.watch_trigger_repricing.gate import evaluate_gate
+from app.services.watch_trigger_repricing.orchestrator import run_repricing_tick
+from app.services.watch_trigger_repricing.selection import CandidateEvent
+from app.services.watch_trigger_repricing.spawn import DrySessionSpawner
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("market", "symbol", "now", "event_uuid", "evidence"),
+    [
+        (
+            "us",
+            "BRK.B",
+            dt.datetime(2026, 8, 18, 14, 0, tzinfo=dt.UTC),  # 10:00 EDT, XNYS
+            "fixed-us-fire",
+            {
+                "market": "us",
+                "symbol": "BRK.B",
+                "metric": "price",
+                "operator": "above",
+                "threshold": "500.25",
+                "currentValue": "501.00",
+                "firedAt": "2026-08-18T14:00:00+00:00",
+            },
+        ),
+        (
+            "crypto",
+            "KRW-BTC",
+            dt.datetime(2026, 8, 22, 2, 0, tzinfo=dt.UTC),  # Saturday: still 24/7
+            "fixed-crypto-fire",
+            {
+                "market": "crypto",
+                "symbol": "KRW-BTC",
+                "metric": "price",
+                "operator": "below",
+                "threshold": "150000000",
+                "currentValue": "149900000",
+                "firedAt": "2026-08-22T02:00:00+00:00",
+            },
+        ),
+    ],
+)
+async def test_fixed_fixture_fire_reaches_its_market_lane_with_evidence(
+    market: str,
+    symbol: str,
+    now: dt.datetime,
+    event_uuid: str,
+    evidence: dict[str, object],
+) -> None:
+    spawner = DrySessionSpawner()
+    result = await run_repricing_tick(
+        [
+            CandidateEvent(
+                event_uuid=event_uuid,
+                symbol=symbol,
+                market=market,
+                outcome="review_required",
+                delivery_status="delivered",
+                delivered_at=now,
+                trigger_evidence=evidence,
+            )
+        ],
+        store=InMemoryClaimStore(),
+        spawner=spawner,
+        now=now,
+        market=market,
+    )
+
+    assert result.gate.should_run is True
+    assert [outcome.request.event_uuid for outcome in result.spawned] == [event_uuid]
+    assert spawner.requests[0].trigger_evidence == evidence
+    assert spawner.requests[0].market_date == (
+        "2026-08-18" if market == "us" else "2026-08-22"
+    )
+
+
+def test_us_uses_xnys_regular_hours_not_kr_hours() -> None:
+    # 10:00 EDT is open; this is 23:00 KST, which proves the KR window was
+    # not copied into the US lane.
+    decision = evaluate_gate(
+        now=dt.datetime(2026, 8, 18, 14, 0, tzinfo=dt.UTC), market="us"
+    )
+    assert decision.should_run is True
+    assert decision.market_date == "2026-08-18"
+
+
+def test_crypto_does_not_inherit_equity_weekend_closure() -> None:
+    decision = evaluate_gate(
+        now=dt.datetime(2026, 8, 22, 2, 0, tzinfo=dt.UTC), market="crypto"
+    )
+    assert decision.should_run is True
+    assert decision.reason == "ok_24x7"
+    assert decision.session_status == "open_24x7"


### PR DESCRIPTION
## Summary
- add US XNYS-hours and crypto 24/7 watch-fire repricing lanes while preserving KR behavior
- persist trigger condition/value/time evidence through proposal rationale
- document deployment-only triage cutover, rollback, and cross-path dedupe requirements

## Safety
- no scheduler/cron/TaskIQ/Prefect registration, env arm, deployment, broker/order or approval-gate change
- operator-repo work is documented only

## Verification
- `make lint` passed
- targeted gate/US-crypto/invariant tests: 39 passed
- repricing package: 234 passed, 1 failed due pre-existing dual Alembic heads (`20260820_rob1283_bucket`, `20260820_rob1290_reconcile`); no migration change in this PR
- `make test` started once and remains in progress; CI left untouched after this single push
