### PR TITLE
chore: raise crypto auto-approve caps

### DIFF
--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -9,7 +9,7 @@
 # 저항 기반 매도 티어에 하나도 매칭되지 않아 익절 경로가 소멸한다. 그 공백만
 # 닫는 폴백 티어 sell.trim_preplace.breakeven_extension_ladder 를 신설한다.
 # 저항 티어의 대체가 아니며, exclusions.no_resistance_reference 는 유지된다.
-version: "2026-08-20.1"
+version: "2026-08-20.2"
 captured_as_of: "2026-08-12"
 source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change)"
 
@@ -64,7 +64,7 @@ order_proposals:
       # auto-approve (25/25 sell proposals carded on 2026-08-13). 800 admits
       # one-share exits while still capping multi-share notional.
       us: 1500
-      crypto: 100000
+      crypto: 1000000
     daily_cap:
       kr: 5000000
       # §71차 (2026-08-14): 800 -> 5000. The §65차 same-value pairing was wrong
@@ -75,7 +75,7 @@ order_proposals:
       # 5000 covers an observed full trim session (~10% of book/day/account);
       # the $800 per-order cap and per-rung veto cards remain the guardrails.
       us: 20000
-      crypto: 300000
+      crypto: 5000000
     # AUTO-APPROVE-EXPAND (§40차) — inputs to the profit-take classification,
     # consumed only when ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded.
     #

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -215,7 +215,7 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
     }
     # advisory keys are echoed with the same version/content_hash stamp as
     # every other section of the response (ROB-932).
-    assert out["version"] == "2026-08-20.1"
+    assert out["version"] == "2026-08-20.2"
     assert out["content_hash"]
 
 

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -40,8 +40,10 @@ _ROB1298_ADDITIVE_TIE_BREAK_KEYS = (
 _ROB1292_ALLOWED_POLICY_DELTAS = (
     ("order_proposals.auto_approve.per_order_cap.kr", 400000, 1000000),
     ("order_proposals.auto_approve.per_order_cap.us", 800, 1500),
+    ("order_proposals.auto_approve.per_order_cap.crypto", 100000, 1000000),
     ("order_proposals.auto_approve.daily_cap.kr", 400000, 5000000),
     ("order_proposals.auto_approve.daily_cap.us", 5000, 20000),
+    ("order_proposals.auto_approve.daily_cap.crypto", 300000, 5000000),
 )
 
 
@@ -149,7 +151,7 @@ def _breakeven_reserve_trim_triggered(
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
-    assert doc.version == "2026-08-20.1"
+    assert doc.version == "2026-08-20.2"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -1023,9 +1025,9 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
             "tie_breaks"
         ][key]
 
-    # Only the four explicitly enumerated §106차 cap deltas and the enumerated
+    # Only the six explicitly enumerated cap deltas and the enumerated
     # §115차 additions are accepted; every other pre-existing key/value,
-    # including both crypto caps and the retained exclusions list, must still
+    # including the retained exclusions list, must still
     # match the ROB-1289 baseline exactly.
     assert normalized_current_dump == baseline_dump
 
@@ -1520,7 +1522,7 @@ def test_rob_1298_leaves_loss_guard_d7_and_auto_approve_gates_untouched():
     ):
         assert current["thresholds"][key] == baseline["thresholds"][key]
 
-    # Auto-approve gate: only the four §106차 cap deltas already enumerated by
+    # Auto-approve gate: only the enumerated cap deltas already enumerated by
     # ROB-1292 differ; every other auto-approve key is unchanged by ROB-1298.
     current_auto = deepcopy(current["order_proposals"]["auto_approve"])
     baseline_auto = deepcopy(baseline["order_proposals"]["auto_approve"])

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -914,8 +914,8 @@ def test_policy_caps_match_the_operator_declared_limits():
     assert (kr.per_order_cap, kr.daily_cap) == (Decimal("1000000"), Decimal("5000000"))
     assert (us.per_order_cap, us.daily_cap) == (Decimal("1500"), Decimal("20000"))
     assert (crypto.per_order_cap, crypto.daily_cap) == (
-        Decimal("100000"),
-        Decimal("300000"),
+        Decimal("1000000"),
+        Decimal("5000000"),
     )
 
 


### PR DESCRIPTION
## Summary\n- raise crypto per-order auto-approve cap from 100,000 to 1,000,000\n- raise crypto daily auto-approve cap from 300,000 to 5,000,000\n- bump policy version to 2026-08-20.2 and update cap/version contracts\n\n## Verification\n-  — 148 passed\n- uv run ruff check app/ tests/ research/ scripts/
All checks passed!
uv run ruff format --check app/ tests/ research/ scripts/
4005 files already formatted
uv run ty check app/ --error-on-warning
All checks passed! — passed\n- normalized policy comparison against : exactly version + two crypto cap keys; KR/US caps unchanged\n- uv run pytest tests/ -q -ra -m "not live" running at PR creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased automatic approval limits for cryptocurrency orders:
    * Per-order cap: 1,000,000
    * Daily cap: 5,000,000

* **Documentation**
  * Updated the trading policy version to 2026-08-20.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->