### PR TITLE
feat(ROB-1299): improve Telegram order card readability

### DIFF
--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -12,6 +12,7 @@ from decimal import ROUND_CEILING, Decimal, InvalidOperation
 from typing import Any
 
 from app.core.invest_deep_links import build_loss_cut_approval_url
+from app.core.portfolio_links import build_position_detail_url
 from app.core.timezone import KST
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
@@ -209,6 +210,7 @@ def build_batch_approval_message(
     batch: Any,
     proposals: Sequence[tuple[Any, Sequence[Any]]],
     binding: DispatchBinding,
+    display_names: Mapping[str, str] | None = None,
 ) -> tuple[str, dict]:
     """Render a pending manual-approval batch without exposing raw nonces."""
     if len(proposals) < 2:
@@ -228,6 +230,7 @@ def build_batch_approval_message(
     ]
     for group, rungs in proposals:
         symbol = str(getattr(group, "symbol", None) or "미기재")
+        display_name = (display_names or {}).get(str(getattr(group, "proposal_id", "")))
         side = str(getattr(group, "side", None) or "미기재")
         market = str(getattr(group, "market", None) or "")
         currency = _currency_for_market(market=market, symbol=symbol) or "기타"
@@ -260,7 +263,7 @@ def build_batch_approval_message(
                 f"{_format_money(None if is_market_order else getattr(rung, 'limit_price', None), currency=currency, none_label='시장가')}"
             )
         lines.append(
-            f"- `{_escape_inline_code(symbol)}` "
+            f"- {_format_symbol_label(symbol, display_name=display_name)} "
             f"`{_escape_inline_code(side)}` · "
             f"{_escape_markdown(account_label)} · " + "; ".join(rung_parts)
         )
@@ -366,6 +369,7 @@ def build_approval_message(
     cash_stress: dict | None = None,
     diff: dict | None = None,
     evidence_reference: str | None = None,
+    display_name: str | None = None,
     binding: DispatchBinding,
 ) -> tuple[str, dict]:
     """Render a proposal and its Telegram inline keyboard without raw digests."""
@@ -416,7 +420,7 @@ def build_approval_message(
     title = "*주문 제안 재확인*" if explicit_reconfirm else "*주문 제안 승인*"
     lines = [
         title,
-        f"- 종목: `{_escape_inline_code(symbol)}`",
+        f"- 종목: {_format_symbol_label(symbol, display_name=display_name)}",
         "- 시장/방향/유형: "
         f"`{_escape_inline_code(f'{market} / {side} / {order_type}')}`",
     ]
@@ -477,6 +481,10 @@ def build_approval_message(
                 f"- /invest 증거·확인: {approval_url}",
             ]
         )
+
+    detail_url = build_position_detail_url(symbol, market)
+    if detail_url is not None:
+        lines.append(f"- /invest 상세: {detail_url}")
 
     time_lines = _build_time_lines(group)
     if time_lines:
@@ -540,6 +548,10 @@ def build_approval_message(
                 }
             ]
         )
+    if detail_url is not None:
+        inline_keyboard["inline_keyboard"].append(
+            [{"text": "🔎 /invest 상세", "url": detail_url}]
+        )
     return text, inline_keyboard
 
 
@@ -550,6 +562,7 @@ def build_approval_dispatch_messages(
     cash_stress: dict | None = None,
     diff: dict | None = None,
     suffix_blocks: Sequence[str] = (),
+    display_name: str | None = None,
     binding: DispatchBinding,
 ) -> ApprovalDispatchMessages:
     """Render one compact card; detailed evidence belongs to the future hub."""
@@ -558,6 +571,7 @@ def build_approval_dispatch_messages(
         rungs=rungs,
         cash_stress=cash_stress,
         diff=diff,
+        display_name=display_name,
         binding=binding,
     )
     if suffix_blocks:
@@ -575,6 +589,7 @@ def build_loss_cut_confirmation_message(
     group: Any,
     rungs: Sequence[Any],
     evidence: Mapping[str, Any],
+    display_name: str | None = None,
     binding: DispatchBinding,
 ) -> tuple[str, dict]:
     """Render the explicit second-step loss-cut confirmation prompt."""
