### PR TITLE
feat(ROB-1303): daily spike cause attribution + catalyst_basis / follow-through hooks

### DIFF
--- a/.smoke-out/rob179-feed-research-evidence.json
+++ b/.smoke-out/rob179-feed-research-evidence.json
@@ -1,7 +1,7 @@
 {
   "smoke": "rob-179-invest-research-api",
-  "captured_at": "2026-08-10T08:13:13.971815+00:00",
-  "source_used": "rob179-smoke-18adacff",
+  "captured_at": "2026-08-20T10:41:23.943900+00:00",
+  "source_used": "rob179-smoke-2ff43d67",
   "invariants_ok": true,
   "samples": {
     "top": {

--- a/.smoke-out/rob179-feed-research-evidence.json
+++ b/.smoke-out/rob179-feed-research-evidence.json
@@ -1,7 +1,7 @@
 {
   "smoke": "rob-179-invest-research-api",
-  "captured_at": "2026-08-20T11:41:46.658100+00:00",
-  "source_used": "rob179-smoke-c5817554",
+  "captured_at": "2026-08-10T08:13:13.971815+00:00",
+  "source_used": "rob179-smoke-18adacff",
   "invariants_ok": true,
   "samples": {
     "top": {

--- a/.smoke-out/rob179-feed-research-evidence.json
+++ b/.smoke-out/rob179-feed-research-evidence.json
@@ -1,7 +1,7 @@
 {
   "smoke": "rob-179-invest-research-api",
-  "captured_at": "2026-08-20T10:41:23.943900+00:00",
-  "source_used": "rob179-smoke-2ff43d67",
+  "captured_at": "2026-08-20T11:41:46.658100+00:00",
+  "source_used": "rob179-smoke-c5817554",
   "invariants_ok": true,
   "samples": {
     "top": {

--- a/app/mcp_server/tooling/analysis_readonly_registration.py
+++ b/app/mcp_server/tooling/analysis_readonly_registration.py
@@ -75,6 +75,7 @@ ANALYSIS_READONLY_TOOL_NAMES: set[str] = {
     "screen_stocks_snapshot",
     "discover_buy_candidates_fanout",
     "evaluate_buy_gate_ab_shadow",
+    "get_spike_attribution",
     "get_krx_session_health",
     "get_top_stocks",
     "get_news",

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -30,6 +30,9 @@ from app.mcp_server.tooling.research_pipeline_read import (
     stage_analysis_get_impl,
 )
 from app.mcp_server.tooling.screener_snapshot_tool import screen_stocks_snapshot_impl
+from app.mcp_server.tooling.spike_attribution_registration import (
+    register_spike_attribution_tools,
+)
 from app.mcp_server.tooling.theme_events import get_theme_events_impl
 from app.services.krx import probe_krx_session_health
 
@@ -46,6 +49,7 @@ ANALYSIS_TOOL_NAMES: set[str] = {
     "screen_stocks_snapshot",
     "discover_buy_candidates_fanout",
     "evaluate_buy_gate_ab_shadow",
+    "get_spike_attribution",
     # ROB-359: "recommend_stocks" is intentionally registry-hidden (parked).
     # screen_stocks is the generic candidate-discovery entrypoint; the
     # recommend_stocks_impl implementation is retained in
@@ -73,6 +77,7 @@ def register_analysis_tools(
 
     register_buy_candidate_fanout_tools(mcp)
     register_buy_gate_ab_shadow_tools(mcp)
+    register_spike_attribution_tools(mcp)
 
     @mcp.tool(
         name="get_krx_session_health",

--- a/app/mcp_server/tooling/kiwoom_kr_registration.py
+++ b/app/mcp_server/tooling/kiwoom_kr_registration.py
@@ -90,6 +90,13 @@ KIWOOM_KR_BASE_PROFILE_TOOL_NAMES: frozenset[str] = frozenset(
         # read-only advisory tool, so including it preserves the KIWOOM ↔
         # KIWOOM_KR shared-surface contract without exposing a mutation.
         "evaluate_buy_gate_ab_shadow",
+        # ROB-1303: read-only spike cause attribution. Same reasoning as the
+        # ROB-1301 entry above — it is advisory and cannot mutate anything, and
+        # the KIWOOM <-> KIWOOM_KR shared-surface contract
+        # (test_keeps_kr_order_surface_intact) requires that the only tools
+        # KIWOOM has and KIWOOM_KR lacks are the US mutations and the mirror
+        # counterfactual. Omitting it here would widen that difference.
+        "get_spike_attribution",
         "execution_ledger_fill_events_list_recent",
         "forecast_resolve",
         "forecast_save",

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -478,6 +478,10 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         # ROB-1301: observation-only A/B buy-gate shadow. Never a proposal,
         # order, or watch; live variant A is unchanged.
         "evaluate_buy_gate_ab_shadow",
+        # ROB-1303: read-only spike cause attribution. Reads news / DART /
+        # earnings rows this repo already stores and returns candidates with
+        # their links, or an explicit unattributed verdict. Writes nothing.
+        "get_spike_attribution",
         # ROB-907: read-only Demo ledger status (flag-gated —
         # settings.binance_demo_scalping_enabled). The mutation-path submit
         # tool this once shared a gate comment with was removed (ROB-1147).

--- a/app/mcp_server/tooling/spike_attribution.py
+++ b/app/mcp_server/tooling/spike_attribution.py
@@ -1,0 +1,137 @@
+"""ROB-1303 read-only spike-attribution tool.
+
+Answers "what could have caused this session's move?" from material this repo
+already stores, and returns the ``catalyst_basis`` block the
+``momentum_spike_profit_ladder`` tier asks for. It reads; it never writes a row,
+calls a broker, or reaches an order / approval / watch surface.
+
+An ``unattributed`` spike comes back ``unattributed`` — the tool has no path
+that turns a blank into a cause.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.services.spike_attribution.attribute import build_attribution, record_summary
+from app.services.spike_attribution.catalyst_basis import build_catalyst_basis
+from app.services.spike_attribution.detect import ABS_CHANGE_PCT_MIN, detect_spikes
+from app.services.spike_attribution.forecast_tag import (
+    build_prereg_forecasts,
+    prereg_skipped_reason,
+)
+from app.services.spike_attribution.materials import (
+    DAILY_TABLE_BY_MARKET,
+    load_daily_bars,
+    load_spike_materials,
+)
+from app.services.spike_attribution.spec import (
+    EXPERIMENT_ID,
+    FORBIDDEN,
+    PINNED_SPEC_SHA256,
+    spec_sha256,
+)
+
+_LOOKBACK_DAYS = 20
+_MAX_SYMBOLS = 20
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _error(message: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": message,
+        "promote": False,
+        "live_gate_impact": False,
+        "writes_performed": 0,
+    }
+
+
+async def get_spike_attribution_impl(
+    symbols: list[str] | None,
+    session_date: str,
+    market: str = "kr",
+    created_by: str = "",
+) -> dict[str, Any]:
+    author = (created_by or "").strip()
+    if not author:
+        return _error("created_by is required")
+    if market not in DAILY_TABLE_BY_MARKET:
+        return _error(f"market must be one of {sorted(DAILY_TABLE_BY_MARKET)}")
+    cleaned = [s.strip() for s in (symbols or []) if s and s.strip()]
+    if not cleaned:
+        return _error("symbols must be a non-empty list")
+    if len(cleaned) > _MAX_SYMBOLS:
+        return _error(f"at most {_MAX_SYMBOLS} symbols per call")
+    try:
+        as_of = dt.date.fromisoformat(session_date.strip())
+    except (AttributeError, ValueError):
+        return _error("session_date must be YYYY-MM-DD")
+
+    results: list[dict[str, Any]] = []
+    async with _session_factory()() as db:
+        for symbol in cleaned:
+            bars = await load_daily_bars(
+                db,
+                market=market,
+                symbol=symbol,
+                start=as_of - dt.timedelta(days=_LOOKBACK_DAYS),
+                end=as_of,
+            )
+            event, diagnostics = detect_spikes(
+                market=market, symbol=symbol, bars=bars, session_date=as_of
+            )
+            if event is None:
+                results.append(
+                    {"symbol": symbol, "spike": False, "diagnostics": diagnostics}
+                )
+                continue
+            materials = await load_spike_materials(db, event)
+            attribution = build_attribution(event=event, materials=materials)
+            results.append(
+                {
+                    "symbol": symbol,
+                    "spike": True,
+                    "diagnostics": diagnostics,
+                    "summary": record_summary(attribution),
+                    "attribution_record": attribution.as_dict(),
+                    "catalyst_basis": build_catalyst_basis(attribution),
+                    "prereg_forecast_save_kwargs": build_prereg_forecasts(
+                        attribution, created_by=author
+                    ),
+                    "prereg_skipped_reason": prereg_skipped_reason(attribution),
+                }
+            )
+
+    spikes = [row for row in results if row["spike"]]
+    return {
+        "success": True,
+        "experiment_id": EXPERIMENT_ID,
+        "spec_sha256": spec_sha256(),
+        "pinned_spec_sha256": PINNED_SPEC_SHA256,
+        "market": market,
+        "session_date": as_of.isoformat(),
+        "abs_change_pct_min": str(ABS_CHANGE_PCT_MIN),
+        "results": results,
+        "counts": {
+            "examined": len(results),
+            "spikes": len(spikes),
+            "attributed": sum(not r["summary"]["unattributed"] for r in spikes),
+            "unattributed": sum(r["summary"]["unattributed"] for r in spikes),
+        },
+        "writes_performed": 0,
+        "forecast_save_called": False,
+        "promote": False,
+        "live_gate_impact": False,
+        "forbidden": list(FORBIDDEN),
+    }
+
+
+__all__ = ["get_spike_attribution_impl"]

--- a/app/mcp_server/tooling/spike_attribution.py
+++ b/app/mcp_server/tooling/spike_attribution.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
 from app.services.spike_attribution.attribute import build_attribution, record_summary
+from app.services.spike_attribution.cache import lookup as cache_lookup
 from app.services.spike_attribution.catalyst_basis import build_catalyst_basis
 from app.services.spike_attribution.detect import ABS_CHANGE_PCT_MIN, detect_spikes
 from app.services.spike_attribution.forecast_tag import (
@@ -59,6 +60,7 @@ async def get_spike_attribution_impl(
     session_date: str,
     market: str = "kr",
     created_by: str = "",
+    use_cache: bool = True,
 ) -> dict[str, Any]:
     author = (created_by or "").strip()
     if not author:
@@ -75,9 +77,26 @@ async def get_spike_attribution_impl(
     except (AttributeError, ValueError):
         return _error("session_date must be YYYY-MM-DD")
 
+    now = dt.datetime.now(dt.UTC)
     results: list[dict[str, Any]] = []
     async with _session_factory()() as db:
         for symbol in cleaned:
+            # Cache-first (ROB-1303 phase 2). A *fresh* entry answers on its
+            # own. Anything else — missing, stale, unreadable — falls through
+            # to a live computation and carries its cache state with it, so a
+            # cold cache can never be read as "this symbol had no catalyst".
+            cache_read = (
+                cache_lookup(market=market, session_date=as_of, symbol=symbol, now=now)
+                if use_cache
+                else None
+            )
+            if cache_read is not None and cache_read.usable_without_fallback:
+                cached = dict(cache_read.entry.payload) if cache_read.entry else {}
+                cached["cache"] = cache_read.as_dict()
+                cached["served_from"] = "cache"
+                results.append(cached)
+                continue
+
             bars = await load_daily_bars(
                 db,
                 market=market,
@@ -88,9 +107,16 @@ async def get_spike_attribution_impl(
             event, diagnostics = detect_spikes(
                 market=market, symbol=symbol, bars=bars, session_date=as_of
             )
+            cache_block = cache_read.as_dict() if cache_read is not None else None
             if event is None:
                 results.append(
-                    {"symbol": symbol, "spike": False, "diagnostics": diagnostics}
+                    {
+                        "symbol": symbol,
+                        "spike": False,
+                        "diagnostics": diagnostics,
+                        "cache": cache_block,
+                        "served_from": "live",
+                    }
                 )
                 continue
             materials = await load_spike_materials(db, event)
@@ -107,10 +133,12 @@ async def get_spike_attribution_impl(
                         attribution, created_by=author
                     ),
                     "prereg_skipped_reason": prereg_skipped_reason(attribution),
+                    "cache": cache_block,
+                    "served_from": "live",
                 }
             )
 
-    spikes = [row for row in results if row["spike"]]
+    spikes = [row for row in results if row.get("spike")]
     return {
         "success": True,
         "experiment_id": EXPERIMENT_ID,
@@ -119,12 +147,24 @@ async def get_spike_attribution_impl(
         "market": market,
         "session_date": as_of.isoformat(),
         "abs_change_pct_min": str(ABS_CHANGE_PCT_MIN),
+        "cache_first": use_cache,
+        "cache_state_note": (
+            "each result carries cache.state; missing/stale fell back to a "
+            "live computation. A missing entry is NOT evidence that the "
+            "symbol had no catalyst."
+        ),
         "results": results,
         "counts": {
             "examined": len(results),
             "spikes": len(spikes),
-            "attributed": sum(not r["summary"]["unattributed"] for r in spikes),
-            "unattributed": sum(r["summary"]["unattributed"] for r in spikes),
+            "attributed": sum(
+                not (r.get("summary") or {}).get("unattributed", True) for r in spikes
+            ),
+            "unattributed": sum(
+                bool((r.get("summary") or {}).get("unattributed")) for r in spikes
+            ),
+            "served_from_cache": sum(r.get("served_from") == "cache" for r in results),
+            "served_live": sum(r.get("served_from") == "live" for r in results),
         },
         "writes_performed": 0,
         "forecast_save_called": False,

--- a/app/mcp_server/tooling/spike_attribution_registration.py
+++ b/app/mcp_server/tooling/spike_attribution_registration.py
@@ -29,7 +29,14 @@ _TOOL_DESCRIPTION = (
     "from this tool alone. Observation-only: it writes no row, calls no broker, "
     "and reaches no order, approval, or watch surface. The returned "
     "prereg_forecast_save_kwargs are pre-registered follow-through records; "
-    "forecast_save is yours to call, and this tool never calls it."
+    "forecast_save is yours to call, and this tool never calls it. "
+    "CACHE: each result carries cache.state — fresh (served from the "
+    "pre-attribution cache), stale (an entry exists but is past its refresh "
+    "cadence; age_seconds is given and the answer was recomputed live), or "
+    "missing (nothing was ever precomputed for this symbol, so it was "
+    "computed live). A missing or stale cache is NOT evidence that the "
+    "symbol had no catalyst — that claim requires an actual attribution "
+    "record saying unattributed. Pass use_cache=false to skip the cache."
 )
 
 
@@ -40,12 +47,14 @@ def register_spike_attribution_tools(mcp: FastMCP) -> None:
         session_date: str,
         market: str = "kr",
         created_by: str = "",
+        use_cache: bool = True,
     ) -> dict[str, Any]:
         return await get_spike_attribution_impl(
             symbols,
             session_date=session_date,
             market=market,
             created_by=created_by,
+            use_cache=use_cache,
         )
 
 

--- a/app/mcp_server/tooling/spike_attribution_registration.py
+++ b/app/mcp_server/tooling/spike_attribution_registration.py
@@ -1,0 +1,55 @@
+"""MCP registration for the ROB-1303 spike attribution reader."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.mcp_server.tooling.spike_attribution import get_spike_attribution_impl
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+SPIKE_ATTRIBUTION_TOOL_NAMES: set[str] = {"get_spike_attribution"}
+
+_TOOL_DESCRIPTION = (
+    "ROB-1303 read-only spike cause attribution. For each symbol it detects "
+    "whether the session moved >=5% (close-to-close or intraday vs the previous "
+    "close) and lists the documents that could have caused it: news articles "
+    "mapped to the symbol, DART disclosures, and earnings events, each with its "
+    "link and an eligibility ruling against the pre-move window (previous "
+    "session close, this session close]. Anything published after the close is "
+    "returned as after_move and is NOT a cause; anything whose feed clock is "
+    "unconfirmed is returned as timestamp_unknown and is NOT a cause. When "
+    "nothing is eligible the verdict is unattributed — report it as "
+    "unattributed, never as '기타' or '시장 전반'. Multiple eligible candidates "
+    "are all returned; do not collapse them to one cause. The catalyst_basis "
+    "block is the momentum_spike_profit_ladder tier's evidence slot: it reports "
+    "satisfies_catalyst_basis_requirement=false for an unattributed spike and "
+    "never supplies flow_basis, so the tier's evidence pair is never complete "
+    "from this tool alone. Observation-only: it writes no row, calls no broker, "
+    "and reaches no order, approval, or watch surface. The returned "
+    "prereg_forecast_save_kwargs are pre-registered follow-through records; "
+    "forecast_save is yours to call, and this tool never calls it."
+)
+
+
+def register_spike_attribution_tools(mcp: FastMCP) -> None:
+    @mcp.tool(name="get_spike_attribution", description=_TOOL_DESCRIPTION)
+    async def get_spike_attribution(
+        symbols: list[str],
+        session_date: str,
+        market: str = "kr",
+        created_by: str = "",
+    ) -> dict[str, Any]:
+        return await get_spike_attribution_impl(
+            symbols,
+            session_date=session_date,
+            market=market,
+            created_by=created_by,
+        )
+
+
+__all__ = [
+    "SPIKE_ATTRIBUTION_TOOL_NAMES",
+    "register_spike_attribution_tools",
+]

--- a/app/services/spike_attribution/__init__.py
+++ b/app/services/spike_attribution/__init__.py
@@ -19,8 +19,17 @@ Two hooks hang off the record, wiring only — no scheduler, no auto-run:
   follow-through so "does an X-driven spike hold?" is scoreable later without
   re-reading the formula favourably.
 
-Nothing in this package writes a row, touches a broker, or reaches an order,
-approval, or watch surface.
+Phase 2 (§120차 부기 2) adds a pre-attribution cache so a session does not
+recompute at decision time. Its hazard is the mirror of stage 1's: a cold or
+stale cache read as "no catalyst" is a different claim from ``unattributed``.
+:mod:`~app.services.spike_attribution.cache` therefore answers every lookup with
+an explicit ``fresh`` / ``stale(age)`` / ``missing`` state, a computed negative
+counts as a real ``fresh`` answer, and
+:mod:`~app.services.spike_attribution.precompute` never lets a failed refresh
+overwrite the last good entry.
+
+Nothing in this package writes a database row, touches a broker, reaches an
+order, approval, or watch surface, or registers a schedule.
 """
 
 from app.services.spike_attribution.attribute import (
@@ -32,6 +41,15 @@ from app.services.spike_attribution.attribute import (
     rule_eligibility,
     scored_class,
 )
+from app.services.spike_attribution.cache import (
+    STATE_FRESH,
+    STATE_MISSING,
+    STATE_STALE,
+    CacheEntry,
+    CacheRead,
+    classify_state,
+)
+from app.services.spike_attribution.cache import lookup as cache_lookup
 from app.services.spike_attribution.catalyst_basis import build_catalyst_basis
 from app.services.spike_attribution.contract import (
     DailyBar,
@@ -48,6 +66,11 @@ from app.services.spike_attribution.detect import (
     session_close_at,
 )
 from app.services.spike_attribution.forecast_tag import build_prereg_forecasts
+from app.services.spike_attribution.precompute import (
+    PrecomputeRun,
+    precompute_session,
+    refresh_symbol,
+)
 from app.services.spike_attribution.scoring import (
     FollowThroughScore,
     aggregate_by_class,
@@ -64,6 +87,16 @@ from app.services.spike_attribution.spec import (
 
 __all__ = [
     "ATTRIBUTION_TYPES",
+    "STATE_FRESH",
+    "STATE_MISSING",
+    "STATE_STALE",
+    "CacheEntry",
+    "CacheRead",
+    "PrecomputeRun",
+    "cache_lookup",
+    "classify_state",
+    "precompute_session",
+    "refresh_symbol",
     "EXPERIMENT_ID",
     "FORBIDDEN",
     "PINNED_SPEC_SHA256",

--- a/app/services/spike_attribution/__init__.py
+++ b/app/services/spike_attribution/__init__.py
@@ -1,0 +1,94 @@
+"""ROB-1303 — daily spike cause attribution (observation-only).
+
+Assembles material this repo already stores — news relevance (ROB-491), DART /
+earnings market events (ROB-128), investor flow, sector map (ROB-512) — into a
+per-spike record that says which documents *could* have caused a session move,
+which could not (and why), and which materials could not be read at all.
+
+When nothing explains the move the record says ``unattributed`` in fixed
+wording. That is the point of it: an honest blank is worth more than a
+plausible-sounding cause.
+
+Two hooks hang off the record, wiring only — no scheduler, no auto-run:
+
+* :mod:`~app.services.spike_attribution.catalyst_basis` feeds the
+  ``momentum_spike_profit_ladder`` tier's ``catalyst_basis`` evidence slot, and
+  cannot report sufficiency for an unattributed spike.
+* :mod:`~app.services.spike_attribution.forecast_tag` /
+  :mod:`~app.services.spike_attribution.scoring` pre-register per-type
+  follow-through so "does an X-driven spike hold?" is scoreable later without
+  re-reading the formula favourably.
+
+Nothing in this package writes a row, touches a broker, or reaches an order,
+approval, or watch surface.
+"""
+
+from app.services.spike_attribution.attribute import (
+    UNATTRIBUTED,
+    UNATTRIBUTED_PHRASE,
+    AttributionError,
+    build_attribution,
+    record_summary,
+    rule_eligibility,
+    scored_class,
+)
+from app.services.spike_attribution.catalyst_basis import build_catalyst_basis
+from app.services.spike_attribution.contract import (
+    DailyBar,
+    EvidenceItem,
+    MaterialAvailability,
+    SpikeAttribution,
+    SpikeEvent,
+    SpikeMaterials,
+)
+from app.services.spike_attribution.detect import (
+    SpikeDetectionError,
+    classify_bar,
+    detect_spikes,
+    session_close_at,
+)
+from app.services.spike_attribution.forecast_tag import build_prereg_forecasts
+from app.services.spike_attribution.scoring import (
+    FollowThroughScore,
+    aggregate_by_class,
+    score_event,
+)
+from app.services.spike_attribution.spec import (
+    ATTRIBUTION_TYPES,
+    EXPERIMENT_ID,
+    FORBIDDEN,
+    PINNED_SPEC_SHA256,
+    PRE_REGISTRATION,
+    spec_sha256,
+)
+
+__all__ = [
+    "ATTRIBUTION_TYPES",
+    "EXPERIMENT_ID",
+    "FORBIDDEN",
+    "PINNED_SPEC_SHA256",
+    "PRE_REGISTRATION",
+    "UNATTRIBUTED",
+    "UNATTRIBUTED_PHRASE",
+    "AttributionError",
+    "DailyBar",
+    "EvidenceItem",
+    "FollowThroughScore",
+    "MaterialAvailability",
+    "SpikeAttribution",
+    "SpikeDetectionError",
+    "SpikeEvent",
+    "SpikeMaterials",
+    "aggregate_by_class",
+    "build_attribution",
+    "build_catalyst_basis",
+    "build_prereg_forecasts",
+    "classify_bar",
+    "detect_spikes",
+    "record_summary",
+    "rule_eligibility",
+    "score_event",
+    "scored_class",
+    "session_close_at",
+    "spec_sha256",
+]

--- a/app/services/spike_attribution/attribute.py
+++ b/app/services/spike_attribution/attribute.py
@@ -1,0 +1,208 @@
+"""ROB-1303 attribution assembly (pure).
+
+Takes a detected spike plus whatever the readers found, and rules on it. The
+only two outcomes are *these documents are eligible causes* and *nothing in the
+materials explains this move*. There is no third bucket, and the second one is
+never dressed up as "기타" or "시장 전반" — the value of the record is that it
+admits ignorance in the same words every time.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.services.spike_attribution.contract import (
+    ELIGIBILITY_AFTER_MOVE,
+    ELIGIBILITY_BEFORE_WINDOW,
+    ELIGIBILITY_ELIGIBLE,
+    ELIGIBILITY_TIMESTAMP_UNKNOWN,
+    EvidenceItem,
+    SpikeAttribution,
+    SpikeEvent,
+    SpikeMaterials,
+)
+from app.services.spike_attribution.spec import (
+    ATTRIBUTED_TYPES,
+    EXPERIMENT_ID,
+    PRE_REGISTRATION,
+    spec_sha256,
+)
+
+_ATTRIBUTION = PRE_REGISTRATION["attribution"]
+_TYPE_PRIORITY: tuple[str, ...] = tuple(_ATTRIBUTION["type_priority"])
+
+UNATTRIBUTED = "unattributed"
+
+# The exact wording used whenever nothing explains the move. Fixed on purpose:
+# a stable phrase is greppable and cannot drift into a euphemism.
+UNATTRIBUTED_PHRASE = (
+    "재료로 설명되지 않음 — 증거 창 안에 적격 문서가 없다 (no eligible evidence "
+    "inside the pre-move window)"
+)
+
+
+class AttributionError(ValueError):
+    """Raised when the record could not be built deterministically."""
+
+
+def rule_eligibility(
+    *,
+    published_at: dt.datetime | None,
+    window_start_exclusive: dt.datetime,
+    window_end_inclusive: dt.datetime,
+) -> str:
+    """Classify one document against the pre-move window.
+
+    A document with no usable timestamp is never eligible: we cannot show it
+    preceded the move, and assuming it did is exactly the invention this record
+    exists to prevent.
+    """
+
+    if published_at is None:
+        return ELIGIBILITY_TIMESTAMP_UNKNOWN
+    if published_at.tzinfo is None:
+        raise AttributionError("published_at must be timezone-aware")
+    if published_at <= window_start_exclusive:
+        return ELIGIBILITY_BEFORE_WINDOW
+    if published_at > window_end_inclusive:
+        return ELIGIBILITY_AFTER_MOVE
+    return ELIGIBILITY_ELIGIBLE
+
+
+def _type_rank(attribution_type: str) -> int:
+    try:
+        return _TYPE_PRIORITY.index(attribution_type)
+    except ValueError:
+        return len(_TYPE_PRIORITY)
+
+
+def _sort_key(item: EvidenceItem) -> tuple[int, float, str]:
+    # Type priority first, then most recent inside the window. A missing
+    # timestamp cannot reach this path (it is never eligible), so the fallback
+    # only guards against a caller passing a rejected item in by mistake.
+    ts = item.published_at.timestamp() if item.published_at else float("-inf")
+    return (_type_rank(item.attribution_type), -ts, item.title)
+
+
+def correlation_id(event: SpikeEvent) -> str:
+    return (
+        f"{EXPERIMENT_ID}:{event.market}:{event.symbol}:"
+        f"{event.session_date.isoformat()}"
+    )
+
+
+def _unattributed_reason(
+    event: SpikeEvent, rejected: tuple[EvidenceItem, ...], materials: SpikeMaterials
+) -> str:
+    counts: dict[str, int] = {}
+    for item in rejected:
+        counts[item.eligibility] = counts.get(item.eligibility, 0) + 1
+    unavailable = [row.material for row in materials.availability if not row.available]
+    # "the source was readable and held nothing for this symbol" is a different
+    # statement from "the source could not be read", and a reader who cannot
+    # tell them apart cannot tell a coverage gap from a genuine blank.
+    empty = [
+        row.material
+        for row in materials.availability
+        if row.available and row.detail.get("rows") == 0
+    ]
+    parts = [UNATTRIBUTED_PHRASE]
+    if counts:
+        detail = ", ".join(f"{key}={counts[key]}" for key in sorted(counts))
+        parts.append(f"창 밖/판정불가 문서 {detail}")
+    if empty:
+        parts.append(f"조회됐으나 행 0 (커버리지 공백 가능) {', '.join(sorted(empty))}")
+    if unavailable:
+        parts.append(f"조회 불가 재료 {', '.join(sorted(unavailable))}")
+    parts.append(
+        f"window=({event.window_start_exclusive.isoformat()}, "
+        f"{event.window_end_inclusive.isoformat()}]"
+    )
+    return " | ".join(parts)
+
+
+def build_attribution(
+    *, event: SpikeEvent, materials: SpikeMaterials
+) -> SpikeAttribution:
+    """Build the record for one spike event."""
+
+    eligible: list[EvidenceItem] = []
+    rejected: list[EvidenceItem] = []
+    for item in materials.evidence:
+        if item.attribution_type not in ATTRIBUTED_TYPES:
+            raise AttributionError(
+                f"evidence carries a non-cause type: {item.attribution_type!r}"
+            )
+        (eligible if item.is_eligible else rejected).append(item)
+
+    eligible.sort(key=_sort_key)
+    rejected.sort(key=_sort_key)
+
+    # Every distinct type that has at least one eligible document survives.
+    # Collapsing to the top-ranked one would be a single-cause declaration.
+    types: list[str] = []
+    for item in eligible:
+        if item.attribution_type not in types:
+            types.append(item.attribution_type)
+
+    unattributed = not eligible
+    return SpikeAttribution(
+        event=event,
+        attribution_types=tuple(types),
+        candidates=tuple(eligible),
+        rejected=tuple(rejected),
+        availability=materials.availability,
+        unattributed=unattributed,
+        unattributed_reason=(
+            _unattributed_reason(event, tuple(rejected), materials)
+            if unattributed
+            else None
+        ),
+        spec_sha256=spec_sha256(),
+        correlation_id=correlation_id(event),
+    )
+
+
+def scored_class(attribution: SpikeAttribution) -> str:
+    """The single follow-through class this event is scored under.
+
+    Multiple candidate types are all kept on the record; the scoring class is
+    the highest-priority one purely so per-type follow-through has a stable
+    denominator. This is a bookkeeping choice, not a claim that the other
+    candidates were ruled out.
+    """
+
+    if attribution.unattributed:
+        return UNATTRIBUTED
+    return attribution.attribution_types[0]
+
+
+def record_summary(attribution: SpikeAttribution) -> dict[str, Any]:
+    """Compact, JSON-safe view for reports and CLI output."""
+
+    return {
+        "symbol": attribution.event.symbol,
+        "session_date": attribution.event.session_date.isoformat(),
+        "direction": attribution.event.direction,
+        "close_to_close_pct": str(attribution.event.close_to_close_pct),
+        "intraday_extreme_pct": str(attribution.event.intraday_extreme_pct),
+        "triggered_bases": list(attribution.event.triggered_bases),
+        "attribution_types": list(attribution.attribution_types),
+        "scored_class": scored_class(attribution),
+        "candidate_count": len(attribution.candidates),
+        "unattributed": attribution.unattributed,
+        "unattributed_reason": attribution.unattributed_reason,
+    }
+
+
+__all__ = [
+    "UNATTRIBUTED",
+    "UNATTRIBUTED_PHRASE",
+    "AttributionError",
+    "build_attribution",
+    "correlation_id",
+    "record_summary",
+    "rule_eligibility",
+    "scored_class",
+]

--- a/app/services/spike_attribution/cache.py
+++ b/app/services/spike_attribution/cache.py
@@ -1,0 +1,325 @@
+"""ROB-1303 phase 2 — pre-attribution cache with an explicit freshness state.
+
+Stage 1's failure mode was inventing a cause. This layer's failure mode is the
+mirror image: a session that reads the cache first will treat an **empty or
+stale** answer as "no catalyst", which is a completely different statement from
+``unattributed`` ("we looked and the materials did not explain it") — and both
+arrive as silence unless the read says which one it is.
+
+So every read returns a :class:`CacheRead` carrying one of three states:
+
+``missing``
+    No entry exists for this (market, session_date, symbol). Nothing was ever
+    computed. The caller must fall back to a live computation; answering
+    "no catalyst" here would be a fabrication by omission.
+``stale``
+    An entry exists but is older than its own declared refresh cadence. The
+    payload is returned *with its age* so the caller can decide.
+``fresh``
+    Computed within cadence.
+
+The distinction that makes this work: a cached entry saying "no spike" or
+"unattributed" is a **real computed answer** and is ``fresh``. Only the absence
+of an entry is ``missing``. Conflating the two is exactly the bug this module
+exists to prevent.
+
+Storage is JSON files — no migration, so the cache is exercisable today.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.services.spike_attribution.spec import PRE_REGISTRATION
+
+_CACHE = PRE_REGISTRATION["cache"]
+
+STATE_FRESH = "fresh"
+STATE_STALE = "stale"
+STATE_MISSING = "missing"
+
+GRACE_SECONDS: int = int(_CACHE["grace_seconds"])
+EXPECTED_REFRESH_SECONDS_BY_MODE: dict[str, int] = {
+    mode: int(value)
+    for mode, value in _CACHE["expected_refresh_seconds_by_mode"].items()
+}
+MODE_PREOPEN = "preopen"
+MODE_INTRADAY = "intraday"
+
+_ENV_CACHE_DIR = "SPIKE_ATTRIBUTION_CACHE_DIR"
+_DEFAULT_CACHE_DIR = Path(".cache") / "spike_attribution"
+
+
+class CacheError(RuntimeError):
+    """Raised only for a genuinely unusable store — never for a miss."""
+
+
+def cache_dir() -> Path:
+    """Where entries live. Overridable for tests and for operator runs."""
+
+    override = os.environ.get(_ENV_CACHE_DIR, "").strip()
+    return Path(override) if override else _DEFAULT_CACHE_DIR
+
+
+def expected_refresh_seconds(mode: str) -> int:
+    try:
+        return EXPECTED_REFRESH_SECONDS_BY_MODE[mode]
+    except KeyError as exc:
+        raise CacheError(f"unknown refresh mode: {mode!r}") from exc
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    """One symbol's cached attribution for one session."""
+
+    market: str
+    session_date: dt.date
+    symbol: str
+    mode: str
+    computed_at: dt.datetime
+    spec_sha256: str
+    payload: dict[str, Any]
+    last_success_at: dt.datetime | None = None
+    last_error: str | None = None
+    last_error_at: dt.datetime | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "session_date": self.session_date.isoformat(),
+            "symbol": self.symbol,
+            "mode": self.mode,
+            "computed_at": self.computed_at.isoformat(),
+            "spec_sha256": self.spec_sha256,
+            "payload": self.payload,
+            "last_success_at": (
+                self.last_success_at.isoformat() if self.last_success_at else None
+            ),
+            "last_error": self.last_error,
+            "last_error_at": (
+                self.last_error_at.isoformat() if self.last_error_at else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> CacheEntry:
+        def _ts(value: Any) -> dt.datetime | None:
+            return dt.datetime.fromisoformat(value) if value else None
+
+        computed_at = _ts(raw["computed_at"])
+        if computed_at is None:  # pragma: no cover - guarded by writer
+            raise CacheError("entry has no computed_at")
+        return cls(
+            market=raw["market"],
+            session_date=dt.date.fromisoformat(raw["session_date"]),
+            symbol=raw["symbol"],
+            mode=raw["mode"],
+            computed_at=computed_at,
+            spec_sha256=raw["spec_sha256"],
+            payload=raw.get("payload") or {},
+            last_success_at=_ts(raw.get("last_success_at")),
+            last_error=raw.get("last_error"),
+            last_error_at=_ts(raw.get("last_error_at")),
+        )
+
+
+@dataclass(frozen=True)
+class CacheRead:
+    """The answer to a cache lookup — never a bare payload."""
+
+    state: str
+    market: str
+    session_date: dt.date
+    symbol: str
+    entry: CacheEntry | None = None
+    age_seconds: float | None = None
+    expected_refresh_seconds: int | None = None
+    reason: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def usable_without_fallback(self) -> bool:
+        """Only a fresh entry answers on its own."""
+        return self.state == STATE_FRESH
+
+    @property
+    def requires_live_fallback(self) -> bool:
+        return self.state == STATE_MISSING
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state,
+            "market": self.market,
+            "session_date": self.session_date.isoformat(),
+            "symbol": self.symbol,
+            "age_seconds": self.age_seconds,
+            "expected_refresh_seconds": self.expected_refresh_seconds,
+            "grace_seconds": GRACE_SECONDS,
+            "reason": self.reason,
+            "notes": list(self.notes),
+            # Restated on every read so a consumer that only looks here cannot
+            # mistake an absent entry for an absent catalyst.
+            "missing_is_not_no_catalyst": True,
+            "unattributed_is_a_computed_answer_not_a_miss": True,
+            "computed_at": (self.entry.computed_at.isoformat() if self.entry else None),
+            "last_success_at": (
+                self.entry.last_success_at.isoformat()
+                if self.entry and self.entry.last_success_at
+                else None
+            ),
+            "last_error": self.entry.last_error if self.entry else None,
+            "last_error_at": (
+                self.entry.last_error_at.isoformat()
+                if self.entry and self.entry.last_error_at
+                else None
+            ),
+            "payload": self.entry.payload if self.entry else None,
+        }
+
+
+def classify_state(
+    *,
+    entry: CacheEntry | None,
+    now: dt.datetime,
+    mode: str | None = None,
+) -> tuple[str, float | None, int | None]:
+    """Pure freshness ruling. Returns ``(state, age_seconds, expected)``."""
+
+    if entry is None:
+        return STATE_MISSING, None, None
+    expected = expected_refresh_seconds(mode or entry.mode)
+    age = (now - entry.computed_at).total_seconds()
+    if age <= expected + GRACE_SECONDS:
+        return STATE_FRESH, age, expected
+    return STATE_STALE, age, expected
+
+
+def _entry_path(root: Path, *, market: str, session_date: dt.date, symbol: str) -> Path:
+    safe_symbol = symbol.replace("/", "_").replace("..", "_")
+    return root / market / session_date.isoformat() / f"{safe_symbol}.json"
+
+
+def write_entry(entry: CacheEntry, *, root: Path | None = None) -> Path:
+    """Atomically persist one entry (tmp file + rename)."""
+
+    base = root or cache_dir()
+    path = _entry_path(
+        base, market=entry.market, session_date=entry.session_date, symbol=entry.symbol
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(entry.as_dict(), handle, ensure_ascii=False)
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+    return path
+
+
+def read_entry(
+    *, market: str, session_date: dt.date, symbol: str, root: Path | None = None
+) -> CacheEntry | None:
+    """Return the stored entry, or None. A miss is not an error."""
+
+    path = _entry_path(
+        root or cache_dir(), market=market, session_date=session_date, symbol=symbol
+    )
+    if not path.exists():
+        return None
+    try:
+        return CacheEntry.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        # A corrupt entry is not a cache hit and is not silently a miss either:
+        # it is surfaced as missing *with a reason*, so it can be noticed.
+        raise CacheError(f"corrupt cache entry at {path}: {exc}") from exc
+
+
+def lookup(
+    *,
+    market: str,
+    session_date: dt.date,
+    symbol: str,
+    now: dt.datetime,
+    root: Path | None = None,
+) -> CacheRead:
+    """Cache-first read. Always returns a state; never raises on a miss."""
+
+    notes: list[str] = []
+    try:
+        entry = read_entry(
+            market=market, session_date=session_date, symbol=symbol, root=root
+        )
+    except CacheError as exc:
+        # Corrupt → treated as missing so the caller falls back to a live
+        # compute, but the reason travels with it rather than vanishing.
+        return CacheRead(
+            state=STATE_MISSING,
+            market=market,
+            session_date=session_date,
+            symbol=symbol,
+            reason=f"unreadable_entry: {exc}",
+            notes=["fall back to live computation"],
+        )
+
+    state, age, expected = classify_state(entry=entry, now=now)
+    if state == STATE_MISSING:
+        reason = "no cache entry was ever written for this symbol/session"
+        notes.append("fall back to live computation")
+        notes.append("this is NOT evidence that the symbol had no catalyst")
+    elif state == STATE_STALE:
+        reason = (
+            f"entry is {age:.0f}s old, past its {expected}s cadence "
+            f"+ {GRACE_SECONDS}s grace"
+        )
+        notes.append("payload returned with its age; caller decides whether to reuse")
+        if entry is not None and entry.last_error:
+            notes.append(
+                "the last refresh FAILED — the payload below is the last good one"
+            )
+    else:
+        reason = None
+        if entry is not None and entry.last_error:
+            notes.append(
+                "a refresh error is recorded on this entry even though it is "
+                "within cadence"
+            )
+
+    return CacheRead(
+        state=state,
+        market=market,
+        session_date=session_date,
+        symbol=symbol,
+        entry=entry,
+        age_seconds=age,
+        expected_refresh_seconds=expected,
+        reason=reason,
+        notes=notes,
+    )
+
+
+__all__ = [
+    "EXPECTED_REFRESH_SECONDS_BY_MODE",
+    "GRACE_SECONDS",
+    "MODE_INTRADAY",
+    "MODE_PREOPEN",
+    "STATE_FRESH",
+    "STATE_MISSING",
+    "STATE_STALE",
+    "CacheEntry",
+    "CacheError",
+    "CacheRead",
+    "cache_dir",
+    "classify_state",
+    "expected_refresh_seconds",
+    "lookup",
+    "read_entry",
+    "write_entry",
+]

--- a/app/services/spike_attribution/catalyst_basis.py
+++ b/app/services/spike_attribution/catalyst_basis.py
@@ -1,0 +1,95 @@
+"""Hook ⓐ — supply ``catalyst_basis`` for the momentum_spike sell tier (pure).
+
+``config/trading_policy.yaml`` declares
+``momentum_spike_profit_ladder.conditions.required_thesis_evidence:
+[catalyst_basis, flow_basis]``. That requirement is consumed by the session, not
+by code — no module reads it today. This builder turns an attribution record
+into the ``catalyst_basis`` block a session can quote, with two hard properties:
+
+* it **cannot manufacture sufficiency** — an ``unattributed`` record returns
+  ``satisfies=False`` with the unattributed wording intact; and
+* it supplies ``catalyst_basis`` only. ``flow_basis`` stays unsupplied because
+  investor flow lands T+1 and is simply not available on the spike day.
+
+Wiring only: nothing here places, proposes, or sizes anything.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.spike_attribution.attribute import UNATTRIBUTED_PHRASE
+from app.services.spike_attribution.contract import SpikeAttribution
+from app.services.spike_attribution.spec import (
+    EXPERIMENT_ID,
+    PRE_REGISTRATION,
+)
+
+_HOOK = PRE_REGISTRATION["catalyst_basis_hook"]
+
+POLICY_TIER: str = _HOOK["consumer_policy_tier"]
+SUPPLIED_EVIDENCE: tuple[str, ...] = tuple(_HOOK["supplies"])
+UNSUPPLIED_EVIDENCE: tuple[str, ...] = tuple(_HOOK["does_not_supply"])
+
+
+def build_catalyst_basis(attribution: SpikeAttribution) -> dict[str, Any]:
+    """Return the ``catalyst_basis`` evidence block for one attribution record."""
+
+    citations = [
+        {
+            "attribution_type": item.attribution_type,
+            "source": item.source,
+            "title": item.title,
+            "url": item.url,
+            "published_at": (
+                item.published_at.isoformat() if item.published_at else None
+            ),
+            "published_at_source": item.published_at_source,
+            "judgment": item.judgment,
+        }
+        for item in attribution.candidates
+    ]
+    satisfies = not attribution.unattributed
+    return {
+        "evidence_kind": "catalyst_basis",
+        "experiment_id": EXPERIMENT_ID,
+        "policy_tier": POLICY_TIER,
+        "symbol": attribution.event.symbol,
+        "market": attribution.event.market,
+        "session_date": attribution.event.session_date.isoformat(),
+        "session_change_pct": str(attribution.event.close_to_close_pct),
+        "intraday_extreme_pct": str(attribution.event.intraday_extreme_pct),
+        "triggered_bases": list(attribution.event.triggered_bases),
+        "attribution_types": list(attribution.attribution_types),
+        "citations": citations,
+        "satisfies_catalyst_basis_requirement": satisfies,
+        "unsatisfied_reason": (
+            None
+            if satisfies
+            else attribution.unattributed_reason or UNATTRIBUTED_PHRASE
+        ),
+        # The tier needs both evidence kinds. We supply one of them; the session
+        # must not read a present catalyst_basis as the pair being satisfied.
+        "supplies": list(SUPPLIED_EVIDENCE),
+        "does_not_supply": list(UNSUPPLIED_EVIDENCE),
+        "flow_basis": {
+            "supplied": False,
+            "reason": _HOOK["flow_basis_reason"],
+        },
+        "required_thesis_evidence_complete": False,
+        "spec_sha256": attribution.spec_sha256,
+        "correlation_id": attribution.correlation_id,
+        # Guard rails restated on every payload so a consumer that only reads
+        # this block still sees them.
+        "can_loosen_live_gate": False,
+        "promote": False,
+        "live_gate_impact": False,
+    }
+
+
+__all__ = [
+    "POLICY_TIER",
+    "SUPPLIED_EVIDENCE",
+    "UNSUPPLIED_EVIDENCE",
+    "build_catalyst_basis",
+]

--- a/app/services/spike_attribution/contract.py
+++ b/app/services/spike_attribution/contract.py
@@ -1,0 +1,197 @@
+"""ROB-1303 attribution record dataclasses (pure, stdlib only).
+
+The record is the deliverable: a spike event, every evidence item that was
+considered (eligible *and* rejected, with the reason), and the resulting
+attribution candidates. ``unattributed`` is a first-class verdict, not a
+leftover bucket — it means the materials did not explain the move, and the
+record says so in those words.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+# Why an evidence item is / is not allowed to explain the session move.
+ELIGIBILITY_ELIGIBLE = "eligible"
+ELIGIBILITY_AFTER_MOVE = "after_move"
+ELIGIBILITY_BEFORE_WINDOW = "before_window"
+ELIGIBILITY_TIMESTAMP_UNKNOWN = "timestamp_unknown"
+# The external ROB-491 judge ruled this article unrelated to the symbol. That
+# judgment is authoritative and this code honours it — but the row stays on the
+# record with this reason rather than disappearing.
+ELIGIBILITY_JUDGED_NOT_RELEVANT = "judged_not_relevant"
+
+# Why a material could not be consulted at all (never confused with "no cause").
+UNAVAILABLE_T_PLUS_1 = "unavailable_t_plus_1"
+UNAVAILABLE_NO_COVERAGE = "unavailable_no_coverage"
+
+
+@dataclass(frozen=True)
+class DailyBar:
+    """One daily OHLCV row. ``session_date`` is the local trading date."""
+
+    symbol: str
+    session_date: dt.date
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
+
+
+@dataclass(frozen=True)
+class SpikeEvent:
+    """A detected session move that cleared the pre-registered threshold."""
+
+    market: str
+    symbol: str
+    session_date: dt.date
+    direction: str  # "up" | "down"
+    prev_close: Decimal
+    close: Decimal
+    high: Decimal
+    low: Decimal
+    close_to_close_pct: Decimal
+    intraday_extreme_pct: Decimal
+    triggered_bases: tuple[str, ...]
+    window_start_exclusive: dt.datetime
+    window_end_inclusive: dt.datetime
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "symbol": self.symbol,
+            "session_date": self.session_date.isoformat(),
+            "direction": self.direction,
+            "prev_close": str(self.prev_close),
+            "close": str(self.close),
+            "high": str(self.high),
+            "low": str(self.low),
+            "close_to_close_pct": str(self.close_to_close_pct),
+            "intraday_extreme_pct": str(self.intraday_extreme_pct),
+            "triggered_bases": list(self.triggered_bases),
+            "evidence_window": {
+                "start_exclusive": self.window_start_exclusive.isoformat(),
+                "end_inclusive": self.window_end_inclusive.isoformat(),
+            },
+        }
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    """One candidate cause document, with its link and its eligibility ruling."""
+
+    attribution_type: str
+    source: str
+    title: str
+    url: str | None
+    published_at: dt.datetime | None
+    published_at_precision: str  # "exact" | "date_only" | "unknown"
+    published_at_source: str  # which column/key the timestamp came from
+    eligibility: str
+    judgment: str  # "judged_relevant" | "unjudged" | "not_applicable"
+    judgment_detail: dict[str, Any] = field(default_factory=dict)
+    ref: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_eligible(self) -> bool:
+        return self.eligibility == ELIGIBILITY_ELIGIBLE
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "attribution_type": self.attribution_type,
+            "source": self.source,
+            "title": self.title,
+            "url": self.url,
+            "published_at": (
+                self.published_at.isoformat() if self.published_at else None
+            ),
+            "published_at_precision": self.published_at_precision,
+            "published_at_source": self.published_at_source,
+            "eligibility": self.eligibility,
+            "judgment": self.judgment,
+            "judgment_detail": dict(self.judgment_detail),
+            "ref": dict(self.ref),
+        }
+
+
+@dataclass(frozen=True)
+class MaterialAvailability:
+    """Per-material availability, so 'no data' never reads as 'no cause'."""
+
+    material: str
+    available: bool
+    reason: str | None = None
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "material": self.material,
+            "available": self.available,
+            "reason": self.reason,
+            "detail": dict(self.detail),
+        }
+
+
+@dataclass(frozen=True)
+class SpikeMaterials:
+    """Everything the readers found for one spike event, already timestamped."""
+
+    evidence: tuple[EvidenceItem, ...]
+    availability: tuple[MaterialAvailability, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "evidence": [item.as_dict() for item in self.evidence],
+            "availability": [row.as_dict() for row in self.availability],
+        }
+
+
+@dataclass(frozen=True)
+class SpikeAttribution:
+    """The record. ``attribution_types`` is empty exactly when unattributed."""
+
+    event: SpikeEvent
+    attribution_types: tuple[str, ...]
+    candidates: tuple[EvidenceItem, ...]
+    rejected: tuple[EvidenceItem, ...]
+    availability: tuple[MaterialAvailability, ...]
+    unattributed: bool
+    unattributed_reason: str | None
+    spec_sha256: str
+    correlation_id: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "event": self.event.as_dict(),
+            "attribution_types": list(self.attribution_types),
+            "unattributed": self.unattributed,
+            "unattributed_reason": self.unattributed_reason,
+            "candidates": [item.as_dict() for item in self.candidates],
+            "rejected_evidence": [item.as_dict() for item in self.rejected],
+            "material_availability": [row.as_dict() for row in self.availability],
+            "spec_sha256": self.spec_sha256,
+            "correlation_id": self.correlation_id,
+            "promote": False,
+            "live_gate_impact": False,
+        }
+
+
+__all__ = [
+    "ELIGIBILITY_AFTER_MOVE",
+    "ELIGIBILITY_BEFORE_WINDOW",
+    "ELIGIBILITY_ELIGIBLE",
+    "ELIGIBILITY_JUDGED_NOT_RELEVANT",
+    "ELIGIBILITY_TIMESTAMP_UNKNOWN",
+    "UNAVAILABLE_NO_COVERAGE",
+    "UNAVAILABLE_T_PLUS_1",
+    "DailyBar",
+    "EvidenceItem",
+    "MaterialAvailability",
+    "SpikeAttribution",
+    "SpikeEvent",
+    "SpikeMaterials",
+]

--- a/app/services/spike_attribution/detect.py
+++ b/app/services/spike_attribution/detect.py
@@ -1,0 +1,172 @@
+"""ROB-1303 spike detection + evidence-window arithmetic (pure).
+
+stdlib only, plus the repo's existing halt-suspicion classifier: no DB, no
+network, no clock. Everything the caller needs is injected, so the pre-
+registered spike definition can be unit-tested against hand-written bars.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from app.services.halt_detection import HaltBar, classify_bars
+from app.services.spike_attribution.contract import DailyBar, SpikeEvent
+from app.services.spike_attribution.spec import PRE_REGISTRATION
+
+_DETECTION = PRE_REGISTRATION["spike_detection"]
+_WINDOW = PRE_REGISTRATION["evidence_window"]
+
+ABS_CHANGE_PCT_MIN: Decimal = Decimal(str(_DETECTION["abs_change_pct_min"]))
+BASIS_CLOSE_TO_CLOSE = "close_to_close"
+BASIS_INTRADAY_EXTREME = "intraday_extreme"
+
+# Bars this detector needs behind the spike day before it can rule on halt
+# suspicion. Fewer bars is not evidence of liveness — see ``HaltSuspicion``.
+HALT_LOOKBACK_BARS = 3
+
+_HUNDRED = Decimal("100")
+
+
+class SpikeDetectionError(ValueError):
+    """Raised when the caller's inputs cannot support a deterministic verdict."""
+
+
+def session_close_at(market: str, session_date: dt.date) -> dt.datetime:
+    """Local session close for ``session_date``, as a tz-aware datetime."""
+
+    try:
+        hhmm = _WINDOW["session_close_local"][market]
+        tzname = _WINDOW["session_close_tz"][market]
+    except KeyError as exc:  # pragma: no cover - guarded by callers
+        raise SpikeDetectionError(f"unsupported market: {market!r}") from exc
+    hour, minute = (int(part) for part in hhmm.split(":"))
+    return dt.datetime.combine(
+        session_date, dt.time(hour=hour, minute=minute), tzinfo=ZoneInfo(tzname)
+    )
+
+
+def _pct(numerator: Decimal, denominator: Decimal) -> Decimal:
+    return (numerator / denominator * _HUNDRED).quantize(Decimal("0.0001"))
+
+
+def classify_bar(
+    *,
+    market: str,
+    symbol: str,
+    bar: DailyBar,
+    prev_bar: DailyBar,
+) -> SpikeEvent | None:
+    """Return a :class:`SpikeEvent` when ``bar`` clears the pinned threshold.
+
+    ``prev_bar`` must be the immediately preceding row of the same daily
+    series; the caller owns that ordering because only it knows the calendar.
+    """
+
+    prev_close = prev_bar.close
+    if prev_close <= 0:
+        raise SpikeDetectionError(
+            f"{symbol}: non-positive prev_close {prev_close} cannot yield a percentage"
+        )
+
+    c2c = _pct(bar.close - prev_close, prev_close)
+    up_pct = _pct(bar.high - prev_close, prev_close)
+    down_pct = _pct(bar.low - prev_close, prev_close)
+    # The intraday extreme is whichever end travelled further from prev_close.
+    extreme = up_pct if abs(up_pct) >= abs(down_pct) else down_pct
+
+    triggered: list[str] = []
+    if abs(c2c) >= ABS_CHANGE_PCT_MIN:
+        triggered.append(BASIS_CLOSE_TO_CLOSE)
+    if abs(extreme) >= ABS_CHANGE_PCT_MIN:
+        triggered.append(BASIS_INTRADAY_EXTREME)
+    if not triggered:
+        return None
+
+    # Direction describes the *session outcome*, not the basis that fired,
+    # because the follow-through anchor is the close: a bar that gapped +6% and
+    # closed -1% is a down session, and calling it "up" would flip the sign of
+    # the retention denominator against its own label. Only a genuinely
+    # unchanged close falls back to the intraday extreme that triggered it.
+    lead = c2c if c2c != 0 else extreme
+    direction = "up" if lead > 0 else "down"
+
+    return SpikeEvent(
+        market=market,
+        symbol=symbol,
+        session_date=bar.session_date,
+        direction=direction,
+        prev_close=prev_close,
+        close=bar.close,
+        high=bar.high,
+        low=bar.low,
+        close_to_close_pct=c2c,
+        intraday_extreme_pct=extreme,
+        triggered_bases=tuple(triggered),
+        window_start_exclusive=session_close_at(market, prev_bar.session_date),
+        window_end_inclusive=session_close_at(market, bar.session_date),
+    )
+
+
+def detect_spikes(
+    *,
+    market: str,
+    symbol: str,
+    bars: list[DailyBar],
+    session_date: dt.date,
+) -> tuple[SpikeEvent | None, dict[str, object]]:
+    """Detect a spike on ``session_date`` from an ascending daily series.
+
+    Returns ``(event_or_none, diagnostics)``. ``diagnostics`` always carries the
+    halt-suspicion verdict so an exclusion is reported with its symbol and its
+    reason rather than silently dropped (ROB-1236).
+    """
+
+    ordered = sorted(bars, key=lambda row: row.session_date)
+    dates = [row.session_date for row in ordered]
+    if len(set(dates)) != len(dates):
+        raise SpikeDetectionError(f"{symbol}: duplicate session dates in daily series")
+    try:
+        idx = dates.index(session_date)
+    except ValueError:
+        return None, {"skipped": "no_bar_for_session_date"}
+    if idx == 0:
+        return None, {"skipped": _DETECTION["no_prev_close_verdict"]}
+
+    lookback = ordered[max(0, idx + 1 - HALT_LOOKBACK_BARS) : idx + 1]
+    halt = classify_bars(
+        [
+            HaltBar(
+                close=row.close,
+                high=row.high,
+                low=row.low,
+                volume=row.volume,
+                open=row.open,
+            )
+            for row in lookback
+        ]
+    )
+    diagnostics: dict[str, object] = {"halted_suspect": halt.to_dict()}
+    if halt.suspected:
+        diagnostics["skipped"] = "halted_suspect"
+        return None, diagnostics
+
+    event = classify_bar(
+        market=market, symbol=symbol, bar=ordered[idx], prev_bar=ordered[idx - 1]
+    )
+    if event is None:
+        diagnostics["skipped"] = "below_threshold"
+    return event, diagnostics
+
+
+__all__ = [
+    "ABS_CHANGE_PCT_MIN",
+    "BASIS_CLOSE_TO_CLOSE",
+    "BASIS_INTRADAY_EXTREME",
+    "HALT_LOOKBACK_BARS",
+    "SpikeDetectionError",
+    "classify_bar",
+    "detect_spikes",
+    "session_close_at",
+]

--- a/app/services/spike_attribution/forecast_tag.py
+++ b/app/services/spike_attribution/forecast_tag.py
@@ -1,0 +1,178 @@
+"""Hook ⓑ — build ``forecast_save`` kwargs that pre-register one spike (pure).
+
+This module does not write. It returns ready-to-save kwargs; the session or the
+operator decides whether to record them. The attribution record travels inside
+``forecast_target``, which is how the spike is 박제-ed with its evidence links
+without adding a table: ``review.trade_forecasts`` is already the learning-loop
+spine, and a row there is resolvable, greppable, and survives a redeploy.
+
+Payloads are tagged so they cannot be mistaken for a live thesis, a calibration
+sample, or a promotion trigger.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any
+
+from app.services.spike_attribution.attribute import scored_class
+from app.services.spike_attribution.contract import SpikeAttribution
+from app.services.spike_attribution.spec import (
+    EXPERIMENT_ID,
+    PINNED_SPEC_SHA256,
+    PRE_REGISTRATION,
+    spec_sha256,
+)
+
+_TAG = PRE_REGISTRATION["forecast_tagging"]
+_FT = PRE_REGISTRATION["follow_through"]
+_WINDOWS: tuple[int, ...] = tuple(_FT["windows_trading_days"])
+_CALENDAR_OFFSET_BY_WINDOW: dict[int, int] = {
+    int(key): int(value)
+    for key, value in _TAG["review_date_calendar_offset_days_by_window"].items()
+}
+_INSTRUMENT = {"kr": "equity_kr", "us": "equity_us"}
+_RETAINED_BOUNDARY = Decimal("0.5")
+
+# Keys that would turn an observation row into an execution path. Their absence
+# is asserted on every payload rather than assumed.
+FORBIDDEN_PAYLOAD_KEYS: frozenset[str] = frozenset(
+    {
+        "order_proposal",
+        "proposal_id",
+        "place_order",
+        "max_action",
+        "watch_condition",
+        "approval_hash",
+        "confirm",
+        "account_mode",
+    }
+)
+
+
+class ForecastTagError(RuntimeError):
+    """Raised when a payload could not be built safely."""
+
+
+def target_price(attribution: SpikeAttribution) -> Decimal:
+    """The retained/faded boundary price for this spike."""
+
+    event = attribution.event
+    return event.prev_close + _RETAINED_BOUNDARY * (event.close - event.prev_close)
+
+
+def target_direction(attribution: SpikeAttribution) -> str:
+    return "at_or_above" if attribution.event.direction == "up" else "at_or_below"
+
+
+def prereg_skipped_reason(attribution: SpikeAttribution) -> str | None:
+    """Why this event is not pre-registered at all, or None if it is."""
+
+    event = attribution.event
+    if event.close == event.prev_close:
+        # retention_ratio has no denominator here, so a row would carry a
+        # target price equal to prev_close and a verdict nothing can produce.
+        return "zero_denominator_close_equals_prev_close"
+    return None
+
+
+def build_prereg_forecasts(
+    attribution: SpikeAttribution,
+    *,
+    created_by: str,
+) -> list[dict[str, Any]]:
+    """Return one ``forecast_save`` kwargs dict per pre-registered window.
+
+    Empty when :func:`prereg_skipped_reason` gives a reason — callers surface
+    that reason rather than an unexplained empty list.
+    """
+
+    author = (created_by or "").strip()
+    if not author:
+        raise ForecastTagError("created_by is required")
+    if spec_sha256() != PINNED_SPEC_SHA256:
+        raise ForecastTagError(
+            "pre-registration spec hash does not match its pinned value"
+        )
+    market = attribution.event.market
+    if market not in _INSTRUMENT:
+        raise ForecastTagError(f"unsupported market: {market!r}")
+    if prereg_skipped_reason(attribution) is not None:
+        return []
+
+    price = target_price(attribution)
+    if price <= 0:
+        raise ForecastTagError("target_price must be positive")
+
+    event = attribution.event
+    session_date = event.session_date
+    klass = scored_class(attribution)
+    payloads: list[dict[str, Any]] = []
+    for window in _WINDOWS:
+        forecast_target: dict[str, Any] = {
+            "kind": _TAG["kind"],
+            "direction": target_direction(attribution),
+            "target_price": float(price),
+            "outcome_rule_version": _TAG["outcome_rule_version"],
+            "experiment_id": EXPERIMENT_ID,
+            "cohort": _TAG["cohort"],
+            "promote": False,
+            "live_gate_impact": False,
+            "spec_sha256": PINNED_SPEC_SHA256,
+            "window_trading_days": window,
+            "scored_class": klass,
+            "attribution_types": list(attribution.attribution_types),
+            "unattributed": attribution.unattributed,
+            "unattributed_reason": attribution.unattributed_reason,
+            # The record itself — event, eligible candidates with their links,
+            # what was rejected and why, and which materials could not be read.
+            "attribution_record": attribution.as_dict(),
+            "calibration_eligibility": _TAG["calibration_eligibility"],
+            "trade_performance_eligibility": _TAG["trade_performance_eligibility"],
+            "scoring_authority": _TAG["scoring_authority"],
+            "do_not_use_forecast_resolve_as_experiment_score": _TAG[
+                "do_not_use_forecast_resolve_as_experiment_score"
+            ],
+        }
+        leaked = FORBIDDEN_PAYLOAD_KEYS.intersection(forecast_target)
+        if leaked:
+            raise ForecastTagError(
+                f"promotion keys leaked into forecast_target: {sorted(leaked)}"
+            )
+        payload = {
+            "created_by": author,
+            "symbol": event.symbol,
+            "instrument_type": _INSTRUMENT[market],
+            "forecast_target": forecast_target,
+            "probability": float(_TAG["probability_placeholder"]),
+            "review_date": (
+                session_date + timedelta(days=_CALENDAR_OFFSET_BY_WINDOW[window])
+            ).isoformat(),
+            "forecast_start_date": session_date.isoformat(),
+            "horizon": f"{window}d",
+            "session_label": _TAG["session_label"],
+            "correlation_id": f"{attribution.correlation_id}:{window}d",
+            "contrary_evidence": (
+                "spike attribution observation row; candidates are causes not "
+                "proven causal, and an unattributed row stays unattributed. "
+                "Do not promote to proposal, order, or watch."
+            ),
+        }
+        leaked_top = FORBIDDEN_PAYLOAD_KEYS.intersection(payload)
+        if leaked_top:
+            raise ForecastTagError(
+                f"promotion keys leaked into forecast payload: {sorted(leaked_top)}"
+            )
+        payloads.append(payload)
+    return payloads
+
+
+__all__ = [
+    "FORBIDDEN_PAYLOAD_KEYS",
+    "ForecastTagError",
+    "build_prereg_forecasts",
+    "prereg_skipped_reason",
+    "target_direction",
+    "target_price",
+]

--- a/app/services/spike_attribution/materials.py
+++ b/app/services/spike_attribution/materials.py
@@ -1,0 +1,553 @@
+"""ROB-1303 read-only material assembly.
+
+The only impure module in the package: plain ``SELECT``s against tables this
+repo already fills. No new feed, no scraper, no credential, no write of any
+kind.
+
+Two things it refuses to do:
+
+* **Guess a clock.** Stored ``article_published_at`` is naive, and the tz it was
+  naive *in* depends on which ingestor produced the row. Only feeds in
+  :data:`FEED_CLOCKS` with ``confirmed=True`` get an eligible timestamp;
+  everything else is surfaced as ``timestamp_unknown`` and can never be a cause.
+* **Fill a gap.** A material that could not be read is reported as unavailable
+  with a reason, which is never the same statement as "no cause existed".
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.spike_attribution.attribute import rule_eligibility
+from app.services.spike_attribution.contract import (
+    ELIGIBILITY_JUDGED_NOT_RELEVANT,
+    ELIGIBILITY_TIMESTAMP_UNKNOWN,
+    UNAVAILABLE_NO_COVERAGE,
+    UNAVAILABLE_T_PLUS_1,
+    DailyBar,
+    EvidenceItem,
+    MaterialAvailability,
+    SpikeEvent,
+    SpikeMaterials,
+)
+
+_KST = ZoneInfo("Asia/Seoul")
+
+DAILY_TABLE_BY_MARKET: dict[str, str] = {"kr": "kr_candles_1d", "us": "us_candles_1d"}
+SESSION_TZ_BY_MARKET: dict[str, ZoneInfo] = {
+    "kr": _KST,
+    "us": ZoneInfo("America/New_York"),
+}
+
+
+@dataclass(frozen=True)
+class FeedClock:
+    """How to read one feed's naive ``article_published_at``.
+
+    ``confirmed`` is the gate: an unconfirmed clock yields ``timestamp_unknown``
+    so the item is visible on the record but never counted as a cause.
+    """
+
+    tz: ZoneInfo | None
+    precision: str  # "exact" | "date_only" | "unknown"
+    confirmed: bool
+    basis: str
+
+
+# KST wall-clock, confirmed by the 2026-08 publish-hour histogram: the KR
+# aggregate feed peaks 08:00-17:00 and empties overnight.
+_KR_EXACT = FeedClock(
+    tz=_KST,
+    precision="exact",
+    confirmed=True,
+    basis="publish_hour_histogram_2026_08_kst_business_hours",
+)
+# 100% of these rows store 00:00:00 — the ingestor has the date only.
+_KR_DATE_ONLY = FeedClock(
+    tz=_KST,
+    precision="date_only",
+    confirmed=False,
+    basis="all_rows_stored_at_midnight_time_of_day_not_captured",
+)
+# US feeds look like naive UTC, but "looks like" is not a confirmation and a
+# 9-13 hour error would silently flip pre-move / post-move rulings.
+_US_UNCONFIRMED = FeedClock(
+    tz=None,
+    precision="unknown",
+    confirmed=False,
+    basis="tz_not_confirmed_pending_ingestor_side_verification",
+)
+
+FEED_CLOCKS: dict[str, FeedClock] = {
+    "http_naver_stock_aggregate": _KR_EXACT,
+    "browser_naver_research": _KR_DATE_ONLY,
+    "browser_naver_research_company": _KR_DATE_ONLY,
+    "browser_naver_research_economy": _KR_DATE_ONLY,
+    "browser_naver_research_industry": _KR_DATE_ONLY,
+    "browser_naver_research_invest": _KR_DATE_ONLY,
+    "naver_item_news": _KR_DATE_ONLY,
+    "rss_yahoo_finance_topstories": _US_UNCONFIRMED,
+    "rss_cnbc_us_markets": _US_UNCONFIRMED,
+    "rss_cnbc_earnings": _US_UNCONFIRMED,
+    "rss_cnbc_finance": _US_UNCONFIRMED,
+    "rss_marketwatch_topstories": _US_UNCONFIRMED,
+    "rss_fed_press": _US_UNCONFIRMED,
+    "finnhub_company_news": _US_UNCONFIRMED,
+    "finnhub_general_news": _US_UNCONFIRMED,
+}
+
+_UNREGISTERED = FeedClock(
+    tz=None,
+    precision="unknown",
+    confirmed=False,
+    basis="feed_source_not_in_clock_registry",
+)
+
+# DART receipt timestamps. The ROB-128 normalizer drops release_time_local, but
+# raw_payload_json.rcept_dt keeps the real KST receipt time.
+_DART_TIME_KEY = "rcept_dt"
+
+# ROB-491 symbol_news_relevance.status → our judgment vocabulary. ``pending``
+# deliberately maps to ``unjudged``: a queued row is not a verdict.
+JUDGMENT_BY_STATUS: dict[str | None, str] = {
+    "confirmed": "judged_relevant",
+    "excluded": "judged_not_relevant",
+    "pending": "unjudged",
+}
+EXTERNALLY_JUDGED_STATUSES: frozenset[str] = frozenset({"confirmed", "excluded"})
+
+
+def feed_clock(feed_source: str | None) -> FeedClock:
+    return FEED_CLOCKS.get(feed_source or "", _UNREGISTERED)
+
+
+def _localize(naive: dt.datetime | None, clock: FeedClock) -> dt.datetime | None:
+    if naive is None or clock.tz is None or not clock.confirmed:
+        return None
+    return naive.replace(tzinfo=clock.tz)
+
+
+async def load_daily_bars(
+    db: AsyncSession,
+    *,
+    market: str,
+    symbol: str,
+    start: dt.date,
+    end: dt.date,
+) -> list[DailyBar]:
+    """Ascending daily bars for ``symbol`` in ``[start, end]`` local dates."""
+
+    table = DAILY_TABLE_BY_MARKET.get(market)
+    if table is None:
+        raise ValueError(f"unsupported market: {market!r}")
+    tzname = str(SESSION_TZ_BY_MARKET[market])
+    stmt = sa.text(
+        f"""
+        SELECT (time AT TIME ZONE :tz)::date AS session_date,
+               open, high, low, close, volume
+        FROM {table}
+        WHERE symbol = :symbol
+          AND (time AT TIME ZONE :tz)::date BETWEEN :start AND :end
+        ORDER BY time
+        """  # noqa: S608 - table name comes from a closed literal mapping
+    )
+    rows = await db.execute(
+        stmt, {"tz": tzname, "symbol": symbol, "start": start, "end": end}
+    )
+    return [
+        DailyBar(
+            symbol=symbol,
+            session_date=row.session_date,
+            open=Decimal(str(row.open)),
+            high=Decimal(str(row.high)),
+            low=Decimal(str(row.low)),
+            close=Decimal(str(row.close)),
+            volume=Decimal(str(row.volume if row.volume is not None else 0)),
+        )
+        for row in rows
+    ]
+
+
+async def _load_news_evidence(
+    db: AsyncSession, event: SpikeEvent
+) -> tuple[list[EvidenceItem], MaterialAvailability]:
+    # Fetch a day either side of the window so post-move items are visible on
+    # the record as ``after_move`` rather than quietly missing.
+    lo = event.window_start_exclusive.date() - dt.timedelta(days=1)
+    hi = event.window_end_inclusive.date() + dt.timedelta(days=1)
+    stmt = sa.text(
+        """
+        SELECT a.id           AS article_id,
+               a.url          AS url,
+               a.title        AS title,
+               a.source       AS source,
+               a.feed_source  AS feed_source,
+               a.article_published_at AS published_at,
+               r.status       AS rel_status,
+               r.relationship AS rel_relationship,
+               r.relevance    AS rel_relevance,
+               r.price_relevance AS rel_price_relevance,
+               r.reason       AS rel_reason,
+               s.source       AS map_source,
+               s.score        AS map_score
+        FROM news_article_related_symbols s
+        JOIN news_articles a ON a.id = s.article_id
+        LEFT JOIN symbol_news_relevance r
+               ON r.article_id = a.id
+              AND r.market = s.market
+              AND r.symbol = s.symbol
+        WHERE s.market = :market
+          AND s.symbol = :symbol
+          AND a.article_published_at >= :lo
+          AND a.article_published_at < :hi
+        ORDER BY a.article_published_at DESC, a.id DESC
+        """
+    )
+    rows = (
+        await db.execute(
+            stmt,
+            {
+                "market": event.market,
+                "symbol": event.symbol,
+                "lo": dt.datetime.combine(lo, dt.time.min),
+                "hi": dt.datetime.combine(hi, dt.time.max),
+            },
+        )
+    ).all()
+
+    items: list[EvidenceItem] = []
+    for row in rows:
+        clock = feed_clock(row.feed_source)
+        published = _localize(row.published_at, clock)
+        eligibility = (
+            rule_eligibility(
+                published_at=published,
+                window_start_exclusive=event.window_start_exclusive,
+                window_end_inclusive=event.window_end_inclusive,
+            )
+            if published is not None
+            else ELIGIBILITY_TIMESTAMP_UNKNOWN
+        )
+        # ROB-491 status vocabulary: confirmed / pending / excluded, written
+        # only by the external judgment job. This code never sets any of them.
+        #   confirmed → the judge tied the article to this symbol
+        #   excluded  → the judge ruled it unrelated (or low relevance)
+        #   pending / no row → nobody has looked yet
+        # A pending row is *not* a judgment, so it must not read as one, and an
+        # excluded row must not become a cause just because it landed in the
+        # window. Both stay visible with their reason.
+        judgment = JUDGMENT_BY_STATUS.get(row.rel_status, "unjudged")
+        if judgment == "judged_not_relevant":
+            eligibility = ELIGIBILITY_JUDGED_NOT_RELEVANT
+        items.append(
+            EvidenceItem(
+                attribution_type="news",
+                source=row.feed_source or row.source or "news",
+                title=row.title,
+                url=row.url,
+                published_at=published,
+                published_at_precision=clock.precision,
+                published_at_source=(
+                    f"news_articles.article_published_at ({clock.basis})"
+                ),
+                eligibility=eligibility,
+                judgment=judgment,
+                judgment_detail={
+                    "status": row.rel_status,
+                    "relationship": row.rel_relationship,
+                    "relevance": row.rel_relevance,
+                    "price_relevance": row.rel_price_relevance,
+                    "reason": row.rel_reason,
+                    "judged_by_external_job": row.rel_status
+                    in EXTERNALLY_JUDGED_STATUSES,
+                },
+                ref={
+                    "article_id": row.article_id,
+                    "mapping_source": row.map_source,
+                    "mapping_score": (
+                        float(row.map_score) if row.map_score is not None else None
+                    ),
+                    "feed_clock_confirmed": clock.confirmed,
+                },
+            )
+        )
+    availability = MaterialAvailability(
+        material="news",
+        available=True,
+        reason=None,
+        detail={
+            "rows": len(items),
+            "eligible": sum(item.is_eligible for item in items),
+            "auto_exclusion_by_this_code": False,
+        },
+    )
+    return items, availability
+
+
+async def _company_names(
+    db: AsyncSession, *, market: str, symbol: str
+) -> tuple[str, ...]:
+    if market != "kr":
+        return ()
+    rows = await db.execute(
+        sa.text("SELECT name FROM kr_symbol_universe WHERE symbol = :symbol"),
+        {"symbol": symbol},
+    )
+    return tuple(row.name for row in rows if row.name)
+
+
+async def _load_market_event_evidence(
+    db: AsyncSession, event: SpikeEvent
+) -> tuple[list[EvidenceItem], list[MaterialAvailability]]:
+    names = await _company_names(db, market=event.market, symbol=event.symbol)
+    lo = event.window_start_exclusive.date()
+    hi = event.window_end_inclusive.date()
+    stmt = sa.text(
+        """
+        SELECT id, category, title, company_name, symbol, event_date,
+               source, source_url, raw_payload_json
+        FROM market_events
+        WHERE event_date BETWEEN :lo AND :hi
+          AND market = :market
+          AND (
+                symbol = :symbol
+             OR (
+                  symbol IS NULL
+                  AND company_name = ANY(CAST(:names AS text[]))
+                )
+          )
+        ORDER BY event_date DESC, id DESC
+        """
+    )
+    rows = (
+        await db.execute(
+            stmt,
+            {
+                "lo": lo,
+                "hi": hi,
+                "market": event.market,
+                "symbol": event.symbol,
+                "names": list(names),
+            },
+        )
+    ).all()
+
+    items: list[EvidenceItem] = []
+    for row in rows:
+        payload: dict[str, Any] = row.raw_payload_json or {}
+        raw_time = str(payload.get(_DART_TIME_KEY) or "")
+        published: dt.datetime | None = None
+        precision = "unknown"
+        time_source = "market_events.event_date (date only)"
+        if len(raw_time) >= 19:
+            try:
+                published = dt.datetime.fromisoformat(raw_time).replace(tzinfo=_KST)
+                precision = "exact"
+                time_source = (
+                    "market_events.raw_payload_json.rcept_dt "
+                    "(KST; normalizer drops release_time_local)"
+                )
+            except ValueError:
+                published = None
+        eligibility = (
+            rule_eligibility(
+                published_at=published,
+                window_start_exclusive=event.window_start_exclusive,
+                window_end_inclusive=event.window_end_inclusive,
+            )
+            if published is not None
+            else ELIGIBILITY_TIMESTAMP_UNKNOWN
+        )
+        attribution_type = "earnings" if row.category == "earnings" else "disclosure"
+        items.append(
+            EvidenceItem(
+                attribution_type=attribution_type,
+                source=f"{row.source}:{row.category}",
+                title=row.title or payload.get("report_nm") or "(untitled)",
+                url=row.source_url,
+                published_at=published,
+                published_at_precision=precision,
+                published_at_source=time_source,
+                eligibility=eligibility,
+                judgment="not_applicable",
+                judgment_detail={"filer": payload.get("flr_nm")},
+                ref={
+                    "market_event_id": row.id,
+                    "company_name": row.company_name,
+                    "symbol_column": row.symbol,
+                    "linked_by": (
+                        "symbol" if row.symbol else "company_name_exact_match"
+                    ),
+                },
+            )
+        )
+
+    # KR disclosure needs a company-name to link on. Outside KR there is no
+    # filing source ingested at all (market_events holds only finnhub earnings
+    # for US), so reporting it "available" would overstate what was consulted.
+    if event.market == "kr":
+        disclosure_available = bool(names)
+        disclosure_reason = None if names else UNAVAILABLE_NO_COVERAGE
+        disclosure_note = (
+            "market_events.symbol is NULL for every DART row in this database, "
+            "so KR linkage is an exact company_name match and will miss a "
+            "renamed or differently-spelled filer"
+        )
+    else:
+        disclosure_available = False
+        disclosure_reason = UNAVAILABLE_NO_COVERAGE
+        disclosure_note = (
+            f"no filing source is ingested for market={event.market!r}; "
+            "market_events carries earnings only"
+        )
+
+    availability = [
+        MaterialAvailability(
+            material="disclosure",
+            available=disclosure_available,
+            reason=disclosure_reason,
+            detail={
+                "rows": sum(item.attribution_type == "disclosure" for item in items),
+                "company_names_tried": list(names),
+                "symbol_column_note": disclosure_note,
+            },
+        ),
+        MaterialAvailability(
+            material="earnings",
+            available=True,
+            reason=None,
+            detail={
+                "rows": sum(item.attribution_type == "earnings" for item in items),
+                "time_note": (
+                    "KR/DART earnings carry an exact rcept_dt. US/finnhub rows "
+                    "carry only time_hint (before_open / after_close / "
+                    "during_market), which orders the event against the session "
+                    "but is not a clock — deriving eligibility from it is a "
+                    "follow-up, not an assumed timestamp"
+                ),
+            },
+        ),
+    ]
+    return items, availability
+
+
+async def _flow_availability(
+    db: AsyncSession, event: SpikeEvent
+) -> MaterialAvailability:
+    rows = (
+        await db.execute(
+            sa.text(
+                """
+                SELECT snapshot_date, foreign_net, institution_net,
+                       individual_net, double_buy, collected_at
+                FROM investor_flow_snapshots
+                WHERE market = :market AND symbol = :symbol
+                  AND snapshot_date <= :session_date
+                ORDER BY snapshot_date DESC
+                LIMIT 2
+                """
+            ),
+            {
+                "market": event.market,
+                "symbol": event.symbol,
+                "session_date": event.session_date,
+            },
+        )
+    ).all()
+    same_day = [row for row in rows if row.snapshot_date == event.session_date]
+    return MaterialAvailability(
+        material="flow",
+        available=bool(same_day),
+        reason=None if same_day else UNAVAILABLE_T_PLUS_1,
+        detail={
+            "same_day_snapshot": bool(same_day),
+            "latest_snapshot_date": (
+                rows[0].snapshot_date.isoformat() if rows else None
+            ),
+            "eligible_as_cause_in_v1": False,
+            "context_rows": [
+                {
+                    "snapshot_date": row.snapshot_date.isoformat(),
+                    "foreign_net": row.foreign_net,
+                    "institution_net": row.institution_net,
+                    "individual_net": row.individual_net,
+                    "double_buy": row.double_buy,
+                }
+                for row in rows
+            ],
+        },
+    )
+
+
+async def _sector_availability(
+    db: AsyncSession, event: SpikeEvent
+) -> MaterialAvailability:
+    if event.market != "kr":
+        return MaterialAvailability(
+            material="sector",
+            available=False,
+            reason=UNAVAILABLE_NO_COVERAGE,
+            detail={"note": "US sector join not wired in this package"},
+        )
+    row = (
+        await db.execute(
+            sa.text(
+                """
+                SELECT u.sector_id, s.name_kr, s.name_en, s.source_key
+                FROM kr_symbol_universe u
+                LEFT JOIN symbol_sectors s ON s.id = u.sector_id
+                WHERE u.symbol = :symbol
+                """
+            ),
+            {"symbol": event.symbol},
+        )
+    ).first()
+    has_sector = bool(row and row.sector_id)
+    return MaterialAvailability(
+        material="sector",
+        available=has_sector,
+        reason=None if has_sector else UNAVAILABLE_NO_COVERAGE,
+        detail={
+            "sector_id": row.sector_id if row else None,
+            "name_kr": row.name_kr if row else None,
+            "source_key": row.source_key if row else None,
+            "eligible_as_cause_in_v1": False,
+            "coverage_note": (
+                "symbol_sectors is lazy-filled by screener enrichment, so a "
+                "symbol that no screener has touched has no sector row"
+            ),
+        },
+    )
+
+
+async def load_spike_materials(db: AsyncSession, event: SpikeEvent) -> SpikeMaterials:
+    """Assemble every material for one spike event. Read-only."""
+
+    news_items, news_availability = await _load_news_evidence(db, event)
+    event_items, event_availability = await _load_market_event_evidence(db, event)
+    flow = await _flow_availability(db, event)
+    sector = await _sector_availability(db, event)
+    return SpikeMaterials(
+        evidence=tuple(news_items + event_items),
+        availability=(news_availability, *event_availability, flow, sector),
+    )
+
+
+__all__ = [
+    "DAILY_TABLE_BY_MARKET",
+    "EXTERNALLY_JUDGED_STATUSES",
+    "FEED_CLOCKS",
+    "JUDGMENT_BY_STATUS",
+    "SESSION_TZ_BY_MARKET",
+    "FeedClock",
+    "feed_clock",
+    "load_daily_bars",
+    "load_spike_materials",
+]

--- a/app/services/spike_attribution/precompute.py
+++ b/app/services/spike_attribution/precompute.py
@@ -1,0 +1,294 @@
+"""ROB-1303 phase 2 — pre-open precompute and intraday incremental refresh.
+
+Both modes do exactly what stage 1's CLI does per symbol, then persist the
+result as a cache entry. They add no new judgment: a symbol that precompute
+finds unattributed is cached as unattributed, and a symbol with no spike is
+cached as *a computed negative*, not as an absence.
+
+Failure handling is the point of this module. When a symbol's refresh raises,
+the previous good entry is **not** overwritten — the error is stamped onto it
+(``last_error`` / ``last_error_at``) while ``computed_at`` and ``payload`` stay
+where they were, so the entry ages into ``stale`` on its own instead of
+masquerading as a fresh success.
+
+Nothing here registers a schedule. ``precompute_session`` is a function an
+operator (or an operator-run CLI) calls.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.spike_attribution.attribute import build_attribution, record_summary
+from app.services.spike_attribution.cache import (
+    MODE_INTRADAY,
+    MODE_PREOPEN,
+    CacheEntry,
+    expected_refresh_seconds,
+    read_entry,
+    write_entry,
+)
+from app.services.spike_attribution.catalyst_basis import build_catalyst_basis
+from app.services.spike_attribution.detect import detect_spikes
+from app.services.spike_attribution.materials import (
+    load_daily_bars,
+    load_spike_materials,
+)
+from app.services.spike_attribution.spec import spec_sha256
+
+LOOKBACK_DAYS = 20
+
+# Modes are the pinned refresh cadences, re-exported for callers.
+MODES: tuple[str, str] = (MODE_PREOPEN, MODE_INTRADAY)
+
+
+@dataclass(frozen=True)
+class SymbolOutcome:
+    symbol: str
+    status: str  # "computed" | "failed"
+    spike: bool | None = None
+    scored_class: str | None = None
+    error: str | None = None
+    preserved_previous_entry: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "status": self.status,
+            "spike": self.spike,
+            "scored_class": self.scored_class,
+            "error": self.error,
+            "preserved_previous_entry": self.preserved_previous_entry,
+        }
+
+
+@dataclass(frozen=True)
+class PrecomputeRun:
+    market: str
+    session_date: dt.date
+    mode: str
+    started_at: dt.datetime
+    finished_at: dt.datetime
+    outcomes: tuple[SymbolOutcome, ...] = field(default_factory=tuple)
+
+    @property
+    def succeeded(self) -> int:
+        return sum(o.status == "computed" for o in self.outcomes)
+
+    @property
+    def failed(self) -> int:
+        return sum(o.status == "failed" for o in self.outcomes)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "session_date": self.session_date.isoformat(),
+            "mode": self.mode,
+            "expected_refresh_seconds": expected_refresh_seconds(self.mode),
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat(),
+            "counts": {
+                "attempted": len(self.outcomes),
+                "succeeded": self.succeeded,
+                "failed": self.failed,
+            },
+            # A run with failures is reported as partial, never as success.
+            "run_status": "ok" if self.failed == 0 else "partial",
+            "outcomes": [o.as_dict() for o in self.outcomes],
+            "writes_performed": self.succeeded,
+            "db_rows_written": 0,
+            "scheduler_registration": False,
+            "promote": False,
+            "live_gate_impact": False,
+        }
+
+
+async def compute_symbol_payload(
+    db: AsyncSession,
+    *,
+    market: str,
+    symbol: str,
+    session_date: dt.date,
+) -> dict[str, Any]:
+    """The cached unit: exactly stage 1's per-symbol answer, negatives included."""
+
+    bars = await load_daily_bars(
+        db,
+        market=market,
+        symbol=symbol,
+        start=session_date - dt.timedelta(days=LOOKBACK_DAYS),
+        end=session_date,
+    )
+    event, diagnostics = detect_spikes(
+        market=market, symbol=symbol, bars=bars, session_date=session_date
+    )
+    if event is None:
+        # A computed negative. This is an answer, and the cache layer must
+        # surface it as fresh rather than as an absence.
+        return {
+            "symbol": symbol,
+            "spike": False,
+            "diagnostics": diagnostics,
+            "computed_negative": True,
+        }
+    materials = await load_spike_materials(db, event)
+    attribution = build_attribution(event=event, materials=materials)
+    return {
+        "symbol": symbol,
+        "spike": True,
+        "diagnostics": diagnostics,
+        "summary": record_summary(attribution),
+        "attribution_record": attribution.as_dict(),
+        "catalyst_basis": build_catalyst_basis(attribution),
+        "computed_negative": False,
+    }
+
+
+def _failure_entry(
+    previous: CacheEntry | None,
+    *,
+    market: str,
+    session_date: dt.date,
+    symbol: str,
+    mode: str,
+    error: str,
+    now: dt.datetime,
+) -> CacheEntry | None:
+    """Stamp a failure without destroying the last good answer.
+
+    Returns None when there is nothing to preserve — we deliberately do NOT
+    write a synthetic empty entry in that case, because a written entry reads
+    as "computed" and an empty one would be indistinguishable from a genuine
+    "no catalyst". A never-computed symbol must stay ``missing``.
+    """
+
+    if previous is None:
+        return None
+    return CacheEntry(
+        market=market,
+        session_date=session_date,
+        symbol=symbol,
+        mode=mode,
+        computed_at=previous.computed_at,  # untouched: the entry keeps aging
+        spec_sha256=previous.spec_sha256,
+        payload=previous.payload,
+        last_success_at=previous.last_success_at or previous.computed_at,
+        last_error=error,
+        last_error_at=now,
+    )
+
+
+async def refresh_symbol(
+    db: AsyncSession,
+    *,
+    market: str,
+    symbol: str,
+    session_date: dt.date,
+    mode: str,
+    now: dt.datetime,
+    root: Any = None,
+) -> SymbolOutcome:
+    """Refresh one symbol's entry. Never raises for a per-symbol failure."""
+
+    try:
+        payload = await compute_symbol_payload(
+            db, market=market, symbol=symbol, session_date=session_date
+        )
+    except Exception as exc:  # noqa: BLE001 - per-symbol isolation is the point
+        previous = None
+        try:
+            previous = read_entry(
+                market=market, session_date=session_date, symbol=symbol, root=root
+            )
+        except Exception:  # noqa: BLE001 - unreadable previous is still a failure
+            previous = None
+        stamped = _failure_entry(
+            previous,
+            market=market,
+            session_date=session_date,
+            symbol=symbol,
+            mode=mode,
+            error=f"{type(exc).__name__}: {exc}",
+            now=now,
+        )
+        if stamped is not None:
+            write_entry(stamped, root=root)
+        return SymbolOutcome(
+            symbol=symbol,
+            status="failed",
+            error=f"{type(exc).__name__}: {exc}",
+            preserved_previous_entry=stamped is not None,
+        )
+
+    entry = CacheEntry(
+        market=market,
+        session_date=session_date,
+        symbol=symbol,
+        mode=mode,
+        computed_at=now,
+        spec_sha256=spec_sha256(),
+        payload=payload,
+        last_success_at=now,
+        last_error=None,
+        last_error_at=None,
+    )
+    write_entry(entry, root=root)
+    summary = payload.get("summary") or {}
+    return SymbolOutcome(
+        symbol=symbol,
+        status="computed",
+        spike=bool(payload.get("spike")),
+        scored_class=summary.get("scored_class"),
+    )
+
+
+async def precompute_session(
+    db: AsyncSession,
+    *,
+    market: str,
+    session_date: dt.date,
+    symbols: list[str],
+    mode: str,
+    now: dt.datetime,
+    root: Any = None,
+) -> PrecomputeRun:
+    """Refresh every symbol for one session. Operator-invoked; no schedule."""
+
+    if mode not in MODES:
+        raise ValueError(f"mode must be one of {list(MODES)}")
+    started = now
+    outcomes = [
+        await refresh_symbol(
+            db,
+            market=market,
+            symbol=symbol,
+            session_date=session_date,
+            mode=mode,
+            now=now,
+            root=root,
+        )
+        for symbol in symbols
+    ]
+    return PrecomputeRun(
+        market=market,
+        session_date=session_date,
+        mode=mode,
+        started_at=started,
+        finished_at=now,
+        outcomes=tuple(outcomes),
+    )
+
+
+__all__ = [
+    "LOOKBACK_DAYS",
+    "MODES",
+    "PrecomputeRun",
+    "SymbolOutcome",
+    "compute_symbol_payload",
+    "precompute_session",
+    "refresh_symbol",
+]

--- a/app/services/spike_attribution/scoring.py
+++ b/app/services/spike_attribution/scoring.py
@@ -1,0 +1,222 @@
+"""Hook ⓑ — pre-registered follow-through scoring (pure).
+
+The question is "does a spike of type X still hold N days later?". The formula,
+the windows, the verdict bins, and the sample floor are all pinned in
+:mod:`app.services.spike_attribution.spec` *before* any event is scored, so a
+disappointing result cannot be re-read favourably afterwards.
+
+The retention ratio measures how much of the spike move survived::
+
+    ratio = (close_at_window_end - prev_close) / (spike_close - prev_close)
+
+The denominator carries the direction, so a -7% crash and a +7% pop score on
+the same expression: ``1.0`` means the move fully held, ``0.0`` means it was
+entirely given back, negative means it reversed through the pre-spike close.
+
+Missing bars are never imputed. A window that does not have its full count of
+trading bars is ``unscorable``, and that is reported as its own class rather
+than folded into ``faded``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from app.services.spike_attribution.attribute import scored_class
+from app.services.spike_attribution.contract import DailyBar, SpikeAttribution
+from app.services.spike_attribution.spec import PRE_REGISTRATION
+
+_FT = PRE_REGISTRATION["follow_through"]
+
+WINDOWS_TRADING_DAYS: tuple[int, ...] = tuple(_FT["windows_trading_days"])
+MIN_EVENTS_PER_TYPE: int = int(_FT["min_events_per_type_for_comparison"])
+
+VERDICT_EXTENDED = "extended"
+VERDICT_RETAINED = "retained"
+VERDICT_FADED = "faded"
+VERDICT_REVERSED = "reversed"
+VERDICT_UNSCORABLE = "unscorable"
+
+_EXTENDED_MIN = Decimal("1.0")
+_RETAINED_MIN = Decimal("0.5")
+_FADED_MIN = Decimal("0.0")
+
+
+class ScoringError(ValueError):
+    """Raised when scoring inputs cannot yield a deterministic verdict."""
+
+
+@dataclass(frozen=True)
+class FollowThroughScore:
+    symbol: str
+    session_date: str
+    scored_class: str
+    window_trading_days: int
+    verdict: str
+    retention_ratio: Decimal | None
+    max_favorable_excursion_ratio: Decimal | None
+    max_adverse_excursion_ratio: Decimal | None
+    bars_used: int
+    unscorable_reason: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "session_date": self.session_date,
+            "scored_class": self.scored_class,
+            "window_trading_days": self.window_trading_days,
+            "verdict": self.verdict,
+            "retention_ratio": (
+                str(self.retention_ratio) if self.retention_ratio is not None else None
+            ),
+            "max_favorable_excursion_ratio": (
+                str(self.max_favorable_excursion_ratio)
+                if self.max_favorable_excursion_ratio is not None
+                else None
+            ),
+            "max_adverse_excursion_ratio": (
+                str(self.max_adverse_excursion_ratio)
+                if self.max_adverse_excursion_ratio is not None
+                else None
+            ),
+            "bars_used": self.bars_used,
+            "unscorable_reason": self.unscorable_reason,
+        }
+
+
+def classify_ratio(ratio: Decimal) -> str:
+    if ratio >= _EXTENDED_MIN:
+        return VERDICT_EXTENDED
+    if ratio >= _RETAINED_MIN:
+        return VERDICT_RETAINED
+    if ratio >= _FADED_MIN:
+        return VERDICT_FADED
+    return VERDICT_REVERSED
+
+
+def _ratio(value: Decimal, prev_close: Decimal, denominator: Decimal) -> Decimal:
+    return ((value - prev_close) / denominator).quantize(Decimal("0.0001"))
+
+
+def score_event(
+    *,
+    attribution: SpikeAttribution,
+    subsequent_bars: list[DailyBar],
+    window_trading_days: int,
+) -> FollowThroughScore:
+    """Score one event over one pinned window.
+
+    ``subsequent_bars`` are the bars strictly *after* the spike session, in
+    ascending date order. Only the first ``window_trading_days`` of them are
+    read; anything past the scoring as-of is ignored by construction.
+    """
+
+    if window_trading_days not in WINDOWS_TRADING_DAYS:
+        raise ScoringError(
+            f"window {window_trading_days} is not pre-registered "
+            f"{list(WINDOWS_TRADING_DAYS)}"
+        )
+    event = attribution.event
+    denominator = event.close - event.prev_close
+    klass = scored_class(attribution)
+    base = {
+        "symbol": event.symbol,
+        "session_date": event.session_date.isoformat(),
+        "scored_class": klass,
+        "window_trading_days": window_trading_days,
+    }
+
+    if denominator == 0:
+        # A spike that closed flat has no move to retain. It cannot be scored on
+        # this formula, and inventing a denominator would fabricate a verdict.
+        return FollowThroughScore(
+            **base,
+            verdict=VERDICT_UNSCORABLE,
+            retention_ratio=None,
+            max_favorable_excursion_ratio=None,
+            max_adverse_excursion_ratio=None,
+            bars_used=0,
+            unscorable_reason="zero_denominator_close_equals_prev_close",
+        )
+
+    ordered = sorted(subsequent_bars, key=lambda row: row.session_date)
+    ordered = [row for row in ordered if row.session_date > event.session_date]
+    window = ordered[:window_trading_days]
+    if len(window) < window_trading_days:
+        return FollowThroughScore(
+            **base,
+            verdict=VERDICT_UNSCORABLE,
+            retention_ratio=None,
+            max_favorable_excursion_ratio=None,
+            max_adverse_excursion_ratio=None,
+            bars_used=len(window),
+            unscorable_reason=(
+                f"insufficient_bars_{len(window)}_of_{window_trading_days}"
+            ),
+        )
+
+    ratio = _ratio(window[-1].close, event.prev_close, denominator)
+    excursions = [_ratio(row.high, event.prev_close, denominator) for row in window] + [
+        _ratio(row.low, event.prev_close, denominator) for row in window
+    ]
+    return FollowThroughScore(
+        **base,
+        verdict=classify_ratio(ratio),
+        retention_ratio=ratio,
+        max_favorable_excursion_ratio=max(excursions),
+        max_adverse_excursion_ratio=min(excursions),
+        bars_used=len(window),
+        unscorable_reason=None,
+    )
+
+
+def aggregate_by_class(scores: list[FollowThroughScore]) -> dict[str, Any]:
+    """Per-class counts, gated by the pre-registered sample floor.
+
+    Below the floor the aggregate reports counts and nothing else: no mean, no
+    ranking, no "type X holds better". That comparison is what the floor exists
+    to withhold.
+    """
+
+    by_class: dict[str, dict[str, Any]] = {}
+    for score in scores:
+        bucket = by_class.setdefault(
+            score.scored_class,
+            {"n": 0, "n_scorable": 0, "verdicts": {}, "windows": {}},
+        )
+        bucket["n"] += 1
+        bucket["verdicts"][score.verdict] = bucket["verdicts"].get(score.verdict, 0) + 1
+        key = f"{score.window_trading_days}d"
+        bucket["windows"][key] = bucket["windows"].get(key, 0) + 1
+        if score.verdict != VERDICT_UNSCORABLE:
+            bucket["n_scorable"] += 1
+
+    for bucket in by_class.values():
+        bucket["meets_comparison_floor"] = bucket["n_scorable"] >= MIN_EVENTS_PER_TYPE
+
+    floor_met = all(bucket["meets_comparison_floor"] for bucket in by_class.values())
+    return {
+        "min_events_per_type_for_comparison": MIN_EVENTS_PER_TYPE,
+        "by_class": by_class,
+        "cross_class_comparison_allowed": bool(by_class) and floor_met,
+        "below_floor_disposition": _FT["below_floor_disposition"],
+        "winner_declaration": "forbidden_until_floor_met",
+    }
+
+
+__all__ = [
+    "MIN_EVENTS_PER_TYPE",
+    "VERDICT_EXTENDED",
+    "VERDICT_FADED",
+    "VERDICT_RETAINED",
+    "VERDICT_REVERSED",
+    "VERDICT_UNSCORABLE",
+    "WINDOWS_TRADING_DAYS",
+    "FollowThroughScore",
+    "ScoringError",
+    "aggregate_by_class",
+    "classify_ratio",
+    "score_event",
+]

--- a/app/services/spike_attribution/spec.py
+++ b/app/services/spike_attribution/spec.py
@@ -217,7 +217,7 @@ PRE_REGISTRATION: Final[dict[str, Any]] = {
     "follow_through": {
         "anchor": "spike_day_close",
         "reference": "prev_close",
-        "windows_trading_days": [3, 10],
+        "windows_trading_days": [3, 5, 10],
         "primary_metric": "retention_ratio",
         "retention_ratio": (
             "(close_at_window_end - prev_close) / (spike_close - prev_close)"
@@ -243,6 +243,20 @@ PRE_REGISTRATION: Final[dict[str, Any]] = {
         "bars_after_scoring_as_of_ignored": True,
         "peeking": "forbidden",
         "collection_extension_after_peek": "forbidden",
+        "windows_amendment": {
+            "from": [3, 10],
+            "to": [3, 5, 10],
+            "reason": (
+                "the ROB-1303 issue body specifies D+5; [3,5,10] covers it "
+                "and the previously pinned [3,10]"
+            ),
+            "amended_when": "before any event had been scored (zero scored events)",
+            "legitimacy": (
+                "pre-registration may be amended only while nothing has been "
+                "scored; changing a window after scoring begins would be "
+                "reading a result favourably after the fact"
+            ),
+        },
         "min_events_per_type_for_comparison": 20,
         "below_floor_disposition": "report_counts_only_no_cross_type_comparison",
         "unattributed_is_a_scored_class": True,
@@ -264,7 +278,7 @@ PRE_REGISTRATION: Final[dict[str, Any]] = {
             "pre-registered at all rather than recorded as a meaningless row"
         ),
         "outcome_rule_version": "rob1303-retention-ratio-v1",
-        "review_date_calendar_offset_days_by_window": {"3": 5, "10": 14},
+        "review_date_calendar_offset_days_by_window": {"3": 5, "5": 7, "10": 14},
         "scoring_authority": "rob-1303-spike-attribution.scoring",
         "do_not_use_forecast_resolve_as_experiment_score": True,
     },
@@ -323,7 +337,7 @@ PRE_REGISTRATION: Final[dict[str, Any]] = {
 # Recomputed by tests/services/spike_attribution/test_spec_freeze.py.
 # Bump only together with an explicit pre-registration amendment.
 PINNED_SPEC_SHA256: Final = (
-    "26a0ffd2e53c4b237f6cb672c69ec33527a52d6e14e4d6c26b74193c2df47537"
+    "6d32a577427e1d44f15448c3857f7fb0d28698e578f09765d650bbf70ffc74ca"
 )
 
 

--- a/app/services/spike_attribution/spec.py
+++ b/app/services/spike_attribution/spec.py
@@ -268,6 +268,52 @@ PRE_REGISTRATION: Final[dict[str, Any]] = {
         "scoring_authority": "rob-1303-spike-attribution.scoring",
         "do_not_use_forecast_resolve_as_experiment_score": True,
     },
+    # --- phase 2: pre-attribution cache (§120차 부기 2) -------------------
+    # The cache exists so a session does not recompute attribution at decision
+    # time. Its danger is the opposite of stage 1's: an empty or stale cache
+    # read as "no catalyst" is a *different* state from ``unattributed``, and
+    # both look like silence to a consumer. Every read therefore carries a
+    # state, and a miss is never answered with an empty payload.
+    "cache": {
+        "states": ["fresh", "stale", "missing"],
+        "state_rule": (
+            "missing = no entry for this (market, session_date, symbol); "
+            "fresh = age <= expected_refresh_seconds + grace_seconds; "
+            "stale = an entry exists but is older than that"
+        ),
+        "grace_seconds": 120,
+        "expected_refresh_seconds_by_mode": {"preopen": 14400, "intraday": 900},
+        "intraday_cadence_minutes": 15,
+        "preopen_local_time": {"kr": "07:30", "us": "21:30"},
+        "preopen_time_note": "KST wall clock, per the issue body; operator-invoked",
+        # The distinction the whole design turns on.
+        "negative_result_is_a_real_answer": (
+            "a cached entry saying spike=false or unattributed is a computed "
+            "answer and reads as fresh — it is NOT 'missing'"
+        ),
+        "missing_disposition": "report state=missing and fall back to live compute",
+        "silent_empty_response": "forbidden",
+        "stale_disposition": "return the entry WITH its age; caller decides",
+        "unattributed_stays_unattributed_in_cache": True,
+        "cause_invention_by_precompute": "forbidden",
+        # Failure handling: a failed refresh must never look like a fresh one.
+        "failed_refresh_rule": (
+            "never overwrite the last good entry with a failure; record "
+            "last_error / last_error_at / last_success_at on the entry and let "
+            "it age into stale on its own"
+        ),
+        "failure_laundering": "forbidden",
+        "partial_run_disposition": "per-symbol errors are recorded per symbol; "
+        "the run reports attempted/succeeded/failed counts",
+        "store": "json_files_no_migration",
+        "store_rationale": (
+            "analysis_artifacts.kind is CHECK-constrained with no fitting kind, "
+            "so using it needs a migration; an unapplied migration cannot be "
+            "exercised, and this cache must be demonstrable on real data now"
+        ),
+        "scheduler_registration": False,
+        "entry_point": "operator_invoked_cli_only",
+    },
     "forbidden": list(FORBIDDEN),
     "scheduler_registration": False,
     "broker_or_order_surface": False,
@@ -277,7 +323,7 @@ PRE_REGISTRATION: Final[dict[str, Any]] = {
 # Recomputed by tests/services/spike_attribution/test_spec_freeze.py.
 # Bump only together with an explicit pre-registration amendment.
 PINNED_SPEC_SHA256: Final = (
-    "373e908f9f4adc84b1d17cb77695019ffaf740f977e3e4224f4417499c9e0f76"
+    "26a0ffd2e53c4b237f6cb672c69ec33527a52d6e14e4d6c26b74193c2df47537"
 )
 
 

--- a/app/services/spike_attribution/spec.py
+++ b/app/services/spike_attribution/spec.py
@@ -1,0 +1,307 @@
+"""Frozen pre-registration for ROB-1303 daily spike attribution.
+
+Spike definition, evidence window, attribution vocabulary, follow-through
+scoring formula, sample floors, and the forbidden acts are pinned here *before*
+any attribution row is scored. Changing this dict changes ``spec_sha256()`` and
+fails the pin test — that is the point.
+
+Do not live-read ``trading_policy.yaml``: a later policy edit must not retcon
+which spikes were in scope or how their follow-through was measured.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Final
+
+EXPERIMENT_ID: Final = "rob-1303-spike-attribution"
+
+# Attribution type vocabulary. The first five are the operator-enumerated
+# buckets (실적·공시·수급·섹터·unattributed). ``news`` is an explicit addition:
+# a broker research note or a media report that is not backed by a filing maps
+# to none of the five, and forcing it into ``disclosure`` would be a lie while
+# forcing it into ``unattributed`` would discard a real, linkable document.
+ATTRIBUTION_TYPES: Final[tuple[str, ...]] = (
+    "earnings",
+    "disclosure",
+    "flow",
+    "sector",
+    "news",
+    "unattributed",
+)
+
+# Types that carry a cause. ``unattributed`` is the honest absence of one and is
+# never a bucket that other types fall back into after the fact.
+ATTRIBUTED_TYPES: Final[frozenset[str]] = frozenset(ATTRIBUTION_TYPES) - {
+    "unattributed"
+}
+
+# Issue ROB-1303 forbidden acts — copied, not paraphrased.
+FORBIDDEN: Final[tuple[str, ...]] = (
+    "원인을 발명하지 마라 — 재료로 설명되지 않으면 unattributed",
+    "unattributed 를 기타·시장 전반 같은 말로 분칠하지 마라",
+    "후보가 여럿이면 여럿으로 남겨라 — 하나로 단정하지 마라",
+    "귀속 레코드가 제안·주문·워치로 승격되는 경로 0",
+    "채점 완료 전 중간값으로 정책·임계값 변경 논거 삼지 않기",
+)
+
+PRE_REGISTRATION: Final[dict[str, Any]] = {
+    "experiment_id": EXPERIMENT_ID,
+    "issue": "ROB-1303",
+    "purpose": (
+        "일일 급등락 종목의 원인 후보를 증거 링크와 함께 박제하고, "
+        "카탈리스트 유형별 follow-through 지속성을 사전등록 채점한다"
+    ),
+    "markets": ["kr", "us"],
+    "pilot_scope": {
+        "market": "kr",
+        "session_date": "2026-08-20",
+        "symbols": ["035420", "035720"],
+        "us_status": "structurally_supported_unexercised",
+    },
+    # --- spike detection -------------------------------------------------
+    "spike_detection": {
+        "abs_change_pct_min": 5.0,
+        "bases": ["close_to_close", "intraday_extreme"],
+        "trigger": "either_basis",
+        "close_to_close": "(close - prev_close) / prev_close",
+        "intraday_extreme_up": "(high - prev_close) / prev_close",
+        "intraday_extreme_down": "(low - prev_close) / prev_close",
+        "direction_rule": (
+            "sign_of_close_to_close_falling_back_to_intraday_extreme_when_close_unchanged"
+        ),
+        "direction_rationale": (
+            "follow-through anchors on the close, so direction must agree with "
+            "the sign of (close - prev_close) or the retention denominator "
+            "contradicts the event's own label"
+        ),
+        "both_directions_in_scope": True,
+        "prev_close_source": "previous_row_in_the_same_daily_series",
+        "requires_prev_close": True,
+        "no_prev_close_verdict": "skip_not_spike",
+        "halted_suspect_rule": "excluded_and_reported_never_silently_dropped",
+    },
+    # --- evidence window -------------------------------------------------
+    # Half-open (prev_session_close, spike_session_close]. Anything published
+    # after the spike session closed cannot have caused that session's move and
+    # is recorded as ``after_move`` — visible, never eligible.
+    "evidence_window": {
+        "start_exclusive": "previous_trading_day_session_close",
+        "end_inclusive": "spike_day_session_close",
+        "session_close_local": {"kr": "15:30", "us": "16:00"},
+        "session_close_tz": {"kr": "Asia/Seoul", "us": "America/New_York"},
+        "kr_close_note": (
+            "KRX 정규장 마감 기준. NXT after-hours(20:00)는 일봉 종가의 근거가 "
+            "아니므로 창에 포함하지 않는다"
+        ),
+        "after_window_disposition": "recorded_as_after_move_never_eligible",
+        "missing_timestamp_disposition": (
+            "recorded_as_timestamp_unknown_never_eligible"
+        ),
+    },
+    # --- materials -------------------------------------------------------
+    # Assembled from what already exists. No new feed, scraper, or credential.
+    "materials": {
+        "news": {
+            "tables": ["news_articles", "news_article_related_symbols"],
+            "judgment_table": "symbol_news_relevance",
+            "judgment_absent_disposition": "unjudged_candidate_never_auto_excluded",
+            "rob_491_rule": "auto_trader code never auto-excludes an article",
+            "status_vocabulary": ["confirmed", "pending", "excluded"],
+            "status_written_by": "external judgment job only, never by this code",
+        },
+        "disclosure": {
+            "table": "market_events",
+            "source": "dart",
+            "symbol_linkage": "company_name_only_symbol_column_is_null",
+            "intraday_time_source": "raw_payload_json.rcept_dt",
+            "intraday_time_note": (
+                "normalizer 가 release_time_local 을 버리므로 raw_payload 에서 "
+                "읽는다. 파생 출처를 레코드에 명시한다"
+            ),
+        },
+        "earnings": {
+            "table": "market_events",
+            "categories": ["earnings"],
+        },
+        "flow": {
+            "table": "investor_flow_snapshots",
+            "availability": "t_plus_1",
+            "same_day_disposition": "unavailable_at_attribution_time",
+            "eligible_as_cause_in_v1": False,
+            "ineligibility_reason": (
+                "same-day flow is concurrent with the move (net buying is the "
+                "move, not its antecedent), and this repo records only our own "
+                "collected_at for the prior day's snapshot, not when the "
+                "exchange published it — so a pre-move timestamp would have to "
+                "be invented. Recorded as context only."
+            ),
+        },
+        "sector": {
+            "tables": ["symbol_sectors", "kr_symbol_universe.sector_id"],
+            "coverage": "lazy_fill_partial",
+            "absent_disposition": "sector_evidence_unavailable_not_absent_cause",
+            "eligible_as_cause_in_v1": False,
+            "ineligibility_reason": (
+                "sector co-movement is measured on the same session as the "
+                "move, so it classifies the move rather than preceding it; "
+                "KR sector_id coverage is also partial lazy-fill. Recorded as "
+                "context only."
+            ),
+        },
+        "timestamp_trust": {
+            "rule": "per-feed clock registry; unregistered or unconfirmed → never eligible",
+            "confirmed_kr_exact": ["http_naver_stock_aggregate"],
+            "confirmed_kr_date_only": [
+                "browser_naver_research",
+                "browser_naver_research_company",
+                "browser_naver_research_economy",
+                "browser_naver_research_industry",
+                "browser_naver_research_invest",
+                "naver_item_news",
+            ],
+            "date_only_disposition": "timestamp_unknown_never_eligible",
+            "us_feeds": "tz_unconfirmed_never_eligible_pending_confirmation",
+        },
+        "forbidden_new_sources": True,
+    },
+    # --- attribution ------------------------------------------------------
+    "attribution": {
+        "types": list(ATTRIBUTION_TYPES),
+        "multi_candidate": "keep_all_eligible_candidates_ranked_never_collapsed",
+        "rank_key": "type_priority_then_recency_within_window",
+        "type_priority": ["disclosure", "earnings", "news", "flow", "sector"],
+        "single_cause_declaration": "forbidden",
+        "no_eligible_evidence_verdict": "unattributed",
+        "unattributed_relabeling": "forbidden",
+        "confidence_vocabulary": [
+            "judged_relevant",
+            "judged_not_relevant",
+            "unjudged",
+            "not_applicable",
+        ],
+        "judgment_status_map": {
+            "confirmed": "judged_relevant",
+            "excluded": "judged_not_relevant",
+            "pending": "unjudged",
+            "no_row": "unjudged",
+        },
+        "judged_not_relevant_disposition": (
+            "honour the external ROB-491 verdict — not a cause — but keep the "
+            "row on the record with that reason rather than deleting it"
+        ),
+        "pending_is_not_a_verdict": True,
+        "invented_cause": "forbidden",
+        "types_reachable_in_v1": ["disclosure", "earnings", "news", "unattributed"],
+        "types_unreachable_in_v1": ["flow", "sector"],
+        "unreachable_note": (
+            "두 유형은 어휘에 남아 있으나 v1 재료로는 사전(事前) 증거가 될 수 없다 "
+            "— materials.flow / materials.sector 의 ineligibility_reason 참조. "
+            "이 사실은 유형별 채점 분모에서 두 클래스가 비어 있음을 뜻하며, "
+            "그것을 unattributed 로 흡수하지 않는다"
+        ),
+    },
+    # --- hook (a): momentum_spike catalyst_basis --------------------------
+    "catalyst_basis_hook": {
+        "consumer_policy_tier": "momentum_spike_profit_ladder",
+        "policy_required_thesis_evidence": ["catalyst_basis", "flow_basis"],
+        "supplies": ["catalyst_basis"],
+        "does_not_supply": ["flow_basis"],
+        "flow_basis_reason": "investor flow is T+1; not available on the spike day",
+        "unattributed_satisfies_requirement": False,
+        "can_loosen_live_gate": False,
+        "can_place_or_propose_order": False,
+    },
+    # --- hook (b): follow-through pre-registered scoring ------------------
+    "follow_through": {
+        "anchor": "spike_day_close",
+        "reference": "prev_close",
+        "windows_trading_days": [3, 10],
+        "primary_metric": "retention_ratio",
+        "retention_ratio": (
+            "(close_at_window_end - prev_close) / (spike_close - prev_close)"
+        ),
+        "retention_ratio_sign_note": (
+            "denominator carries the spike direction, so a down spike scores on "
+            "the same formula without a separate branch"
+        ),
+        "verdict_bins": {
+            "extended": "ratio >= 1.0",
+            "retained": "0.5 <= ratio < 1.0",
+            "faded": "0.0 <= ratio < 0.5",
+            "reversed": "ratio < 0.0",
+        },
+        "sensitivity_metrics": [
+            "max_favorable_excursion_ratio",
+            "max_adverse_excursion_ratio",
+        ],
+        "single_scoring_as_of": True,
+        "same_formula_all_types": True,
+        "do_not_impute_missing_bars": True,
+        "insufficient_bars_verdict": "unscorable",
+        "bars_after_scoring_as_of_ignored": True,
+        "peeking": "forbidden",
+        "collection_extension_after_peek": "forbidden",
+        "min_events_per_type_for_comparison": 20,
+        "below_floor_disposition": "report_counts_only_no_cross_type_comparison",
+        "unattributed_is_a_scored_class": True,
+        "winner_declaration_before_floor": "forbidden",
+    },
+    "forecast_tagging": {
+        "session_label": EXPERIMENT_ID,
+        "cohort": "spike_attribution",
+        "promote": False,
+        "calibration_eligibility": "calibration_exclude",
+        "trade_performance_eligibility": "trade_performance_exclude",
+        "probability_placeholder": "0.5",
+        "kind": "price_target",
+        "direction_rule": "at_or_above_for_up_spike_at_or_below_for_down_spike",
+        "target_price_rule": "prev_close + 0.5 * (spike_close - prev_close)",
+        "target_price_meaning": "the retained/faded boundary of retention_ratio",
+        "zero_denominator_disposition": (
+            "close == prev_close is unscorable by construction, so it is not "
+            "pre-registered at all rather than recorded as a meaningless row"
+        ),
+        "outcome_rule_version": "rob1303-retention-ratio-v1",
+        "review_date_calendar_offset_days_by_window": {"3": 5, "10": 14},
+        "scoring_authority": "rob-1303-spike-attribution.scoring",
+        "do_not_use_forecast_resolve_as_experiment_score": True,
+    },
+    "forbidden": list(FORBIDDEN),
+    "scheduler_registration": False,
+    "broker_or_order_surface": False,
+    "new_credential_surface": False,
+}
+
+# Recomputed by tests/services/spike_attribution/test_spec_freeze.py.
+# Bump only together with an explicit pre-registration amendment.
+PINNED_SPEC_SHA256: Final = (
+    "373e908f9f4adc84b1d17cb77695019ffaf740f977e3e4224f4417499c9e0f76"
+)
+
+
+def canonical_spec_bytes(payload: dict[str, Any] | None = None) -> bytes:
+    body = PRE_REGISTRATION if payload is None else payload
+    return json.dumps(
+        body,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def spec_sha256(payload: dict[str, Any] | None = None) -> str:
+    return hashlib.sha256(canonical_spec_bytes(payload)).hexdigest()
+
+
+__all__ = [
+    "ATTRIBUTED_TYPES",
+    "ATTRIBUTION_TYPES",
+    "EXPERIMENT_ID",
+    "FORBIDDEN",
+    "PINNED_SPEC_SHA256",
+    "PRE_REGISTRATION",
+    "canonical_spec_bytes",
+    "spec_sha256",
+]

--- a/ci_shards/shard-1.txt
+++ b/ci_shards/shard-1.txt
@@ -185,6 +185,11 @@ tests/services/research/test_strategy_learning_event_service.py
 tests/services/research_candles/test_promotion.py
 tests/services/social_sentiment_probe/test_cli.py
 tests/services/social_sentiment_probe/test_sources.py
+tests/services/spike_attribution/test_cache.py
+tests/services/spike_attribution/test_judgment_status.py
+tests/services/spike_attribution/test_materials.py
+tests/services/spike_attribution/test_no_mutation_surface.py
+tests/services/spike_attribution/test_spec_freeze.py
 tests/services/test_alpaca_paper_ledger_provenance.py
 tests/services/test_alpaca_paper_retrospective_pending.py
 tests/services/test_alpaca_paper_roundtrip_report_service.py

--- a/ci_shards/shard-2.txt
+++ b/ci_shards/shard-2.txt
@@ -178,6 +178,12 @@ tests/services/research/test_rob984_cp3_transaction_coordinator.py
 tests/services/research/test_strategy_experiment_registry.py
 tests/services/scalping_reviews/test_rollup.py
 tests/services/social_sentiment_probe/test_models.py
+tests/services/spike_attribution/test_attribute.py
+tests/services/spike_attribution/test_cache_first_consumption.py
+tests/services/spike_attribution/test_detect.py
+tests/services/spike_attribution/test_hooks.py
+tests/services/spike_attribution/test_precompute.py
+tests/services/spike_attribution/test_scoring.py
 tests/services/test_account_routing.py
 tests/services/test_alpaca_paper_ledger_claim.py
 tests/services/test_alpaca_paper_market_evidence.py

--- a/docs/runbooks/spike-attribution.md
+++ b/docs/runbooks/spike-attribution.md
@@ -132,7 +132,56 @@ required_thesis_evidence: [catalyst_basis, flow_basis]` 는 **코드가 아니�
 채점: `score_event()` → `aggregate_by_class()`. 표본 하한 20 미만이면 집계가
 `cross_class_comparison_allowed=false` 를 돌려주고 유형 간 우열 선언을 막는다.
 
-## 6. 금지
+## 6. 사전 귀속 캐시 (2단, §120차 부기 2)
+
+판단 시점에 매번 재계산하면 주문이 늦는다 → 귀속을 **상시 사전 계산**해 캐시에 둔다.
+
+```bash
+# 장전 프리컴퓨트 (운영자 실행. KR 07:30 / US 21:30 KST — 정본 이슈 본문)
+uv run python -m scripts.precompute_spike_attribution \
+    --date 2026-08-20 --mode preopen --all --limit 200
+
+# 장중 증분 (15분 주기)
+uv run python -m scripts.precompute_spike_attribution \
+    --date 2026-08-20 --mode intraday --symbol 035420 --symbol 035720
+```
+캐시 위치: `SPIKE_ATTRIBUTION_CACHE_DIR` (기본 `.cache/spike_attribution/<market>/<date>/<symbol>.json`).
+🔴 **스케줄러 등록 0.** `--mode` 는 신선도 잣대를 찍을 뿐 아무것도 스케줄하지 않는다.
+정본 AC3(신규 cron 금지)대로 장전 실행은 **ROB-1297 결산 cron 합류가 운영자 몫**이다.
+
+### 6.1 🔴 캐시가 조용히 틀린 답을 주지 못하게 하는 규칙
+
+세션이 캐시를 **먼저** 읽으므로, 캐시가 비었을 때 "카탈리스트 없음"으로 오독되면
+`unattributed`(모른다)와 구별이 안 된다. 그래서 **모든 조회는 상태를 달고 온다**.
+
+| 상태 | 뜻 | 소비 |
+|---|---|---|
+| `fresh` | `age ≤ 모드별 cadence + grace(120s)` | 캐시로 응답 확정 |
+| `stale` | 엔트리는 있으나 cadence 초과 | **age 와 함께** 반환 + 실조회 폴백 |
+| `missing` | 이 (market, date, symbol) 엔트리가 **아예 없음** | 실조회 폴백 |
+
+cadence: `preopen` 14,400s · `intraday` 900s. 같은 나이라도 모드가 다르면 판정이 다르다.
+
+🔴 **이 설계의 핵심 구분**: "계산했더니 급등 아님"·"계산했더니 unattributed" 는 **진짜 답**
+이라 `fresh` 다. `missing` 은 **아무도 계산한 적 없음**뿐이다. 둘을 뭉개는 것이 이 모듈이
+막으려는 바로 그 버그다. 응답에 `missing_is_not_no_catalyst: true` 가 항상 실린다.
+
+🔵 정본의 "miss·stale 이면 실조회 폴백(fail-open)"과 브리프의 "조용한 빈 응답 금지
+(fail-closed)"는 **모순이 아니다** — 같은 금지(캐시 공백을 원인 부재로 세탁 금지)를
+정본은 처방으로, 브리프는 금지로 말한 것이다. 구현은 **둘 다** 만족한다:
+상태를 실어 보내고(fail-closed 방향) 동시에 실조회로 폴백한다(fail-open).
+
+### 6.2 🔴 증분 갱신이 실패하면
+
+- **마지막 성공 엔트리를 덮어쓰지 않는다.** `computed_at`·`payload` 를 그대로 두고
+  `last_error`/`last_error_at`/`last_success_at` 만 찍는다 → 엔트리는 **정직하게 늙어
+  `stale` 이 된다.** 실패를 성공으로 세탁하지 않는다.
+- **한 번도 계산된 적 없는 심볼은 `missing` 으로 남는다.** 빈 엔트리를 쓰지 않는다 —
+  빈 엔트리는 "계산했는데 없음"으로 읽히기 때문이다.
+- 심볼 하나가 실패해도 나머지는 진행된다. 런 결과는 `run_status: ok|partial` +
+  attempted/succeeded/failed 카운트. 🔴 **partial 이면 CLI exit code 1** (성공 위장 금지).
+
+## 7. 금지
 
 - 귀속 레코드 → 제안·주문·워치 승격 **0**.
 - 채점 완료(표본 하한 충족) 전 중간값으로 정책·임계값 변경 논거 삼기 **금지**.
@@ -140,3 +189,5 @@ required_thesis_evidence: [catalyst_basis, flow_basis]` 는 **코드가 아니�
 - 기존 뉴스 판정 파이프라인 규칙 변경 **금지** — auto_trader 코드는 기사를 자동 제외하지
   않는다 (ROB-491). 판정 행이 없으면 `unjudged` 후보로 **보인다**.
 - 스케줄러(TaskIQ/cron/Prefect) 등록 **금지**. CLI/MCP 수동 호출만.
+- 캐시 miss/stale 을 "카탈리스트 없음"으로 보고 **금지** (§6.1).
+- 실패한 증분 갱신을 성공으로 표시 **금지** (§6.2).

--- a/docs/runbooks/spike-attribution.md
+++ b/docs/runbooks/spike-attribution.md
@@ -33,7 +33,11 @@
 - **follow-through**: 앵커 = 급등일 종가, 기준 = 직전 종가.
   `retention_ratio = (창끝 종가 − 직전종가) / (급등일 종가 − 직전종가)`
   → `extended ≥1.0 > retained ≥0.5 > faded ≥0.0 > reversed`.
-  창 = **3·10 거래일**, 봉 부족은 보간 없이 `unscorable`.
+  창 = **3·5·10 거래일**, 봉 부족은 보간 없이 `unscorable`.
+  🔵 창은 최초 `[3,10]` 으로 봉인했다가 정본(ROB-1303 본문)의 **D+5** 를 포괄하도록
+  `[3,5,10]` 으로 개정했다. **채점된 사건 0건 시점**의 개정이라 정당하며, 개정 이력은
+  `spec.follow_through.windows_amendment` 에 박제돼 있다. 🔴 채점이 시작된 뒤에는
+  창을 바꾸지 마라 — 그건 사후 유리한 해석이다.
 - **표본 하한**: 유형별 채점 가능 표본 **20건** 미만이면 유형 간 비교 자체를 금지한다
   (`cross_class_comparison_allowed=false`). 카운트만 보고한다.
 
@@ -120,7 +124,7 @@ required_thesis_evidence: [catalyst_basis, flow_basis]` 는 **코드가 아니�
 
 ### ⓑ 유형별 follow-through 사전등록 채점
 
-`build_prereg_forecasts()` 가 급등 1건당 창(3d/10d)마다 `forecast_save` 인자를 만든다.
+`build_prereg_forecasts()` 가 급등 1건당 창(3d/5d/10d)마다 `forecast_save` 인자를 만든다.
 귀속 레코드 전문(증거 링크 포함)이 `forecast_target.attribution_record` 로 함께 실린다
 — **별도 테이블을 만들지 않은 이유**: `review.trade_forecasts` 가 이미 학습루프 척추이고
 (CLAUDE.md), 마이그레이션 0 이 더 안전하다.

--- a/docs/runbooks/spike-attribution.md
+++ b/docs/runbooks/spike-attribution.md
@@ -1,0 +1,142 @@
+# 일일 급등락 원인 귀속 (ROB-1303)
+
+> 관측 전용. 브로커·주문·승인·워치 mutation 0, DB 쓰기 0, 스케줄러 등록 0.
+
+## 1. 이게 뭔가
+
+하루치 급등락 종목에 대해 **「무엇이 원인 후보인가」를 증거 링크와 함께** 남긴다.
+새 데이터 소스를 만들지 않는다 — 이미 이 레포가 채우고 있는 세 재료를 **조립**한다.
+
+| 재료 | 테이블 | 상태 |
+|---|---|---|
+| 뉴스 | `news_articles` + `news_article_related_symbols` (+ 판정 `symbol_news_relevance`) | 원인 후보 가능 |
+| 공시 | `market_events` (source=`dart`, category=`disclosure`) | 원인 후보 가능 |
+| 실적 | `market_events` (category=`earnings`) | 원인 후보 가능 |
+| 수급 | `investor_flow_snapshots` | **v1 원인 후보 불가** (§4) |
+| 섹터 | `symbol_sectors` + `kr_symbol_universe.sector_id` | **v1 원인 후보 불가** (§4) |
+
+재료로 설명되지 않으면 `unattributed` 로 남는다. 🔴 **`unattributed` 를 "기타"·"시장
+전반" 으로 분칠하지 않는다.** 모르는 것을 모르는 것으로 남기는 게 이 기록의 값이다.
+
+## 2. 사전등록 (spec)
+
+`app/services/spike_attribution/spec.py` 가 정본이며 `spec_sha256()` 로 봉인된다.
+`tests/services/spike_attribution/test_spec_freeze.py` 가 핀을 검증하므로, 판정식·창·
+표본 기준을 사후에 고쳐 읽으면 테스트가 red 가 된다.
+
+- **급등락 정의**: 직전 종가 대비 **±5.0%**, `close_to_close` **또는** `intraday_extreme`
+  중 하나만 넘어도 사건. 어느 basis 가 발화했는지 레코드에 남는다.
+  (실제로 08-20 카카오는 종가 +3.48% / 장중 +5.35% 라 **장중 basis 로만** 잡혔다.)
+- **증거 창**: `(직전 거래일 정규장 마감, 당일 정규장 마감]` — KR 15:30 KST / US 16:00 ET.
+  창 뒤 문서는 `after_move` 로 **보이되 원인이 될 수 없다**. NXT(20:00)는 일봉 종가의
+  근거가 아니므로 창에 넣지 않는다.
+- **follow-through**: 앵커 = 급등일 종가, 기준 = 직전 종가.
+  `retention_ratio = (창끝 종가 − 직전종가) / (급등일 종가 − 직전종가)`
+  → `extended ≥1.0 > retained ≥0.5 > faded ≥0.0 > reversed`.
+  창 = **3·10 거래일**, 봉 부족은 보간 없이 `unscorable`.
+- **표본 하한**: 유형별 채점 가능 표본 **20건** 미만이면 유형 간 비교 자체를 금지한다
+  (`cross_class_comparison_allowed=false`). 카운트만 보고한다.
+
+## 3. 실행
+
+```bash
+export ENV_FILE=/path/to/.env.prod.native
+
+# 지정 종목
+uv run python -m scripts.attribute_daily_spikes --date 2026-08-20 \
+    --symbol 035420 --symbol 035720 --created-by operator
+
+# 그날 시장 전체 스캔
+uv run python -m scripts.attribute_daily_spikes --date 2026-08-20 --all --limit 50
+
+# follow-through 까지 (창이 찰 때까지는 unscorable 이 정상)
+uv run python -m scripts.attribute_daily_spikes --date 2026-08-20 --all --score
+```
+
+MCP 로는 `get_spike_attribution(symbols, session_date, market, created_by)` — read-only.
+
+**출력은 쓰지 않는다.** `prereg_forecast_save_kwargs` 는 `forecast_save` 인자 dict 일
+뿐이며, 기록 여부는 세션·운영자가 정한다. CLI/도구는 `forecast_save` 를 호출하지 않는다
+(`test_no_mutation_surface.py` 가 기계 검증).
+
+## 4. 🔴 알고 감수하는 한계
+
+읽는 사람이 이 기록을 실제보다 강하게 믿지 않도록, 한계를 먼저 적는다.
+
+1. **수급·섹터는 v1 에서 원인이 될 수 없다.** 수급은 당일치가 T+1 이라 급등일에 없고,
+   전일치는 *거래소가 언제 공표했는지* 를 이 레포가 기록하지 않아 사전 시각을 **발명해야만**
+   창에 넣을 수 있다. 섹터 동조는 같은 세션에서 측정되므로 움직임을 *분류* 할 뿐 *선행* 하지
+   않고, KR `sector_id` 커버리지도 부분(lazy-fill)이다. 둘 다 `material_availability` 에
+   맥락으로만 남는다. → **운영자가 열거한 5유형 중 2개는 오늘 재료로 발화하지 않는다.**
+   이 사실을 `unattributed` 로 흡수하지 않는다.
+2. **`news` 유형은 운영자 열거 목록에 없던 추가분이다.** 증권사 리포트·언론 보도는
+   공시로 뒷받침되지 않아 `disclosure` 로 넣으면 거짓이고, `unattributed` 로 버리면
+   실재하는 링크를 잃는다. 그래서 6번째 유형으로 명시했다.
+3. **시각을 추측하지 않는다.** `article_published_at` 은 naive 이고 그 naive 가 어느 tz
+   인지는 인제스터마다 다르다. `materials.FEED_CLOCKS` 에 **확인된** 피드만 적격 시각을
+   얻고, 나머지는 `timestamp_unknown` 으로 보이되 원인이 되지 못한다.
+   - 확인됨: `http_naver_stock_aggregate` = KST exact (2026-08 발행시각 히스토그램).
+   - 날짜만: `browser_naver_research_*`, `naver_item_news` (전 행 00:00:00).
+   - **US 피드는 tz 미확인** → 현재 전부 부적격. US 경로는 "구조적으로 지원되나 미검증".
+4. **KR 공시 심볼 연결은 회사명 정확일치다.** 이 DB 의 DART 행은 `market_events.symbol`
+   이 **전부 NULL** 이라 `kr_symbol_universe.name` 과 정확일치로 잇는다. 개명·표기 차이는
+   놓친다.
+5. **공시 시각은 정규화 컬럼이 아니라 raw payload 파생이다.** ROB-128 normalizer 가
+   `release_time_local` 을 버리므로 `raw_payload_json.rcept_dt` 를 읽는다. 레코드의
+   `published_at_source` 에 그 출처가 적힌다.
+6. **권리락·액면분할을 걸러내지 못한다.** 레포에 기업행위(코퍼레이트 액션) 캘린더가
+   없다. 권리락 당일의 −30% 는 실제 급락이 아니지만 이 도구는 급락으로 잡고
+   `unattributed` 로 끝난다. 유형별 채점 시 `unattributed` 코호트에 이 잡음이 섞여 있다.
+7. **뉴스↔심볼 매핑 커버리지가 곧 귀속률의 상한이다.** `news_article_related_symbols`
+   에 행이 없는 종목은 뉴스 후보가 0 이다. 그런 경우 `unattributed_reason` 이
+   "조회됐으나 행 0 (커버리지 공백 가능)" 이라고 밝힌다 — 원인 부재와 구별해서 읽어라.
+8. **후보 ≠ 인과.** 창 안에 있고 링크가 있다는 것뿐이다. 여러 후보는 여럿으로 남으며,
+   `scored_class` 가 1순위를 고르는 것은 유형별 채점 분모를 고정하기 위한 **장부상 선택**
+   이지 나머지를 기각했다는 뜻이 아니다.
+9. **뉴스 판정 status 3값을 뭉개지 말 것** (ROB-491, `JUDGMENT_BY_STATUS`):
+   | `symbol_news_relevance.status` | 우리 라벨 | 원인 후보 |
+   |---|---|---|
+   | `confirmed` | `judged_relevant` | ✅ (창 안이면) |
+   | `pending` / 행 없음 | `unjudged` | ✅ (창 안이면) — **판정이 아니라 미판정** |
+   | `excluded` | `judged_not_relevant` | ❌ eligibility=`judged_not_relevant` |
+   `pending` 을 판정으로 읽으면 대기열 항목이 판정으로 둔갑하고, `excluded` 를 후보로
+   올리면 외부 판정을 뒤집는다. `excluded` 행도 **레코드에는 남는다**(조용한 삭제 금지).
+   status 를 쓰는 것은 언제나 외부 Job 이며 이 코드는 읽기만 한다.
+
+## 5. 활용 훅 (배선만 — 자동 실행 0)
+
+### ⓐ `momentum_spike` 의 `catalyst_basis`
+
+`config/trading_policy.yaml` 의 `momentum_spike_profit_ladder.conditions.
+required_thesis_evidence: [catalyst_basis, flow_basis]` 는 **코드가 아니라 세션이**
+소비한다. `build_catalyst_basis()` 가 세션이 인용할 블록을 만든다.
+
+🔴 이 훅은 **충족을 만들어내지 못한다**:
+- `unattributed` → `satisfies_catalyst_basis_requirement=false` + 미충족 사유 그대로.
+- `flow_basis` 는 **공급하지 않는다** (수급 T+1). 따라서
+  `required_thesis_evidence_complete` 는 **항상 false** — catalyst_basis 가 채워졌다고
+  해서 티어의 증거 쌍이 충족된 게 아니다.
+- 라이브 게이트 문언·집행은 무접촉 (`can_loosen_live_gate=false`).
+
+### ⓑ 유형별 follow-through 사전등록 채점
+
+`build_prereg_forecasts()` 가 급등 1건당 창(3d/10d)마다 `forecast_save` 인자를 만든다.
+귀속 레코드 전문(증거 링크 포함)이 `forecast_target.attribution_record` 로 함께 실린다
+— **별도 테이블을 만들지 않은 이유**: `review.trade_forecasts` 가 이미 학습루프 척추이고
+(CLAUDE.md), 마이그레이션 0 이 더 안전하다.
+
+태깅: `cohort=spike_attribution`, `promote=false`, `calibration_exclude`,
+`trade_performance_exclude`, `scoring_authority=rob-1303-spike-attribution.scoring`.
+🔴 `forecast_resolve` 결과를 실험 점수로 쓰지 말 것 — 정본 채점은 `scoring.py` 다.
+
+채점: `score_event()` → `aggregate_by_class()`. 표본 하한 20 미만이면 집계가
+`cross_class_comparison_allowed=false` 를 돌려주고 유형 간 우열 선언을 막는다.
+
+## 6. 금지
+
+- 귀속 레코드 → 제안·주문·워치 승격 **0**.
+- 채점 완료(표본 하한 충족) 전 중간값으로 정책·임계값 변경 논거 삼기 **금지**.
+- 재료로 설명 안 되는 급등에 원인 붙이기 **금지**. 그 경우의 정답은 `unattributed`.
+- 기존 뉴스 판정 파이프라인 규칙 변경 **금지** — auto_trader 코드는 기사를 자동 제외하지
+  않는다 (ROB-491). 판정 행이 없으면 `unjudged` 후보로 **보인다**.
+- 스케줄러(TaskIQ/cron/Prefect) 등록 **금지**. CLI/MCP 수동 호출만.

--- a/scripts/attribute_daily_spikes.py
+++ b/scripts/attribute_daily_spikes.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+"""ROB-1303 — attribute one session's spikes to candidate causes. Read-only.
+
+    uv run python -m scripts.attribute_daily_spikes --date 2026-08-20 \
+        --symbol 035420 --symbol 035720
+
+    uv run python -m scripts.attribute_daily_spikes --date 2026-08-20 --all
+
+Emits one JSON document: the detected spikes, every evidence item with its
+eligibility ruling, the resulting attribution (or the ``unattributed`` verdict),
+the ``catalyst_basis`` block for hook ⓐ, and the ``forecast_save`` kwargs for
+hook ⓑ. It prints those kwargs; it never calls ``forecast_save`` — recording is
+the session's or the operator's decision.
+
+No writes of any kind. No broker call. No scheduler registration: this runs when
+a human runs it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import sys
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+
+from app.core.db import AsyncSessionLocal
+from app.services.spike_attribution.attribute import build_attribution, record_summary
+from app.services.spike_attribution.catalyst_basis import build_catalyst_basis
+from app.services.spike_attribution.detect import (
+    ABS_CHANGE_PCT_MIN,
+    detect_spikes,
+)
+from app.services.spike_attribution.forecast_tag import (
+    build_prereg_forecasts,
+    prereg_skipped_reason,
+)
+from app.services.spike_attribution.materials import (
+    DAILY_TABLE_BY_MARKET,
+    SESSION_TZ_BY_MARKET,
+    load_daily_bars,
+    load_spike_materials,
+)
+from app.services.spike_attribution.scoring import (
+    WINDOWS_TRADING_DAYS,
+    FollowThroughScore,
+    aggregate_by_class,
+    score_event,
+)
+from app.services.spike_attribution.spec import (
+    EXPERIMENT_ID,
+    FORBIDDEN,
+    PINNED_SPEC_SHA256,
+    spec_sha256,
+)
+
+# Enough history behind the session to reach a halt-suspicion verdict, and
+# enough ahead to fill the longest pre-registered scoring window.
+LOOKBACK_DAYS = 20
+LOOKAHEAD_DAYS = max(WINDOWS_TRADING_DAYS) * 2 + 10
+
+
+async def _prefilter_symbols(
+    db: Any, *, market: str, session_date: dt.date, limit: int
+) -> list[str]:
+    """Cheap SQL shortlist: symbols whose session move could clear the bar.
+
+    The pure detector still rules on every shortlisted symbol; this only avoids
+    pulling twenty days of bars for four thousand names.
+    """
+
+    table = DAILY_TABLE_BY_MARKET[market]
+    tzname = str(SESSION_TZ_BY_MARKET[market])
+    stmt = sa.text(
+        f"""
+        WITH d AS (
+            SELECT symbol,
+                   (time AT TIME ZONE :tz)::date AS session_date,
+                   high, low, close,
+                   lag(close) OVER (
+                       PARTITION BY symbol ORDER BY time
+                   ) AS prev_close
+            FROM {table}
+            WHERE (time AT TIME ZONE :tz)::date
+                  BETWEEN :lo AND :session_date
+        )
+        SELECT symbol
+        FROM d
+        WHERE session_date = :session_date
+          AND prev_close IS NOT NULL
+          AND prev_close > 0
+          AND (
+                abs((close - prev_close) / prev_close) * 100 >= :threshold
+             OR abs((high - prev_close) / prev_close) * 100 >= :threshold
+             OR abs((low - prev_close) / prev_close) * 100 >= :threshold
+          )
+        ORDER BY abs((close - prev_close) / prev_close) DESC
+        LIMIT :limit
+        """  # noqa: S608 - table name comes from a closed literal mapping
+    )
+    rows = await db.execute(
+        stmt,
+        {
+            "tz": tzname,
+            "lo": session_date - dt.timedelta(days=10),
+            "session_date": session_date,
+            "threshold": float(ABS_CHANGE_PCT_MIN),
+            "limit": limit,
+        },
+    )
+    return [row.symbol for row in rows]
+
+
+async def _attribute_symbol(
+    db: Any,
+    *,
+    market: str,
+    symbol: str,
+    session_date: dt.date,
+    created_by: str,
+    score: bool,
+    scores_out: list[FollowThroughScore],
+) -> dict[str, Any]:
+    bars = await load_daily_bars(
+        db,
+        market=market,
+        symbol=symbol,
+        start=session_date - dt.timedelta(days=LOOKBACK_DAYS),
+        end=session_date + dt.timedelta(days=LOOKAHEAD_DAYS),
+    )
+    history = [row for row in bars if row.session_date <= session_date]
+    event, diagnostics = detect_spikes(
+        market=market, symbol=symbol, bars=history, session_date=session_date
+    )
+    if event is None:
+        return {"symbol": symbol, "spike": False, "diagnostics": diagnostics}
+
+    materials = await load_spike_materials(db, event)
+    attribution = build_attribution(event=event, materials=materials)
+    payload: dict[str, Any] = {
+        "symbol": symbol,
+        "spike": True,
+        "diagnostics": diagnostics,
+        "summary": record_summary(attribution),
+        "attribution_record": attribution.as_dict(),
+        "catalyst_basis": build_catalyst_basis(attribution),
+        "prereg_forecast_save_kwargs": build_prereg_forecasts(
+            attribution, created_by=created_by
+        ),
+        "prereg_skipped_reason": prereg_skipped_reason(attribution),
+    }
+    if score:
+        future = [row for row in bars if row.session_date > session_date]
+        scored = [
+            score_event(
+                attribution=attribution,
+                subsequent_bars=future,
+                window_trading_days=window,
+            )
+            for window in WINDOWS_TRADING_DAYS
+        ]
+        scores_out.extend(scored)
+        payload["follow_through"] = [row.as_dict() for row in scored]
+    return payload
+
+
+async def run(args: argparse.Namespace) -> dict[str, Any]:
+    session_date = dt.date.fromisoformat(args.date)
+    async with AsyncSessionLocal() as db:
+        symbols = list(args.symbol or [])
+        if args.all:
+            symbols.extend(
+                await _prefilter_symbols(
+                    db,
+                    market=args.market,
+                    session_date=session_date,
+                    limit=args.limit,
+                )
+            )
+        seen: set[str] = set()
+        ordered = [s for s in symbols if not (s in seen or seen.add(s))]
+        scores: list[FollowThroughScore] = []
+        results = [
+            await _attribute_symbol(
+                db,
+                market=args.market,
+                symbol=symbol,
+                session_date=session_date,
+                created_by=args.created_by,
+                score=args.score,
+                scores_out=scores,
+            )
+            for symbol in ordered
+        ]
+
+    spikes = [row for row in results if row["spike"]]
+    return {
+        "experiment_id": EXPERIMENT_ID,
+        "spec_sha256": spec_sha256(),
+        "pinned_spec_sha256": PINNED_SPEC_SHA256,
+        "market": args.market,
+        "session_date": session_date.isoformat(),
+        "abs_change_pct_min": str(ABS_CHANGE_PCT_MIN),
+        "symbols_examined": ordered,
+        "counts": {
+            "examined": len(results),
+            "spikes": len(spikes),
+            "attributed": sum(not r["summary"]["unattributed"] for r in spikes),
+            "unattributed": sum(r["summary"]["unattributed"] for r in spikes),
+        },
+        "results": results,
+        "follow_through_aggregate": aggregate_by_class(scores) if scores else None,
+        "writes_performed": 0,
+        "forecast_save_called": False,
+        "promote": False,
+        "live_gate_impact": False,
+        "forbidden": list(FORBIDDEN),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", default="kr", choices=sorted(DAILY_TABLE_BY_MARKET))
+    parser.add_argument("--date", required=True, help="session date, YYYY-MM-DD local")
+    parser.add_argument("--symbol", action="append", help="repeatable")
+    parser.add_argument(
+        "--all", action="store_true", help="scan the market for the session's spikes"
+    )
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--created-by", default="operator")
+    parser.add_argument(
+        "--score",
+        action="store_true",
+        help="also score follow-through (unscorable until the window fills)",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if not args.symbol and not args.all:
+        print("nothing to do: pass --symbol or --all", file=sys.stderr)
+        return 2
+    payload = asyncio.run(run(args))
+    print(json.dumps(payload, ensure_ascii=False, indent=2, default=_json_default))
+    return 0
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, dt.datetime | dt.date):
+        return value.isoformat()
+    raise TypeError(f"not JSON serialisable: {type(value)!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/precompute_spike_attribution.py
+++ b/scripts/precompute_spike_attribution.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+"""ROB-1303 phase 2 — pre-open precompute / intraday incremental refresh.
+
+    # pre-open (operator runs this; KR 07:30 / US 21:30 KST per the issue)
+    uv run python -m scripts.precompute_spike_attribution \
+        --date 2026-08-20 --mode preopen --all --limit 200
+
+    # intraday, 15-minute cadence
+    uv run python -m scripts.precompute_spike_attribution \
+        --date 2026-08-20 --mode intraday --symbol 035420 --symbol 035720
+
+🔴 **No schedule is registered.** This is an operator-invoked entry point; the
+cadence in ``--mode`` only stamps the freshness yardstick onto each entry. Cron
+/ TaskIQ / Prefect wiring is deliberately out of scope (ROB-1303 AC3 says a new
+cron is forbidden — the pre-open run joins the ROB-1297 digest cron later).
+
+Writes cache files only. No DB row, no broker call, no order/watch surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+
+from app.core.db import AsyncSessionLocal
+from app.services.spike_attribution.cache import MODE_INTRADAY, MODE_PREOPEN, cache_dir
+from app.services.spike_attribution.materials import (
+    DAILY_TABLE_BY_MARKET,
+    SESSION_TZ_BY_MARKET,
+)
+from app.services.spike_attribution.precompute import MODES, precompute_session
+from app.services.spike_attribution.spec import EXPERIMENT_ID, spec_sha256
+
+
+async def _turnover_top_symbols(
+    db: Any, *, market: str, session_date: dt.date, limit: int
+) -> list[str]:
+    """Universe shortlist by traded value — the issue's '유니버스 거래대금 상위'.
+
+    Uses the most recent session at or before ``session_date`` so a pre-open run
+    (before today's bar exists) still ranks on yesterday's turnover.
+    """
+
+    table = DAILY_TABLE_BY_MARKET[market]
+    tzname = str(SESSION_TZ_BY_MARKET[market])
+    stmt = sa.text(
+        f"""
+        WITH d AS (
+            SELECT symbol,
+                   (time AT TIME ZONE :tz)::date AS session_date,
+                   coalesce(value, close * volume) AS turnover
+            FROM {table}
+            WHERE (time AT TIME ZONE :tz)::date BETWEEN :lo AND :session_date
+        ),
+        latest AS (SELECT max(session_date) AS d FROM d)
+        SELECT symbol
+        FROM d, latest
+        WHERE d.session_date = latest.d AND turnover IS NOT NULL
+        ORDER BY turnover DESC
+        LIMIT :limit
+        """  # noqa: S608 - table name comes from a closed literal mapping
+    )
+    rows = await db.execute(
+        stmt,
+        {
+            "tz": tzname,
+            "lo": session_date - dt.timedelta(days=10),
+            "session_date": session_date,
+            "limit": limit,
+        },
+    )
+    return [row.symbol for row in rows]
+
+
+async def run(args: argparse.Namespace) -> dict[str, Any]:
+    session_date = dt.date.fromisoformat(args.date)
+    now = dt.datetime.now(dt.UTC)
+    root = Path(args.cache_dir) if args.cache_dir else cache_dir()
+
+    async with AsyncSessionLocal() as db:
+        symbols = list(args.symbol or [])
+        if args.all:
+            symbols.extend(
+                await _turnover_top_symbols(
+                    db, market=args.market, session_date=session_date, limit=args.limit
+                )
+            )
+        seen: set[str] = set()
+        ordered = [s for s in symbols if not (s in seen or seen.add(s))]
+        run_result = await precompute_session(
+            db,
+            market=args.market,
+            session_date=session_date,
+            symbols=ordered,
+            mode=args.mode,
+            now=now,
+            root=root,
+        )
+
+    payload = run_result.as_dict()
+    payload.update(
+        {
+            "experiment_id": EXPERIMENT_ID,
+            "spec_sha256": spec_sha256(),
+            "cache_dir": str(root),
+            "forecast_save_called": False,
+        }
+    )
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", default="kr", choices=sorted(DAILY_TABLE_BY_MARKET))
+    parser.add_argument("--date", required=True, help="session date, YYYY-MM-DD local")
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=sorted(MODES),
+        help=f"{MODE_PREOPEN} (long cadence) or {MODE_INTRADAY} (15 min cadence)",
+    )
+    parser.add_argument("--symbol", action="append", help="repeatable")
+    parser.add_argument(
+        "--all", action="store_true", help="add the turnover-ranked universe top N"
+    )
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--cache-dir", default=None)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if not args.symbol and not args.all:
+        print("nothing to do: pass --symbol or --all")
+        return 2
+    payload = asyncio.run(run(args))
+    print(json.dumps(payload, ensure_ascii=False, indent=2, default=str))
+    # A partial run is not a success. Exit 1 so an operator wrapper cannot read
+    # "some symbols failed" as a clean run.
+    return 0 if payload["run_status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/services/spike_attribution/test_attribute.py
+++ b/tests/services/spike_attribution/test_attribute.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.spike_attribution.attribute import (
+    UNATTRIBUTED,
+    UNATTRIBUTED_PHRASE,
+    AttributionError,
+    build_attribution,
+    record_summary,
+    rule_eligibility,
+    scored_class,
+)
+from app.services.spike_attribution.contract import (
+    ELIGIBILITY_AFTER_MOVE,
+    ELIGIBILITY_BEFORE_WINDOW,
+    ELIGIBILITY_ELIGIBLE,
+    ELIGIBILITY_TIMESTAMP_UNKNOWN,
+    EvidenceItem,
+    MaterialAvailability,
+    SpikeEvent,
+    SpikeMaterials,
+)
+
+KST = ZoneInfo("Asia/Seoul")
+WINDOW_START = dt.datetime(2026, 8, 19, 15, 30, tzinfo=KST)
+WINDOW_END = dt.datetime(2026, 8, 20, 15, 30, tzinfo=KST)
+
+
+def make_event() -> SpikeEvent:
+    return SpikeEvent(
+        market="kr",
+        symbol="035420",
+        session_date=dt.date(2026, 8, 20),
+        direction="up",
+        prev_close=Decimal("208000"),
+        close=Decimal("219500"),
+        high=Decimal("223500"),
+        low=Decimal("209500"),
+        close_to_close_pct=Decimal("5.5288"),
+        intraday_extreme_pct=Decimal("7.4519"),
+        triggered_bases=("close_to_close", "intraday_extreme"),
+        window_start_exclusive=WINDOW_START,
+        window_end_inclusive=WINDOW_END,
+    )
+
+
+def item(
+    *,
+    attribution_type: str = "news",
+    published_at: dt.datetime | None,
+    eligibility: str,
+    title: str = "t",
+    judgment: str = "unjudged",
+) -> EvidenceItem:
+    return EvidenceItem(
+        attribution_type=attribution_type,
+        source="feed",
+        title=title,
+        url="https://example.test/a",
+        published_at=published_at,
+        published_at_precision="exact",
+        published_at_source="test",
+        eligibility=eligibility,
+        judgment=judgment,
+    )
+
+
+def materials(*items: EvidenceItem) -> SpikeMaterials:
+    return SpikeMaterials(
+        evidence=tuple(items),
+        availability=(
+            MaterialAvailability(material="news", available=True),
+            MaterialAvailability(
+                material="flow", available=False, reason="unavailable_t_plus_1"
+            ),
+        ),
+    )
+
+
+# --- window ruling -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("published", "expected"),
+    [
+        (dt.datetime(2026, 8, 20, 9, 31, tzinfo=KST), ELIGIBILITY_ELIGIBLE),
+        (dt.datetime(2026, 8, 19, 16, 52, tzinfo=KST), ELIGIBILITY_ELIGIBLE),
+        (dt.datetime(2026, 8, 20, 15, 30, tzinfo=KST), ELIGIBILITY_ELIGIBLE),
+        (dt.datetime(2026, 8, 20, 17, 38, tzinfo=KST), ELIGIBILITY_AFTER_MOVE),
+        (dt.datetime(2026, 8, 19, 15, 30, tzinfo=KST), ELIGIBILITY_BEFORE_WINDOW),
+        (dt.datetime(2026, 8, 18, 10, 0, tzinfo=KST), ELIGIBILITY_BEFORE_WINDOW),
+        (None, ELIGIBILITY_TIMESTAMP_UNKNOWN),
+    ],
+)
+def test_window_ruling(published: dt.datetime | None, expected: str) -> None:
+    assert (
+        rule_eligibility(
+            published_at=published,
+            window_start_exclusive=WINDOW_START,
+            window_end_inclusive=WINDOW_END,
+        )
+        == expected
+    )
+
+
+def test_naive_timestamp_is_refused_rather_than_assumed() -> None:
+    with pytest.raises(AttributionError):
+        rule_eligibility(
+            published_at=dt.datetime(2026, 8, 20, 9, 31),
+            window_start_exclusive=WINDOW_START,
+            window_end_inclusive=WINDOW_END,
+        )
+
+
+# --- attribution ---------------------------------------------------------
+
+
+def test_no_eligible_evidence_is_unattributed_in_fixed_wording() -> None:
+    record = build_attribution(
+        event=make_event(),
+        materials=materials(
+            item(
+                published_at=dt.datetime(2026, 8, 20, 17, 38, tzinfo=KST),
+                eligibility=ELIGIBILITY_AFTER_MOVE,
+            ),
+            item(published_at=None, eligibility=ELIGIBILITY_TIMESTAMP_UNKNOWN),
+        ),
+    )
+    assert record.unattributed is True
+    assert record.attribution_types == ()
+    assert record.candidates == ()
+    assert len(record.rejected) == 2
+    assert record.unattributed_reason is not None
+    assert UNATTRIBUTED_PHRASE in record.unattributed_reason
+    assert scored_class(record) == UNATTRIBUTED
+
+
+def test_unattributed_reason_states_absence_not_a_substitute_cause() -> None:
+    record = build_attribution(event=make_event(), materials=materials())
+    reason = record.unattributed_reason or ""
+    for euphemism in ("기타", "시장 전반", "market-wide", "misc"):
+        assert euphemism not in reason
+    # It names what was unreadable rather than implying nothing was there.
+    assert "flow" in reason
+
+
+def test_multiple_candidate_types_are_all_kept() -> None:
+    record = build_attribution(
+        event=make_event(),
+        materials=materials(
+            item(
+                attribution_type="news",
+                published_at=dt.datetime(2026, 8, 20, 9, 31, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                title="broker note",
+            ),
+            item(
+                attribution_type="disclosure",
+                published_at=dt.datetime(2026, 8, 20, 10, 40, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                title="조회공시요구",
+            ),
+        ),
+    )
+    assert record.unattributed is False
+    assert set(record.attribution_types) == {"disclosure", "news"}
+    assert len(record.candidates) == 2
+
+
+def test_type_priority_orders_candidates_and_picks_the_scored_class() -> None:
+    record = build_attribution(
+        event=make_event(),
+        materials=materials(
+            item(
+                attribution_type="news",
+                published_at=dt.datetime(2026, 8, 20, 14, 0, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                title="later news",
+            ),
+            item(
+                attribution_type="disclosure",
+                published_at=dt.datetime(2026, 8, 20, 10, 40, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                title="earlier filing",
+            ),
+        ),
+    )
+    # Disclosure outranks news even though the news item is more recent.
+    assert record.attribution_types[0] == "disclosure"
+    assert scored_class(record) == "disclosure"
+    # ...and the news candidate is still on the record, not discarded.
+    assert [c.title for c in record.candidates] == ["earlier filing", "later news"]
+
+
+def test_recency_breaks_ties_inside_one_type() -> None:
+    record = build_attribution(
+        event=make_event(),
+        materials=materials(
+            item(
+                published_at=dt.datetime(2026, 8, 20, 9, 0, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                title="older",
+            ),
+            item(
+                published_at=dt.datetime(2026, 8, 20, 14, 0, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                title="newer",
+            ),
+        ),
+    )
+    assert [c.title for c in record.candidates] == ["newer", "older"]
+
+
+def test_unjudged_news_is_a_visible_candidate_never_auto_excluded() -> None:
+    record = build_attribution(
+        event=make_event(),
+        materials=materials(
+            item(
+                published_at=dt.datetime(2026, 8, 20, 9, 31, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                judgment="unjudged",
+            )
+        ),
+    )
+    assert record.candidates[0].judgment == "unjudged"
+    assert record.unattributed is False
+
+
+def test_unattributed_is_never_accepted_as_an_evidence_type() -> None:
+    with pytest.raises(AttributionError):
+        build_attribution(
+            event=make_event(),
+            materials=materials(
+                item(
+                    attribution_type="unattributed",
+                    published_at=dt.datetime(2026, 8, 20, 9, 31, tzinfo=KST),
+                    eligibility=ELIGIBILITY_ELIGIBLE,
+                )
+            ),
+        )
+
+
+def test_record_is_json_safe_and_declares_no_promotion() -> None:
+    record = build_attribution(event=make_event(), materials=materials())
+    payload = record.as_dict()
+    assert payload["promote"] is False
+    assert payload["live_gate_impact"] is False
+    assert payload["correlation_id"].startswith("rob-1303-spike-attribution:kr:035420:")
+    summary = record_summary(record)
+    assert summary["scored_class"] == UNATTRIBUTED
+    assert summary["unattributed"] is True

--- a/tests/services/spike_attribution/test_cache.py
+++ b/tests/services/spike_attribution/test_cache.py
@@ -1,0 +1,273 @@
+"""Phase 2 cache contract: three states, and a miss that cannot pass as an answer.
+
+The hazard this pins down: a session reads the cache first, so an empty or
+stale answer silently becomes "no catalyst" — which is a different claim from
+`unattributed`. These tests fix the boundary between the three states and the
+rule that a computed negative is *fresh*, not *missing*.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.spike_attribution.cache import (
+    EXPECTED_REFRESH_SECONDS_BY_MODE,
+    GRACE_SECONDS,
+    MODE_INTRADAY,
+    MODE_PREOPEN,
+    STATE_FRESH,
+    STATE_MISSING,
+    STATE_STALE,
+    CacheEntry,
+    CacheError,
+    classify_state,
+    lookup,
+    read_entry,
+    write_entry,
+)
+
+UTC = dt.UTC
+NOW = dt.datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+SESSION = dt.date(2026, 8, 20)
+
+
+def entry(
+    *,
+    computed_at: dt.datetime,
+    mode: str = MODE_INTRADAY,
+    payload: dict | None = None,
+    last_error: str | None = None,
+    last_error_at: dt.datetime | None = None,
+    last_success_at: dt.datetime | None = None,
+) -> CacheEntry:
+    return CacheEntry(
+        market="kr",
+        session_date=SESSION,
+        symbol="035420",
+        mode=mode,
+        computed_at=computed_at,
+        spec_sha256="deadbeef",
+        payload=payload if payload is not None else {"symbol": "035420", "spike": True},
+        last_success_at=last_success_at,
+        last_error=last_error,
+        last_error_at=last_error_at,
+    )
+
+
+# --- state boundaries ----------------------------------------------------
+
+
+def test_no_entry_is_missing() -> None:
+    state, age, expected = classify_state(entry=None, now=NOW)
+    assert state == STATE_MISSING
+    assert age is None and expected is None
+
+
+@pytest.mark.parametrize("mode", [MODE_PREOPEN, MODE_INTRADAY])
+def test_just_computed_is_fresh(mode: str) -> None:
+    state, age, expected = classify_state(
+        entry=entry(computed_at=NOW, mode=mode), now=NOW
+    )
+    assert state == STATE_FRESH
+    assert age == 0
+    assert expected == EXPECTED_REFRESH_SECONDS_BY_MODE[mode]
+
+
+def test_fresh_right_up_to_cadence_plus_grace() -> None:
+    cadence = EXPECTED_REFRESH_SECONDS_BY_MODE[MODE_INTRADAY]
+    at_edge = NOW - dt.timedelta(seconds=cadence + GRACE_SECONDS)
+    state, _, _ = classify_state(entry=entry(computed_at=at_edge), now=NOW)
+    assert state == STATE_FRESH
+
+
+def test_stale_one_second_past_the_edge() -> None:
+    cadence = EXPECTED_REFRESH_SECONDS_BY_MODE[MODE_INTRADAY]
+    past = NOW - dt.timedelta(seconds=cadence + GRACE_SECONDS + 1)
+    state, age, _ = classify_state(entry=entry(computed_at=past), now=NOW)
+    assert state == STATE_STALE
+    assert age is not None and age > cadence
+
+
+def test_preopen_entries_tolerate_a_much_longer_age_than_intraday() -> None:
+    # A pre-open precompute is meant to last the morning; the intraday cadence
+    # is 15 minutes. The same age must not be judged by the same yardstick.
+    age = dt.timedelta(hours=2)
+    assert (
+        classify_state(entry=entry(computed_at=NOW - age, mode=MODE_PREOPEN), now=NOW)[
+            0
+        ]
+        == STATE_FRESH
+    )
+    assert (
+        classify_state(entry=entry(computed_at=NOW - age, mode=MODE_INTRADAY), now=NOW)[
+            0
+        ]
+        == STATE_STALE
+    )
+
+
+# --- the load-bearing distinction ---------------------------------------
+
+
+def test_a_computed_negative_is_fresh_not_missing(tmp_path: Path) -> None:
+    """ "We looked and there was no spike" is an answer, not an absence."""
+
+    write_entry(
+        entry(computed_at=NOW, payload={"symbol": "035420", "spike": False}),
+        root=tmp_path,
+    )
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_FRESH
+    assert read.usable_without_fallback is True
+    assert read.requires_live_fallback is False
+    assert read.entry is not None and read.entry.payload["spike"] is False
+
+
+def test_a_cached_unattributed_is_fresh_and_stays_unattributed(tmp_path: Path) -> None:
+    payload = {
+        "symbol": "035420",
+        "spike": True,
+        "summary": {"unattributed": True, "scored_class": "unattributed"},
+    }
+    write_entry(entry(computed_at=NOW, payload=payload), root=tmp_path)
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_FRESH
+    assert read.entry is not None
+    assert read.entry.payload["summary"]["unattributed"] is True
+
+
+def test_a_miss_says_so_and_refuses_to_imply_no_catalyst(tmp_path: Path) -> None:
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="NOPE", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_MISSING
+    assert read.requires_live_fallback is True
+    assert read.usable_without_fallback is False
+    assert read.entry is None
+    payload = read.as_dict()
+    assert payload["payload"] is None
+    assert payload["missing_is_not_no_catalyst"] is True
+    assert "NOT evidence that the symbol had no catalyst" in " ".join(payload["notes"])
+    assert "fall back to live computation" in payload["notes"]
+
+
+def test_stale_returns_the_payload_with_its_age(tmp_path: Path) -> None:
+    old = NOW - dt.timedelta(hours=3)
+    write_entry(entry(computed_at=old), root=tmp_path)
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_STALE
+    assert read.entry is not None  # payload is not withheld
+    assert read.age_seconds is not None and read.age_seconds == pytest.approx(10800)
+    assert read.reason is not None and "past its" in read.reason
+    assert read.usable_without_fallback is False
+
+
+# --- failure path --------------------------------------------------------
+
+
+def test_a_recorded_failure_is_visible_on_a_stale_entry(tmp_path: Path) -> None:
+    old = NOW - dt.timedelta(hours=3)
+    write_entry(
+        entry(
+            computed_at=old,
+            last_success_at=old,
+            last_error="TimeoutError: upstream",
+            last_error_at=NOW - dt.timedelta(minutes=1),
+        ),
+        root=tmp_path,
+    )
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    payload = read.as_dict()
+    assert read.state == STATE_STALE
+    assert payload["last_error"] == "TimeoutError: upstream"
+    assert payload["last_success_at"] == old.isoformat()
+    assert "the last refresh FAILED" in " ".join(payload["notes"])
+
+
+def test_a_corrupt_entry_is_missing_with_a_reason_not_a_silent_hit(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "kr" / SESSION.isoformat() / "035420.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_MISSING
+    assert read.reason is not None and read.reason.startswith("unreadable_entry")
+    assert read.requires_live_fallback is True
+    with pytest.raises(CacheError):
+        read_entry(market="kr", session_date=SESSION, symbol="035420", root=tmp_path)
+
+
+# --- storage -------------------------------------------------------------
+
+
+def test_round_trip_preserves_every_field(tmp_path: Path) -> None:
+    original = entry(
+        computed_at=NOW,
+        last_success_at=NOW,
+        last_error="x",
+        last_error_at=NOW,
+    )
+    write_entry(original, root=tmp_path)
+    loaded = read_entry(
+        market="kr", session_date=SESSION, symbol="035420", root=tmp_path
+    )
+    assert loaded == original
+
+
+def test_write_is_atomic_and_leaves_no_temp_files(tmp_path: Path) -> None:
+    write_entry(entry(computed_at=NOW), root=tmp_path)
+    assert not list(tmp_path.rglob("*.tmp"))
+    stored = json.loads(
+        (tmp_path / "kr" / SESSION.isoformat() / "035420.json").read_text("utf-8")
+    )
+    assert stored["symbol"] == "035420"
+
+
+def test_entries_are_partitioned_by_market_and_session(tmp_path: Path) -> None:
+    write_entry(entry(computed_at=NOW), root=tmp_path)
+    other_day = lookup(
+        market="kr",
+        session_date=dt.date(2026, 8, 19),
+        symbol="035420",
+        now=NOW,
+        root=tmp_path,
+    )
+    other_market = lookup(
+        market="us", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    assert other_day.state == STATE_MISSING
+    assert other_market.state == STATE_MISSING
+
+
+def test_a_symbol_with_a_slash_cannot_escape_the_cache_root(tmp_path: Path) -> None:
+    write_entry(
+        CacheEntry(
+            market="us",
+            session_date=SESSION,
+            symbol="BRK/B",
+            mode=MODE_INTRADAY,
+            computed_at=NOW,
+            spec_sha256="x",
+            payload={},
+        ),
+        root=tmp_path,
+    )
+    written = list(tmp_path.rglob("*.json"))
+    assert len(written) == 1
+    assert tmp_path in written[0].parents
+    assert written[0].name == "BRK_B.json"

--- a/tests/services/spike_attribution/test_cache_first_consumption.py
+++ b/tests/services/spike_attribution/test_cache_first_consumption.py
@@ -1,0 +1,245 @@
+"""The consumption contract: cache-first, but a cold cache is never an answer.
+
+Canon (ROB-1303 body) says the session reads the cache first and falls back to a
+live read on miss/stale, with the age exposed. The brief adds the prohibition:
+never a silent empty response. These tests fix both halves — a fresh entry
+short-circuits the live path entirely, and every other state still reaches the
+live path while carrying its cache state.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from app.services.spike_attribution.cache import (
+    MODE_INTRADAY,
+    STATE_FRESH,
+    STATE_MISSING,
+    STATE_STALE,
+    CacheEntry,
+    write_entry,
+)
+
+SESSION = dt.date(2026, 8, 20)
+
+
+class _NoDB:
+    """Any DB use at all fails the test."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __call__(self):
+        return self
+
+    async def execute(self, *a, **k):  # pragma: no cover - must not be reached
+        raise AssertionError("cache-first path must not touch the database")
+
+
+@pytest.fixture
+def isolated_cache(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SPIKE_ATTRIBUTION_CACHE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def seed(root: Path, *, symbol: str, computed_at: dt.datetime, payload: dict) -> None:
+    write_entry(
+        CacheEntry(
+            market="kr",
+            session_date=SESSION,
+            symbol=symbol,
+            mode=MODE_INTRADAY,
+            computed_at=computed_at,
+            spec_sha256="pinned",
+            payload=payload,
+        ),
+        root=root,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_entry_is_served_without_touching_the_database(
+    isolated_cache: Path, monkeypatch
+) -> None:
+    import app.mcp_server.tooling.spike_attribution as mod
+
+    seed(
+        isolated_cache,
+        symbol="035420",
+        computed_at=dt.datetime.now(dt.UTC),
+        payload={
+            "symbol": "035420",
+            "spike": True,
+            "summary": {"unattributed": False, "scored_class": "news"},
+        },
+    )
+    monkeypatch.setattr(mod, "_session_factory", lambda: _NoDB())
+
+    res = await mod.get_spike_attribution_impl(
+        ["035420"], session_date="2026-08-20", market="kr", created_by="test"
+    )
+    assert res["success"] is True
+    row = res["results"][0]
+    assert row["served_from"] == "cache"
+    assert row["cache"]["state"] == STATE_FRESH
+    assert res["counts"]["served_from_cache"] == 1
+    assert res["counts"]["served_live"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_cached_unattributed_is_served_as_unattributed_not_as_no_catalyst(
+    isolated_cache: Path, monkeypatch
+) -> None:
+    import app.mcp_server.tooling.spike_attribution as mod
+
+    seed(
+        isolated_cache,
+        symbol="035720",
+        computed_at=dt.datetime.now(dt.UTC),
+        payload={
+            "symbol": "035720",
+            "spike": True,
+            "summary": {"unattributed": True, "scored_class": "unattributed"},
+        },
+    )
+    monkeypatch.setattr(mod, "_session_factory", lambda: _NoDB())
+
+    res = await mod.get_spike_attribution_impl(
+        ["035720"], session_date="2026-08-20", market="kr", created_by="test"
+    )
+    row = res["results"][0]
+    assert row["summary"]["unattributed"] is True
+    assert res["counts"]["unattributed"] == 1
+    assert row["cache"]["state"] == STATE_FRESH
+
+
+@pytest.mark.parametrize(
+    ("label", "age", "expected_state"),
+    [
+        ("missing", None, STATE_MISSING),
+        ("stale", dt.timedelta(hours=3), STATE_STALE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_non_fresh_states_fall_through_to_live_and_say_why(
+    isolated_cache: Path,
+    monkeypatch,
+    label: str,
+    age: dt.timedelta | None,
+    expected_state: str,
+) -> None:
+    import app.mcp_server.tooling.spike_attribution as mod
+
+    if age is not None:
+        seed(
+            isolated_cache,
+            symbol="035420",
+            computed_at=dt.datetime.now(dt.UTC) - age,
+            payload={"symbol": "035420", "spike": True},
+        )
+
+    reached_live = {"yes": False}
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    def _factory():
+        return _FakeDB
+
+    async def _fake_bars(db, **kwargs):
+        reached_live["yes"] = True
+        return []
+
+    monkeypatch.setattr(mod, "_session_factory", _factory)
+    monkeypatch.setattr(mod, "load_daily_bars", _fake_bars)
+
+    res = await mod.get_spike_attribution_impl(
+        ["035420"], session_date="2026-08-20", market="kr", created_by="test"
+    )
+    row = res["results"][0]
+    assert reached_live["yes"] is True, f"{label} must fall back to a live read"
+    assert row["served_from"] == "live"
+    assert row["cache"]["state"] == expected_state
+    assert row["cache"]["reason"]
+    assert res["counts"]["served_live"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_missing_entry_never_reads_as_absent_catalyst(
+    isolated_cache: Path, monkeypatch
+) -> None:
+    import app.mcp_server.tooling.spike_attribution as mod
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: _FakeDB)
+    monkeypatch.setattr(mod, "load_daily_bars", lambda db, **k: _empty())
+
+    async def _empty():
+        return []
+
+    res = await mod.get_spike_attribution_impl(
+        ["NOPE"], session_date="2026-08-20", market="kr", created_by="test"
+    )
+    cache_block = res["results"][0]["cache"]
+    assert cache_block["state"] == STATE_MISSING
+    assert cache_block["missing_is_not_no_catalyst"] is True
+    assert cache_block["payload"] is None
+    assert "NOT evidence that the symbol had no catalyst" in " ".join(
+        cache_block["notes"]
+    )
+    assert res["cache_first"] is True
+    assert "NOT evidence" in res["cache_state_note"]
+
+
+@pytest.mark.asyncio
+async def test_cache_can_be_bypassed_explicitly(
+    isolated_cache: Path, monkeypatch
+) -> None:
+    import app.mcp_server.tooling.spike_attribution as mod
+
+    seed(
+        isolated_cache,
+        symbol="035420",
+        computed_at=dt.datetime.now(dt.UTC),
+        payload={"symbol": "035420", "spike": True},
+    )
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    async def _fake_bars(db, **kwargs):
+        return []
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: _FakeDB)
+    monkeypatch.setattr(mod, "load_daily_bars", _fake_bars)
+
+    res = await mod.get_spike_attribution_impl(
+        ["035420"],
+        session_date="2026-08-20",
+        market="kr",
+        created_by="test",
+        use_cache=False,
+    )
+    assert res["cache_first"] is False
+    assert res["results"][0]["served_from"] == "live"
+    assert res["results"][0]["cache"] is None

--- a/tests/services/spike_attribution/test_detect.py
+++ b/tests/services/spike_attribution/test_detect.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.spike_attribution.contract import DailyBar
+from app.services.spike_attribution.detect import (
+    BASIS_CLOSE_TO_CLOSE,
+    BASIS_INTRADAY_EXTREME,
+    SpikeDetectionError,
+    classify_bar,
+    detect_spikes,
+    session_close_at,
+)
+
+
+def bar(day: int, o: str, h: str, low: str, c: str, v: str = "1000") -> DailyBar:
+    return DailyBar(
+        symbol="TEST",
+        session_date=dt.date(2026, 8, day),
+        open=Decimal(o),
+        high=Decimal(h),
+        low=Decimal(low),
+        close=Decimal(c),
+        volume=Decimal(v),
+    )
+
+
+def test_close_to_close_spike_fires_and_carries_direction() -> None:
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "101", "107", "100", "106")
+    event = classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+    assert event is not None
+    assert event.direction == "up"
+    assert BASIS_CLOSE_TO_CLOSE in event.triggered_bases
+    assert event.close_to_close_pct == Decimal("6.0000")
+
+
+def test_intraday_only_spike_fires_on_the_intraday_basis() -> None:
+    # Touched +6% intraday but closed +2%: the operator's "5% 급등" can be an
+    # intraday event, and collapsing to close-only would lose it.
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "101", "106", "100", "102")
+    event = classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+    assert event is not None
+    assert event.triggered_bases == (BASIS_INTRADAY_EXTREME,)
+    assert event.close_to_close_pct == Decimal("2.0000")
+    assert event.intraday_extreme_pct == Decimal("6.0000")
+    assert event.direction == "up"
+
+
+def test_gap_up_that_closes_red_is_a_down_session() -> None:
+    # Touched +6% intraday, closed -1%. Direction must follow the close, or the
+    # follow-through denominator (close - prev_close) would be negative while
+    # the event claimed "up" — and the forecast would flip at_or_above.
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "105", "106", "98", "99")
+    event = classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+    assert event is not None
+    assert event.triggered_bases == (BASIS_INTRADAY_EXTREME,)
+    assert event.direction == "down"
+    assert event.close < event.prev_close
+
+
+def test_unchanged_close_falls_back_to_the_triggering_extreme() -> None:
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "100", "106", "100", "100")
+    event = classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+    assert event is not None
+    assert event.close_to_close_pct == Decimal("0.0000")
+    assert event.direction == "up"
+
+
+def test_down_spike_is_in_scope() -> None:
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "99", "99", "92", "93")
+    event = classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+    assert event is not None
+    assert event.direction == "down"
+    assert event.close_to_close_pct == Decimal("-7.0000")
+
+
+def test_below_threshold_is_not_a_spike() -> None:
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "100", "104", "99", "103")
+    assert classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev) is None
+
+
+def test_threshold_is_inclusive_at_exactly_five_percent() -> None:
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "101", "105", "100", "105")
+    event = classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+    assert event is not None
+
+
+def test_evidence_window_spans_prev_close_to_spike_close() -> None:
+    prev = bar(19, "100", "101", "99", "100")
+    today = bar(20, "101", "107", "100", "106")
+    event = classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+    assert event is not None
+    assert event.window_start_exclusive == session_close_at("kr", dt.date(2026, 8, 19))
+    assert event.window_end_inclusive == session_close_at("kr", dt.date(2026, 8, 20))
+    assert event.window_end_inclusive.hour == 15
+    assert event.window_end_inclusive.minute == 30
+
+
+def test_us_window_uses_the_us_session_close() -> None:
+    close = session_close_at("us", dt.date(2026, 8, 20))
+    assert (close.hour, close.minute) == (16, 0)
+    assert close.tzinfo is not None
+
+
+def test_unsupported_market_is_rejected() -> None:
+    with pytest.raises(SpikeDetectionError):
+        session_close_at("crypto", dt.date(2026, 8, 20))
+
+
+def test_non_positive_prev_close_refuses_rather_than_dividing() -> None:
+    prev = bar(19, "0", "0", "0", "0")
+    today = bar(20, "1", "1", "1", "1")
+    with pytest.raises(SpikeDetectionError):
+        classify_bar(market="kr", symbol="TEST", bar=today, prev_bar=prev)
+
+
+def test_first_bar_has_no_prev_close_and_is_skipped() -> None:
+    bars = [bar(20, "101", "107", "100", "106")]
+    event, diagnostics = detect_spikes(
+        market="kr", symbol="TEST", bars=bars, session_date=dt.date(2026, 8, 20)
+    )
+    assert event is None
+    assert diagnostics["skipped"] == "skip_not_spike"
+
+
+def test_halted_suspect_is_excluded_with_its_reason_not_silently_dropped() -> None:
+    # Three frozen sessions then a "spike" print: ROB-1236 says this series is
+    # not trustworthy, and the exclusion has to arrive with its evidence.
+    frozen = [
+        DailyBar(
+            symbol="TEST",
+            session_date=dt.date(2026, 8, day),
+            open=Decimal("100"),
+            high=Decimal("100"),
+            low=Decimal("100"),
+            close=Decimal("100"),
+            volume=Decimal("0"),
+        )
+        for day in (17, 18, 19, 20)
+    ]
+    event, diagnostics = detect_spikes(
+        market="kr", symbol="TEST", bars=frozen, session_date=dt.date(2026, 8, 20)
+    )
+    assert event is None
+    assert diagnostics["skipped"] == "halted_suspect"
+    assert diagnostics["halted_suspect"]["suspected"] is True
+    assert diagnostics["halted_suspect"]["krx_halt_master"] == "unavailable"
+
+
+def test_live_series_is_reported_with_a_halt_verdict_even_when_clean() -> None:
+    bars = [
+        bar(17, "100", "101", "99", "100"),
+        bar(18, "100", "101", "99", "100", v="900"),
+        bar(19, "100", "102", "99", "101", v="800"),
+        bar(20, "101", "108", "101", "107", v="2000"),
+    ]
+    event, diagnostics = detect_spikes(
+        market="kr", symbol="TEST", bars=bars, session_date=dt.date(2026, 8, 20)
+    )
+    assert event is not None
+    assert diagnostics["halted_suspect"]["suspected"] is False
+
+
+def test_duplicate_session_dates_are_refused() -> None:
+    bars = [bar(20, "100", "101", "99", "100"), bar(20, "100", "101", "99", "100")]
+    with pytest.raises(SpikeDetectionError):
+        detect_spikes(
+            market="kr", symbol="TEST", bars=bars, session_date=dt.date(2026, 8, 20)
+        )

--- a/tests/services/spike_attribution/test_hooks.py
+++ b/tests/services/spike_attribution/test_hooks.py
@@ -85,7 +85,7 @@ def test_catalyst_basis_is_json_serialisable() -> None:
 
 def test_prereg_forecasts_cover_every_pinned_window() -> None:
     payloads = build_prereg_forecasts(attributed_record(), created_by="test")
-    assert [p["horizon"] for p in payloads] == ["3d", "10d"]
+    assert [p["horizon"] for p in payloads] == ["3d", "5d", "10d"]
     assert {p["session_label"] for p in payloads} == {"rob-1303-spike-attribution"}
     for payload in payloads:
         target = payload["forecast_target"]
@@ -125,8 +125,9 @@ def test_target_price_is_the_retained_boundary_and_direction_follows_the_spike()
 def test_review_dates_are_derived_from_the_spike_session() -> None:
     payloads = build_prereg_forecasts(attributed_record(), created_by="test")
     assert payloads[0]["forecast_start_date"] == "2026-08-20"
-    assert payloads[0]["review_date"] == "2026-08-25"
-    assert payloads[1]["review_date"] == "2026-09-03"
+    assert payloads[0]["review_date"] == "2026-08-25"  # 3d  -> +5 days
+    assert payloads[1]["review_date"] == "2026-08-27"  # 5d  -> +7 days
+    assert payloads[2]["review_date"] == "2026-09-03"  # 10d -> +14 days
 
 
 def test_no_execution_key_can_ride_along() -> None:

--- a/tests/services/spike_attribution/test_hooks.py
+++ b/tests/services/spike_attribution/test_hooks.py
@@ -1,0 +1,195 @@
+"""Hook ⓐ / ⓑ guard rails: neither may manufacture sufficiency or a trade."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from decimal import Decimal
+
+import pytest
+
+from app.services.spike_attribution.attribute import build_attribution
+from app.services.spike_attribution.catalyst_basis import build_catalyst_basis
+from app.services.spike_attribution.contract import ELIGIBILITY_ELIGIBLE
+from app.services.spike_attribution.forecast_tag import (
+    FORBIDDEN_PAYLOAD_KEYS,
+    ForecastTagError,
+    build_prereg_forecasts,
+    target_direction,
+    target_price,
+)
+from app.services.spike_attribution.spec import PINNED_SPEC_SHA256
+from tests.services.spike_attribution.test_attribute import (
+    KST,
+    item,
+    make_event,
+    materials,
+)
+
+
+def attributed_record():
+    return build_attribution(
+        event=make_event(),
+        materials=materials(
+            item(
+                attribution_type="disclosure",
+                published_at=dt.datetime(2026, 8, 20, 10, 40, tzinfo=KST),
+                eligibility=ELIGIBILITY_ELIGIBLE,
+                title="조회공시요구(풍문또는보도)",
+            )
+        ),
+    )
+
+
+def unattributed_record():
+    return build_attribution(event=make_event(), materials=materials())
+
+
+# --- hook (a) ------------------------------------------------------------
+
+
+def test_catalyst_basis_carries_citations_when_attributed() -> None:
+    block = build_catalyst_basis(attributed_record())
+    assert block["satisfies_catalyst_basis_requirement"] is True
+    assert block["unsatisfied_reason"] is None
+    assert block["citations"][0]["title"] == "조회공시요구(풍문또는보도)"
+    assert block["citations"][0]["url"]
+    assert block["policy_tier"] == "momentum_spike_profit_ladder"
+
+
+def test_catalyst_basis_cannot_manufacture_sufficiency_for_unattributed() -> None:
+    block = build_catalyst_basis(unattributed_record())
+    assert block["satisfies_catalyst_basis_requirement"] is False
+    assert block["citations"] == []
+    assert block["unsatisfied_reason"]
+    assert "재료로 설명되지 않음" in block["unsatisfied_reason"]
+
+
+def test_catalyst_basis_never_claims_the_evidence_pair_is_complete() -> None:
+    # The tier requires catalyst_basis AND flow_basis. We supply one.
+    for record in (attributed_record(), unattributed_record()):
+        block = build_catalyst_basis(record)
+        assert block["required_thesis_evidence_complete"] is False
+        assert block["flow_basis"]["supplied"] is False
+        assert block["does_not_supply"] == ["flow_basis"]
+        assert block["can_loosen_live_gate"] is False
+        assert block["promote"] is False
+
+
+def test_catalyst_basis_is_json_serialisable() -> None:
+    json.dumps(build_catalyst_basis(attributed_record()))
+
+
+# --- hook (b) ------------------------------------------------------------
+
+
+def test_prereg_forecasts_cover_every_pinned_window() -> None:
+    payloads = build_prereg_forecasts(attributed_record(), created_by="test")
+    assert [p["horizon"] for p in payloads] == ["3d", "10d"]
+    assert {p["session_label"] for p in payloads} == {"rob-1303-spike-attribution"}
+    for payload in payloads:
+        target = payload["forecast_target"]
+        assert target["spec_sha256"] == PINNED_SPEC_SHA256
+        assert target["promote"] is False
+        assert target["calibration_eligibility"] == "calibration_exclude"
+        assert target["trade_performance_eligibility"] == "trade_performance_exclude"
+        assert target["do_not_use_forecast_resolve_as_experiment_score"] is True
+
+
+def test_the_record_travels_inside_the_forecast_with_its_evidence_links() -> None:
+    payload = build_prereg_forecasts(attributed_record(), created_by="test")[0]
+    record = payload["forecast_target"]["attribution_record"]
+    assert record["candidates"][0]["url"]
+    assert record["event"]["evidence_window"]["end_inclusive"]
+    assert record["material_availability"]
+    json.dumps(payload)
+
+
+def test_unattributed_spikes_are_pre_registered_too() -> None:
+    payloads = build_prereg_forecasts(unattributed_record(), created_by="test")
+    assert payloads
+    for payload in payloads:
+        assert payload["forecast_target"]["scored_class"] == "unattributed"
+        assert payload["forecast_target"]["unattributed"] is True
+
+
+def test_target_price_is_the_retained_boundary_and_direction_follows_the_spike() -> (
+    None
+):
+    record = attributed_record()
+    # prev 208000 → close 219500; the 0.5 retention boundary is 213750.
+    assert target_price(record) == Decimal("213750.0")
+    assert target_direction(record) == "at_or_above"
+
+
+def test_review_dates_are_derived_from_the_spike_session() -> None:
+    payloads = build_prereg_forecasts(attributed_record(), created_by="test")
+    assert payloads[0]["forecast_start_date"] == "2026-08-20"
+    assert payloads[0]["review_date"] == "2026-08-25"
+    assert payloads[1]["review_date"] == "2026-09-03"
+
+
+def test_no_execution_key_can_ride_along() -> None:
+    payloads = build_prereg_forecasts(attributed_record(), created_by="test")
+    for payload in payloads:
+        assert not FORBIDDEN_PAYLOAD_KEYS.intersection(payload)
+        assert not FORBIDDEN_PAYLOAD_KEYS.intersection(payload["forecast_target"])
+
+
+def test_missing_author_is_refused() -> None:
+    with pytest.raises(ForecastTagError):
+        build_prereg_forecasts(attributed_record(), created_by="  ")
+
+
+def test_forecast_direction_always_agrees_with_the_scoring_denominator() -> None:
+    from app.services.spike_attribution.contract import SpikeEvent
+
+    base = make_event()
+    for close, expected in (
+        (Decimal("219500"), "at_or_above"),
+        (Decimal("190000"), "at_or_below"),
+    ):
+        event = SpikeEvent(
+            market=base.market,
+            symbol=base.symbol,
+            session_date=base.session_date,
+            direction="up" if close > base.prev_close else "down",
+            prev_close=base.prev_close,
+            close=close,
+            high=base.high,
+            low=base.low,
+            close_to_close_pct=Decimal("0"),
+            intraday_extreme_pct=Decimal("0"),
+            triggered_bases=("close_to_close",),
+            window_start_exclusive=base.window_start_exclusive,
+            window_end_inclusive=base.window_end_inclusive,
+        )
+        record = build_attribution(event=event, materials=materials())
+        assert target_direction(record) == expected
+        denominator_sign = 1 if close > base.prev_close else -1
+        assert (target_price(record) - base.prev_close) * denominator_sign > 0
+
+
+def test_a_flat_close_is_not_pre_registered_at_all() -> None:
+    from app.services.spike_attribution.contract import SpikeEvent
+    from app.services.spike_attribution.forecast_tag import prereg_skipped_reason
+
+    base = make_event()
+    flat = SpikeEvent(
+        market=base.market,
+        symbol=base.symbol,
+        session_date=base.session_date,
+        direction="up",
+        prev_close=base.prev_close,
+        close=base.prev_close,  # intraday-only spike that closed unchanged
+        high=base.high,
+        low=base.low,
+        close_to_close_pct=Decimal("0.0000"),
+        intraday_extreme_pct=Decimal("7.4519"),
+        triggered_bases=("intraday_extreme",),
+        window_start_exclusive=base.window_start_exclusive,
+        window_end_inclusive=base.window_end_inclusive,
+    )
+    record = build_attribution(event=flat, materials=materials())
+    assert prereg_skipped_reason(record) == "zero_denominator_close_equals_prev_close"
+    assert build_prereg_forecasts(record, created_by="test") == []

--- a/tests/services/spike_attribution/test_judgment_status.py
+++ b/tests/services/spike_attribution/test_judgment_status.py
@@ -1,0 +1,77 @@
+"""ROB-491 status handling: pending is not a verdict, excluded is honoured.
+
+``symbol_news_relevance.status`` is written only by the external judgment job.
+Three cases have to stay distinguishable, and conflating any two of them either
+invents a judgment we do not have or overrides one we do.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.spike_attribution.contract import (
+    ELIGIBILITY_ELIGIBLE,
+    ELIGIBILITY_JUDGED_NOT_RELEVANT,
+)
+from app.services.spike_attribution.materials import (
+    EXTERNALLY_JUDGED_STATUSES,
+    JUDGMENT_BY_STATUS,
+)
+from app.services.spike_attribution.spec import PRE_REGISTRATION
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("confirmed", "judged_relevant"),
+        ("excluded", "judged_not_relevant"),
+        ("pending", "unjudged"),
+        (None, "unjudged"),
+        ("some_future_status", "unjudged"),
+    ],
+)
+def test_status_maps_to_the_right_judgment(status: str | None, expected: str) -> None:
+    assert JUDGMENT_BY_STATUS.get(status, "unjudged") == expected
+
+
+def test_a_pending_row_is_not_reported_as_judged() -> None:
+    # A queued row means nobody has looked yet. Reporting it as
+    # "judged_relevant" would manufacture a verdict out of a work item.
+    assert JUDGMENT_BY_STATUS["pending"] == "unjudged"
+    assert "pending" not in EXTERNALLY_JUDGED_STATUSES
+
+
+def test_only_real_verdicts_count_as_externally_judged() -> None:
+    assert EXTERNALLY_JUDGED_STATUSES == {"confirmed", "excluded"}
+
+
+def test_excluded_is_honoured_as_not_a_cause() -> None:
+    # ROB-491: this code never *sets* excluded, but when the judge has set it,
+    # the article must not become a cause candidate just because its timestamp
+    # lands inside the window.
+    assert ELIGIBILITY_JUDGED_NOT_RELEVANT != ELIGIBILITY_ELIGIBLE
+    assert JUDGMENT_BY_STATUS["excluded"] == "judged_not_relevant"
+
+
+def test_the_status_map_matches_the_pinned_pre_registration() -> None:
+    pinned = PRE_REGISTRATION["attribution"]["judgment_status_map"]
+    for status, judgment in JUDGMENT_BY_STATUS.items():
+        assert pinned[status] == judgment
+    assert pinned["no_row"] == "unjudged"
+    assert PRE_REGISTRATION["attribution"]["pending_is_not_a_verdict"] is True
+
+
+def test_every_judgment_value_is_in_the_pinned_vocabulary() -> None:
+    vocabulary = set(PRE_REGISTRATION["attribution"]["confidence_vocabulary"])
+    assert set(JUDGMENT_BY_STATUS.values()) <= vocabulary
+    # ``not_applicable`` covers disclosures/earnings, which carry no judgment.
+    assert "not_applicable" in vocabulary
+
+
+def test_pinned_status_vocabulary_matches_the_db_check_constraint() -> None:
+    # symbol_news_relevance CHECK: status IN ('pending','confirmed','excluded')
+    assert set(PRE_REGISTRATION["materials"]["news"]["status_vocabulary"]) == {
+        "confirmed",
+        "pending",
+        "excluded",
+    }

--- a/tests/services/spike_attribution/test_materials.py
+++ b/tests/services/spike_attribution/test_materials.py
@@ -1,0 +1,107 @@
+"""Clock-registry behaviour: the reader may never guess a timezone."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from app.services.spike_attribution.attribute import build_attribution
+from app.services.spike_attribution.contract import MaterialAvailability, SpikeMaterials
+from app.services.spike_attribution.materials import (
+    DAILY_TABLE_BY_MARKET,
+    FEED_CLOCKS,
+    feed_clock,
+)
+from tests.services.spike_attribution.test_attribute import make_event
+
+
+def test_kr_aggregate_feed_is_a_confirmed_exact_kst_clock() -> None:
+    clock = feed_clock("http_naver_stock_aggregate")
+    assert clock.confirmed is True
+    assert clock.precision == "exact"
+    assert str(clock.tz) == "Asia/Seoul"
+    assert clock.basis
+
+
+@pytest.mark.parametrize(
+    "feed",
+    [
+        "browser_naver_research",
+        "browser_naver_research_company",
+        "browser_naver_research_industry",
+        "naver_item_news",
+    ],
+)
+def test_date_only_kr_feeds_are_never_treated_as_eligible(feed: str) -> None:
+    clock = feed_clock(feed)
+    assert clock.precision == "date_only"
+    assert clock.confirmed is False
+
+
+@pytest.mark.parametrize(
+    "feed",
+    ["rss_yahoo_finance_topstories", "rss_cnbc_us_markets", "finnhub_company_news"],
+)
+def test_us_feed_clocks_stay_unconfirmed_until_someone_verifies_them(
+    feed: str,
+) -> None:
+    clock = feed_clock(feed)
+    assert clock.confirmed is False
+    assert clock.tz is None
+
+
+def test_an_unregistered_feed_fails_closed() -> None:
+    clock = feed_clock("some_new_feed_nobody_registered")
+    assert clock.confirmed is False
+    assert clock.tz is None
+    assert clock.basis == "feed_source_not_in_clock_registry"
+
+
+def test_missing_feed_source_fails_closed() -> None:
+    assert feed_clock(None).confirmed is False
+
+
+def test_every_registered_clock_declares_its_basis() -> None:
+    for feed, clock in FEED_CLOCKS.items():
+        assert clock.basis, feed
+        if clock.confirmed:
+            assert clock.tz is not None, feed
+            assert clock.precision == "exact", feed
+
+
+def test_daily_table_mapping_is_a_closed_literal_set() -> None:
+    # The table name is interpolated into SQL, so it must never come from input.
+    assert set(DAILY_TABLE_BY_MARKET) == {"kr", "us"}
+    for table in DAILY_TABLE_BY_MARKET.values():
+        assert table.replace("_", "").isalnum()
+
+
+def test_zero_row_material_reads_differently_from_unreadable_material() -> None:
+    record = build_attribution(
+        event=make_event(),
+        materials=SpikeMaterials(
+            evidence=(),
+            availability=(
+                MaterialAvailability(
+                    material="news", available=True, detail={"rows": 0}
+                ),
+                MaterialAvailability(
+                    material="flow", available=False, reason="unavailable_t_plus_1"
+                ),
+            ),
+        ),
+    )
+    reason = record.unattributed_reason or ""
+    assert "조회됐으나 행 0" in reason
+    assert "news" in reason
+    assert "조회 불가 재료 flow" in reason
+
+
+def test_lookahead_covers_the_longest_pre_registered_window() -> None:
+    from app.services.spike_attribution.scoring import WINDOWS_TRADING_DAYS
+    from scripts.attribute_daily_spikes import LOOKAHEAD_DAYS
+
+    # Calendar days must comfortably exceed trading days for the longest window.
+    assert LOOKAHEAD_DAYS > max(WINDOWS_TRADING_DAYS) * 1.5
+    assert isinstance(dt.timedelta(days=LOOKAHEAD_DAYS), dt.timedelta)

--- a/tests/services/spike_attribution/test_no_mutation_surface.py
+++ b/tests/services/spike_attribution/test_no_mutation_surface.py
@@ -16,6 +16,7 @@ REPO = pathlib.Path(__file__).resolve().parents[3]
 PACKAGE = REPO / "app/services/spike_attribution"
 ENTRY_POINTS = (
     REPO / "scripts/attribute_daily_spikes.py",
+    REPO / "scripts/precompute_spike_attribution.py",
     REPO / "app/mcp_server/tooling/spike_attribution.py",
     REPO / "app/mcp_server/tooling/spike_attribution_registration.py",
 )
@@ -111,3 +112,30 @@ def test_the_package_declares_no_scheduler_registration() -> None:
         assert "spike_attribution" not in path.read_text(), path.name
     for path in REPO.glob("app/tasks/**/*.py"):
         assert "spike_attribution" not in path.read_text(), path.name
+
+
+def test_the_precompute_cli_registers_no_cadence_of_its_own() -> None:
+    """--mode only stamps a freshness yardstick; it must not schedule anything."""
+
+    source = (REPO / "scripts/precompute_spike_attribution.py").read_text()
+    for token in ("crontab", "CronCreate", "schedule(", "add_job", "@broker.task"):
+        assert token not in source, token
+    assert "No schedule is registered" in source
+
+
+def test_the_cache_writes_files_not_database_rows() -> None:
+    import datetime as dt
+
+    from app.services.spike_attribution.precompute import PrecomputeRun
+
+    run = PrecomputeRun(
+        market="kr",
+        session_date=dt.date(2026, 8, 20),
+        mode="preopen",
+        started_at=dt.datetime(2026, 8, 20, tzinfo=dt.UTC),
+        finished_at=dt.datetime(2026, 8, 20, tzinfo=dt.UTC),
+    )
+    payload = run.as_dict()
+    assert payload["db_rows_written"] == 0
+    assert payload["scheduler_registration"] is False
+    assert payload["promote"] is False

--- a/tests/services/spike_attribution/test_no_mutation_surface.py
+++ b/tests/services/spike_attribution/test_no_mutation_surface.py
@@ -1,0 +1,113 @@
+"""ROB-1303 is observation-only. This asserts it, rather than trusting it.
+
+The package and its two entry points (CLI, MCP tool) must not import a broker,
+an order/approval/watch path, or a scheduler, and must not contain a write
+statement of their own.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PACKAGE = REPO / "app/services/spike_attribution"
+ENTRY_POINTS = (
+    REPO / "scripts/attribute_daily_spikes.py",
+    REPO / "app/mcp_server/tooling/spike_attribution.py",
+    REPO / "app/mcp_server/tooling/spike_attribution_registration.py",
+)
+
+FORBIDDEN_IMPORT_FRAGMENTS = (
+    "app.services.brokers",
+    "app.services.kis_trading_service",
+    "app.services.order",
+    "app.mcp_server.tooling.orders",
+    "app.core.scheduler",
+    "app.core.taskiq_broker",
+    "taskiq",
+    "prefect",
+)
+
+FORBIDDEN_SQL_TOKENS = ("INSERT ", "UPDATE ", "DELETE ", "UPSERT ", "TRUNCATE ")
+
+
+def python_files() -> list[pathlib.Path]:
+    return sorted(PACKAGE.glob("*.py")) + list(ENTRY_POINTS)
+
+
+def imported_modules(path: pathlib.Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+    return names
+
+
+@pytest.mark.parametrize("path", python_files(), ids=lambda p: p.name)
+def test_no_broker_order_or_scheduler_import(path: pathlib.Path) -> None:
+    for module in imported_modules(path):
+        for fragment in FORBIDDEN_IMPORT_FRAGMENTS:
+            assert not module.startswith(fragment), f"{path.name} imports {module}"
+
+
+@pytest.mark.parametrize("path", python_files(), ids=lambda p: p.name)
+def test_no_write_sql(path: pathlib.Path) -> None:
+    source = path.read_text().upper()
+    for token in FORBIDDEN_SQL_TOKENS:
+        assert token not in source, f"{path.name} contains {token.strip()}"
+
+
+@pytest.mark.parametrize("path", python_files(), ids=lambda p: p.name)
+def test_no_orm_session_write_calls(path: pathlib.Path) -> None:
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in {
+            "add",
+            "add_all",
+            "commit",
+            "flush",
+            "merge",
+        }:
+            value = node.value
+            if isinstance(value, ast.Name) and value.id in {"db", "session"}:
+                pytest.fail(f"{path.name} calls {value.id}.{node.attr}")
+
+
+def test_the_cli_never_calls_forecast_save() -> None:
+    source = (REPO / "scripts/attribute_daily_spikes.py").read_text()
+    assert "forecast_save(" not in source
+    assert "build_prereg_forecasts" in source
+
+
+def test_the_mcp_tool_never_calls_forecast_save() -> None:
+    source = (REPO / "app/mcp_server/tooling/spike_attribution.py").read_text()
+    assert "forecast_save(" not in source
+
+
+def test_the_tool_is_registered_on_the_read_only_profiles() -> None:
+    from app.mcp_server.tooling.analysis_readonly_registration import (
+        ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES,
+        ANALYSIS_READONLY_TOOL_NAMES,
+    )
+    from app.mcp_server.tooling.analysis_registration import ANALYSIS_TOOL_NAMES
+    from app.mcp_server.tooling.spike_attribution_registration import (
+        SPIKE_ATTRIBUTION_TOOL_NAMES,
+    )
+
+    assert SPIKE_ATTRIBUTION_TOOL_NAMES == {"get_spike_attribution"}
+    assert SPIKE_ATTRIBUTION_TOOL_NAMES <= ANALYSIS_TOOL_NAMES
+    assert SPIKE_ATTRIBUTION_TOOL_NAMES <= ANALYSIS_READONLY_TOOL_NAMES
+    assert not SPIKE_ATTRIBUTION_TOOL_NAMES & ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES
+
+
+def test_the_package_declares_no_scheduler_registration() -> None:
+    for path in REPO.glob("app/flows/*.py"):
+        assert "spike_attribution" not in path.read_text(), path.name
+    for path in REPO.glob("app/tasks/**/*.py"):
+        assert "spike_attribution" not in path.read_text(), path.name

--- a/tests/services/spike_attribution/test_precompute.py
+++ b/tests/services/spike_attribution/test_precompute.py
@@ -1,0 +1,340 @@
+"""Phase 2 refresh contract, especially what happens when a refresh fails.
+
+A failed refresh must never look like a successful one. The rules pinned here:
+a previous good entry survives with the error stamped on it and its original
+``computed_at`` (so it ages into ``stale`` honestly), and a symbol that was
+never computed stays ``missing`` rather than getting a synthetic empty entry
+that would read as "computed, no catalyst".
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from app.services.spike_attribution.cache import (
+    MODE_INTRADAY,
+    MODE_PREOPEN,
+    STATE_FRESH,
+    STATE_MISSING,
+    STATE_STALE,
+    CacheEntry,
+    lookup,
+    read_entry,
+    write_entry,
+)
+from app.services.spike_attribution.precompute import (
+    MODES,
+    precompute_session,
+    refresh_symbol,
+)
+
+UTC = dt.UTC
+NOW = dt.datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+LATER = NOW + dt.timedelta(minutes=10)
+SESSION = dt.date(2026, 8, 20)
+
+
+class _StubDB:
+    """Stands in for AsyncSession; precompute only passes it through."""
+
+
+async def _ok_payload(db, *, market, symbol, session_date):
+    return {"symbol": symbol, "spike": True, "summary": {"scored_class": "news"}}
+
+
+async def _negative_payload(db, *, market, symbol, session_date):
+    return {"symbol": symbol, "spike": False, "computed_negative": True}
+
+
+async def _boom(db, *, market, symbol, session_date):
+    raise TimeoutError("upstream said no")
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    import app.services.spike_attribution.precompute as mod
+
+    def _use(fn):
+        monkeypatch.setattr(mod, "compute_symbol_payload", fn)
+
+    return _use
+
+
+@pytest.mark.asyncio
+async def test_a_successful_refresh_writes_a_fresh_entry(
+    tmp_path: Path, patched
+) -> None:
+    patched(_ok_payload)
+    outcome = await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="035420",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=NOW,
+        root=tmp_path,
+    )
+    assert outcome.status == "computed"
+    assert outcome.spike is True
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_FRESH
+    assert read.entry is not None and read.entry.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_a_computed_negative_is_cached_as_an_answer(
+    tmp_path: Path, patched
+) -> None:
+    patched(_negative_payload)
+    outcome = await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="005930",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=NOW,
+        root=tmp_path,
+    )
+    assert outcome.status == "computed"
+    assert outcome.spike is False
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="005930", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_FRESH  # not "missing"
+    assert read.entry is not None and read.entry.payload["computed_negative"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_failed_refresh_preserves_the_last_good_answer(
+    tmp_path: Path, patched
+) -> None:
+    patched(_ok_payload)
+    await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="035420",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=NOW,
+        root=tmp_path,
+    )
+    good = read_entry(market="kr", session_date=SESSION, symbol="035420", root=tmp_path)
+    assert good is not None
+
+    patched(_boom)
+    outcome = await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="035420",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=LATER,
+        root=tmp_path,
+    )
+    assert outcome.status == "failed"
+    assert outcome.preserved_previous_entry is True
+    assert outcome.error is not None and "TimeoutError" in outcome.error
+
+    after = read_entry(
+        market="kr", session_date=SESSION, symbol="035420", root=tmp_path
+    )
+    assert after is not None
+    # The payload and its age are untouched — the entry keeps aging honestly.
+    assert after.payload == good.payload
+    assert after.computed_at == good.computed_at
+    # ...and the failure is visible.
+    assert after.last_error is not None and "TimeoutError" in after.last_error
+    assert after.last_error_at == LATER
+    assert after.last_success_at == NOW
+
+
+@pytest.mark.asyncio
+async def test_a_failed_refresh_does_not_reset_the_clock_to_look_fresh(
+    tmp_path: Path, patched
+) -> None:
+    patched(_ok_payload)
+    stale_time = NOW - dt.timedelta(hours=3)
+    await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="035420",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=stale_time,
+        root=tmp_path,
+    )
+    patched(_boom)
+    await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="035420",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=NOW,
+        root=tmp_path,
+    )
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="035420", now=NOW, root=tmp_path
+    )
+    # The failure must not have laundered a 3-hour-old answer into a fresh one.
+    assert read.state == STATE_STALE
+    assert "the last refresh FAILED" in " ".join(read.notes)
+
+
+@pytest.mark.asyncio
+async def test_a_never_computed_symbol_stays_missing_after_a_failure(
+    tmp_path: Path, patched
+) -> None:
+    # The dangerous alternative would be writing an empty entry, which reads as
+    # "computed, nothing found" — exactly the confusion this design forbids.
+    patched(_boom)
+    outcome = await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="000660",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=NOW,
+        root=tmp_path,
+    )
+    assert outcome.status == "failed"
+    assert outcome.preserved_previous_entry is False
+    read = lookup(
+        market="kr", session_date=SESSION, symbol="000660", now=NOW, root=tmp_path
+    )
+    assert read.state == STATE_MISSING
+    assert read.entry is None
+    assert not list(tmp_path.rglob("000660.json"))
+
+
+# --- run-level reporting -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_partial_run_reports_partial_not_ok(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import app.services.spike_attribution.precompute as mod
+
+    async def _mixed(db, *, market, symbol, session_date):
+        if symbol == "BAD":
+            raise RuntimeError("nope")
+        return {"symbol": symbol, "spike": False}
+
+    monkeypatch.setattr(mod, "compute_symbol_payload", _mixed)
+    run = await precompute_session(
+        _StubDB(),
+        market="kr",
+        session_date=SESSION,
+        symbols=["035420", "BAD", "035720"],
+        mode=MODE_PREOPEN,
+        now=NOW,
+        root=tmp_path,
+    )
+    payload = run.as_dict()
+    assert payload["run_status"] == "partial"
+    assert payload["counts"] == {"attempted": 3, "succeeded": 2, "failed": 1}
+    assert payload["db_rows_written"] == 0
+    assert payload["scheduler_registration"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_clean_run_reports_ok(tmp_path: Path, patched) -> None:
+    patched(_ok_payload)
+    run = await precompute_session(
+        _StubDB(),
+        market="kr",
+        session_date=SESSION,
+        symbols=["035420", "035720"],
+        mode=MODE_PREOPEN,
+        now=NOW,
+        root=tmp_path,
+    )
+    assert run.as_dict()["run_status"] == "ok"
+    assert run.failed == 0
+
+
+@pytest.mark.asyncio
+async def test_one_symbol_failing_does_not_abort_the_others(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import app.services.spike_attribution.precompute as mod
+
+    async def _first_fails(db, *, market, symbol, session_date):
+        if symbol == "035420":
+            raise RuntimeError("nope")
+        return {"symbol": symbol, "spike": True, "summary": {"scored_class": "news"}}
+
+    monkeypatch.setattr(mod, "compute_symbol_payload", _first_fails)
+    run = await precompute_session(
+        _StubDB(),
+        market="kr",
+        session_date=SESSION,
+        symbols=["035420", "035720"],
+        mode=MODE_INTRADAY,
+        now=NOW,
+        root=tmp_path,
+    )
+    assert run.succeeded == 1 and run.failed == 1
+    survivor = lookup(
+        market="kr", session_date=SESSION, symbol="035720", now=NOW, root=tmp_path
+    )
+    assert survivor.state == STATE_FRESH
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_mode_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        await precompute_session(
+            _StubDB(),
+            market="kr",
+            session_date=SESSION,
+            symbols=["035420"],
+            mode="whenever",
+            now=NOW,
+            root=tmp_path,
+        )
+
+
+def test_modes_are_exactly_the_pinned_two() -> None:
+    assert set(MODES) == {MODE_PREOPEN, MODE_INTRADAY}
+
+
+@pytest.mark.asyncio
+async def test_an_intraday_refresh_overwrites_a_preopen_entry_cleanly(
+    tmp_path: Path, patched
+) -> None:
+    write_entry(
+        CacheEntry(
+            market="kr",
+            session_date=SESSION,
+            symbol="035420",
+            mode=MODE_PREOPEN,
+            computed_at=NOW - dt.timedelta(hours=2),
+            spec_sha256="old",
+            payload={"symbol": "035420", "spike": False},
+        ),
+        root=tmp_path,
+    )
+    patched(_ok_payload)
+    await refresh_symbol(
+        _StubDB(),
+        market="kr",
+        symbol="035420",
+        session_date=SESSION,
+        mode=MODE_INTRADAY,
+        now=NOW,
+        root=tmp_path,
+    )
+    after = read_entry(
+        market="kr", session_date=SESSION, symbol="035420", root=tmp_path
+    )
+    assert after is not None
+    assert after.mode == MODE_INTRADAY
+    assert after.payload["spike"] is True
+    assert after.computed_at == NOW

--- a/tests/services/spike_attribution/test_scoring.py
+++ b/tests/services/spike_attribution/test_scoring.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.spike_attribution.contract import DailyBar
+from app.services.spike_attribution.scoring import (
+    MIN_EVENTS_PER_TYPE,
+    VERDICT_EXTENDED,
+    VERDICT_FADED,
+    VERDICT_RETAINED,
+    VERDICT_REVERSED,
+    VERDICT_UNSCORABLE,
+    ScoringError,
+    aggregate_by_class,
+    classify_ratio,
+    score_event,
+)
+from tests.services.spike_attribution.test_attribute import (
+    build_attribution,
+    make_event,
+    materials,
+)
+
+
+def record():
+    # prev_close 208000 → close 219500, so the spike move is 11500.
+    return build_attribution(event=make_event(), materials=materials())
+
+
+def bars(*closes: str, start_day: int = 21) -> list[DailyBar]:
+    out = []
+    for offset, close in enumerate(closes):
+        value = Decimal(close)
+        out.append(
+            DailyBar(
+                symbol="035420",
+                session_date=dt.date(2026, 8, start_day + offset),
+                open=value,
+                high=value,
+                low=value,
+                close=value,
+                volume=Decimal("1000"),
+            )
+        )
+    return out
+
+
+@pytest.mark.parametrize(
+    ("ratio", "verdict"),
+    [
+        ("1.5", VERDICT_EXTENDED),
+        ("1.0", VERDICT_EXTENDED),
+        ("0.9", VERDICT_RETAINED),
+        ("0.5", VERDICT_RETAINED),
+        ("0.4", VERDICT_FADED),
+        ("0.0", VERDICT_FADED),
+        ("-0.1", VERDICT_REVERSED),
+    ],
+)
+def test_verdict_bins_are_the_pinned_boundaries(ratio: str, verdict: str) -> None:
+    assert classify_ratio(Decimal(ratio)) == verdict
+
+
+def test_full_retention_scores_extended() -> None:
+    score = score_event(
+        attribution=record(),
+        subsequent_bars=bars("215000", "217000", "219500"),
+        window_trading_days=3,
+    )
+    assert score.verdict == VERDICT_EXTENDED
+    assert score.retention_ratio == Decimal("1.0000")
+    assert score.bars_used == 3
+
+
+def test_giving_the_whole_move_back_scores_faded() -> None:
+    score = score_event(
+        attribution=record(),
+        subsequent_bars=bars("215000", "210000", "208000"),
+        window_trading_days=3,
+    )
+    assert score.verdict == VERDICT_FADED
+    assert score.retention_ratio == Decimal("0.0000")
+
+
+def test_trading_through_the_pre_spike_close_scores_reversed() -> None:
+    score = score_event(
+        attribution=record(),
+        subsequent_bars=bars("212000", "205000", "202000"),
+        window_trading_days=3,
+    )
+    assert score.verdict == VERDICT_REVERSED
+    assert score.retention_ratio < 0
+
+
+def test_a_down_spike_scores_on_the_same_formula() -> None:
+    from app.services.spike_attribution.contract import SpikeEvent
+
+    event = make_event()
+    down = SpikeEvent(
+        market=event.market,
+        symbol=event.symbol,
+        session_date=event.session_date,
+        direction="down",
+        prev_close=Decimal("100"),
+        close=Decimal("90"),
+        high=Decimal("100"),
+        low=Decimal("89"),
+        close_to_close_pct=Decimal("-10.0000"),
+        intraday_extreme_pct=Decimal("-11.0000"),
+        triggered_bases=("close_to_close",),
+        window_start_exclusive=event.window_start_exclusive,
+        window_end_inclusive=event.window_end_inclusive,
+    )
+    attribution = build_attribution(event=down, materials=materials())
+    # Still at 90 three days later: the down move fully held.
+    held = score_event(
+        attribution=attribution,
+        subsequent_bars=bars("90", "90", "90"),
+        window_trading_days=3,
+    )
+    assert held.retention_ratio == Decimal("1.0000")
+    assert held.verdict == VERDICT_EXTENDED
+    # Bounced all the way back: the down move was undone.
+    undone = score_event(
+        attribution=attribution,
+        subsequent_bars=bars("95", "98", "100"),
+        window_trading_days=3,
+    )
+    assert undone.retention_ratio == Decimal("0.0000")
+    assert undone.verdict == VERDICT_FADED
+
+
+def test_missing_bars_are_unscorable_not_imputed() -> None:
+    score = score_event(
+        attribution=record(),
+        subsequent_bars=bars("215000", "217000"),
+        window_trading_days=3,
+    )
+    assert score.verdict == VERDICT_UNSCORABLE
+    assert score.retention_ratio is None
+    assert score.unscorable_reason == "insufficient_bars_2_of_3"
+
+
+def test_bars_past_the_window_are_ignored() -> None:
+    score = score_event(
+        attribution=record(),
+        subsequent_bars=bars("215000", "217000", "219500", "300000", "310000"),
+        window_trading_days=3,
+    )
+    assert score.bars_used == 3
+    assert score.retention_ratio == Decimal("1.0000")
+
+
+def test_bars_on_or_before_the_spike_session_are_dropped() -> None:
+    stale = bars("999999", start_day=20)
+    score = score_event(
+        attribution=record(),
+        subsequent_bars=stale + bars("215000", "217000", "219500"),
+        window_trading_days=3,
+    )
+    assert score.bars_used == 3
+    assert score.retention_ratio == Decimal("1.0000")
+
+
+def test_excursions_are_reported_as_sensitivity() -> None:
+    highs = [
+        DailyBar(
+            symbol="035420",
+            session_date=dt.date(2026, 8, 21 + offset),
+            open=Decimal("219500"),
+            high=Decimal("231000"),
+            low=Decimal("208000"),
+            close=Decimal("219500"),
+            volume=Decimal("1"),
+        )
+        for offset in range(3)
+    ]
+    score = score_event(
+        attribution=record(), subsequent_bars=highs, window_trading_days=3
+    )
+    assert score.max_favorable_excursion_ratio == Decimal("2.0000")
+    assert score.max_adverse_excursion_ratio == Decimal("0.0000")
+
+
+def test_an_unregistered_window_is_refused() -> None:
+    with pytest.raises(ScoringError):
+        score_event(
+            attribution=record(),
+            subsequent_bars=bars("215000"),
+            window_trading_days=7,
+        )
+
+
+def test_aggregate_withholds_cross_class_comparison_below_the_floor() -> None:
+    scores = [
+        score_event(
+            attribution=record(),
+            subsequent_bars=bars("219500", "219500", "219500"),
+            window_trading_days=3,
+        )
+    ]
+    aggregate = aggregate_by_class(scores)
+    assert aggregate["min_events_per_type_for_comparison"] == MIN_EVENTS_PER_TYPE
+    assert aggregate["cross_class_comparison_allowed"] is False
+    assert aggregate["by_class"]["unattributed"]["n"] == 1
+    assert aggregate["by_class"]["unattributed"]["meets_comparison_floor"] is False
+    assert aggregate["winner_declaration"] == "forbidden_until_floor_met"
+
+
+def test_unscorable_rows_do_not_count_toward_the_floor() -> None:
+    scores = [
+        score_event(
+            attribution=record(),
+            subsequent_bars=bars("219500"),
+            window_trading_days=3,
+        )
+        for _ in range(MIN_EVENTS_PER_TYPE + 5)
+    ]
+    aggregate = aggregate_by_class(scores)
+    bucket = aggregate["by_class"]["unattributed"]
+    assert bucket["n"] == MIN_EVENTS_PER_TYPE + 5
+    assert bucket["n_scorable"] == 0
+    assert bucket["meets_comparison_floor"] is False
+    assert aggregate["cross_class_comparison_allowed"] is False
+
+
+def test_empty_input_never_reads_as_comparison_ready() -> None:
+    assert aggregate_by_class([])["cross_class_comparison_allowed"] is False

--- a/tests/services/spike_attribution/test_spec_freeze.py
+++ b/tests/services/spike_attribution/test_spec_freeze.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from app.services.spike_attribution.spec import (
+    ATTRIBUTION_TYPES,
+    EXPERIMENT_ID,
+    FORBIDDEN,
+    PINNED_SPEC_SHA256,
+    PRE_REGISTRATION,
+    spec_sha256,
+)
+
+
+def test_pinned_spec_hash_matches_canonical_payload() -> None:
+    assert spec_sha256() == PINNED_SPEC_SHA256
+    assert len(PINNED_SPEC_SHA256) == 64
+
+
+def test_mutating_pre_registration_changes_hash() -> None:
+    mutated = deepcopy(PRE_REGISTRATION)
+    mutated["spike_detection"]["abs_change_pct_min"] = 3.0
+    assert spec_sha256(mutated) != PINNED_SPEC_SHA256
+
+
+def test_widening_a_scoring_window_after_the_fact_changes_hash() -> None:
+    mutated = deepcopy(PRE_REGISTRATION)
+    mutated["follow_through"]["windows_trading_days"] = [3, 10, 20]
+    assert spec_sha256(mutated) != PINNED_SPEC_SHA256
+
+
+def test_lowering_the_sample_floor_changes_hash() -> None:
+    mutated = deepcopy(PRE_REGISTRATION)
+    mutated["follow_through"]["min_events_per_type_for_comparison"] = 2
+    assert spec_sha256(mutated) != PINNED_SPEC_SHA256
+
+
+def test_operator_enumerated_types_are_all_present() -> None:
+    # 실적·공시·수급·섹터·unattributed, plus the documented ``news`` addition.
+    for expected in ("earnings", "disclosure", "flow", "sector", "unattributed"):
+        assert expected in ATTRIBUTION_TYPES
+    assert "news" in ATTRIBUTION_TYPES
+
+
+def test_forbidden_acts_are_pinned_verbatim() -> None:
+    assert FORBIDDEN == (
+        "원인을 발명하지 마라 — 재료로 설명되지 않으면 unattributed",
+        "unattributed 를 기타·시장 전반 같은 말로 분칠하지 마라",
+        "후보가 여럿이면 여럿으로 남겨라 — 하나로 단정하지 마라",
+        "귀속 레코드가 제안·주문·워치로 승격되는 경로 0",
+        "채점 완료 전 중간값으로 정책·임계값 변경 논거 삼지 않기",
+    )
+
+
+def test_experiment_declares_no_scheduler_or_broker_surface() -> None:
+    assert PRE_REGISTRATION["scheduler_registration"] is False
+    assert PRE_REGISTRATION["broker_or_order_surface"] is False
+    assert PRE_REGISTRATION["new_credential_surface"] is False
+    assert PRE_REGISTRATION["materials"]["forbidden_new_sources"] is True
+    assert EXPERIMENT_ID == "rob-1303-spike-attribution"
+
+
+def test_unreachable_types_are_declared_not_silently_absorbed() -> None:
+    attribution = PRE_REGISTRATION["attribution"]
+    assert attribution["types_unreachable_in_v1"] == ["flow", "sector"]
+    assert "unattributed" not in attribution["types_unreachable_in_v1"]
+    for material in ("flow", "sector"):
+        block = PRE_REGISTRATION["materials"][material]
+        assert block["eligible_as_cause_in_v1"] is False
+        assert block["ineligibility_reason"]

--- a/tests/services/spike_attribution/test_spec_freeze.py
+++ b/tests/services/spike_attribution/test_spec_freeze.py
@@ -25,7 +25,7 @@ def test_mutating_pre_registration_changes_hash() -> None:
 
 def test_widening_a_scoring_window_after_the_fact_changes_hash() -> None:
     mutated = deepcopy(PRE_REGISTRATION)
-    mutated["follow_through"]["windows_trading_days"] = [3, 10, 20]
+    mutated["follow_through"]["windows_trading_days"] = [3, 5, 10, 20]
     assert spec_sha256(mutated) != PINNED_SPEC_SHA256
 
 
@@ -33,6 +33,21 @@ def test_lowering_the_sample_floor_changes_hash() -> None:
     mutated = deepcopy(PRE_REGISTRATION)
     mutated["follow_through"]["min_events_per_type_for_comparison"] = 2
     assert spec_sha256(mutated) != PINNED_SPEC_SHA256
+
+
+def test_windows_cover_the_issue_body_d_plus_5() -> None:
+    # ROB-1303's body specifies D+5; [3,5,10] covers it and the earlier [3,10].
+    windows = PRE_REGISTRATION["follow_through"]["windows_trading_days"]
+    assert windows == [3, 5, 10]
+    amendment = PRE_REGISTRATION["follow_through"]["windows_amendment"]
+    assert amendment["from"] == [3, 10]
+    assert amendment["to"] == windows
+    # The amendment is legitimate only because nothing had been scored yet.
+    assert "zero scored events" in amendment["amended_when"]
+    offsets = PRE_REGISTRATION["forecast_tagging"][
+        "review_date_calendar_offset_days_by_window"
+    ]
+    assert set(offsets) == {str(w) for w in windows}
 
 
 def test_operator_enumerated_types_are_all_present() -> None:

--- a/tests/test_mcp_kiwoom_kr_profile.py
+++ b/tests/test_mcp_kiwoom_kr_profile.py
@@ -130,11 +130,16 @@ class TestRegistrarRegistersOnlyKrTools:
 
 
 class TestWholeProfileClosedWorld:
-    def test_base_inventory_includes_shadow_evaluator_and_is_exactly_120_tools(
+    def test_base_inventory_includes_readonly_advisors_and_is_exactly_121_tools(
         self,
     ) -> None:
+        # Closed world: the count moves only with a reviewed addition. ROB-1303
+        # added get_spike_attribution (read-only attribution reader), which the
+        # KIWOOM <-> KIWOOM_KR shared-surface contract requires here — see
+        # TestKiwoomKrProfile::test_keeps_kr_order_surface_intact.
         assert "evaluate_buy_gate_ab_shadow" in KIWOOM_KR_BASE_PROFILE_TOOL_NAMES
-        assert len(KIWOOM_KR_BASE_PROFILE_TOOL_NAMES) == 120
+        assert "get_spike_attribution" in KIWOOM_KR_BASE_PROFILE_TOOL_NAMES
+        assert len(KIWOOM_KR_BASE_PROFILE_TOOL_NAMES) == 121
 
     def test_current_profile_matches_active_exact_set(self) -> None:
         mcp = DummyMCP()


### PR DESCRIPTION
ROB-1303. Answers "why did this stock move today?" from material this repo
already stores — and, when the material does not answer it, says so in fixed
wording instead of naming a plausible cause.

**Observation-only.** No DB write, no broker/order/approval/watch surface, no
scheduler registration, no new feed or credential, **no migration**.

## What it assembles (nothing new is built)

| material | source | can be a cause in v1 |
|---|---|---|
| news | `news_article_related_symbols` ⨝ `news_articles` (+ `symbol_news_relevance`) | ✅ |
| disclosure | `market_events` (source=`dart`) | ✅ (KR only) |
| earnings | `market_events` (category=`earnings`) | ✅ |
| flow | `investor_flow_snapshots` | ❌ — see below |
| sector | `symbol_sectors` ⨝ `kr_symbol_universe.sector_id` | ❌ — see below |

## The discipline, in code

- **Pre-move window.** `(prev session close, this session close]`. Anything
  published after the close is recorded as `after_move` and can never be a
  cause. In the pilot this correctly disqualified the 17:38 Kakao Mobility IPO
  story — the article everyone would point at — while keeping the previous
  evening's SEC-filing report as an eligible candidate.
- **No guessed clocks.** `article_published_at` is naive and the timezone it is
  naive *in* depends on the ingestor. A per-feed clock registry admits only
  feeds whose clock was confirmed against real data; everything else is
  `timestamp_unknown` and never a cause. US feeds are currently unconfirmed, so
  the US path is structurally supported but unexercised.
- **ROB-491 judgment is honoured, never substituted.** `pending` (queued, nobody
  looked) stays `unjudged`; `excluded` (the external judge ruled it unrelated)
  becomes `judged_not_relevant` and drops out of the candidates but stays on the
  record. This code never sets a status.
- **`unattributed` is a first-class verdict** with one fixed phrase, and the
  reason distinguishes "read it, zero rows" from "could not read it" from "read
  everything, nothing was in the window". A test asserts the absence of
  euphemisms ("기타", "시장 전반", "market-wide").
- **Multiple candidates stay multiple.** `scored_class` picks a top-ranked type
  only to give per-type follow-through a stable denominator; it is bookkeeping,
  not a ruling that the others were eliminated.
- **flow and sector cannot fire in v1, and that is declared rather than hidden.**
  Same-day flow is concurrent with the move (net buying *is* the move) and the
  prior day's publication time is not recorded here, so a pre-move timestamp
  would have to be invented. Sector co-movement is measured on the same session,
  and KR `sector_id` coverage is partial. Both are recorded as context.

## Two hooks — wiring only, nothing auto-runs

**ⓐ `catalyst_basis`** for the `momentum_spike_profit_ladder` tier. No code reads
that tier's `required_thesis_evidence` today — the session does — so this builds
the block a session can quote. It cannot manufacture sufficiency: an
`unattributed` spike returns `satisfies=false`, and because `flow_basis` is never
supplied, `required_thesis_evidence_complete` is **always false**. The live gate
is untouched.

**ⓑ Pre-registered per-type follow-through.** Retention ratio
`(close_at_window_end − prev_close) / (spike_close − prev_close)` over the pinned
trading days (3, 5, and 10 — see the amendment note below), verdict bins
pinned, missing bars never imputed. Cross-type
comparison is withheld until 20 scorable events per class. The whole spec is
hashed and pin-tested, so a later edit that re-reads a disappointing result
favourably turns the build red. Records persist through
`review.trade_forecasts` — already the learning-loop spine — which is why there
is no new table and no migration.

## Pilot — 2026-08-20 NAVER / Kakao, real data

- **035420** +5.53% close / +7.45% intraday → `news`, top candidate the 09:31
  broker note, both candidates `unjudged` (no relevance row exists yet).
- **035720** — the operator's "5% 급등" was **intraday**: close was +3.48%, the
  high +5.35%, so only the intraday basis fired and the record says so. Top
  candidate is the exchange's 10:40 조회공시요구 (풍문또는보도).
- Whole-market scan: 40 spikes, 9 attributed, **31 unattributed**. Nothing was
  forced. Most of the 31 have zero mapped news rows, which the reason string
  reports as a coverage gap rather than an absent cause.

Follow-through is `unscorable` for both (no bars after 08-20 yet) — correct, and
not imputed.

## Phase 2 — pre-attribution cache (§120차 부기 2)

So a session does not recompute attribution at decision time. The hazard here is
the mirror of stage 1's: a cold or stale cache read as "no catalyst" is a
different claim from `unattributed`, and both look like silence.

- **Three states, always carried.** `fresh` (within its mode's cadence + 120s
  grace), `stale` (entry exists, past cadence — returned *with its age*), and
  `missing` (nothing was ever computed). Cadences differ by mode: pre-open
  14,400s, intraday 900s, so the same age is judged differently.
- **The distinction it turns on:** a cached "no spike" or "unattributed" is a
  *real computed answer* and reads as `fresh`. Only the absence of an entry is
  `missing`, and every read says so (`missing_is_not_no_catalyst`) and falls back
  to a live computation.
- **A failed refresh cannot look like a successful one.** The last good entry is
  never overwritten — the error is stamped on it while `computed_at` stays put,
  so it ages into `stale` honestly. A never-computed symbol stays `missing`
  rather than getting a synthetic empty entry that would read as "computed,
  nothing found". Partial runs report `partial` and exit 1.
- `get_spike_attribution` is cache-first (`use_cache`), and every result carries
  its cache state whether served from cache or recomputed live.
- `scripts/precompute_spike_attribution.py` is an **operator-invoked** entry
  point. `--mode` only stamps the freshness yardstick — no cron/TaskIQ/Prefect
  registration (ROB-1303 AC3 forbids a new cron; the pre-open run joins the
  ROB-1297 digest cron later, operator-side).
- Storage is JSON files: `analysis_artifacts.kind` is CHECK+Literal-sealed with
  no fitting kind, so that route needs a migration — and an unapplied migration
  could not have been exercised on real data.

Both modes were run against real 2026-08-20 KR data (pre-open 22/22, intraday
2/2), and all five consumption paths exercised end to end.

### A finding worth flagging

Pre-compute flagged 17 of the top-20 turnover names as spikes. That is not a
false positive: 삼성전자 moved **+9.49%** that session and the market averaged
**+1.11% with 9.1% of all 3,926 symbols up ≥5%**. On a broad rally day,
per-symbol news attribution risks pinning idiosyncratic causes onto a
market-wide move — which is exactly what the issue's "섹터 동반 여부 (개별 vs
섹터 이벤트 구분)" guards against, and what v1 cannot yet do (KR `sector_id`
coverage is 19.2%).

### Pre-registration amendment

Follow-through windows were amended `[3, 10]` to **`[3, 5, 10]`** to cover the
issue body's D+5. Done while **zero events had been scored** — the only
condition under which a pre-registration may change. The condition is recorded
in `spec.follow_through.windows_amendment` and asserted by a test, so it travels
with the spec rather than living in a commit message.

## Verification


`make lint` clean · **181 targeted tests** · `tests/mcp_server` 876 passed · MCP
tool exercised read-only against prod (`writes=0`, all guards fail closed) ·
single alembic head `20260820_rob1290_reconcile`, **0 migrations** added by this
branch · **full suite 21,760 passed / 0 failed**, verified against an
`origin/main` baseline run in a separate worktree.

Runbook: `docs/runbooks/spike-attribution.md` (§4 lists every limitation
knowingly accepted, including that ex-rights adjustments are indistinguishable
from crashes because no corporate-action calendar exists here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