@@ -596,7 +611,7 @@ def build_loss_cut_confirmation_message(
 
     lines = [
         "*⚠️ 손절 확인*",
-        f"- 종목: `{_escape_inline_code(symbol)}`",
+        f"- 종목: {_format_symbol_label(symbol, display_name=display_name)}",
         "",
         "*주문 및 손실 요약*",
     ]
@@ -650,6 +665,9 @@ def build_loss_cut_confirmation_message(
     lines.extend(["", "이 손절 주문을 다시 확인해 주세요."])
     approval_url = build_loss_cut_approval_url(proposal_id=proposal_id)
     lines.append(f"/invest 증거·확인: {approval_url}")
+    detail_url = build_position_detail_url(symbol, market)
+    if detail_url is not None:
+        lines.append(f"/invest 상세: {detail_url}")
     text = "\n".join(lines).replace(str(nonce), "[비공개]")
     keyboard = {
         "inline_keyboard": [
@@ -678,7 +696,20 @@ def build_loss_cut_confirmation_message(
     keyboard["inline_keyboard"].append(
         [{"text": "🔎 /invest 증거", "url": approval_url}]
     )
+    if detail_url is not None:
+        keyboard["inline_keyboard"].append(
+            [{"text": "🔎 /invest 상세", "url": detail_url}]
+        )
     return text, keyboard
+
+
+def _format_symbol_label(symbol: str, *, display_name: str | None) -> str:
+    """Keep the durable code visible while optionally adding a resolved name."""
+    code = f"`{_escape_inline_code(symbol)}`"
+    normalized_name = " ".join(str(display_name or "").split())
+    if not normalized_name or normalized_name == symbol:
+        return code
+    return f"{code} · {_escape_markdown(normalized_name)}"
 
 
 def _build_order_core_metrics(*, group: Any, rungs: Sequence[Any]) -> str:

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -43,11 +43,13 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from app.core.config import settings
+from app.core.portfolio_links import build_position_detail_url
 from app.services.order_proposals.approval_message import (
     _build_order_core_metrics,
     _escape_inline_code,
     _escape_markdown,
     _format_datetime,
+    _format_symbol_label,
     build_callback_data,
 )
 from app.services.order_proposals.auto_approve_audit import (
@@ -712,6 +714,7 @@ def build_auto_approved_message(
     rungs: list[Any],
     nonce: str,
     policy_version: str,
+    display_name: str | None = None,
     binding: DispatchBinding,
 ) -> tuple[str, dict[str, Any]]:
     """Render a compact post-submit summary with a single-use veto button."""
@@ -725,7 +728,7 @@ def build_auto_approved_message(
     )
     lines = [
         "✅ *자동 접수됨*",
-        f"- 종목: `{_escape_inline_code(group.symbol)}`",
+        f"- 종목: {_format_symbol_label(group.symbol, display_name=display_name)}",
         f"- 방향: `{_escape_inline_code(group.side)}`",
     ]
     ordered_rungs = sorted(rungs, key=lambda item: item.rung_index)
@@ -748,9 +751,15 @@ def build_auto_approved_message(
             f"- `auto:policy@{policy_version}`",
         ]
     )
-    return "\n".join(lines), {
-        "inline_keyboard": [[{"text": "취소", "callback_data": callback}]]
-    }
+    detail_url = build_position_detail_url(group.symbol, group.market)
+    if detail_url is not None:
+        lines.append(f"- /invest 상세: {detail_url}")
+    keyboard = {"inline_keyboard": [[{"text": "취소", "callback_data": callback}]]}
+    if detail_url is not None:
+        keyboard["inline_keyboard"].append(
+            [{"text": "🔎 /invest 상세", "url": detail_url}]
+        )
+    return "\n".join(lines), keyboard
 
 
 __all__ = [

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
+from app.services.fill_notification import resolve_display_name_db
 from app.services.order_proposals.approval_message import (
     ApprovalDispatchMessages,
     build_approval_dispatch_messages,
@@ -203,6 +204,24 @@ def _mirror_decimal_text(value: Any) -> str:
     except Exception:  # noqa: BLE001 - display degradation must not raise
         return str(value)
     return normalized.rstrip("0").rstrip(".") if "." in normalized else normalized
+
+
+async def _resolve_card_display_name(group: Any) -> str | None:
+    """Reuse the notification name resolver; rendering remains fail-open to code."""
+    symbol = str(getattr(group, "symbol", "") or "").strip()
+    market = {"equity_kr": "kr", "equity_us": "us"}.get(
+        str(getattr(group, "market", "") or ""),
+        str(getattr(group, "market", "") or ""),
+    )
+    if not symbol:
+        return None
+    try:
+        name = await resolve_display_name_db(market, symbol)
+    except Exception:  # noqa: BLE001 - alerts must still reach the operator
+        logger.debug("order proposal display-name resolution failed", exc_info=True)
+        return None
+    normalized = " ".join(str(name or "").split())
+    return normalized or None
 
 
 async def _mirror_auto_veto_card(
@@ -449,10 +468,16 @@ async def _register_and_publish_batch_summary(
             await session.commit()
             return
 
+    display_names = {
+        str(group.proposal_id): name
+        for group, _rungs in proposals
+        if (name := await _resolve_card_display_name(group)) is not None
+    }
     text, keyboard = build_batch_approval_message(
         batch=batch,
         proposals=proposals,
         binding=registration.binding,
+        display_names=display_names,
     )
     messages = ApprovalDispatchMessages(
         context_messages=(),
@@ -630,6 +655,7 @@ async def send_proposal_for_approval(
         messages = build_approval_dispatch_messages(
             group=group,
             rungs=rungs,
+            display_name=await _resolve_card_display_name(group),
             suffix_blocks=(
                 (rejection_block,)
                 if (
@@ -988,6 +1014,7 @@ async def dispatch_proposal(
                     rungs=rungs,
                     nonce=veto_nonce,
                     policy_version=limits.policy_version,
+                    display_name=await _resolve_card_display_name(group),
                     binding=binding,
                 )
                 messages = ApprovalDispatchMessages(

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -87,7 +87,10 @@ from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
     fetch_target_order,
 )
-from app.services.order_proposals.dispatch import publish_approval_messages
+from app.services.order_proposals.dispatch import (
+    _resolve_card_display_name,
+    publish_approval_messages,
+)
 from app.services.order_proposals.dispatch_contract import (
     ApprovalCardKind,
     ApprovalPublication,
@@ -919,6 +922,7 @@ async def _handle_approve(
             rungs=rungs,
             diff=reconfirm_outcomes[0].detail,
             suffix_blocks=suffix_blocks,
+            display_name=await _resolve_card_display_name(group),
             binding=binding,
         )
         send_window = await _evaluate_bound_window(
@@ -1548,7 +1552,11 @@ async def _handle_loss_cut_first_click(
         current_membership_revision=group.approval_dispatch_membership_revision,
     )
     text, keyboard = build_loss_cut_confirmation_message(
-        group=group, rungs=rungs, evidence=evidence, binding=binding
+        group=group,
+        rungs=rungs,
+        evidence=evidence,
+        display_name=await _resolve_card_display_name(group),
+        binding=binding,
     )
     publish_window = await _evaluate_bound_window(
         group,

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -328,6 +328,33 @@ def test_compact_approval_card_has_required_contract_fields_individually():
 
 
 @pytest.mark.unit
+def test_kis_live_card_shows_resolved_name_and_existing_invest_detail_link():
+    """ROB-1299: a real KIS-live-shaped card stays compact but identifiable."""
+    group = _group(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        thesis="실적 회복과 현금흐름 개선을 확인한 매수 근거",
+        valid_until=datetime(2026, 8, 20, 7, 30, tzinfo=UTC),
+    )
+    text, keyboard = build_approval_message(
+        group=group,
+        rungs=[_rung(quantity=Decimal("2"), limit_price=Decimal("71000"))],
+        display_name="삼성전자",
+    )
+
+    assert "종목: `005930` · 삼성전자" in text
+    assert "시장/방향/유형: `equity_kr / buy / limit`" in text
+    assert "#1: 2주 × ₩71,000" in text
+    assert "투자 논지: 실적 회복과 현금흐름 개선을 확인한 매수 근거" in text
+    assert "유효기간: ~16:30 KST (2026-08-20)" in text
+    assert "/invest/stocks/kr/005930" in text
+    assert telegram_text_length(text) < TELEGRAM_SEND_MESSAGE_TEXT_LIMIT
+    assert keyboard["inline_keyboard"][-1][0]["text"] == "🔎 /invest 상세"
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("detail", "expected"),
     [
@@ -456,6 +483,28 @@ def test_loss_cut_confirmation_callback_and_summary():
     assert approval_url.endswith(f"/invest/approvals/loss-cut/{group.proposal_id}")
     assert approval_url in text
     assert group.approval_nonce not in approval_url
+
+
+@pytest.mark.unit
+def test_loss_cut_second_step_retains_loss_rate_and_second_window_contract():
+    """A deletion-prone compacting regression: both fields are mandatory."""
+    group = _group(
+        exit_intent="loss_cut",
+        source_asof={
+            "loss_cut_confirmation": {"expires_at": "2026-07-14T01:30:00+00:00"}
+        },
+    )
+    text, _keyboard = build_loss_cut_confirmation_message(
+        group=group,
+        rungs=[_rung()],
+        evidence={
+            "rungs": [{"rung_index": 0, "loss_pct": "-12.34"}],
+            "retrospective_id": 42,
+        },
+    )
+
+    assert "손실률 -12.34%" in text
+    assert "2차 창(유효시간): 10:30 KST (2026-07-14)" in text
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -847,15 +847,17 @@ def test_auto_veto_card_has_symbol_quantity_price_and_thesis_fields():
         rungs=[_rung(quantity=Decimal("2"), limit_price=Decimal("97000"))],
         nonce="fixture-nonce",
         policy_version="fixture-policy",
+        display_name="삼성전자",
         binding=binding,
     )
 
-    assert "종목: `005930`" in text
+    assert "종목: `005930` · 삼성전자" in text
     assert "수량: #1 2" in text
     assert "가격: #1 97000" in text
     assert "핵심 수치: 총수량 2주 / 주문금액 ₩194,000" in text
     assert "근거: valuation dislocation" in text
     assert "유효기간: 10:30 KST (2026-07-14)" in text
+    assert "/invest/stocks/kr/005930" in text
 
 
 def test_auto_veto_missing_thesis_stays_none_and_routes_to_human():

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 
@@ -51,6 +52,26 @@ def _known_market_session(monkeypatch):
     monkeypatch.setattr(
         revalidation_module, "evaluate_approval_window", allow_known_session
     )
+
+
+@pytest.mark.asyncio
+async def test_card_name_resolution_reuses_notification_source_and_fails_open(
+    monkeypatch,
+):
+    group = SimpleNamespace(symbol="005930", market="equity_kr")
+
+    async def resolved(market: str, symbol: str) -> str:
+        assert (market, symbol) == ("kr", "005930")
+        return "삼성전자"
+
+    monkeypatch.setattr(dispatch_module, "resolve_display_name_db", resolved)
+    assert await dispatch_module._resolve_card_display_name(group) == "삼성전자"
+
+    async def unavailable(_market: str, _symbol: str) -> str:
+        raise RuntimeError("name lookup unavailable")
+
+    monkeypatch.setattr(dispatch_module, "resolve_display_name_db", unavailable)
+    assert await dispatch_module._resolve_card_display_name(group) is None
 
 
 class _FakeNotifier:


### PR DESCRIPTION
## Summary
- show resolved symbol names beside the durable code on Telegram order cards
- add existing /invest stock-detail links without changing approval, broker, or policy behavior
- preserve loss-cut second-step loss-rate and expiry-window fields

## Verification
- uv run ruff check app/ tests/ research/ scripts/
All checks passed!
uv run ruff format --check app/ tests/ research/ scripts/
3998 files already formatted
uv run ty check app/ --error-on-warning
All checks passed!
- focused order-proposal formatter tests
- full uv run pytest tests/ -q -ra -m "not live" is running locally