### PR TITLE
feat(D2): implement the named d2_remediation_single writer

### DIFF
--- a/app/services/brokers/binance/demo/ledger/service.py
+++ b/app/services/brokers/binance/demo/ledger/service.py
@@ -345,6 +345,86 @@ class BinanceDemoLedgerService:
                     now=now,
                 )
 
+    # ------------------------------------------------------------------
+    # Durable claim surface (ROB-298 / D2) — independently committed.
+    #
+    # ``record_planned`` writes into the *caller's* transaction and only
+    # flushes, so a caller that sends to a broker and then dies before its own
+    # commit leaves no row at all. For a writer whose whole safety argument is
+    # "a restart must see the prior attempt", that ordering is backwards: the
+    # claim has to be committed *before* the send, in a transaction the caller
+    # cannot roll back.
+    #
+    # These two methods use the same independent-session machinery
+    # ``reserve_root_planned`` already relies on. They are additive; every
+    # existing method keeps its current transaction semantics.
+    #
+    # Deliberately not named ``record_*``. That prefix is a signed contract
+    # (ROB-1271 C3-4): the ``record_*`` set *is* the writer/state map, one
+    # method per typed lifecycle state, and a second method writing ``planned``
+    # would make the map ambiguous at exactly the place a reader is told to
+    # read it off. This is a durable claim, not a state transition.
+    # ------------------------------------------------------------------
+
+    async def commit_planned_claim(
+        self,
+        *,
+        instrument_id: int,
+        product: str,
+        venue_host: str,
+        client_order_id: str,
+        side: str,
+        order_type: str,
+        qty: Decimal,
+        price: Decimal | None,
+        notional_usdt: Decimal | None = None,
+        extra_metadata: dict[str, Any] | None = None,
+        now: dt.datetime,
+    ) -> str:
+        """Insert a ``planned`` row and **commit it** in its own transaction.
+
+        Returns the committed row's ``client_order_id`` rather than the ORM
+        object: the object belongs to a session that closes here, and handing it
+        back would invite a caller to read it after detachment.
+        """
+        if product not in _ALLOWED_PRODUCTS:
+            raise BinanceDemoInvalidProduct(
+                f"product={product!r} not in {sorted(_ALLOWED_PRODUCTS)}"
+            )
+        self._reject_premature_fill_metadata(extra_metadata)
+        factory = self._get_reservation_session_factory()
+        async with factory() as claim_session:
+            async with claim_session.begin():
+                row = await BinanceDemoLedgerRepository(claim_session).insert_planned(
+                    instrument_id=instrument_id,
+                    product=product,
+                    venue_host=venue_host,
+                    client_order_id=client_order_id,
+                    side=side,
+                    order_type=order_type,
+                    qty=qty,
+                    price=price,
+                    notional_usdt=notional_usdt,
+                    extra_metadata=extra_metadata,
+                    now=now,
+                )
+                return str(row.client_order_id)
+
+    async def committed_lifecycle_state(self, client_order_id: str) -> str | None:
+        """Read one row's state through an **independent** transaction.
+
+        Reading through the owner session would see the owner's own uncommitted
+        work, which is exactly what a durability check must not do. Going out to
+        a separate transaction means a returned state is one that survived a
+        commit and is visible to any other process.
+        """
+        factory = self._get_reservation_session_factory()
+        async with factory() as read_session:
+            row = await BinanceDemoLedgerRepository(
+                read_session
+            ).get_by_client_order_id(client_order_id)
+            return None if row is None else str(row.lifecycle_state)
+
     async def _transition(
         self,
         *,

--- a/app/services/brokers/binance/spot_demo/d2_remediation_single.py
+++ b/app/services/brokers/binance/spot_demo/d2_remediation_single.py
@@ -24,15 +24,18 @@ script would have created an *unreviewed* execution surface.  A reviewed,
 narrower one is the correct answer, so this module exists and both CLIs name
 each other.
 
-**This module creates no execution authority.**  That is a structural claim,
-not a promise: :data:`D2_KNOWN_SEALED_PAYLOADS` is the complete set of sealed
-payload digests this writer will even parse, every entry in it today carries
-``dispatch_authorized=False``, and an unknown digest is refused outright.  With
-both env gates armed and a live lease in hand, ``--confirm`` still cannot
-dispatch, because no digest in this repository permits it.  Granting dispatch
-requires a reviewed change that adds the re-signed payload's digest — the
-operator's re-sign is what produces those bytes, and their hash is what this
-file would have to be taught.
+**No sealed payload in this repository authorizes a dispatch.**
+:data:`D2_KNOWN_SEALED_PAYLOADS` is the complete set of digests
+:func:`load_sealed_authority` will parse; every entry carries
+``dispatch_authorized=False``, and :func:`_assert_closed_order_set` refuses to
+import if one does not.  So a caller entering through these functions — both env
+gates armed, live lease in hand — reaches ``--confirm`` and is refused, because
+there is nothing here to act under.  Granting dispatch takes the operator's
+re-sign (which produces different bytes, hence a different digest) plus a
+reviewed change that registers it.
+
+That is a statement about this module's entry points, not about the process.
+See the threat model below.
 
 Every ROB-298 safety boundary is inherited unchanged and none is widened:
 
@@ -56,10 +59,13 @@ What this module adds on top of those inherited gates:
    ``mutation_authorized=true``, and the sealed credential fingerprint must
    match the signed J2A registry.  Each failure is reported by name; none is
    waived.
-2. **A J3A lease as an unforgeable capability.**  The writer requires a real
+2. **A typed J3A lease, re-proved per submit.**  The writer requires a real
    :class:`PostgresAdvisoryKeysetLease` — a duck-typed stand-in is rejected by
    ``isinstance`` before anything else runs — and re-proves ownership
-   immediately before each submit rather than trusting acquisition time.
+   immediately before each submit rather than trusting acquisition time.  The
+   ``isinstance`` check catches a wrong object, not a determined one: an
+   in-process caller can construct the real class over a fabricated lock
+   authority.  See the threat model below.
 3. **A durable, deterministic replay fence.**  The ``client_order_id`` is
    derived from the seal and the order, not from a UUID, so the same bound
    order has the same id in every process.  Before any submit the ledger is
@@ -76,6 +82,17 @@ What this module adds on top of those inherited gates:
    **timeInForce** are compared by closed equality against the seal; a response
    that cannot prove the sealed price is a failure, not a success.
 7. **Two fresh proof epochs**, collected while the lease is still held.
+
+**Threat model (operator-confirmed).**  These gates cover accidental misuse: a
+wrong parameter, a doctored or unregistered payload file, an account that has
+drifted from the seal, a malformed or foreign broker response, and a re-send
+after a crash.  They do **not** cover deliberate forgery by code running in this
+same process.  A caller already executing here can read the module-private
+authority token, construct a real :class:`PostgresAdvisoryKeysetLease` over a
+fabricated lock authority, subclass the ledger service, or rebind any constant
+in this module — and, more simply, can call
+:class:`BinanceSpotDemoExecutionClient` directly and never enter this file at
+all.  No writer-level check closes that, and none here claims to.
 
 Deliberate absences: no scheduler registration, no retry queue, no MARKET
 path, no cancel path, no quantity/price arithmetic (the sealed floor values are
@@ -191,7 +208,8 @@ _CLIENT_ORDER_ID_DOMAIN: Final[bytes] = b"auto-trader:d2-remediation-single:v1\x
 #: therefore never picked up as orders.
 _SEALED_ACTIONABLE_DISPOSITION: Final[str] = "REVIEWED_SCOPE_LIMIT_CANDIDATE"
 
-#: Only :func:`load_sealed_authority` may mint a :class:`SealedAuthority`.
+#: Module-private token gating :class:`SealedAuthority` construction. Private
+#: by convention, which is all Python offers — see the threat model at the top.
 _AUTHORITY_TOKEN: Final[object] = object()
 
 
@@ -639,6 +657,43 @@ def _sealed_order(symbol: str, entry: Mapping[str, Any]) -> D2BoundOrder | None:
     )
 
 
+#: Spellings that a JSON serialiser, a client library, or an ``str()`` call
+#: produces when the underlying value was absent. None of them is an
+#: identifier, and treating any of them as one is how a malformed broker
+#: response becomes "evidence".
+_PSEUDO_NULL_TOKENS: Final[frozenset[str]] = frozenset(
+    {"", "none", "null", "nil", "nan", "undefined", "<none>", "n/a", "-"}
+)
+
+
+def broker_identifier_problem(value: Any, *, field: str) -> str | None:
+    """Return why ``value`` cannot serve as a broker identifier, or ``None``.
+
+    Reads the **raw** response value, never a stringified DTO field. That
+    distinction is the whole point: ``str(None)`` is ``'None'``, which is
+    non-empty, non-blank, and passes every naive presence check — so a null
+    ``orderId`` laundered through ``str()`` used to look like proof that an
+    order exists.
+
+    Booleans are rejected before the integer branch because ``bool`` is a
+    subclass of ``int`` and ``True`` would otherwise read as id ``1``.
+    """
+
+    if value is None:
+        return f"{field} is null"
+    if isinstance(value, bool):
+        return f"{field} is a boolean ({value!r}), not an identifier"
+    if isinstance(value, int):
+        # Binance order ids are positive int64 values; 0 and negatives are
+        # sentinels, not orders.
+        return None if value > 0 else f"{field} is {value!r}, not a positive id"
+    if not isinstance(value, str):
+        return f"{field} has non-identifier type {type(value).__name__}"
+    if value.strip().lower() in _PSEUDO_NULL_TOKENS:
+        return f"{field} is {value!r}, which is a spelling of absent"
+    return None
+
+
 def _describe(orders: Sequence[D2BoundOrder]) -> str:
     return (
         "["
@@ -761,11 +816,12 @@ def _parse_expiry(raw: Any) -> dt.datetime | None:
 class SealedAuthority:
     """A sealed payload whose *bytes* were verified, plus what it authorizes.
 
-    Only :func:`load_sealed_authority` can mint one: the constructor demands a
-    module-private token, so an in-process caller cannot hand the writer a
-    hand-built authority object and skip the digest check. The writer accepts
-    nothing else, which is what keeps "orders come from the seal" true against
-    argument injection as well as against a doctored file.
+    The constructor demands a module-private token, so the ordinary ways of
+    producing one — a dict, a look-alike object, a hand-built instance — fail,
+    and :func:`load_sealed_authority` is the only route that ends in a usable
+    authority. That stops a caller from *accidentally* bypassing the digest
+    check; it does not stop one that imports the token deliberately, and it is
+    not offered as doing so.
 
     Binding and *authorization* are kept apart on purpose. A payload can bind
     perfectly — right hash, right three orders, right account — and still
@@ -1171,12 +1227,13 @@ class D2RemediationSingleWriter:
             )
         if not isinstance(lease, PostgresAdvisoryKeysetLease):
             # A duck-typed stand-in with `.released` and `.assert_owned` would
-            # otherwise satisfy every later check while proving nothing about
-            # the account.
+            # otherwise satisfy every later check. This rejects the wrong
+            # *type*; it is not a provenance check, and the class can still be
+            # constructed over a fabricated lock authority in-process.
             raise D2LeaseNotHeld(
                 D2ReasonCode.LEASE_NOT_A_CAPABILITY,
                 "lease must be a real PostgresAdvisoryKeysetLease; a duck-typed "
-                f"{type(lease).__name__} cannot prove account coordination",
+                f"{type(lease).__name__} is not one",
             )
         if not isinstance(ledger, BinanceDemoLedgerService):
             raise D2LedgerRequired(
@@ -1628,12 +1685,16 @@ class D2RemediationSingleWriter:
     def _echo_from_status(
         self, op: D2PlannedOperation, status_body: Mapping[str, Any]
     ) -> SpotDemoOrderSubmitResult:
-        # No default for clientOrderId. Substituting the id we asked about would
-        # manufacture the very evidence the echo check is supposed to demand.
+        # No default for clientOrderId, and no ``str()`` around a possibly-null
+        # orderId. Substituting the id we asked about, or turning ``None`` into
+        # the four-character string ``'None'``, manufactures the very evidence
+        # the echo check exists to demand. Absent stays absent here; the check
+        # below is what decides.
         raw_cid = status_body.get("clientOrderId")
+        raw_oid = status_body.get("orderId")
         return SpotDemoOrderSubmitResult(
             client_order_id="" if raw_cid is None else str(raw_cid),
-            broker_order_id=str(status_body.get("orderId", "")),
+            broker_order_id="" if raw_oid is None else str(raw_oid),
             symbol=str(status_body.get("symbol", "")),
             side=str(status_body.get("side", "")),
             order_type=str(status_body.get("type", "")),
@@ -1666,6 +1727,13 @@ class D2RemediationSingleWriter:
         ``clientOrderId`` must equal the deterministic id we sent, and a broker
         order id must be present. Without both, this response might describe
         someone else's order and we would be booking it as ours.
+
+        Both identifiers are read from the **raw** body through
+        :func:`broker_identifier_problem`, not from the stringified DTO fields.
+        A null ``orderId`` that has been through ``str()`` arrives as the
+        four-character string ``'None'`` and passes any "is it non-empty"
+        test; the same goes for ``'null'``, ``''``, whitespace, and ``0``.
+        Those are spellings of absent, and absent is a failure.
         """
 
         order = op.order
@@ -1675,18 +1743,23 @@ class D2RemediationSingleWriter:
             mismatches.append(
                 f"clientOrderId {result.client_order_id!r} != {op.client_order_id!r}"
             )
-        echoed_cid = raw.get("clientOrderId")
-        if echoed_cid is None:
+        cid_problem = broker_identifier_problem(
+            raw.get("clientOrderId"), field="clientOrderId"
+        )
+        if cid_problem is not None:
             mismatches.append(
-                "broker response carries no clientOrderId — this response is "
-                "not proven to be about our order"
+                f"{cid_problem} — this response is not proven to be about our order"
             )
-        elif str(echoed_cid) != op.client_order_id:
+        elif str(raw.get("clientOrderId")) != op.client_order_id:
             mismatches.append(
-                f"raw clientOrderId {echoed_cid!r} != {op.client_order_id!r}"
+                f"raw clientOrderId {raw.get('clientOrderId')!r} != "
+                f"{op.client_order_id!r}"
             )
-        if not str(result.broker_order_id or "").strip():
-            mismatches.append("broker response carries no orderId")
+        oid_problem = broker_identifier_problem(raw.get("orderId"), field="orderId")
+        if oid_problem is not None:
+            mismatches.append(
+                f"{oid_problem} — a fill has no evidence without a broker order id"
+            )
         if result.symbol != order.symbol:
             mismatches.append(f"symbol {result.symbol!r} != {order.symbol!r}")
         if result.side != order.side:
@@ -1909,6 +1982,7 @@ __all__ = [
     "assert_registry_credential_fingerprint",
     "assert_writer_freeze",
     "bind_sealed_orders",
+    "broker_identifier_problem",
     "d2_advisory_keyset",
     "d2_physical_account_id",
     "d2_physical_account_scope",

--- a/app/services/brokers/binance/spot_demo/d2_remediation_single.py
+++ b/app/services/brokers/binance/spot_demo/d2_remediation_single.py
@@ -211,6 +211,7 @@ class D2ReasonCode(StrEnum):
     LEASE_NOT_A_CAPABILITY = "d2_lease_not_a_capability"
     LEASE_SCOPE_MISMATCH = "d2_lease_scope_mismatch"
     LEDGER_REQUIRED = "d2_ledger_required"
+    CLAIM_NOT_DURABLE = "d2_claim_not_durable"
     WRITER_FREEZE_VIOLATED = "d2_writer_freeze_violated"
     ACCOUNT_TRUTH_DRIFT = "d2_account_truth_drift"
     PRIOR_ATTEMPT_UNRESOLVED = "d2_prior_attempt_unresolved"
@@ -251,6 +252,10 @@ class D2LeaseNotHeld(D2RemediationError):
 
 class D2LedgerRequired(D2RemediationError):
     """No durable ledger; the dispatch path is unreachable without one."""
+
+
+class D2ClaimNotDurable(D2RemediationError):
+    """The pre-send claim did not survive its own commit, so nothing may send."""
 
 
 class D2AccountTruthDrift(D2RemediationError):
@@ -1479,13 +1484,12 @@ class D2RemediationSingleWriter:
 
     async def _dispatch_one(self, op: D2PlannedOperation) -> D2DispatchOutcome:
         order = op.order
-        # The durable fence, checked before anything else: has this exact bound
-        # order been attempted, in this process or any earlier one?
-        prior = await self._ledger.get_by_client_order_id(op.client_order_id)
+        # The durable fence, read through an independent transaction so it sees
+        # what *other processes* committed rather than this session's own
+        # uncommitted work: has this exact bound order been attempted before?
+        prior = await self._ledger.committed_lifecycle_state(op.client_order_id)
         if prior is not None:
-            return await self._resolve_prior_attempt(
-                op, prior_state=prior.lifecycle_state
-            )
+            return await self._resolve_prior_attempt(op, prior_state=prior)
 
         instrument_id = await self._ledger.resolve_or_create_instrument(
             venue=D2_VENUE,
@@ -1494,7 +1498,13 @@ class D2RemediationSingleWriter:
             base_asset=order.asset,
             quote_asset=D2_QUOTE_ASSET,
         )
-        await self._ledger.record_planned(
+        # Record, then execute — never the other way round. The claim is
+        # committed in its own transaction *before* any broker call, so a
+        # process that dies between the POST and its own commit still leaves the
+        # row a restart needs. Writing into the caller's transaction and
+        # committing afterwards, as this did before, meant exactly that crash
+        # window erased the fence and the restart re-sent.
+        await self._ledger.commit_planned_claim(
             instrument_id=instrument_id,
             product=D2_PRODUCT,
             venue_host=D2_VENUE_HOST,
@@ -1506,6 +1516,19 @@ class D2RemediationSingleWriter:
             extra_metadata=self._evidence_metadata(op),
             now=self._now_fn(),
         )
+        # Prove the claim is durable by reading it back out of a *different*
+        # transaction. A ledger whose writes go nowhere fails here, before the
+        # broker is touched: requiring the type was never the same as requiring
+        # the effect.
+        observed = await self._ledger.committed_lifecycle_state(op.client_order_id)
+        if observed != "planned":
+            raise D2ClaimNotDurable(
+                D2ReasonCode.CLAIM_NOT_DURABLE,
+                f"{op.operation_id}: the pre-send claim for "
+                f"{op.client_order_id!r} is not visible outside its own "
+                f"transaction (read back {observed!r}). Refusing to send an "
+                "order no restart could recognise.",
+            )
         await self._ledger.record_previewed(
             client_order_id=op.client_order_id, now=self._now_fn()
         )
@@ -1605,8 +1628,11 @@ class D2RemediationSingleWriter:
     def _echo_from_status(
         self, op: D2PlannedOperation, status_body: Mapping[str, Any]
     ) -> SpotDemoOrderSubmitResult:
+        # No default for clientOrderId. Substituting the id we asked about would
+        # manufacture the very evidence the echo check is supposed to demand.
+        raw_cid = status_body.get("clientOrderId")
         return SpotDemoOrderSubmitResult(
-            client_order_id=str(status_body.get("clientOrderId", op.client_order_id)),
+            client_order_id="" if raw_cid is None else str(raw_cid),
             broker_order_id=str(status_body.get("orderId", "")),
             symbol=str(status_body.get("symbol", "")),
             side=str(status_body.get("side", "")),
@@ -1633,11 +1659,34 @@ class D2RemediationSingleWriter:
         DTO fields, so they are read from there. Their *absence* is a failure,
         not a pass: a response that cannot prove the sealed price has not
         proved it.
+
+        The same applies to *which order* the response is about. Matching
+        contents are not identity — the shared Demo account can carry another
+        order with the same symbol, side, quantity, and price — so the echoed
+        ``clientOrderId`` must equal the deterministic id we sent, and a broker
+        order id must be present. Without both, this response might describe
+        someone else's order and we would be booking it as ours.
         """
 
         order = op.order
         raw = result.raw_response_redacted or {}
         mismatches: list[str] = []
+        if result.client_order_id != op.client_order_id:
+            mismatches.append(
+                f"clientOrderId {result.client_order_id!r} != {op.client_order_id!r}"
+            )
+        echoed_cid = raw.get("clientOrderId")
+        if echoed_cid is None:
+            mismatches.append(
+                "broker response carries no clientOrderId — this response is "
+                "not proven to be about our order"
+            )
+        elif str(echoed_cid) != op.client_order_id:
+            mismatches.append(
+                f"raw clientOrderId {echoed_cid!r} != {op.client_order_id!r}"
+            )
+        if not str(result.broker_order_id or "").strip():
+            mismatches.append("broker response carries no orderId")
         if result.symbol != order.symbol:
             mismatches.append(f"symbol {result.symbol!r} != {order.symbol!r}")
         if result.side != order.side:
@@ -1836,6 +1885,7 @@ __all__ = [
     "D2AccountTruthDrift",
     "D2BlindRetryRefused",
     "D2BoundOrder",
+    "D2ClaimNotDurable",
     "D2DispatchNotAuthorized",
     "D2DispatchOutcome",
     "D2DryRunReport",

--- a/app/services/brokers/binance/spot_demo/d2_remediation_single.py
+++ b/app/services/brokers/binance/spot_demo/d2_remediation_single.py
@@ -1,0 +1,1238 @@
+"""D2 one-shot remediation writer — ``d2_remediation_single``.
+
+``operator_contract.yaml`` names this writer by hand::
+
+    binance_demo_remediation_20260820:
+      surfaces:      [binance_spot_demo_remediation_only]
+      writer:        d2_remediation_single
+      allowed_operations:
+        - BTCUSDT_sell_limit_bound_to_sealed_snapshot
+        - ETHUSDT_sell_limit_bound_to_sealed_snapshot
+        - USDCUSDT_sell_limit_conversion
+
+Naming a writer does not create one, and until this module existed there was
+nothing to run: the D2 execution attempt of 2026-08-20 stopped at
+``D2_DUAL_ATTESTATION=FAIL`` because a static search for the named writer
+returned no match.  This module is that named writer and nothing else.
+
+**It is a second approved entry point, not a bypass.**
+``scripts/binance_spot_demo_smoke.py`` is the ROB-298 BUY-round-trip smoke
+path and stays exactly what it is; it does not wire a SELL ``--confirm`` and
+therefore cannot express the three authorized operations.  Reaching around it
+by calling :meth:`BinanceSpotDemoExecutionClient.submit_order` from an ad-hoc
+script would have created an *unreviewed* execution surface.  A reviewed,
+narrower one is the correct answer, so this module exists and both CLIs name
+each other.
+
+Every ROB-298 safety boundary is inherited unchanged and none is widened:
+
+* the transport still pins ``demo-api.binance.com`` (this module re-asserts
+  the host through :func:`assert_spot_demo_host` before it composes anything);
+* ``submit_order(..., confirm=True)`` remains the only route to a signed POST,
+  and this module's own default is likewise ``confirm=False``;
+* ``BINANCE_SPOT_DEMO_ENABLED`` still gates client construction, and this
+  module adds a *second*, independent, default-off gate
+  (:data:`D2_REMEDIATION_ENABLED_ENV`) on top of it.
+
+What this module adds on top of those inherited gates:
+
+1. **A closed order set.**  :data:`D2_BOUND_ORDERS` is exactly three
+   ``SELL``/``LIMIT`` tuples read out of the sealed r7 attempt-2 payload.  The
+   writer never accepts an order from a caller: it accepts the *sealed
+   payload*, re-derives the set, and refuses unless the derived set is ``==``
+   the frozen constant.  A different symbol, side, order type, quantity, price,
+   a fourth order, or a different ``pre_snapshot_hash`` all fail closed here,
+   before any lease, DB, or socket work.
+2. **A J3A lease precondition.**  No broker call is reachable without a live,
+   re-attested :class:`PostgresAdvisoryKeysetLease` over the Binance Demo
+   physical-account advisory key.  Ownership is re-proved immediately before
+   each submit, never assumed from acquisition time.
+3. **No blind retry.**  One dispatch per ``client_order_id``, enforced by a
+   claim set rather than by the absence of a retry loop.  An ambiguous submit
+   is resolved by *readback* (``GET /api/v3/order``), and an unresolved outcome
+   stops the whole run instead of re-sending.
+4. **Ledger evidence through the service.**  Every lifecycle write goes through
+   :class:`BinanceDemoLedgerService`; the repository is never touched.
+5. **Two fresh proof epochs.**  Post-dispatch state is proved twice from
+   independent bounded observations, collected while the lease is still held.
+
+Deliberate absences: no scheduler registration, no retry queue, no MARKET
+path, no cancel path, no quantity/price arithmetic (the sealed floor values are
+used verbatim), and no way to widen the order set at runtime.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal, DecimalException
+from enum import StrEnum
+from typing import Any, Final, Protocol
+from urllib.parse import urlsplit
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from app.services.brokers.binance.demo.errors import BinanceDemoOrderNotFound
+from app.services.brokers.binance.demo.ledger.service import BinanceDemoLedgerService
+from app.services.brokers.binance.spot_demo.dto import (
+    SpotDemoOrderSubmitResult,
+    SpotDemoOrderTestResult,
+)
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+    SpotDemoDryRunResult,
+)
+from app.services.brokers.binance.spot_demo.host_allowlist import (
+    assert_spot_demo_host,
+)
+from app.services.mock_integration.coordination import (
+    AdvisoryLeaseGrant,
+    LockAuthorityConnection,
+    PhysicalAccountScope,
+    PostgresAdvisoryKeysetLease,
+    SqlAlchemyLockAuthority,
+    acquire_physical_account_lease,
+    physical_account_scope_for_entry,
+)
+from app.services.mock_lane_registry import get_lane_registry_entry
+
+# --------------------------------------------------------------------------
+# Identity — the sealed object this writer is bound to
+# --------------------------------------------------------------------------
+
+#: ``operator_contract.yaml`` names this exact string.  Changing it silently
+#: detaches the code from the authority that permits it to run.
+WRITER_NAME: Final[str] = "d2_remediation_single"
+
+#: ``operator_contract.yaml: strategy_order_exceptions``.
+D2_EXCEPTION_ID: Final[str] = "binance-demo-remediation-20260820"
+
+#: ``binding-payload-proposed.json: remediation_id``.
+D2_REMEDIATION_ID: Final[str] = "d2-binance-demo-both-remediation-v2.1-20260818"
+
+#: r7 attempt-2 — the only snapshot this writer will act under.  A payload
+#: carrying any other hash is refused; there is no override argument.
+D2_PRE_SNAPSHOT_HASH: Final[str] = (
+    "sha256:5ba70a814654513c745e45c49206f11cf5f5d061478c668f86602af493e6b898"
+)
+
+#: ``r7-snapshot/attempt-2-authoritative.json`` selects attempt-2 and binds
+#: these two digests to it.  Carried for evidence; the hash above is the gate.
+D2_SNAPSHOT_SEAL_SHA256: Final[str] = (
+    "d4c9a13a148f6c6c0d4451264da275826084f0b27c7a69a7698fb8c2b7952ed9"
+)
+D2_BINDING_PAYLOAD_SHA256: Final[str] = (
+    "e1c2d250d73ae3bdb631289a7293c35c217b9e5c6e2694d3f8ea572d1835a3aa"
+)
+
+#: The J2A lane whose ``physical_account_id`` names the shared Binance Demo
+#: account.  Spot, sidecar, and futures all derive the same advisory key, which
+#: is exactly why one lease is enough for the whole account.
+D2_LANE_ID: Final[str] = "crypto.binance.spot_demo.canonical"
+
+D2_PRODUCT: Final[str] = "spot"
+D2_PRODUCT_DOMAIN: Final[str] = "both"
+D2_VENUE: Final[str] = "binance"
+D2_VENUE_HOST: Final[str] = "demo-api.binance.com"
+D2_QUOTE_ASSET: Final[str] = "USDT"
+
+#: Second, independent env gate.  ``BINANCE_SPOT_DEMO_ENABLED`` still has to be
+#: true for the client to construct at all; this one is additional and also
+#: defaults to off.  Neither is relaxed by the other.
+D2_REMEDIATION_ENABLED_ENV: Final[str] = "D2_REMEDIATION_SINGLE_ENABLED"
+
+#: D6 leaves no order-type or time-in-force choice: LIMIT/GTC, explicit
+#: quantity, exposure-reducing only.
+D2_ORDER_TYPE: Final[str] = "LIMIT"
+D2_SIDE: Final[str] = "SELL"
+D2_TIME_IN_FORCE: Final[str] = "GTC"
+
+#: Binance client-order-id prefix for this one-shot.  Kept short so the
+#: ``<prefix>-<symbol>-<12 hex>`` form stays inside the 36-char constraint the
+#: execution client asserts.
+D2_CLIENT_ORDER_ID_PREFIX: Final[str] = "d2rem"
+
+#: The sealed payload marks the three actionable rows with this disposition.
+#: Dust (SOL/XRP/DOGE) and quote cash (USDT) carry different ones and are
+#: therefore never picked up as orders.
+_SEALED_ACTIONABLE_DISPOSITION: Final[str] = "REVIEWED_SCOPE_LIMIT_CANDIDATE"
+
+
+class D2ReasonCode(StrEnum):
+    """The complete refusal vocabulary; no free-form alternatives."""
+
+    DISABLED = "d2_remediation_disabled"
+    SEAL_HASH_MISMATCH = "d2_seal_hash_mismatch"
+    SEAL_IDENTITY_MISMATCH = "d2_seal_identity_mismatch"
+    SEAL_ORDER_SET_MISMATCH = "d2_seal_order_set_mismatch"
+    SEAL_MALFORMED = "d2_seal_malformed"
+    UNAUTHORIZED_OPERATION = "d2_unauthorized_operation"
+    LEASE_NOT_HELD = "d2_lease_not_held"
+    LEASE_SCOPE_MISMATCH = "d2_lease_scope_mismatch"
+    BLIND_RETRY_REFUSED = "d2_blind_retry_refused"
+    BROKER_ECHO_MISMATCH = "d2_broker_echo_mismatch"
+    OUTCOME_UNKNOWN = "d2_outcome_unknown"
+    HOST_NOT_SPOT_DEMO = "d2_host_not_spot_demo"
+    PROOF_EPOCHS_INCOMPLETE = "d2_proof_epochs_incomplete"
+
+
+class D2RemediationError(RuntimeError):
+    """Base class carrying a machine-readable reason code."""
+
+    def __init__(self, reason_code: D2ReasonCode, detail: str = "") -> None:
+        self.reason_code = reason_code
+        super().__init__(f"{reason_code}: {detail}" if detail else str(reason_code))
+
+
+class D2RemediationDisabled(D2RemediationError):
+    """The dedicated env gate is not armed."""
+
+
+class D2SealBindingMismatch(D2RemediationError):
+    """The supplied sealed payload is not the one this writer is bound to."""
+
+
+class D2UnauthorizedOperation(D2RemediationError):
+    """An operation outside the three authorized ones was requested."""
+
+
+class D2LeaseNotHeld(D2RemediationError):
+    """No live, attested J3A lease over the Binance Demo physical account."""
+
+
+class D2BlindRetryRefused(D2RemediationError):
+    """A second dispatch of one client_order_id was attempted."""
+
+
+class D2OutcomeUnknown(D2RemediationError):
+    """A dispatch outcome could not be established by readback."""
+
+
+# --------------------------------------------------------------------------
+# The closed order set
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class D2BoundOrder:
+    """One of exactly three authorized operations.
+
+    Frozen and slotted so equality is structural: the seal check below is a
+    plain ``==`` against :data:`D2_BOUND_ORDERS`, not a name or substring
+    match.  ``Decimal`` comparison is by value, so ``0.00015`` and
+    ``0.00015000`` are the same order while ``0.00016`` is not.
+    """
+
+    symbol: str
+    asset: str
+    side: str
+    order_type: str
+    quantity: Decimal
+    price: Decimal
+    time_in_force: str
+
+    def request_params(self) -> dict[str, str]:
+        """The exact broker request fields, as strings, for evidence output."""
+
+        return {
+            "symbol": self.symbol,
+            "side": self.side,
+            "type": self.order_type,
+            "quantity": format(self.quantity, "f"),
+            "price": format(self.price, "f"),
+            "timeInForce": self.time_in_force,
+        }
+
+
+#: The three operations, in dispatch order.  Read from r7 attempt-2's
+#: ``binding-payload-proposed.json``:
+#:
+#:   BTCUSDT  SELL LIMIT 0.00015000 @ 69266.01000000
+#:   ETHUSDT  SELL LIMIT 0.00520000 @  2248.56000000
+#:   USDCUSDT SELL LIMIT 5000.00000000 @ 1.00072000
+#:
+#: This tuple is the authority the runtime checks against.  The payload is
+#: re-read at runtime so a doctored file is caught, but the payload can only
+#: ever *match* this constant — it can never extend it.
+D2_BOUND_ORDERS: Final[tuple[D2BoundOrder, ...]] = (
+    D2BoundOrder(
+        symbol="BTCUSDT",
+        asset="BTC",
+        side=D2_SIDE,
+        order_type=D2_ORDER_TYPE,
+        quantity=Decimal("0.00015000"),
+        price=Decimal("69266.01000000"),
+        time_in_force=D2_TIME_IN_FORCE,
+    ),
+    D2BoundOrder(
+        symbol="ETHUSDT",
+        asset="ETH",
+        side=D2_SIDE,
+        order_type=D2_ORDER_TYPE,
+        quantity=Decimal("0.00520000"),
+        price=Decimal("2248.56000000"),
+        time_in_force=D2_TIME_IN_FORCE,
+    ),
+    D2BoundOrder(
+        symbol="USDCUSDT",
+        asset="USDC",
+        side=D2_SIDE,
+        order_type=D2_ORDER_TYPE,
+        quantity=Decimal("5000.00000000"),
+        price=Decimal("1.00072000"),
+        time_in_force=D2_TIME_IN_FORCE,
+    ),
+)
+
+#: ``allowed_operations`` from ``operator_contract.yaml``, in the same order as
+#: :data:`D2_BOUND_ORDERS`.  Kept as a separate constant so the contract's own
+#: wording is checkable against the code rather than only readable next to it.
+D2_ALLOWED_OPERATION_IDS: Final[tuple[str, ...]] = (
+    "BTCUSDT_sell_limit_bound_to_sealed_snapshot",
+    "ETHUSDT_sell_limit_bound_to_sealed_snapshot",
+    "USDCUSDT_sell_limit_conversion",
+)
+
+
+def _assert_closed_order_set() -> None:
+    """Import-time invariants over the constant itself.
+
+    A future edit that adds a fourth row, flips a side, or introduces MARKET
+    fails here rather than at a broker.
+    """
+
+    if len(D2_BOUND_ORDERS) != 3:
+        raise D2UnauthorizedOperation(
+            D2ReasonCode.UNAUTHORIZED_OPERATION,
+            f"the D2 exception authorizes exactly 3 operations, "
+            f"got {len(D2_BOUND_ORDERS)}",
+        )
+    if len(D2_ALLOWED_OPERATION_IDS) != len(D2_BOUND_ORDERS):
+        raise D2UnauthorizedOperation(
+            D2ReasonCode.UNAUTHORIZED_OPERATION,
+            "allowed_operations and bound orders disagree in length",
+        )
+    symbols = tuple(order.symbol for order in D2_BOUND_ORDERS)
+    if len(set(symbols)) != len(symbols):
+        raise D2UnauthorizedOperation(
+            D2ReasonCode.UNAUTHORIZED_OPERATION, "duplicate symbol in bound order set"
+        )
+    for order, operation_id in zip(
+        D2_BOUND_ORDERS, D2_ALLOWED_OPERATION_IDS, strict=True
+    ):
+        if order.side != D2_SIDE or order.order_type != D2_ORDER_TYPE:
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                f"{order.symbol}: only {D2_SIDE}/{D2_ORDER_TYPE} is authorized",
+            )
+        if order.quantity <= 0 or order.price <= 0:
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                f"{order.symbol}: non-positive quantity or price",
+            )
+        if not operation_id.startswith(f"{order.symbol}_"):
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                f"allowed_operation {operation_id!r} does not name {order.symbol}",
+            )
+
+
+_assert_closed_order_set()
+
+
+# --------------------------------------------------------------------------
+# Seal binding
+# --------------------------------------------------------------------------
+
+
+def _decimal(value: Any, *, what: str) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (DecimalException, TypeError, ValueError) as exc:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, f"{what}: not a decimal ({value!r})"
+        ) from exc
+
+
+def _sealed_order(symbol: str, entry: Any) -> D2BoundOrder | None:
+    """Map one sealed ``authorized_symbols.spot`` row onto a bound order.
+
+    Returns ``None`` for rows that are not actionable (dust attestations and
+    the USDT quote-cash row), so those can never become orders by accident.
+    Anything actionable but malformed raises rather than being skipped — a
+    silently dropped row would shrink the set without saying so.
+    """
+
+    if not isinstance(entry, Mapping):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, f"{symbol}: row is not a mapping"
+        )
+    if entry.get("disposition") != _SEALED_ACTIONABLE_DISPOSITION:
+        return None
+    step = entry.get("proposed_one_step")
+    if not isinstance(step, Mapping):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, f"{symbol}: proposed_one_step missing"
+        )
+    time_in_force = step.get("time_in_force")
+    if time_in_force is not None and time_in_force != D2_TIME_IN_FORCE:
+        # The sealed payload leaves TIF null (it sealed a price/quantity, not a
+        # wire format).  Null is accepted and D6's GTC is supplied here; any
+        # *other* explicit value is a disagreement, not a default.
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_ORDER_SET_MISMATCH,
+            f"{symbol}: sealed time_in_force {time_in_force!r} is not "
+            f"{D2_TIME_IN_FORCE!r}",
+        )
+    return D2BoundOrder(
+        symbol=str(symbol),
+        asset=str(entry.get("asset", "")),
+        side=str(step.get("side", "")),
+        order_type=str(step.get("order_type", "")),
+        quantity=_decimal(step.get("proposed_quantity_floor"), what=f"{symbol} qty"),
+        price=_decimal(step.get("proposed_limit_price_floor"), what=f"{symbol} price"),
+        time_in_force=D2_TIME_IN_FORCE,
+    )
+
+
+def bind_sealed_orders(payload: Mapping[str, Any]) -> tuple[D2BoundOrder, ...]:
+    """Re-derive the order set from a sealed payload and prove it is *the* one.
+
+    The return value is :data:`D2_BOUND_ORDERS` itself, never the parsed
+    tuple.  That is deliberate: a parsing bug can then only ever cause a
+    refusal, never a widened order set.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, "sealed payload is not a mapping"
+        )
+    if payload.get("pre_snapshot_hash") != D2_PRE_SNAPSHOT_HASH:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_HASH_MISMATCH,
+            f"expected pre_snapshot_hash={D2_PRE_SNAPSHOT_HASH!r}, "
+            f"got {payload.get('pre_snapshot_hash')!r}",
+        )
+    if payload.get("remediation_id") != D2_REMEDIATION_ID:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_IDENTITY_MISMATCH,
+            f"expected remediation_id={D2_REMEDIATION_ID!r}, "
+            f"got {payload.get('remediation_id')!r}",
+        )
+    if payload.get("product_domain") != D2_PRODUCT_DOMAIN:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_IDENTITY_MISMATCH,
+            f"expected product_domain={D2_PRODUCT_DOMAIN!r}, "
+            f"got {payload.get('product_domain')!r}",
+        )
+
+    authorized = payload.get("authorized_symbols")
+    if not isinstance(authorized, Mapping):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, "authorized_symbols missing"
+        )
+    spot = authorized.get("spot")
+    if not isinstance(spot, Mapping):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, "authorized_symbols.spot missing"
+        )
+
+    derived: list[D2BoundOrder] = []
+    for symbol, entry in spot.items():
+        if not isinstance(symbol, str) or not isinstance(entry, Mapping):
+            continue
+        order = _sealed_order(symbol, entry)
+        if order is not None:
+            derived.append(order)
+
+    expected_by_symbol = {order.symbol: order for order in D2_BOUND_ORDERS}
+    derived_by_symbol = {order.symbol: order for order in derived}
+    if derived_by_symbol != expected_by_symbol:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_ORDER_SET_MISMATCH,
+            "sealed actionable set is not the bound set: "
+            f"expected {_describe(D2_BOUND_ORDERS)}, got {_describe(tuple(derived))}",
+        )
+    return D2_BOUND_ORDERS
+
+
+def _describe(orders: Sequence[D2BoundOrder]) -> str:
+    return (
+        "["
+        + ", ".join(
+            f"{o.symbol} {o.side} {o.order_type} {format(o.quantity, 'f')}"
+            f"@{format(o.price, 'f')}"
+            for o in sorted(orders, key=lambda o: o.symbol)
+        )
+        + "]"
+    )
+
+
+# --------------------------------------------------------------------------
+# Lease
+# --------------------------------------------------------------------------
+
+
+def d2_physical_account_scope() -> PhysicalAccountScope:
+    """The coordination scope of the shared Binance Demo physical account.
+
+    Derived from the signed J2A registry entry — there is no caller-supplied
+    scope string anywhere on this path.
+    """
+
+    return physical_account_scope_for_entry(get_lane_registry_entry(D2_LANE_ID))
+
+
+def d2_advisory_keyset() -> tuple[int, ...]:
+    """The single advisory key one D2 lease must hold."""
+
+    return (d2_physical_account_scope().advisory_key,)
+
+
+async def acquire_d2_lease(*, engine: AsyncEngine) -> PostgresAdvisoryKeysetLease:
+    """Take the account-wide J3A lease this writer refuses to run without.
+
+    One key, because spot, sidecar, and futures all derive the same
+    physical-account scope: the Binance Demo credentials name one account, so
+    one lease covers the whole of it.
+
+    The usual J3A caveat applies and is not softened here — the lease
+    coordinates processes *inside this repository*. Binance never sees it, so
+    an operator at a console or an out-of-repo process reaches the same account
+    without contending for it. It is why the writer also re-attests before each
+    submit and reads the account-wide open-order book in both proof epochs.
+    """
+
+    async def _factory() -> LockAuthorityConnection:
+        connection = await engine.connect()
+        return SqlAlchemyLockAuthority(
+            connection, observer_factory=lambda: engine.connect()
+        )
+
+    return await acquire_physical_account_lease(
+        keys=d2_advisory_keyset(), connection_factory=_factory
+    )
+
+
+# --------------------------------------------------------------------------
+# Results
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class D2PlannedOperation:
+    """One composed request, before anything is dispatched."""
+
+    operation_id: str
+    client_order_id: str
+    order: D2BoundOrder
+    request_params: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class D2DryRunReport:
+    """Full-path rehearsal that stops immediately before the signed POST."""
+
+    remediation_id: str
+    pre_snapshot_hash: str
+    writer: str
+    venue_host: str
+    lease_attested: bool
+    operations: tuple[D2PlannedOperation, ...]
+    order_test_results: tuple[SpotDemoOrderTestResult, ...] = ()
+    broker_mutation_count: int = 0
+
+    def as_evidence(self) -> dict[str, Any]:
+        return {
+            "schema_version": "d2-remediation-single-dry-run.v1",
+            "writer": self.writer,
+            "remediation_id": self.remediation_id,
+            "pre_snapshot_hash": self.pre_snapshot_hash,
+            "venue_host": self.venue_host,
+            "lease_attested": self.lease_attested,
+            "broker_mutation_count": self.broker_mutation_count,
+            "order_test_count": len(self.order_test_results),
+            "operations": [
+                {
+                    "operation_id": op.operation_id,
+                    "client_order_id": op.client_order_id,
+                    "request_params": op.request_params,
+                }
+                for op in self.operations
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class D2ProofEpoch:
+    """One bounded post-dispatch observation.
+
+    Two of these, collected independently while the lease is still held,
+    are the contract's "dual independent proof".
+    """
+
+    epoch_index: int
+    observed_at_utc: str
+    open_orders: tuple[dict[str, str], ...]
+    balances: tuple[dict[str, str], ...]
+    ledger_states: dict[str, str]
+
+    def as_evidence(self) -> dict[str, Any]:
+        return {
+            "schema_version": "d2-remediation-single-proof-epoch.v1",
+            "epoch_index": self.epoch_index,
+            "observed_at_utc": self.observed_at_utc,
+            "account_wide_open_orders": list(self.open_orders),
+            "balances": list(self.balances),
+            "ledger_states": dict(self.ledger_states),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class D2DispatchOutcome:
+    """What happened to one authorized operation."""
+
+    operation_id: str
+    client_order_id: str
+    order: D2BoundOrder
+    request_params: dict[str, str]
+    status: str
+    broker_order_id: str | None = None
+    ledger_state: str = ""
+    readback_used: bool = False
+    anomaly_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class D2ExecutionReport:
+    remediation_id: str
+    pre_snapshot_hash: str
+    writer: str
+    outcomes: tuple[D2DispatchOutcome, ...]
+    proof_epochs: tuple[D2ProofEpoch, ...]
+    broker_submit_count: int
+    halted_reason: str | None = None
+
+    def as_evidence(self) -> dict[str, Any]:
+        return {
+            "schema_version": "d2-remediation-single-execution.v1",
+            "writer": self.writer,
+            "remediation_id": self.remediation_id,
+            "pre_snapshot_hash": self.pre_snapshot_hash,
+            "broker_submit_count": self.broker_submit_count,
+            "halted_reason": self.halted_reason,
+            "outcomes": [
+                {
+                    "operation_id": o.operation_id,
+                    "client_order_id": o.client_order_id,
+                    "request_params": o.request_params,
+                    "status": o.status,
+                    "broker_order_id": o.broker_order_id,
+                    "ledger_state": o.ledger_state,
+                    "readback_used": o.readback_used,
+                    "anomaly_reason": o.anomaly_reason,
+                }
+                for o in self.outcomes
+            ],
+            "proof_epochs": [epoch.as_evidence() for epoch in self.proof_epochs],
+        }
+
+
+class _ClientOrderIdFactory(Protocol):
+    def __call__(self, *, symbol: str) -> str: ...
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def d2_remediation_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    """The dedicated, additional, default-off gate for this writer."""
+
+    env = os.environ if environ is None else environ
+    return _truthy(env.get(D2_REMEDIATION_ENABLED_ENV))
+
+
+# --------------------------------------------------------------------------
+# The writer
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class _DispatchClaims:
+    """One dispatch per client_order_id — the structural no-retry guard.
+
+    This is a claim set rather than "we happened not to write a retry loop":
+    a second dispatch of the same id raises before the transport is reached,
+    so a future edit that adds a loop still cannot double-send.
+    """
+
+    claimed: set[str] = field(default_factory=set)
+
+    def claim(self, client_order_id: str) -> None:
+        if client_order_id in self.claimed:
+            raise D2BlindRetryRefused(
+                D2ReasonCode.BLIND_RETRY_REFUSED,
+                f"client_order_id={client_order_id!r} was already dispatched; "
+                "an ambiguous outcome is resolved by readback, never by "
+                "re-sending",
+            )
+        self.claimed.add(client_order_id)
+
+
+class D2RemediationSingleWriter:
+    """The ``d2_remediation_single`` writer.
+
+    Construction binds the sealed payload; nothing else can supply orders.
+    ``execute`` defaults to ``confirm=False`` and dispatches zero mutations.
+    """
+
+    writer_name: Final[str] = WRITER_NAME
+
+    def __init__(
+        self,
+        *,
+        execution_client: BinanceSpotDemoExecutionClient,
+        sealed_payload: Mapping[str, Any],
+        lease: PostgresAdvisoryKeysetLease,
+        lease_grant: AdvisoryLeaseGrant,
+        ledger: BinanceDemoLedgerService | None = None,
+        now_fn: Callable[[], dt.datetime] | None = None,
+        client_order_id_factory: _ClientOrderIdFactory | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> None:
+        if not d2_remediation_enabled(environ):
+            raise D2RemediationDisabled(
+                D2ReasonCode.DISABLED,
+                f"{D2_REMEDIATION_ENABLED_ENV} is not truthy; this one-shot "
+                "writer is default-disabled independently of "
+                "BINANCE_SPOT_DEMO_ENABLED",
+            )
+        # Re-assert the host here even though the transport already pins it:
+        # this module composes signed order params, so it proves for itself
+        # that they are going to the Spot Demo host.
+        self._assert_spot_demo_endpoint(execution_client)
+        # The orders come from the seal, never from a caller argument. The
+        # bound tuple is the module constant regardless of what parsed.
+        self._orders = bind_sealed_orders(sealed_payload)
+        if self._orders is not D2_BOUND_ORDERS:  # pragma: no cover - defensive
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                "bound order set is not the frozen constant",
+            )
+        self._client = execution_client
+        self._ledger = ledger
+        self._lease = lease
+        self._lease_grant = lease_grant
+        self._now_fn = now_fn or (lambda: dt.datetime.now(dt.UTC))
+        self._client_order_id_factory = (
+            client_order_id_factory or _default_client_order_id
+        )
+        self._claims = _DispatchClaims()
+        self._submit_count = 0
+
+    # -- preconditions -------------------------------------------------
+
+    @staticmethod
+    def _assert_spot_demo_endpoint(
+        execution_client: BinanceSpotDemoExecutionClient,
+    ) -> None:
+        base_url = getattr(execution_client, "_base_url", "")
+        host = urlsplit(str(base_url)).hostname or ""
+        try:
+            assert_spot_demo_host(host)
+        except Exception as exc:
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.HOST_NOT_SPOT_DEMO,
+                f"execution client base_url host {host!r} is not a Spot Demo host",
+            ) from exc
+
+    async def _require_lease(self) -> None:
+        """Re-prove the lease immediately before every broker mutation.
+
+        Acquisition-time success is not carried forward: a transparently
+        reconnected session owns nothing, and ``assert_owned`` is what
+        notices.
+        """
+
+        lease = self._lease
+        if lease is None or lease.released:
+            raise D2LeaseNotHeld(
+                D2ReasonCode.LEASE_NOT_HELD,
+                "no live J3A physical-account lease; the D2 order path is "
+                "unreachable without one",
+            )
+        expected_keys = d2_advisory_keyset()
+        if tuple(self._lease_grant.keys) != expected_keys:
+            raise D2LeaseNotHeld(
+                D2ReasonCode.LEASE_SCOPE_MISMATCH,
+                f"lease grant covers {self._lease_grant.keys!r}, but the "
+                f"Binance Demo physical account needs {expected_keys!r}",
+            )
+        try:
+            await lease.assert_owned(self._lease_grant)
+        except D2RemediationError:  # pragma: no cover - defensive
+            raise
+        except Exception as exc:
+            raise D2LeaseNotHeld(
+                D2ReasonCode.LEASE_NOT_HELD,
+                f"lease ownership could not be re-attested: {exc}",
+            ) from exc
+
+    # -- planning ------------------------------------------------------
+
+    def plan(self) -> tuple[D2PlannedOperation, ...]:
+        """Compose the three requests. Pure — no lease, no I/O, no signing."""
+
+        return tuple(
+            D2PlannedOperation(
+                operation_id=operation_id,
+                client_order_id=self._client_order_id_factory(symbol=order.symbol),
+                order=order,
+                request_params=order.request_params(),
+            )
+            for order, operation_id in zip(
+                self._orders, D2_ALLOWED_OPERATION_IDS, strict=True
+            )
+        )
+
+    # -- execution -----------------------------------------------------
+
+    async def execute(
+        self,
+        *,
+        confirm: bool = False,
+        include_order_test: bool = True,
+    ) -> D2DryRunReport | D2ExecutionReport:
+        """Run the writer. ``confirm=False`` (the default) mutates nothing.
+
+        The dry run walks the *whole* path — env gate, host re-assertion, seal
+        binding, lease attestation, request composition, and (optionally) the
+        non-mutating ``POST /api/v3/order/test`` shape check — and stops there.
+        """
+
+        await self._require_lease()
+        operations = self.plan()
+        if not confirm:
+            return await self._dry_run(
+                operations, include_order_test=include_order_test
+            )
+        return await self._confirmed_run(
+            operations, include_order_test=include_order_test
+        )
+
+    async def _dry_run(
+        self,
+        operations: tuple[D2PlannedOperation, ...],
+        *,
+        include_order_test: bool,
+    ) -> D2DryRunReport:
+        tests: list[SpotDemoOrderTestResult] = []
+        if include_order_test:
+            for op in operations:
+                tests.append(
+                    await self._client.order_test(
+                        symbol=op.order.symbol,
+                        side=op.order.side,
+                        order_type=op.order.order_type,
+                        qty=op.order.quantity,
+                        price=op.order.price,
+                        time_in_force=op.order.time_in_force,
+                    )
+                )
+        return D2DryRunReport(
+            remediation_id=D2_REMEDIATION_ID,
+            pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+            writer=WRITER_NAME,
+            venue_host=D2_VENUE_HOST,
+            lease_attested=True,
+            operations=operations,
+            order_test_results=tuple(tests),
+            broker_mutation_count=0,
+        )
+
+    async def _confirmed_run(
+        self,
+        operations: tuple[D2PlannedOperation, ...],
+        *,
+        include_order_test: bool,
+    ) -> D2ExecutionReport:
+        outcomes: list[D2DispatchOutcome] = []
+        halted_reason: str | None = None
+        for op in operations:
+            outcome = await self._dispatch_one(
+                op, include_order_test=include_order_test
+            )
+            outcomes.append(outcome)
+            if outcome.status in {"anomaly", "unknown"}:
+                # An unestablished outcome stops the run. Continuing would mean
+                # mutating an account whose current state is not known.
+                halted_reason = (
+                    f"{op.operation_id}: {outcome.anomaly_reason or outcome.status}"
+                )
+                break
+        epochs = await self._collect_proof_epochs(outcomes)
+        return D2ExecutionReport(
+            remediation_id=D2_REMEDIATION_ID,
+            pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+            writer=WRITER_NAME,
+            outcomes=tuple(outcomes),
+            proof_epochs=epochs,
+            broker_submit_count=self._submit_count,
+            halted_reason=halted_reason,
+        )
+
+    async def _dispatch_one(
+        self, op: D2PlannedOperation, *, include_order_test: bool
+    ) -> D2DispatchOutcome:
+        order = op.order
+        instrument_id = await self._resolve_instrument(order)
+        await self._ledger_planned(op, instrument_id)
+        await self._ledger_transition("previewed", op)
+        if include_order_test:
+            await self._client.order_test(
+                symbol=order.symbol,
+                side=order.side,
+                order_type=order.order_type,
+                qty=order.quantity,
+                price=order.price,
+                time_in_force=order.time_in_force,
+            )
+        await self._ledger_transition("validated", op)
+
+        # Re-prove the lease immediately before the signed POST, not once at
+        # the top of the run.
+        await self._require_lease()
+        self._claims.claim(op.client_order_id)
+        self._submit_count += 1
+        try:
+            result = await self._client.submit_order(
+                symbol=order.symbol,
+                side=order.side,
+                order_type=order.order_type,
+                qty=order.quantity,
+                price=order.price,
+                time_in_force=order.time_in_force,
+                client_order_id=op.client_order_id,
+                confirm=True,
+            )
+        except Exception as exc:
+            return await self._resolve_by_readback(op, submit_error=exc)
+        if isinstance(result, SpotDemoDryRunResult):  # pragma: no cover - defensive
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                "submit_order returned a dry-run sentinel under confirm=True",
+            )
+        self._assert_echo(op, result)
+        await self._ledger_transition(
+            "submitted", op, broker_order_id=result.broker_order_id
+        )
+        return D2DispatchOutcome(
+            operation_id=op.operation_id,
+            client_order_id=op.client_order_id,
+            order=order,
+            request_params=op.request_params,
+            status=str(result.status),
+            broker_order_id=result.broker_order_id,
+            ledger_state="submitted",
+        )
+
+    def _assert_echo(
+        self, op: D2PlannedOperation, result: SpotDemoOrderSubmitResult
+    ) -> None:
+        """The broker must echo back exactly what was authorized.
+
+        A response describing a different symbol, side, type, or quantity is
+        not a success with cosmetic drift; it means the account was mutated in
+        a way the seal does not cover.
+        """
+
+        order = op.order
+        mismatches: list[str] = []
+        if result.symbol != order.symbol:
+            mismatches.append(f"symbol {result.symbol!r} != {order.symbol!r}")
+        if result.side != order.side:
+            mismatches.append(f"side {result.side!r} != {order.side!r}")
+        if result.order_type != order.order_type:
+            mismatches.append(f"type {result.order_type!r} != {order.order_type!r}")
+        if result.qty != order.quantity:
+            mismatches.append(f"qty {result.qty} != {order.quantity}")
+        if result.executed_qty > order.quantity:
+            mismatches.append(
+                f"executedQty {result.executed_qty} exceeds authorized {order.quantity}"
+            )
+        if mismatches:
+            raise D2RemediationError(
+                D2ReasonCode.BROKER_ECHO_MISMATCH,
+                f"{op.operation_id}: " + "; ".join(mismatches),
+            )
+
+    async def _resolve_by_readback(
+        self, op: D2PlannedOperation, *, submit_error: BaseException
+    ) -> D2DispatchOutcome:
+        """Establish an ambiguous dispatch's outcome by *asking*, not re-sending.
+
+        A local failure after a signed POST says nothing about whether the
+        order reached Binance. The only safe move is one bounded read of the
+        order by its client id. Anything short of a positive answer is an
+        anomaly, because "not found" cannot be distinguished from "not yet
+        visible" and both are outranked by the cost of a duplicate order.
+        """
+
+        try:
+            status_body = await self._client.get_order_status(
+                symbol=op.order.symbol, client_order_id=op.client_order_id
+            )
+        except BinanceDemoOrderNotFound:
+            reason = (
+                "submit_outcome_unknown_order_not_found_after_ambiguous_submit: "
+                f"{submit_error!r}"
+            )
+            await self._ledger_anomaly(op, reason)
+            return D2DispatchOutcome(
+                operation_id=op.operation_id,
+                client_order_id=op.client_order_id,
+                order=op.order,
+                request_params=op.request_params,
+                status="anomaly",
+                ledger_state="anomaly",
+                readback_used=True,
+                anomaly_reason=reason,
+            )
+        except Exception as readback_error:
+            reason = (
+                f"submit_outcome_unknown_readback_failed: {readback_error!r} "
+                f"(original: {submit_error!r})"
+            )
+            await self._ledger_anomaly(op, reason)
+            return D2DispatchOutcome(
+                operation_id=op.operation_id,
+                client_order_id=op.client_order_id,
+                order=op.order,
+                request_params=op.request_params,
+                status="anomaly",
+                ledger_state="anomaly",
+                readback_used=True,
+                anomaly_reason=reason,
+            )
+
+        broker_order_id = str(status_body.get("orderId", ""))
+        echoed = SpotDemoOrderSubmitResult(
+            client_order_id=str(status_body.get("clientOrderId", op.client_order_id)),
+            broker_order_id=broker_order_id,
+            symbol=str(status_body.get("symbol", "")),
+            side=str(status_body.get("side", "")),
+            order_type=str(status_body.get("type", "")),
+            qty=_decimal(status_body.get("origQty", "0"), what="readback origQty"),
+            executed_qty=_decimal(
+                status_body.get("executedQty", "0"), what="readback executedQty"
+            ),
+            cummulative_quote_qty=Decimal("0"),
+            status=str(status_body.get("status", "UNKNOWN")),
+        )
+        self._assert_echo(op, echoed)
+        await self._ledger_transition("submitted", op, broker_order_id=broker_order_id)
+        return D2DispatchOutcome(
+            operation_id=op.operation_id,
+            client_order_id=op.client_order_id,
+            order=op.order,
+            request_params=op.request_params,
+            status=echoed.status,
+            broker_order_id=broker_order_id,
+            ledger_state="submitted",
+            readback_used=True,
+        )
+
+    # -- proof epochs --------------------------------------------------
+
+    async def _collect_proof_epochs(
+        self, outcomes: Sequence[D2DispatchOutcome]
+    ) -> tuple[D2ProofEpoch, ...]:
+        """Two independent bounded observations, lease still held.
+
+        Each epoch issues its own account-wide open-order read and its own
+        per-asset balance reads; neither reuses the other's bytes.
+        """
+
+        epochs: list[D2ProofEpoch] = []
+        for index in (1, 2):
+            await self._require_lease()
+            epochs.append(await self.collect_proof_epoch(index, outcomes))
+        if len(epochs) != 2:  # pragma: no cover - defensive
+            raise D2RemediationError(
+                D2ReasonCode.PROOF_EPOCHS_INCOMPLETE,
+                f"expected 2 proof epochs, got {len(epochs)}",
+            )
+        return tuple(epochs)
+
+    async def collect_proof_epoch(
+        self, epoch_index: int, outcomes: Sequence[D2DispatchOutcome]
+    ) -> D2ProofEpoch:
+        open_orders = await self._client.get_all_open_orders()
+        balances: list[dict[str, str]] = []
+        for asset in [order.asset for order in self._orders] + [D2_QUOTE_ASSET]:
+            balance = await self._client.get_asset_balance(asset=asset)
+            balances.append(
+                {
+                    "asset": balance.asset,
+                    "free": format(balance.free, "f"),
+                    "locked": format(balance.locked, "f"),
+                }
+            )
+        ledger_states: dict[str, str] = {}
+        if self._ledger is not None:
+            for outcome in outcomes:
+                row = await self._ledger.get_by_client_order_id(outcome.client_order_id)
+                ledger_states[outcome.client_order_id] = (
+                    "" if row is None else str(row.lifecycle_state)
+                )
+        return D2ProofEpoch(
+            epoch_index=epoch_index,
+            observed_at_utc=self._now_fn().isoformat(),
+            open_orders=tuple(
+                {
+                    "symbol": entry.symbol,
+                    "side": entry.side,
+                    "client_order_id": entry.client_order_id,
+                    "qty": format(entry.qty, "f"),
+                    "status": entry.status,
+                }
+                for entry in open_orders.orders
+            ),
+            balances=tuple(balances),
+            ledger_states=ledger_states,
+        )
+
+    # -- ledger (service only; the repository is never touched) ---------
+
+    async def _resolve_instrument(self, order: D2BoundOrder) -> int:
+        if self._ledger is None:
+            return 0
+        return await self._ledger.resolve_or_create_instrument(
+            venue=D2_VENUE,
+            product=D2_PRODUCT,
+            venue_symbol=order.symbol,
+            base_asset=order.asset,
+            quote_asset=D2_QUOTE_ASSET,
+        )
+
+    async def _ledger_planned(self, op: D2PlannedOperation, instrument_id: int) -> None:
+        if self._ledger is None:
+            return
+        await self._ledger.record_planned(
+            instrument_id=instrument_id,
+            product=D2_PRODUCT,
+            venue_host=D2_VENUE_HOST,
+            client_order_id=op.client_order_id,
+            side=op.order.side,
+            order_type=op.order.order_type,
+            qty=op.order.quantity,
+            price=op.order.price,
+            extra_metadata=self._evidence_metadata(op),
+            now=self._now_fn(),
+        )
+
+    async def _ledger_transition(
+        self,
+        state: str,
+        op: D2PlannedOperation,
+        *,
+        broker_order_id: str | None = None,
+    ) -> None:
+        if self._ledger is None:
+            return
+        now = self._now_fn()
+        if state == "previewed":
+            await self._ledger.record_previewed(
+                client_order_id=op.client_order_id, now=now
+            )
+        elif state == "validated":
+            await self._ledger.record_validated(
+                client_order_id=op.client_order_id, now=now
+            )
+        elif state == "submitted":
+            await self._ledger.record_submitted(
+                client_order_id=op.client_order_id,
+                broker_order_id=broker_order_id or "",
+                now=now,
+            )
+        else:  # pragma: no cover - defensive
+            raise D2RemediationError(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                f"unsupported ledger transition {state!r}",
+            )
+
+    async def _ledger_anomaly(self, op: D2PlannedOperation, reason: str) -> None:
+        if self._ledger is None:
+            return
+        await self._ledger.record_anomaly(
+            client_order_id=op.client_order_id,
+            reason=reason,
+            now=self._now_fn(),
+        )
+
+    def _evidence_metadata(self, op: D2PlannedOperation) -> dict[str, Any]:
+        return {
+            "writer": WRITER_NAME,
+            "d2_exception_id": D2_EXCEPTION_ID,
+            "remediation_id": D2_REMEDIATION_ID,
+            "pre_snapshot_hash": D2_PRE_SNAPSHOT_HASH,
+            "snapshot_seal_sha256": D2_SNAPSHOT_SEAL_SHA256,
+            "binding_payload_sha256": D2_BINDING_PAYLOAD_SHA256,
+            "operation_id": op.operation_id,
+            "canary_or_strategy_use": "forbidden",
+        }
+
+
+def _default_client_order_id(*, symbol: str) -> str:
+    """``d2rem-<symbol>-<12 hex>`` — inside the 36-char Binance constraint."""
+
+    import uuid
+
+    return f"{D2_CLIENT_ORDER_ID_PREFIX}-{symbol}-{uuid.uuid4().hex[:12]}"
+
+
+__all__ = [
+    "D2_ALLOWED_OPERATION_IDS",
+    "D2_BINDING_PAYLOAD_SHA256",
+    "D2_BOUND_ORDERS",
+    "D2_CLIENT_ORDER_ID_PREFIX",
+    "D2_EXCEPTION_ID",
+    "D2_LANE_ID",
+    "D2_ORDER_TYPE",
+    "D2_PRE_SNAPSHOT_HASH",
+    "D2_PRODUCT",
+    "D2_QUOTE_ASSET",
+    "D2_REMEDIATION_ENABLED_ENV",
+    "D2_REMEDIATION_ID",
+    "D2_SIDE",
+    "D2_SNAPSHOT_SEAL_SHA256",
+    "D2_TIME_IN_FORCE",
+    "D2_VENUE",
+    "D2_VENUE_HOST",
+    "D2BoundOrder",
+    "D2DispatchOutcome",
+    "D2DryRunReport",
+    "D2ExecutionReport",
+    "D2LeaseNotHeld",
+    "D2BlindRetryRefused",
+    "D2OutcomeUnknown",
+    "D2PlannedOperation",
+    "D2ProofEpoch",
+    "D2ReasonCode",
+    "D2RemediationDisabled",
+    "D2RemediationError",
+    "D2RemediationSingleWriter",
+    "D2SealBindingMismatch",
+    "D2UnauthorizedOperation",
+    "WRITER_NAME",
+    "acquire_d2_lease",
+    "bind_sealed_orders",
+    "d2_advisory_keyset",
+    "d2_physical_account_scope",
+    "d2_remediation_enabled",
+]

--- a/app/services/brokers/binance/spot_demo/d2_remediation_single.py
+++ b/app/services/brokers/binance/spot_demo/d2_remediation_single.py
@@ -24,6 +24,16 @@ script would have created an *unreviewed* execution surface.  A reviewed,
 narrower one is the correct answer, so this module exists and both CLIs name
 each other.
 
+**This module creates no execution authority.**  That is a structural claim,
+not a promise: :data:`D2_KNOWN_SEALED_PAYLOADS` is the complete set of sealed
+payload digests this writer will even parse, every entry in it today carries
+``dispatch_authorized=False``, and an unknown digest is refused outright.  With
+both env gates armed and a live lease in hand, ``--confirm`` still cannot
+dispatch, because no digest in this repository permits it.  Granting dispatch
+requires a reviewed change that adds the re-signed payload's digest — the
+operator's re-sign is what produces those bytes, and their hash is what this
+file would have to be taught.
+
 Every ROB-298 safety boundary is inherited unchanged and none is widened:
 
 * the transport still pins ``demo-api.binance.com`` (this module re-asserts
@@ -32,29 +42,40 @@ Every ROB-298 safety boundary is inherited unchanged and none is widened:
   and this module's own default is likewise ``confirm=False``;
 * ``BINANCE_SPOT_DEMO_ENABLED`` still gates client construction, and this
   module adds a *second*, independent, default-off gate
-  (:data:`D2_REMEDIATION_ENABLED_ENV`) on top of it.
+  (:data:`D2_REMEDIATION_ENABLED_ENV`) on top of it.  Both are read from the
+  real process environment; there is no injectable ``environ`` seam.
 
 What this module adds on top of those inherited gates:
 
-1. **A closed order set.**  :data:`D2_BOUND_ORDERS` is exactly three
-   ``SELL``/``LIMIT`` tuples read out of the sealed r7 attempt-2 payload.  The
-   writer never accepts an order from a caller: it accepts the *sealed
-   payload*, re-derives the set, and refuses unless the derived set is ``==``
-   the frozen constant.  A different symbol, side, order type, quantity, price,
-   a fourth order, or a different ``pre_snapshot_hash`` all fail closed here,
-   before any lease, DB, or socket work.
-2. **A J3A lease precondition.**  No broker call is reachable without a live,
-   re-attested :class:`PostgresAdvisoryKeysetLease` over the Binance Demo
-   physical-account advisory key.  Ownership is re-proved immediately before
-   each submit, never assumed from acquisition time.
-3. **No blind retry.**  One dispatch per ``client_order_id``, enforced by a
-   claim set rather than by the absence of a retry loop.  An ambiguous submit
-   is resolved by *readback* (``GET /api/v3/order``), and an unresolved outcome
-   stops the whole run instead of re-sending.
-4. **Ledger evidence through the service.**  Every lifecycle write goes through
-   :class:`BinanceDemoLedgerService`; the repository is never touched.
-5. **Two fresh proof epochs.**  Post-dispatch state is proved twice from
-   independent bounded observations, collected while the lease is still held.
+1. **A sealed authority, verified from file bytes.**  Orders are never taken
+   as an argument.  :func:`load_sealed_authority` reads a file, hashes the
+   bytes, refuses an unknown digest, re-derives the three orders, and requires
+   them ``==`` the frozen :data:`D2_BOUND_ORDERS`.  It then evaluates dispatch
+   authority separately: ``operator_authorization`` must be non-null, the
+   expiry must not have passed, every actionable row must carry
+   ``mutation_authorized=true``, and the sealed credential fingerprint must
+   match the signed J2A registry.  Each failure is reported by name; none is
+   waived.
+2. **A J3A lease as an unforgeable capability.**  The writer requires a real
+   :class:`PostgresAdvisoryKeysetLease` — a duck-typed stand-in is rejected by
+   ``isinstance`` before anything else runs — and re-proves ownership
+   immediately before each submit rather than trusting acquisition time.
+3. **A durable, deterministic replay fence.**  The ``client_order_id`` is
+   derived from the seal and the order, not from a UUID, so the same bound
+   order has the same id in every process.  Before any submit the ledger is
+   asked whether that id was already attempted; if it was, the writer reads
+   the broker instead of sending, and never sends.
+4. **A mandatory ledger.**  :class:`BinanceDemoLedgerService` is a required
+   constructor argument. There is no ``None`` default and no path that
+   dispatches without durable evidence.
+5. **Pre-dispatch account truth.**  The account-wide open-order book and the
+   three sealed balances are read *before* the first order, not only after the
+   last one. A foreign resting order or any balance drift from the seal stops
+   the run before a single POST.
+6. **Full broker echo.**  Symbol, side, type, quantity, **price**, and
+   **timeInForce** are compared by closed equality against the seal; a response
+   that cannot prove the sealed price is a failure, not a success.
+7. **Two fresh proof epochs**, collected while the lease is still held.
 
 Deliberate absences: no scheduler registration, no retry queue, no MARKET
 path, no cancel path, no quantity/price arithmetic (the sealed floor values are
@@ -64,12 +85,15 @@ used verbatim), and no way to widen the order set at runtime.
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
+import json
 import os
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from decimal import Decimal, DecimalException
 from enum import StrEnum
-from typing import Any, Final, Protocol
+from pathlib import Path
+from typing import Any, Final
 from urllib.parse import urlsplit
 
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -84,9 +108,7 @@ from app.services.brokers.binance.spot_demo.execution_client import (
     BinanceSpotDemoExecutionClient,
     SpotDemoDryRunResult,
 )
-from app.services.brokers.binance.spot_demo.host_allowlist import (
-    assert_spot_demo_host,
-)
+from app.services.brokers.binance.spot_demo.host_allowlist import assert_spot_demo_host
 from app.services.mock_integration.coordination import (
     AdvisoryLeaseGrant,
     LockAuthorityConnection,
@@ -96,7 +118,10 @@ from app.services.mock_integration.coordination import (
     acquire_physical_account_lease,
     physical_account_scope_for_entry,
 )
-from app.services.mock_lane_registry import get_lane_registry_entry
+from app.services.mock_lane_registry import (
+    CANONICAL_LANE_REGISTRY,
+    get_lane_registry_entry,
+)
 
 # --------------------------------------------------------------------------
 # Identity — the sealed object this writer is bound to
@@ -119,12 +144,17 @@ D2_PRE_SNAPSHOT_HASH: Final[str] = (
 )
 
 #: ``r7-snapshot/attempt-2-authoritative.json`` selects attempt-2 and binds
-#: these two digests to it.  Carried for evidence; the hash above is the gate.
+#: this seal digest to it.  Carried as evidence.
 D2_SNAPSHOT_SEAL_SHA256: Final[str] = (
     "d4c9a13a148f6c6c0d4451264da275826084f0b27c7a69a7698fb8c2b7952ed9"
 )
-D2_BINDING_PAYLOAD_SHA256: Final[str] = (
-    "e1c2d250d73ae3bdb631289a7293c35c217b9e5c6e2694d3f8ea572d1835a3aa"
+
+#: The credential fingerprint the signed J2A registry binds to the shared
+#: Binance Demo physical account.  Pinned here *and* cross-checked against the
+#: registry entry, so a change on either side fails closed rather than silently
+#: re-pointing this one-shot at a different account.
+D2_CREDENTIAL_FINGERPRINT: Final[str] = (
+    "sha256:e33925948f2cb6e03842cca9967b70f11f9242bc5c8f99c69ce0ca5cbc4d73df"
 )
 
 #: The J2A lane whose ``physical_account_id`` names the shared Binance Demo
@@ -140,7 +170,9 @@ D2_QUOTE_ASSET: Final[str] = "USDT"
 
 #: Second, independent env gate.  ``BINANCE_SPOT_DEMO_ENABLED`` still has to be
 #: true for the client to construct at all; this one is additional and also
-#: defaults to off.  Neither is relaxed by the other.
+#: defaults to off.  Read from ``os.environ`` only — there is deliberately no
+#: injectable ``environ`` parameter, because an in-process caller that can pass
+#: a dict could otherwise arm a gate the operator left off.
 D2_REMEDIATION_ENABLED_ENV: Final[str] = "D2_REMEDIATION_SINGLE_ENABLED"
 
 #: D6 leaves no order-type or time-in-force choice: LIMIT/GTC, explicit
@@ -149,28 +181,39 @@ D2_ORDER_TYPE: Final[str] = "LIMIT"
 D2_SIDE: Final[str] = "SELL"
 D2_TIME_IN_FORCE: Final[str] = "GTC"
 
-#: Binance client-order-id prefix for this one-shot.  Kept short so the
-#: ``<prefix>-<symbol>-<12 hex>`` form stays inside the 36-char constraint the
-#: execution client asserts.
+#: Binance client-order-id prefix.  ``d2rem-`` plus a 24-hex digest is 30
+#: characters, inside the 36-char constraint the execution client asserts.
 D2_CLIENT_ORDER_ID_PREFIX: Final[str] = "d2rem"
+_CLIENT_ORDER_ID_DOMAIN: Final[bytes] = b"auto-trader:d2-remediation-single:v1\x00"
 
 #: The sealed payload marks the three actionable rows with this disposition.
 #: Dust (SOL/XRP/DOGE) and quote cash (USDT) carry different ones and are
 #: therefore never picked up as orders.
 _SEALED_ACTIONABLE_DISPOSITION: Final[str] = "REVIEWED_SCOPE_LIMIT_CANDIDATE"
 
+#: Only :func:`load_sealed_authority` may mint a :class:`SealedAuthority`.
+_AUTHORITY_TOKEN: Final[object] = object()
+
 
 class D2ReasonCode(StrEnum):
     """The complete refusal vocabulary; no free-form alternatives."""
 
     DISABLED = "d2_remediation_disabled"
+    SEAL_UNKNOWN_DIGEST = "d2_seal_unknown_digest"
     SEAL_HASH_MISMATCH = "d2_seal_hash_mismatch"
     SEAL_IDENTITY_MISMATCH = "d2_seal_identity_mismatch"
     SEAL_ORDER_SET_MISMATCH = "d2_seal_order_set_mismatch"
     SEAL_MALFORMED = "d2_seal_malformed"
+    SEAL_ACCOUNT_MISMATCH = "d2_seal_account_mismatch"
+    DISPATCH_NOT_AUTHORIZED = "d2_dispatch_not_authorized"
     UNAUTHORIZED_OPERATION = "d2_unauthorized_operation"
     LEASE_NOT_HELD = "d2_lease_not_held"
+    LEASE_NOT_A_CAPABILITY = "d2_lease_not_a_capability"
     LEASE_SCOPE_MISMATCH = "d2_lease_scope_mismatch"
+    LEDGER_REQUIRED = "d2_ledger_required"
+    WRITER_FREEZE_VIOLATED = "d2_writer_freeze_violated"
+    ACCOUNT_TRUTH_DRIFT = "d2_account_truth_drift"
+    PRIOR_ATTEMPT_UNRESOLVED = "d2_prior_attempt_unresolved"
     BLIND_RETRY_REFUSED = "d2_blind_retry_refused"
     BROKER_ECHO_MISMATCH = "d2_broker_echo_mismatch"
     OUTCOME_UNKNOWN = "d2_outcome_unknown"
@@ -194,12 +237,28 @@ class D2SealBindingMismatch(D2RemediationError):
     """The supplied sealed payload is not the one this writer is bound to."""
 
 
+class D2DispatchNotAuthorized(D2RemediationError):
+    """The seal binds, but nothing in it authorizes a broker mutation."""
+
+
 class D2UnauthorizedOperation(D2RemediationError):
     """An operation outside the three authorized ones was requested."""
 
 
 class D2LeaseNotHeld(D2RemediationError):
     """No live, attested J3A lease over the Binance Demo physical account."""
+
+
+class D2LedgerRequired(D2RemediationError):
+    """No durable ledger; the dispatch path is unreachable without one."""
+
+
+class D2AccountTruthDrift(D2RemediationError):
+    """Live account state does not match what the seal observed."""
+
+
+class D2PriorAttemptUnresolved(D2RemediationError):
+    """This bound order was already attempted and its outcome is not settled."""
 
 
 class D2BlindRetryRefused(D2RemediationError):
@@ -223,6 +282,12 @@ class D2BoundOrder:
     plain ``==`` against :data:`D2_BOUND_ORDERS`, not a name or substring
     match.  ``Decimal`` comparison is by value, so ``0.00015`` and
     ``0.00015000`` are the same order while ``0.00016`` is not.
+
+    ``sealed_free_quantity`` / ``sealed_locked_quantity`` are the balances the
+    seal observed.  They are part of the bound identity, not decoration: the
+    pre-dispatch truth check compares the live account against them, so a
+    payload that keeps the order fields but rewrites the observed balance is a
+    different object and is refused.
     """
 
     symbol: str
@@ -232,6 +297,8 @@ class D2BoundOrder:
     quantity: Decimal
     price: Decimal
     time_in_force: str
+    sealed_free_quantity: Decimal
+    sealed_locked_quantity: Decimal
 
     def request_params(self) -> dict[str, str]:
         """The exact broker request fields, as strings, for evidence output."""
@@ -244,6 +311,34 @@ class D2BoundOrder:
             "price": format(self.price, "f"),
             "timeInForce": self.time_in_force,
         }
+
+    @property
+    def client_order_id(self) -> str:
+        """Deterministic id derived from the seal and this exact order.
+
+        Not a UUID, and that is the whole point.  A UUID makes every process
+        believe it is making a first attempt, so a crash after a POST is
+        followed by a *new* id and a duplicate order.  Deriving the id means
+        the same bound order carries the same id in every process, which lets
+        the ledger recognise a prior attempt — and makes Binance itself reject
+        the duplicate as a second, independent fence.
+        """
+
+        digest = hashlib.sha256(
+            _CLIENT_ORDER_ID_DOMAIN
+            + b"|".join(
+                (
+                    D2_PRE_SNAPSHOT_HASH.encode("utf-8"),
+                    self.symbol.encode("utf-8"),
+                    self.side.encode("utf-8"),
+                    self.order_type.encode("utf-8"),
+                    format(self.quantity, "f").encode("utf-8"),
+                    format(self.price, "f").encode("utf-8"),
+                    self.time_in_force.encode("utf-8"),
+                )
+            )
+        ).hexdigest()
+        return f"{D2_CLIENT_ORDER_ID_PREFIX}-{digest[:24]}"
 
 
 #: The three operations, in dispatch order.  Read from r7 attempt-2's
@@ -265,6 +360,8 @@ D2_BOUND_ORDERS: Final[tuple[D2BoundOrder, ...]] = (
         quantity=Decimal("0.00015000"),
         price=Decimal("69266.01000000"),
         time_in_force=D2_TIME_IN_FORCE,
+        sealed_free_quantity=Decimal("0.00015957"),
+        sealed_locked_quantity=Decimal("0"),
     ),
     D2BoundOrder(
         symbol="ETHUSDT",
@@ -274,6 +371,8 @@ D2_BOUND_ORDERS: Final[tuple[D2BoundOrder, ...]] = (
         quantity=Decimal("0.00520000"),
         price=Decimal("2248.56000000"),
         time_in_force=D2_TIME_IN_FORCE,
+        sealed_free_quantity=Decimal("0.00529470"),
+        sealed_locked_quantity=Decimal("0"),
     ),
     D2BoundOrder(
         symbol="USDCUSDT",
@@ -283,6 +382,8 @@ D2_BOUND_ORDERS: Final[tuple[D2BoundOrder, ...]] = (
         quantity=Decimal("5000.00000000"),
         price=Decimal("1.00072000"),
         time_in_force=D2_TIME_IN_FORCE,
+        sealed_free_quantity=Decimal("5000.00000000"),
+        sealed_locked_quantity=Decimal("0"),
     ),
 )
 
@@ -294,6 +395,46 @@ D2_ALLOWED_OPERATION_IDS: Final[tuple[str, ...]] = (
     "ETHUSDT_sell_limit_bound_to_sealed_snapshot",
     "USDCUSDT_sell_limit_conversion",
 )
+
+
+@dataclass(frozen=True, slots=True)
+class SealedPayloadRecord:
+    """One sealed payload this writer is willing to parse at all.
+
+    Keyed by the SHA-256 of the file's exact bytes. ``dispatch_authorized``
+    is the repository-level half of the dispatch gate: even a payload that
+    claims an operator signature cannot dispatch unless a reviewed change has
+    added its digest here with the flag set.
+    """
+
+    sha256: str
+    pre_snapshot_hash: str
+    dispatch_authorized: bool
+    note: str
+
+
+#: The complete set of sealed payloads this writer will parse.
+#:
+#: 🔴 Every entry today is ``dispatch_authorized=False``.  That is what makes
+#: "this module creates no execution authority" a structural fact rather than a
+#: claim: with both env gates armed and a lease held, ``--confirm`` still has
+#: no digest to act under.  When the operator re-signs, the re-signed file has
+#: *different bytes* and therefore a different digest, and teaching this map
+#: about it is a reviewed change with its own diff.
+D2_KNOWN_SEALED_PAYLOADS: Final[Mapping[str, SealedPayloadRecord]] = {
+    "e1c2d250d73ae3bdb631289a7293c35c217b9e5c6e2694d3f8ea572d1835a3aa": (
+        SealedPayloadRecord(
+            sha256=("e1c2d250d73ae3bdb631289a7293c35c217b9e5c6e2694d3f8ea572d1835a3aa"),
+            pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+            dispatch_authorized=False,
+            note=(
+                "r7 attempt-2 binding payload, unsigned: operator_authorization "
+                "is null and every row is mutation_authorized=false. Rehearsal "
+                "only; a re-signed payload will hash differently."
+            ),
+        )
+    ),
+}
 
 
 def _assert_closed_order_set() -> None:
@@ -319,6 +460,12 @@ def _assert_closed_order_set() -> None:
         raise D2UnauthorizedOperation(
             D2ReasonCode.UNAUTHORIZED_OPERATION, "duplicate symbol in bound order set"
         )
+    client_ids = tuple(order.client_order_id for order in D2_BOUND_ORDERS)
+    if len(set(client_ids)) != len(client_ids):
+        raise D2UnauthorizedOperation(
+            D2ReasonCode.UNAUTHORIZED_OPERATION,
+            "derived client_order_ids collide",
+        )
     for order, operation_id in zip(
         D2_BOUND_ORDERS, D2_ALLOWED_OPERATION_IDS, strict=True
     ):
@@ -332,18 +479,106 @@ def _assert_closed_order_set() -> None:
                 D2ReasonCode.UNAUTHORIZED_OPERATION,
                 f"{order.symbol}: non-positive quantity or price",
             )
+        if order.quantity > order.sealed_free_quantity:
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                f"{order.symbol}: sells more than the seal observed as free",
+            )
         if not operation_id.startswith(f"{order.symbol}_"):
             raise D2UnauthorizedOperation(
                 D2ReasonCode.UNAUTHORIZED_OPERATION,
                 f"allowed_operation {operation_id!r} does not name {order.symbol}",
             )
+    if any(record.dispatch_authorized for record in D2_KNOWN_SEALED_PAYLOADS.values()):
+        # Not a prohibition on ever authorizing dispatch — a tripwire, so that
+        # flipping the flag is a deliberate, visible act rather than a quiet
+        # dictionary edit that no reviewer's eye catches.
+        raise D2UnauthorizedOperation(
+            D2ReasonCode.UNAUTHORIZED_OPERATION,
+            "a sealed payload is marked dispatch_authorized; adding one is a "
+            "reviewed operator cutover and must also update this tripwire",
+        )
 
 
 _assert_closed_order_set()
 
 
 # --------------------------------------------------------------------------
-# Seal binding
+# Physical account identity and writer freeze
+# --------------------------------------------------------------------------
+
+
+def d2_physical_account_scope() -> PhysicalAccountScope:
+    """The coordination scope of the shared Binance Demo physical account.
+
+    Derived from the signed J2A registry entry — there is no caller-supplied
+    scope string anywhere on this path.
+    """
+
+    return physical_account_scope_for_entry(get_lane_registry_entry(D2_LANE_ID))
+
+
+def d2_advisory_keyset() -> tuple[int, ...]:
+    """The single advisory key one D2 lease must hold."""
+
+    return (d2_physical_account_scope().advisory_key,)
+
+
+def d2_physical_account_id() -> str:
+    """The canonical J2A identity bytes for the shared Binance Demo account."""
+
+    entry = get_lane_registry_entry(D2_LANE_ID)
+    physical_account_id = entry.physical_account_id
+    if not isinstance(physical_account_id, str) or not physical_account_id.strip():
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_ACCOUNT_MISMATCH,
+            f"{D2_LANE_ID}: physical account identity is unknown",
+        )
+    return physical_account_id
+
+
+def assert_registry_credential_fingerprint() -> None:
+    """Cross-check the pinned fingerprint against the signed registry.
+
+    Two-way on purpose. If the registry is re-pointed at a different Binance
+    Demo account, this fails rather than letting a stale constant carry the
+    one-shot to the wrong place; and if the constant is edited alone, the
+    registry disagrees.
+    """
+
+    if D2_CREDENTIAL_FINGERPRINT not in d2_physical_account_id():
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_ACCOUNT_MISMATCH,
+            "the pinned D2 credential fingerprint does not appear in the "
+            f"signed J2A physical account identity for {D2_LANE_ID}",
+        )
+
+
+def assert_writer_freeze() -> None:
+    """No other lane may hold writer or autonomous authority on this account.
+
+    Contract v2.1 §6 requires an account-wide writer freeze before account
+    truth is taken. The signed registry is where that freeze is expressed, so
+    this reads it rather than restating it: any lane sharing this physical
+    account with ``writer`` or ``auto`` set means the freeze is not in force.
+    """
+
+    account = d2_physical_account_id()
+    unfrozen = sorted(
+        entry.lane_id
+        for entry in CANONICAL_LANE_REGISTRY
+        if entry.physical_account_id == account and (entry.writer or entry.auto)
+    )
+    if unfrozen:
+        raise D2RemediationError(
+            D2ReasonCode.WRITER_FREEZE_VIOLATED,
+            "account-wide writer freeze is not in force; these lanes still "
+            f"hold writer/auto authority on the same physical account: {unfrozen}",
+        )
+
+
+# --------------------------------------------------------------------------
+# Sealed authority
 # --------------------------------------------------------------------------
 
 
@@ -356,7 +591,7 @@ def _decimal(value: Any, *, what: str) -> Decimal:
         ) from exc
 
 
-def _sealed_order(symbol: str, entry: Any) -> D2BoundOrder | None:
+def _sealed_order(symbol: str, entry: Mapping[str, Any]) -> D2BoundOrder | None:
     """Map one sealed ``authorized_symbols.spot`` row onto a bound order.
 
     Returns ``None`` for rows that are not actionable (dust attestations and
@@ -365,10 +600,6 @@ def _sealed_order(symbol: str, entry: Any) -> D2BoundOrder | None:
     silently dropped row would shrink the set without saying so.
     """
 
-    if not isinstance(entry, Mapping):
-        raise D2SealBindingMismatch(
-            D2ReasonCode.SEAL_MALFORMED, f"{symbol}: row is not a mapping"
-        )
     if entry.get("disposition") != _SEALED_ACTIONABLE_DISPOSITION:
         return None
     step = entry.get("proposed_one_step")
@@ -394,15 +625,38 @@ def _sealed_order(symbol: str, entry: Any) -> D2BoundOrder | None:
         quantity=_decimal(step.get("proposed_quantity_floor"), what=f"{symbol} qty"),
         price=_decimal(step.get("proposed_limit_price_floor"), what=f"{symbol} price"),
         time_in_force=D2_TIME_IN_FORCE,
+        sealed_free_quantity=_decimal(
+            step.get("raw_free_quantity"), what=f"{symbol} free"
+        ),
+        sealed_locked_quantity=_decimal(
+            step.get("raw_locked_quantity"), what=f"{symbol} locked"
+        ),
+    )
+
+
+def _describe(orders: Sequence[D2BoundOrder]) -> str:
+    return (
+        "["
+        + ", ".join(
+            f"{o.symbol} {o.side} {o.order_type} {format(o.quantity, 'f')}"
+            f"@{format(o.price, 'f')} free={format(o.sealed_free_quantity, 'f')}"
+            for o in sorted(orders, key=lambda o: o.symbol)
+        )
+        + "]"
     )
 
 
 def bind_sealed_orders(payload: Mapping[str, Any]) -> tuple[D2BoundOrder, ...]:
-    """Re-derive the order set from a sealed payload and prove it is *the* one.
+    """Re-derive the order set from a parsed payload and prove it is *the* one.
 
     The return value is :data:`D2_BOUND_ORDERS` itself, never the parsed
     tuple.  That is deliberate: a parsing bug can then only ever cause a
     refusal, never a widened order set.
+
+    This is the *shape* half of the gate.  It says nothing about whether the
+    bytes are the sealed bytes or whether anyone authorized a dispatch; those
+    are :func:`load_sealed_authority`'s job, and this function is not a
+    sufficient precondition for anything.
     """
 
     if not isinstance(payload, Mapping):
@@ -458,37 +712,194 @@ def bind_sealed_orders(payload: Mapping[str, Any]) -> tuple[D2BoundOrder, ...]:
     return D2_BOUND_ORDERS
 
 
-def _describe(orders: Sequence[D2BoundOrder]) -> str:
-    return (
-        "["
-        + ", ".join(
-            f"{o.symbol} {o.side} {o.order_type} {format(o.quantity, 'f')}"
-            f"@{format(o.price, 'f')}"
-            for o in sorted(orders, key=lambda o: o.symbol)
+def _sealed_credential_fingerprint(payload: Mapping[str, Any]) -> str:
+    identity = payload.get("physical_account_identity")
+    if not isinstance(identity, Mapping):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_ACCOUNT_MISMATCH,
+            "sealed payload carries no physical_account_identity",
         )
-        + "]"
+    fingerprint = identity.get("credential_fingerprint")
+    if not isinstance(fingerprint, str) or not fingerprint.strip():
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_ACCOUNT_MISMATCH,
+            "sealed payload carries no credential_fingerprint",
+        )
+    return fingerprint
+
+
+def _mutation_authorized_symbols(payload: Mapping[str, Any]) -> frozenset[str]:
+    authorized = payload.get("authorized_symbols")
+    spot = authorized.get("spot") if isinstance(authorized, Mapping) else None
+    if not isinstance(spot, Mapping):
+        return frozenset()
+    return frozenset(
+        str(symbol)
+        for symbol, entry in spot.items()
+        if isinstance(entry, Mapping) and entry.get("mutation_authorized") is True
+    )
+
+
+def _parse_expiry(raw: Any) -> dt.datetime | None:
+    if raw is None:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, f"expiry {raw!r} is not an ISO-8601 instant"
+        ) from exc
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class SealedAuthority:
+    """A sealed payload whose *bytes* were verified, plus what it authorizes.
+
+    Only :func:`load_sealed_authority` can mint one: the constructor demands a
+    module-private token, so an in-process caller cannot hand the writer a
+    hand-built authority object and skip the digest check. The writer accepts
+    nothing else, which is what keeps "orders come from the seal" true against
+    argument injection as well as against a doctored file.
+
+    Binding and *authorization* are kept apart on purpose. A payload can bind
+    perfectly — right hash, right three orders, right account — and still
+    authorize nothing, which is exactly the state of the current r7 object.
+    """
+
+    source_path: str
+    payload_sha256: str
+    record: SealedPayloadRecord
+    orders: tuple[D2BoundOrder, ...]
+    credential_fingerprint: str
+    operator_authorization: Any
+    expiry: dt.datetime | None
+    mutation_authorized_symbols: frozenset[str]
+    _token: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._token is not _AUTHORITY_TOKEN:
+            raise D2SealBindingMismatch(
+                D2ReasonCode.SEAL_MALFORMED,
+                "SealedAuthority may only be produced by load_sealed_authority",
+            )
+
+    def dispatch_block_reasons(self, *, now: dt.datetime) -> tuple[str, ...]:
+        """Everything standing between this seal and a broker mutation.
+
+        Reported in full rather than short-circuiting, so an operator reading a
+        dry run sees the whole list instead of discovering the next blocker one
+        run at a time.
+        """
+
+        reasons: list[str] = []
+        if not self.record.dispatch_authorized:
+            reasons.append(
+                f"payload digest {self.payload_sha256} is registered as "
+                f"dispatch_authorized=false ({self.record.note})"
+            )
+        if self.operator_authorization is None:
+            reasons.append("operator_authorization is null — no re-sign is present")
+        if self.expiry is None:
+            reasons.append("expiry is absent — a one-shot authority must expire")
+        elif self.expiry <= now:
+            reasons.append(
+                f"authority expired at {self.expiry.isoformat()} (now {now.isoformat()})"
+            )
+        missing = sorted(
+            order.symbol
+            for order in self.orders
+            if order.symbol not in self.mutation_authorized_symbols
+        )
+        if missing:
+            reasons.append(f"mutation_authorized is not true for {missing}")
+        return tuple(reasons)
+
+    @property
+    def client_order_ids(self) -> frozenset[str]:
+        return frozenset(order.client_order_id for order in self.orders)
+
+    def as_evidence(self) -> dict[str, Any]:
+        return {
+            "source_path": self.source_path,
+            "payload_sha256": self.payload_sha256,
+            "pre_snapshot_hash": self.record.pre_snapshot_hash,
+            "registered_dispatch_authorized": self.record.dispatch_authorized,
+            "operator_authorization_present": self.operator_authorization is not None,
+            "expiry": None if self.expiry is None else self.expiry.isoformat(),
+            "mutation_authorized_symbols": sorted(self.mutation_authorized_symbols),
+            "credential_fingerprint": self.credential_fingerprint,
+        }
+
+
+def load_sealed_authority(path: str | Path) -> SealedAuthority:
+    """Read a sealed payload from disk and verify it end to end.
+
+    The digest is computed over the file's **exact bytes**, before the JSON is
+    parsed, and compared against :data:`D2_KNOWN_SEALED_PAYLOADS`. An unknown
+    digest is refused outright — not downgraded to a warning, and not rescued
+    by the contents looking right, because "the contents look right" is
+    precisely what a doctored file arranges.
+    """
+
+    source = Path(path)
+    try:
+        raw = source.read_bytes()
+    except OSError as exc:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, f"{source}: cannot read sealed payload: {exc}"
+        ) from exc
+    digest = hashlib.sha256(raw).hexdigest()
+    record = D2_KNOWN_SEALED_PAYLOADS.get(digest)
+    if record is None:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_UNKNOWN_DIGEST,
+            f"{source}: sha256={digest} is not a registered sealed payload. "
+            f"Registered: {sorted(D2_KNOWN_SEALED_PAYLOADS)}",
+        )
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, f"{source}: not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED, f"{source}: sealed payload is not an object"
+        )
+
+    orders = bind_sealed_orders(payload)
+    if record.pre_snapshot_hash != payload.get("pre_snapshot_hash"):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_HASH_MISMATCH,
+            "registered digest and payload disagree on pre_snapshot_hash",
+        )
+
+    assert_registry_credential_fingerprint()
+    fingerprint = _sealed_credential_fingerprint(payload)
+    if fingerprint != D2_CREDENTIAL_FINGERPRINT:
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_ACCOUNT_MISMATCH,
+            f"sealed credential_fingerprint {fingerprint!r} is not the shared "
+            "Binance Demo account this one-shot is bound to",
+        )
+
+    return SealedAuthority(
+        source_path=str(source),
+        payload_sha256=digest,
+        record=record,
+        orders=orders,
+        credential_fingerprint=fingerprint,
+        operator_authorization=payload.get("operator_authorization"),
+        expiry=_parse_expiry(payload.get("expiry")),
+        mutation_authorized_symbols=_mutation_authorized_symbols(payload),
+        _token=_AUTHORITY_TOKEN,
     )
 
 
 # --------------------------------------------------------------------------
 # Lease
 # --------------------------------------------------------------------------
-
-
-def d2_physical_account_scope() -> PhysicalAccountScope:
-    """The coordination scope of the shared Binance Demo physical account.
-
-    Derived from the signed J2A registry entry — there is no caller-supplied
-    scope string anywhere on this path.
-    """
-
-    return physical_account_scope_for_entry(get_lane_registry_entry(D2_LANE_ID))
-
-
-def d2_advisory_keyset() -> tuple[int, ...]:
-    """The single advisory key one D2 lease must hold."""
-
-    return (d2_physical_account_scope().advisory_key,)
 
 
 async def acquire_d2_lease(*, engine: AsyncEngine) -> PostgresAdvisoryKeysetLease:
@@ -502,7 +913,7 @@ async def acquire_d2_lease(*, engine: AsyncEngine) -> PostgresAdvisoryKeysetLeas
     coordinates processes *inside this repository*. Binance never sees it, so
     an operator at a console or an out-of-repo process reaches the same account
     without contending for it. It is why the writer also re-attests before each
-    submit and reads the account-wide open-order book in both proof epochs.
+    submit and reads the account-wide open-order book before dispatching.
     """
 
     async def _factory() -> LockAuthorityConnection:
@@ -532,6 +943,23 @@ class D2PlannedOperation:
 
 
 @dataclass(frozen=True, slots=True)
+class D2AccountTruth:
+    """One pre-dispatch bounded observation of the whole account."""
+
+    observed_at_utc: str
+    open_orders: tuple[dict[str, str], ...]
+    balances: tuple[dict[str, str], ...]
+
+    def as_evidence(self) -> dict[str, Any]:
+        return {
+            "schema_version": "d2-remediation-single-account-truth.v1",
+            "observed_at_utc": self.observed_at_utc,
+            "account_wide_open_orders": list(self.open_orders),
+            "balances": list(self.balances),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class D2DryRunReport:
     """Full-path rehearsal that stops immediately before the signed POST."""
 
@@ -540,7 +968,10 @@ class D2DryRunReport:
     writer: str
     venue_host: str
     lease_attested: bool
+    authority: dict[str, Any]
+    dispatch_block_reasons: tuple[str, ...]
     operations: tuple[D2PlannedOperation, ...]
+    account_truth: D2AccountTruth | None = None
     order_test_results: tuple[SpotDemoOrderTestResult, ...] = ()
     broker_mutation_count: int = 0
 
@@ -552,8 +983,14 @@ class D2DryRunReport:
             "pre_snapshot_hash": self.pre_snapshot_hash,
             "venue_host": self.venue_host,
             "lease_attested": self.lease_attested,
+            "authority": self.authority,
+            "dispatch_authorized": not self.dispatch_block_reasons,
+            "dispatch_block_reasons": list(self.dispatch_block_reasons),
             "broker_mutation_count": self.broker_mutation_count,
             "order_test_count": len(self.order_test_results),
+            "account_truth": (
+                None if self.account_truth is None else self.account_truth.as_evidence()
+            ),
             "operations": [
                 {
                     "operation_id": op.operation_id,
@@ -610,9 +1047,11 @@ class D2ExecutionReport:
     remediation_id: str
     pre_snapshot_hash: str
     writer: str
+    authority: dict[str, Any]
     outcomes: tuple[D2DispatchOutcome, ...]
     proof_epochs: tuple[D2ProofEpoch, ...]
     broker_submit_count: int
+    account_truth: D2AccountTruth | None = None
     halted_reason: str | None = None
 
     def as_evidence(self) -> dict[str, Any]:
@@ -621,8 +1060,12 @@ class D2ExecutionReport:
             "writer": self.writer,
             "remediation_id": self.remediation_id,
             "pre_snapshot_hash": self.pre_snapshot_hash,
+            "authority": self.authority,
             "broker_submit_count": self.broker_submit_count,
             "halted_reason": self.halted_reason,
+            "account_truth": (
+                None if self.account_truth is None else self.account_truth.as_evidence()
+            ),
             "outcomes": [
                 {
                     "operation_id": o.operation_id,
@@ -640,21 +1083,22 @@ class D2ExecutionReport:
         }
 
 
-class _ClientOrderIdFactory(Protocol):
-    def __call__(self, *, symbol: str) -> str: ...
-
-
 def _truthy(value: str | None) -> bool:
     if not value:
         return False
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def d2_remediation_enabled(environ: Mapping[str, str] | None = None) -> bool:
-    """The dedicated, additional, default-off gate for this writer."""
+def d2_remediation_enabled() -> bool:
+    """The dedicated, additional, default-off gate for this writer.
 
-    env = os.environ if environ is None else environ
-    return _truthy(env.get(D2_REMEDIATION_ENABLED_ENV))
+    Reads ``os.environ`` and nothing else. An earlier revision accepted an
+    ``environ`` mapping for testability, which meant an in-process caller could
+    arm the gate the operator had deliberately left off — a test seam that was
+    also a bypass. Tests use ``monkeypatch.setenv``, which is the real thing.
+    """
+
+    return _truthy(os.environ.get(D2_REMEDIATION_ENABLED_ENV))
 
 
 # --------------------------------------------------------------------------
@@ -664,11 +1108,12 @@ def d2_remediation_enabled(environ: Mapping[str, str] | None = None) -> bool:
 
 @dataclass
 class _DispatchClaims:
-    """One dispatch per client_order_id — the structural no-retry guard.
+    """One dispatch per client_order_id within this process.
 
-    This is a claim set rather than "we happened not to write a retry loop":
-    a second dispatch of the same id raises before the transport is reached,
-    so a future edit that adds a loop still cannot double-send.
+    The *inner* of two fences, and the weaker one. It cannot survive a restart,
+    which is precisely the case the durable ledger check exists for; keeping it
+    anyway means a bug that bypasses the ledger lookup still cannot double-send
+    inside one run.
     """
 
     claimed: set[str] = field(default_factory=set)
@@ -687,8 +1132,10 @@ class _DispatchClaims:
 class D2RemediationSingleWriter:
     """The ``d2_remediation_single`` writer.
 
-    Construction binds the sealed payload; nothing else can supply orders.
-    ``execute`` defaults to ``confirm=False`` and dispatches zero mutations.
+    Construction takes a verified :class:`SealedAuthority`, a real
+    :class:`PostgresAdvisoryKeysetLease`, and a real
+    :class:`BinanceDemoLedgerService`. None of the three has a permissive
+    default, and none can be substituted by a look-alike.
     """
 
     writer_name: Final[str] = WRITER_NAME
@@ -697,41 +1144,55 @@ class D2RemediationSingleWriter:
         self,
         *,
         execution_client: BinanceSpotDemoExecutionClient,
-        sealed_payload: Mapping[str, Any],
+        authority: SealedAuthority,
         lease: PostgresAdvisoryKeysetLease,
         lease_grant: AdvisoryLeaseGrant,
-        ledger: BinanceDemoLedgerService | None = None,
-        now_fn: Callable[[], dt.datetime] | None = None,
-        client_order_id_factory: _ClientOrderIdFactory | None = None,
-        environ: Mapping[str, str] | None = None,
+        ledger: BinanceDemoLedgerService,
+        now_fn: Any = None,
     ) -> None:
-        if not d2_remediation_enabled(environ):
+        if not d2_remediation_enabled():
             raise D2RemediationDisabled(
                 D2ReasonCode.DISABLED,
-                f"{D2_REMEDIATION_ENABLED_ENV} is not truthy; this one-shot "
-                "writer is default-disabled independently of "
-                "BINANCE_SPOT_DEMO_ENABLED",
+                f"{D2_REMEDIATION_ENABLED_ENV} is not truthy in the process "
+                "environment; this one-shot writer is default-disabled "
+                "independently of BINANCE_SPOT_DEMO_ENABLED",
+            )
+        if not isinstance(authority, SealedAuthority):
+            raise D2SealBindingMismatch(
+                D2ReasonCode.SEAL_MALFORMED,
+                "orders must arrive as a SealedAuthority from "
+                "load_sealed_authority(); a raw payload or a look-alike is "
+                "not accepted",
+            )
+        if not isinstance(lease, PostgresAdvisoryKeysetLease):
+            # A duck-typed stand-in with `.released` and `.assert_owned` would
+            # otherwise satisfy every later check while proving nothing about
+            # the account.
+            raise D2LeaseNotHeld(
+                D2ReasonCode.LEASE_NOT_A_CAPABILITY,
+                "lease must be a real PostgresAdvisoryKeysetLease; a duck-typed "
+                f"{type(lease).__name__} cannot prove account coordination",
+            )
+        if not isinstance(ledger, BinanceDemoLedgerService):
+            raise D2LedgerRequired(
+                D2ReasonCode.LEDGER_REQUIRED,
+                "a real BinanceDemoLedgerService is required; there is no "
+                "ledger-less dispatch path",
             )
         # Re-assert the host here even though the transport already pins it:
         # this module composes signed order params, so it proves for itself
         # that they are going to the Spot Demo host.
         self._assert_spot_demo_endpoint(execution_client)
-        # The orders come from the seal, never from a caller argument. The
-        # bound tuple is the module constant regardless of what parsed.
-        self._orders = bind_sealed_orders(sealed_payload)
-        if self._orders is not D2_BOUND_ORDERS:  # pragma: no cover - defensive
-            raise D2UnauthorizedOperation(
-                D2ReasonCode.UNAUTHORIZED_OPERATION,
-                "bound order set is not the frozen constant",
-            )
+        self._assert_client_account(execution_client, authority)
+        assert_writer_freeze()
+        self._authority = authority
+        # The dispatch set is the module constant, never the parsed tuple.
+        self._orders = D2_BOUND_ORDERS
         self._client = execution_client
         self._ledger = ledger
         self._lease = lease
         self._lease_grant = lease_grant
         self._now_fn = now_fn or (lambda: dt.datetime.now(dt.UTC))
-        self._client_order_id_factory = (
-            client_order_id_factory or _default_client_order_id
-        )
         self._claims = _DispatchClaims()
         self._submit_count = 0
 
@@ -751,6 +1212,25 @@ class D2RemediationSingleWriter:
                 f"execution client base_url host {host!r} is not a Spot Demo host",
             ) from exc
 
+    @staticmethod
+    def _assert_client_account(
+        execution_client: BinanceSpotDemoExecutionClient,
+        authority: SealedAuthority,
+    ) -> None:
+        """The live credentials must be the account the seal observed.
+
+        The Spot Demo host is shared by several demo lanes, so "the host is
+        right" says nothing about *whose* account is about to be sold from.
+        """
+
+        live = getattr(execution_client, "credential_fingerprint", None)
+        if live != authority.credential_fingerprint:
+            raise D2SealBindingMismatch(
+                D2ReasonCode.SEAL_ACCOUNT_MISMATCH,
+                "the execution client's credential fingerprint does not match "
+                "the physical account the seal was taken from",
+            )
+
     async def _require_lease(self) -> None:
         """Re-prove the lease immediately before every broker mutation.
 
@@ -760,11 +1240,11 @@ class D2RemediationSingleWriter:
         """
 
         lease = self._lease
-        if lease is None or lease.released:
+        if lease.released:
             raise D2LeaseNotHeld(
                 D2ReasonCode.LEASE_NOT_HELD,
-                "no live J3A physical-account lease; the D2 order path is "
-                "unreachable without one",
+                "the J3A physical-account lease is released; the D2 order path "
+                "is unreachable without one",
             )
         expected_keys = d2_advisory_keyset()
         if tuple(self._lease_grant.keys) != expected_keys:
@@ -783,21 +1263,119 @@ class D2RemediationSingleWriter:
                 f"lease ownership could not be re-attested: {exc}",
             ) from exc
 
+    def dispatch_block_reasons(self) -> tuple[str, ...]:
+        """Evaluate the authority against the **real** clock.
+
+        Deliberately not ``self._now_fn``. That hook exists so evidence
+        timestamps are reproducible in tests, and letting it feed the expiry
+        comparison would turn a test seam into a bypass: a caller passing a
+        ``now_fn`` fixed in the past could revive an expired one-shot.
+        """
+
+        return self._authority.dispatch_block_reasons(now=dt.datetime.now(dt.UTC))
+
+    def _require_dispatch_authority(self) -> None:
+        reasons = self.dispatch_block_reasons()
+        if reasons:
+            raise D2DispatchNotAuthorized(
+                D2ReasonCode.DISPATCH_NOT_AUTHORIZED,
+                "nothing authorizes a broker mutation under this seal: "
+                + "; ".join(reasons),
+            )
+
     # -- planning ------------------------------------------------------
 
     def plan(self) -> tuple[D2PlannedOperation, ...]:
-        """Compose the three requests. Pure — no lease, no I/O, no signing."""
+        """Compose the three requests. Pure — no lease, no I/O, no signing.
+
+        Deterministic: calling it twice, or in two processes, yields the same
+        ``client_order_id`` for the same bound order.
+        """
 
         return tuple(
             D2PlannedOperation(
                 operation_id=operation_id,
-                client_order_id=self._client_order_id_factory(symbol=order.symbol),
+                client_order_id=order.client_order_id,
                 order=order,
                 request_params=order.request_params(),
             )
             for order, operation_id in zip(
                 self._orders, D2_ALLOWED_OPERATION_IDS, strict=True
             )
+        )
+
+    # -- account truth -------------------------------------------------
+
+    async def collect_account_truth(
+        self, *, expected_client_order_ids: frozenset[str]
+    ) -> D2AccountTruth:
+        """Read the whole account and refuse if it is not what the seal saw.
+
+        Account-wide, not symbol-scoped: a symbol-filtered read cannot answer
+        "is anything else resting on this shared account?", and the Demo
+        credentials are shared with other lanes.
+
+        Runs *before* the first dispatch. The earlier revision read this state
+        only in the post-dispatch proof epochs, which meant a foreign resting
+        order or a drifted balance was discovered after the orders were already
+        on the book.
+        """
+
+        open_orders = await self._client.get_all_open_orders()
+        foreign = sorted(
+            f"{entry.symbol}:{entry.client_order_id}"
+            for entry in open_orders.orders
+            if entry.client_order_id not in expected_client_order_ids
+        )
+        if foreign:
+            raise D2AccountTruthDrift(
+                D2ReasonCode.ACCOUNT_TRUTH_DRIFT,
+                "the shared Demo account has resting orders this one-shot did "
+                f"not place: {foreign}. Contract v2.1 §6 requires open-order "
+                "cancellation or terminal proof before exposure reduction, and "
+                "this writer has no cancel path — clear them first.",
+            )
+
+        balances: list[dict[str, str]] = []
+        drift: list[str] = []
+        for order in self._orders:
+            balance = await self._client.get_asset_balance(asset=order.asset)
+            balances.append(
+                {
+                    "asset": balance.asset,
+                    "free": format(balance.free, "f"),
+                    "locked": format(balance.locked, "f"),
+                }
+            )
+            if balance.free != order.sealed_free_quantity:
+                drift.append(
+                    f"{order.asset} free {format(balance.free, 'f')} != sealed "
+                    f"{format(order.sealed_free_quantity, 'f')}"
+                )
+            if balance.locked != order.sealed_locked_quantity:
+                drift.append(
+                    f"{order.asset} locked {format(balance.locked, 'f')} != sealed "
+                    f"{format(order.sealed_locked_quantity, 'f')}"
+                )
+        if drift:
+            raise D2AccountTruthDrift(
+                D2ReasonCode.ACCOUNT_TRUTH_DRIFT,
+                "live balances have drifted from the sealed observation, so the "
+                f"seal no longer describes this account: {drift}",
+            )
+        return D2AccountTruth(
+            observed_at_utc=self._now_fn().isoformat(),
+            open_orders=tuple(
+                {
+                    "symbol": entry.symbol,
+                    "side": entry.side,
+                    "client_order_id": entry.client_order_id,
+                    "qty": format(entry.qty, "f"),
+                    "status": entry.status,
+                }
+                for entry in open_orders.orders
+            ),
+            balances=tuple(balances),
         )
 
     # -- execution -----------------------------------------------------
@@ -810,9 +1388,15 @@ class D2RemediationSingleWriter:
     ) -> D2DryRunReport | D2ExecutionReport:
         """Run the writer. ``confirm=False`` (the default) mutates nothing.
 
-        The dry run walks the *whole* path — env gate, host re-assertion, seal
-        binding, lease attestation, request composition, and (optionally) the
-        non-mutating ``POST /api/v3/order/test`` shape check — and stops there.
+        The dry run walks the *whole* path — env gate, host re-assertion,
+        account identity, writer freeze, seal binding, lease attestation,
+        pre-dispatch account truth, request composition, and the non-mutating
+        ``POST /api/v3/order/test`` shape check — and stops there. It reports
+        what blocks dispatch rather than raising, because listing the blockers
+        is the point of a rehearsal.
+
+        ``confirm=True`` requires the authority to be complete; if it is not,
+        it raises before any lease-protected work.
         """
 
         await self._require_lease()
@@ -821,9 +1405,10 @@ class D2RemediationSingleWriter:
             return await self._dry_run(
                 operations, include_order_test=include_order_test
             )
-        return await self._confirmed_run(
-            operations, include_order_test=include_order_test
-        )
+        # Under confirm, the order-shape check is not optional: it is the only
+        # broker-side proof that the sealed filters still describe the market.
+        self._require_dispatch_authority()
+        return await self._confirmed_run(operations)
 
     async def _dry_run(
         self,
@@ -831,6 +1416,9 @@ class D2RemediationSingleWriter:
         *,
         include_order_test: bool,
     ) -> D2DryRunReport:
+        truth = await self.collect_account_truth(
+            expected_client_order_ids=self._authority.client_order_ids
+        )
         tests: list[SpotDemoOrderTestResult] = []
         if include_order_test:
             for op in operations:
@@ -850,23 +1438,24 @@ class D2RemediationSingleWriter:
             writer=WRITER_NAME,
             venue_host=D2_VENUE_HOST,
             lease_attested=True,
+            authority=self._authority.as_evidence(),
+            dispatch_block_reasons=self.dispatch_block_reasons(),
             operations=operations,
+            account_truth=truth,
             order_test_results=tuple(tests),
             broker_mutation_count=0,
         )
 
     async def _confirmed_run(
-        self,
-        operations: tuple[D2PlannedOperation, ...],
-        *,
-        include_order_test: bool,
+        self, operations: tuple[D2PlannedOperation, ...]
     ) -> D2ExecutionReport:
+        truth = await self.collect_account_truth(
+            expected_client_order_ids=self._authority.client_order_ids
+        )
         outcomes: list[D2DispatchOutcome] = []
         halted_reason: str | None = None
         for op in operations:
-            outcome = await self._dispatch_one(
-                op, include_order_test=include_order_test
-            )
+            outcome = await self._dispatch_one(op)
             outcomes.append(outcome)
             if outcome.status in {"anomaly", "unknown"}:
                 # An unestablished outcome stops the run. Continuing would mean
@@ -880,29 +1469,57 @@ class D2RemediationSingleWriter:
             remediation_id=D2_REMEDIATION_ID,
             pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
             writer=WRITER_NAME,
+            authority=self._authority.as_evidence(),
             outcomes=tuple(outcomes),
             proof_epochs=epochs,
             broker_submit_count=self._submit_count,
+            account_truth=truth,
             halted_reason=halted_reason,
         )
 
-    async def _dispatch_one(
-        self, op: D2PlannedOperation, *, include_order_test: bool
-    ) -> D2DispatchOutcome:
+    async def _dispatch_one(self, op: D2PlannedOperation) -> D2DispatchOutcome:
         order = op.order
-        instrument_id = await self._resolve_instrument(order)
-        await self._ledger_planned(op, instrument_id)
-        await self._ledger_transition("previewed", op)
-        if include_order_test:
-            await self._client.order_test(
-                symbol=order.symbol,
-                side=order.side,
-                order_type=order.order_type,
-                qty=order.quantity,
-                price=order.price,
-                time_in_force=order.time_in_force,
+        # The durable fence, checked before anything else: has this exact bound
+        # order been attempted, in this process or any earlier one?
+        prior = await self._ledger.get_by_client_order_id(op.client_order_id)
+        if prior is not None:
+            return await self._resolve_prior_attempt(
+                op, prior_state=prior.lifecycle_state
             )
-        await self._ledger_transition("validated", op)
+
+        instrument_id = await self._ledger.resolve_or_create_instrument(
+            venue=D2_VENUE,
+            product=D2_PRODUCT,
+            venue_symbol=order.symbol,
+            base_asset=order.asset,
+            quote_asset=D2_QUOTE_ASSET,
+        )
+        await self._ledger.record_planned(
+            instrument_id=instrument_id,
+            product=D2_PRODUCT,
+            venue_host=D2_VENUE_HOST,
+            client_order_id=op.client_order_id,
+            side=order.side,
+            order_type=order.order_type,
+            qty=order.quantity,
+            price=order.price,
+            extra_metadata=self._evidence_metadata(op),
+            now=self._now_fn(),
+        )
+        await self._ledger.record_previewed(
+            client_order_id=op.client_order_id, now=self._now_fn()
+        )
+        await self._client.order_test(
+            symbol=order.symbol,
+            side=order.side,
+            order_type=order.order_type,
+            qty=order.quantity,
+            price=order.price,
+            time_in_force=order.time_in_force,
+        )
+        await self._ledger.record_validated(
+            client_order_id=op.client_order_id, now=self._now_fn()
+        )
 
         # Re-prove the lease immediately before the signed POST, not once at
         # the top of the run.
@@ -928,8 +1545,10 @@ class D2RemediationSingleWriter:
                 "submit_order returned a dry-run sentinel under confirm=True",
             )
         self._assert_echo(op, result)
-        await self._ledger_transition(
-            "submitted", op, broker_order_id=result.broker_order_id
+        await self._ledger.record_submitted(
+            client_order_id=op.client_order_id,
+            broker_order_id=result.broker_order_id,
+            now=self._now_fn(),
         )
         return D2DispatchOutcome(
             operation_id=op.operation_id,
@@ -941,17 +1560,83 @@ class D2RemediationSingleWriter:
             ledger_state="submitted",
         )
 
+    async def _resolve_prior_attempt(
+        self, op: D2PlannedOperation, *, prior_state: str
+    ) -> D2DispatchOutcome:
+        """A ledger row already exists for this bound order — do not send.
+
+        This is the case a process-local claim set cannot see: the first
+        attempt may have happened in a process that has since died. The only
+        safe move is to ask the broker what became of it.
+        """
+
+        try:
+            status_body = await self._client.get_order_status(
+                symbol=op.order.symbol, client_order_id=op.client_order_id
+            )
+        except BinanceDemoOrderNotFound as exc:
+            raise D2PriorAttemptUnresolved(
+                D2ReasonCode.PRIOR_ATTEMPT_UNRESOLVED,
+                f"{op.operation_id}: the ledger records a prior attempt in state "
+                f"{prior_state!r} but the broker does not know "
+                f"{op.client_order_id!r}. That is unresolvable from here — it "
+                "could equally mean the order never arrived or that it arrived "
+                "and was removed. Refusing to re-send.",
+            ) from exc
+        except Exception as exc:
+            raise D2PriorAttemptUnresolved(
+                D2ReasonCode.PRIOR_ATTEMPT_UNRESOLVED,
+                f"{op.operation_id}: a prior attempt exists in state "
+                f"{prior_state!r} and its outcome could not be read back: {exc!r}",
+            ) from exc
+        echoed = self._echo_from_status(op, status_body)
+        self._assert_echo(op, echoed)
+        return D2DispatchOutcome(
+            operation_id=op.operation_id,
+            client_order_id=op.client_order_id,
+            order=op.order,
+            request_params=op.request_params,
+            status=echoed.status,
+            broker_order_id=echoed.broker_order_id,
+            ledger_state=prior_state,
+            readback_used=True,
+        )
+
+    def _echo_from_status(
+        self, op: D2PlannedOperation, status_body: Mapping[str, Any]
+    ) -> SpotDemoOrderSubmitResult:
+        return SpotDemoOrderSubmitResult(
+            client_order_id=str(status_body.get("clientOrderId", op.client_order_id)),
+            broker_order_id=str(status_body.get("orderId", "")),
+            symbol=str(status_body.get("symbol", "")),
+            side=str(status_body.get("side", "")),
+            order_type=str(status_body.get("type", "")),
+            qty=_decimal(status_body.get("origQty", "0"), what="readback origQty"),
+            executed_qty=_decimal(
+                status_body.get("executedQty", "0"), what="readback executedQty"
+            ),
+            cummulative_quote_qty=Decimal("0"),
+            status=str(status_body.get("status", "UNKNOWN")),
+            raw_response_redacted=dict(status_body),
+        )
+
     def _assert_echo(
         self, op: D2PlannedOperation, result: SpotDemoOrderSubmitResult
     ) -> None:
         """The broker must echo back exactly what was authorized.
 
-        A response describing a different symbol, side, type, or quantity is
-        not a success with cosmetic drift; it means the account was mutated in
-        a way the seal does not cover.
+        A response describing a different symbol, side, type, quantity, price,
+        or time-in-force is not a success with cosmetic drift; it means the
+        account was mutated in a way the seal does not cover.
+
+        Price and time-in-force live in the raw response rather than in typed
+        DTO fields, so they are read from there. Their *absence* is a failure,
+        not a pass: a response that cannot prove the sealed price has not
+        proved it.
         """
 
         order = op.order
+        raw = result.raw_response_redacted or {}
         mismatches: list[str] = []
         if result.symbol != order.symbol:
             mismatches.append(f"symbol {result.symbol!r} != {order.symbol!r}")
@@ -965,6 +1650,24 @@ class D2RemediationSingleWriter:
             mismatches.append(
                 f"executedQty {result.executed_qty} exceeds authorized {order.quantity}"
             )
+        echoed_price = raw.get("price")
+        if echoed_price is None:
+            mismatches.append(
+                "broker response carries no price — the sealed limit price is unproven"
+            )
+        else:
+            try:
+                if Decimal(str(echoed_price)) != order.price:
+                    mismatches.append(f"price {echoed_price!r} != {order.price}")
+            except (DecimalException, TypeError, ValueError):
+                mismatches.append(f"price {echoed_price!r} is not a decimal")
+        echoed_tif = raw.get("timeInForce")
+        if echoed_tif is None:
+            mismatches.append(
+                "broker response carries no timeInForce — GTC is unproven"
+            )
+        elif str(echoed_tif) != order.time_in_force:
+            mismatches.append(f"timeInForce {echoed_tif!r} != {order.time_in_force!r}")
         if mismatches:
             raise D2RemediationError(
                 D2ReasonCode.BROKER_ECHO_MISMATCH,
@@ -992,59 +1695,49 @@ class D2RemediationSingleWriter:
                 "submit_outcome_unknown_order_not_found_after_ambiguous_submit: "
                 f"{submit_error!r}"
             )
-            await self._ledger_anomaly(op, reason)
-            return D2DispatchOutcome(
-                operation_id=op.operation_id,
-                client_order_id=op.client_order_id,
-                order=op.order,
-                request_params=op.request_params,
-                status="anomaly",
-                ledger_state="anomaly",
-                readback_used=True,
-                anomaly_reason=reason,
-            )
+            return await self._anomaly_outcome(op, reason)
         except Exception as readback_error:
             reason = (
                 f"submit_outcome_unknown_readback_failed: {readback_error!r} "
                 f"(original: {submit_error!r})"
             )
-            await self._ledger_anomaly(op, reason)
-            return D2DispatchOutcome(
-                operation_id=op.operation_id,
-                client_order_id=op.client_order_id,
-                order=op.order,
-                request_params=op.request_params,
-                status="anomaly",
-                ledger_state="anomaly",
-                readback_used=True,
-                anomaly_reason=reason,
-            )
+            return await self._anomaly_outcome(op, reason)
 
-        broker_order_id = str(status_body.get("orderId", ""))
-        echoed = SpotDemoOrderSubmitResult(
-            client_order_id=str(status_body.get("clientOrderId", op.client_order_id)),
-            broker_order_id=broker_order_id,
-            symbol=str(status_body.get("symbol", "")),
-            side=str(status_body.get("side", "")),
-            order_type=str(status_body.get("type", "")),
-            qty=_decimal(status_body.get("origQty", "0"), what="readback origQty"),
-            executed_qty=_decimal(
-                status_body.get("executedQty", "0"), what="readback executedQty"
-            ),
-            cummulative_quote_qty=Decimal("0"),
-            status=str(status_body.get("status", "UNKNOWN")),
-        )
+        echoed = self._echo_from_status(op, status_body)
         self._assert_echo(op, echoed)
-        await self._ledger_transition("submitted", op, broker_order_id=broker_order_id)
+        await self._ledger.record_submitted(
+            client_order_id=op.client_order_id,
+            broker_order_id=echoed.broker_order_id,
+            now=self._now_fn(),
+        )
         return D2DispatchOutcome(
             operation_id=op.operation_id,
             client_order_id=op.client_order_id,
             order=op.order,
             request_params=op.request_params,
             status=echoed.status,
-            broker_order_id=broker_order_id,
+            broker_order_id=echoed.broker_order_id,
             ledger_state="submitted",
             readback_used=True,
+        )
+
+    async def _anomaly_outcome(
+        self, op: D2PlannedOperation, reason: str
+    ) -> D2DispatchOutcome:
+        await self._ledger.record_anomaly(
+            client_order_id=op.client_order_id,
+            reason=reason,
+            now=self._now_fn(),
+        )
+        return D2DispatchOutcome(
+            operation_id=op.operation_id,
+            client_order_id=op.client_order_id,
+            order=op.order,
+            request_params=op.request_params,
+            status="anomaly",
+            ledger_state="anomaly",
+            readback_used=True,
+            anomaly_reason=reason,
         )
 
     # -- proof epochs --------------------------------------------------
@@ -1084,12 +1777,11 @@ class D2RemediationSingleWriter:
                 }
             )
         ledger_states: dict[str, str] = {}
-        if self._ledger is not None:
-            for outcome in outcomes:
-                row = await self._ledger.get_by_client_order_id(outcome.client_order_id)
-                ledger_states[outcome.client_order_id] = (
-                    "" if row is None else str(row.lifecycle_state)
-                )
+        for outcome in outcomes:
+            row = await self._ledger.get_by_client_order_id(outcome.client_order_id)
+            ledger_states[outcome.client_order_id] = (
+                "" if row is None else str(row.lifecycle_state)
+            )
         return D2ProofEpoch(
             epoch_index=epoch_index,
             observed_at_utc=self._now_fn().isoformat(),
@@ -1107,74 +1799,6 @@ class D2RemediationSingleWriter:
             ledger_states=ledger_states,
         )
 
-    # -- ledger (service only; the repository is never touched) ---------
-
-    async def _resolve_instrument(self, order: D2BoundOrder) -> int:
-        if self._ledger is None:
-            return 0
-        return await self._ledger.resolve_or_create_instrument(
-            venue=D2_VENUE,
-            product=D2_PRODUCT,
-            venue_symbol=order.symbol,
-            base_asset=order.asset,
-            quote_asset=D2_QUOTE_ASSET,
-        )
-
-    async def _ledger_planned(self, op: D2PlannedOperation, instrument_id: int) -> None:
-        if self._ledger is None:
-            return
-        await self._ledger.record_planned(
-            instrument_id=instrument_id,
-            product=D2_PRODUCT,
-            venue_host=D2_VENUE_HOST,
-            client_order_id=op.client_order_id,
-            side=op.order.side,
-            order_type=op.order.order_type,
-            qty=op.order.quantity,
-            price=op.order.price,
-            extra_metadata=self._evidence_metadata(op),
-            now=self._now_fn(),
-        )
-
-    async def _ledger_transition(
-        self,
-        state: str,
-        op: D2PlannedOperation,
-        *,
-        broker_order_id: str | None = None,
-    ) -> None:
-        if self._ledger is None:
-            return
-        now = self._now_fn()
-        if state == "previewed":
-            await self._ledger.record_previewed(
-                client_order_id=op.client_order_id, now=now
-            )
-        elif state == "validated":
-            await self._ledger.record_validated(
-                client_order_id=op.client_order_id, now=now
-            )
-        elif state == "submitted":
-            await self._ledger.record_submitted(
-                client_order_id=op.client_order_id,
-                broker_order_id=broker_order_id or "",
-                now=now,
-            )
-        else:  # pragma: no cover - defensive
-            raise D2RemediationError(
-                D2ReasonCode.UNAUTHORIZED_OPERATION,
-                f"unsupported ledger transition {state!r}",
-            )
-
-    async def _ledger_anomaly(self, op: D2PlannedOperation, reason: str) -> None:
-        if self._ledger is None:
-            return
-        await self._ledger.record_anomaly(
-            client_order_id=op.client_order_id,
-            reason=reason,
-            now=self._now_fn(),
-        )
-
     def _evidence_metadata(self, op: D2PlannedOperation) -> dict[str, Any]:
         return {
             "writer": WRITER_NAME,
@@ -1182,26 +1806,20 @@ class D2RemediationSingleWriter:
             "remediation_id": D2_REMEDIATION_ID,
             "pre_snapshot_hash": D2_PRE_SNAPSHOT_HASH,
             "snapshot_seal_sha256": D2_SNAPSHOT_SEAL_SHA256,
-            "binding_payload_sha256": D2_BINDING_PAYLOAD_SHA256,
+            "binding_payload_sha256": self._authority.payload_sha256,
+            "credential_fingerprint": self._authority.credential_fingerprint,
             "operation_id": op.operation_id,
             "canary_or_strategy_use": "forbidden",
         }
 
 
-def _default_client_order_id(*, symbol: str) -> str:
-    """``d2rem-<symbol>-<12 hex>`` — inside the 36-char Binance constraint."""
-
-    import uuid
-
-    return f"{D2_CLIENT_ORDER_ID_PREFIX}-{symbol}-{uuid.uuid4().hex[:12]}"
-
-
 __all__ = [
     "D2_ALLOWED_OPERATION_IDS",
-    "D2_BINDING_PAYLOAD_SHA256",
     "D2_BOUND_ORDERS",
     "D2_CLIENT_ORDER_ID_PREFIX",
+    "D2_CREDENTIAL_FINGERPRINT",
     "D2_EXCEPTION_ID",
+    "D2_KNOWN_SEALED_PAYLOADS",
     "D2_LANE_ID",
     "D2_ORDER_TYPE",
     "D2_PRE_SNAPSHOT_HASH",
@@ -1214,14 +1832,19 @@ __all__ = [
     "D2_TIME_IN_FORCE",
     "D2_VENUE",
     "D2_VENUE_HOST",
+    "D2AccountTruth",
+    "D2AccountTruthDrift",
+    "D2BlindRetryRefused",
     "D2BoundOrder",
+    "D2DispatchNotAuthorized",
     "D2DispatchOutcome",
     "D2DryRunReport",
     "D2ExecutionReport",
     "D2LeaseNotHeld",
-    "D2BlindRetryRefused",
+    "D2LedgerRequired",
     "D2OutcomeUnknown",
     "D2PlannedOperation",
+    "D2PriorAttemptUnresolved",
     "D2ProofEpoch",
     "D2ReasonCode",
     "D2RemediationDisabled",
@@ -1229,10 +1852,16 @@ __all__ = [
     "D2RemediationSingleWriter",
     "D2SealBindingMismatch",
     "D2UnauthorizedOperation",
+    "SealedAuthority",
+    "SealedPayloadRecord",
     "WRITER_NAME",
     "acquire_d2_lease",
+    "assert_registry_credential_fingerprint",
+    "assert_writer_freeze",
     "bind_sealed_orders",
     "d2_advisory_keyset",
+    "d2_physical_account_id",
     "d2_physical_account_scope",
     "d2_remediation_enabled",
+    "load_sealed_authority",
 ]

--- a/ci_shards/shard-1.txt
+++ b/ci_shards/shard-1.txt
@@ -119,6 +119,7 @@ tests/services/brokers/binance/futures_demo/test_signing.py
 tests/services/brokers/binance/paper/test_binance_adapter.py
 tests/services/brokers/binance/spot_demo/test_audit_no_live_host.py
 tests/services/brokers/binance/spot_demo/test_config_env.py
+tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
 tests/services/brokers/binance/spot_demo/test_execution_client_fail_closed.py
 tests/services/brokers/binance/spot_demo/test_execution_client_submit_cancel.py
 tests/services/brokers/binance/spot_demo/test_mock_auto_limit.py

--- a/ci_shards/shard-2.txt
+++ b/ci_shards/shard-2.txt
@@ -65,6 +65,7 @@ tests/scripts/b0x/test_cancel.py
 tests/scripts/b0x/test_envelope_and_locks.py
 tests/scripts/b0x/test_kill_switch_and_touch_rule.py
 tests/scripts/b0x/test_labels.py
+tests/scripts/test_binance_spot_demo_d2_remediation_cli.py
 tests/scripts/test_haproxy_render.py
 tests/scripts/test_haproxy_switch.py
 tests/scripts/test_kiwoom_mock_smoke_contract.py

--- a/ci_shards/shard-3.txt
+++ b/ci_shards/shard-3.txt
@@ -113,6 +113,7 @@ tests/services/brokers/binance/futures_demo/test_preflight.py
 tests/services/brokers/binance/futures_demo/test_sizing.py
 tests/services/brokers/binance/spot_demo/test_get_asset_balance.py
 tests/services/brokers/binance/spot_demo/test_host_allowlist.py
+tests/services/brokers/binance/spot_demo/test_spot_demo_submit_callers.py
 tests/services/brokers/binance/spot_demo/test_testnet_env_does_not_activate_demo.py
 tests/services/brokers/binance/test_gap_detection.py
 tests/services/brokers/binance/test_public_futures_stream_allowlist.py

--- a/ci_shards/shard-4.txt
+++ b/ci_shards/shard-4.txt
@@ -90,6 +90,7 @@ tests/services/action_report/snapshot_backed/test_collectors.py
 tests/services/action_report/snapshot_backed/test_no_self_authored_invalidation.py
 tests/services/action_report/snapshot_backed/test_pending_orders_collector.py
 tests/services/analysis_snapshot_bundle/test_capture.py
+tests/services/brokers/binance/demo/test_ledger_durable_claim.py
 tests/services/brokers/binance/demo/test_ledger_futures_product.py
 tests/services/brokers/binance/demo/test_ledger_service.py
 tests/services/brokers/binance/demo_scalping/test_contract.py

--- a/docs/runbooks/binance-spot-demo-d2-remediation.md
+++ b/docs/runbooks/binance-spot-demo-d2-remediation.md
@@ -124,15 +124,37 @@ Neither step is something this repository can do to itself.
 
 ## 5a. The durable replay fence
 
+**Record, then execute.** The claim row is committed in its own transaction
+*before* any broker call, and read back through a second, independent
+transaction to prove it landed. Only then is anything sent.
+
+The earlier ordering was the other way round: the claim was written into the
+CLI's transaction and committed after `execute()` returned, so a process that
+died between the signed POST and its own commit left no row at all — and the
+restart, seeing nothing, re-sent. Measured on a throwaway database with a child
+killed by `os._exit(9)` immediately after the POST:
+
+```text
+old ordering:  fence_row_after_kill = None       -> restart would re-send
+new ordering:  fence_row_after_kill = 'planned'  -> restart goes to readback
+```
+
+The read-back is deliberately *not* done through the writing session. A session
+can see its own flushed-but-uncommitted rows, so reading there would call a
+flush durable. Going out to a separate transaction means a state that comes
+back has survived a commit and is visible to any other process — which is also
+why a ledger whose writes go nowhere fails here, before the broker is touched.
+Requiring the ledger's *type* was never the same as requiring its *effect*.
+
 The `client_order_id` is derived from the seal and the order
 (`d2rem-<24 hex>`), not minted per run. Three consequences:
 
-- a restarted process computes the same id, so the ledger recognises the prior
-  attempt and the writer reads the broker instead of sending;
+- a restarted process computes the same id, so the committed claim is found;
 - Binance rejects a duplicate `newClientOrderId` while the original is live, so
   there is a second fence outside this repository;
-- a changed price or quantity is a different id, so the fence cannot be
-  confused by an unrelated order.
+- `uq_binance_demo_ledger_open_root` is unique on `(product, instrument_id)`
+  across the open lifecycle states, so the database itself refuses a second
+  open root for the same instrument — a third fence, free.
 
 A ledger row with no matching broker record is **unresolvable** and halts the
 run. "Never arrived" and "arrived then vanished" look identical from here, and
@@ -146,8 +168,11 @@ only one of them is safe to act on.
   anomaly and the run halts before the next order.
 * **Broker echo mismatch**: a response describing a different symbol, side,
   type, quantity, **price**, or **timeInForce** is a failure, not cosmetic
-  drift. A response that omits price or timeInForce is also a failure: it has
-  not proved the sealed values.
+  drift. So is one whose **`clientOrderId`** is not the deterministic id we
+  sent, or which carries no **`orderId`**: matching contents are not identity,
+  and the shared Demo account can hold another order with the same symbol,
+  side, quantity, and price. A response that omits any of these has not proved
+  the sealed values — absence is a failure, not a pass.
 * **Account drift**: a resting order this one-shot did not place, or any
   balance that differs from the seal, stops the run before the first POST.
   This writer has no cancel path, so clearing a foreign order is an operator
@@ -158,7 +183,10 @@ only one of them is safe to act on.
   construction.
 * **Unreleased lease**: the CLI releases the lease last, after the proof
   epochs, and exits 2 if the release could not be *proven*. A stuck lease is
-  reported with its hold id rather than swallowed.
+  reported with its hold id rather than swallowed. The client close and the
+  lease release sit in **separate** try/finally layers, so a raising `aclose()`
+  cannot skip the release — that was the one path where the lease was most
+  likely to be stuck and least likely to be reported.
 
 ## 7. Known limits
 
@@ -167,14 +195,18 @@ only one of them is safe to act on.
   account without contending for it. That is why the writer also re-attests per
   submit and reads the *account-wide* open-order book before dispatching and in
   both proof epochs — and why none of those closes the hole, only narrows it.
-* **Residual in-process bypasses.** The gates stop a mistaken caller and a
-  doctored file; they do not stop code running inside this process that is
-  determined to lie. Specifically: a caller can build a real
-  `PostgresAdvisoryKeysetLease` over a fabricated `LockAuthorityConnection`, can
-  subclass `BinanceDemoLedgerService` with no-op writes, can mutate `os.environ`,
-  and can monkeypatch module constants. Each of those is what the *tests* do,
-  which is the honest way to say it. Closing them would require the lease and
-  the ledger to prove themselves to something outside the process.
+* 🔴 **What these gates do and do not cover.** They stop accidental misuse, a
+  wrong parameter, a doctored payload file, a drifted account, a lying broker
+  response, and a re-send after a crash. They do **not** stop deliberate forgery
+  by code running inside the same process. A caller already executing in this
+  process can read `_AUTHORITY_TOKEN` and build a `SealedAuthority` that never
+  saw a file, can construct a real `PostgresAdvisoryKeysetLease` over a
+  fabricated lock authority, can subclass `BinanceDemoLedgerService`, and can
+  mutate `os.environ` or any module constant. No writer-level gate closes that
+  in Python — such a caller can simply call the broker client directly and skip
+  this module altogether. The threat-model question of whether that matters is
+  with the operator; this runbook states the limit rather than claiming a
+  guarantee that does not exist.
 * **Balance drift is checked by exact equality**, so any movement on the three
   sealed assets since the snapshot stops the run. That is deliberate — the seal
   either describes the account or it does not — but it means a stale seal fails

--- a/docs/runbooks/binance-spot-demo-d2-remediation.md
+++ b/docs/runbooks/binance-spot-demo-d2-remediation.md
@@ -1,0 +1,118 @@
+# D2 one-shot remediation — `d2_remediation_single`
+
+`operator_contract.yaml` names a writer for the
+`binance-demo-remediation-20260820` exception. This runbook covers the code that
+answers to that name.
+
+**Scope of this document.** It describes the writer and how to rehearse it. It
+does **not** authorize execution. Execution requires a separate operator
+re-sign, and the runbook cannot supply one.
+
+## 1. What it is
+
+| | |
+|---|---|
+| Writer | `app/services/brokers/binance/spot_demo/d2_remediation_single.py` |
+| CLI | `scripts/binance_spot_demo_d2_remediation.py` |
+| Contract | `~/work/herdr-inbox/contract-d2-binance-remediation-v2.2-20260820.md` |
+| Seal | r7 attempt-2, `pre_snapshot_hash=sha256:5ba70a81…3e6b898` |
+| Surface | `binance_spot_demo_remediation_only` |
+| Canary/strategy use | forbidden |
+
+It can express exactly three orders:
+
+```text
+BTCUSDT  SELL LIMIT 0.00015000    @ 69266.01000000
+ETHUSDT  SELL LIMIT 0.00520000    @  2248.56000000
+USDCUSDT SELL LIMIT 5000.00000000 @     1.00072000
+```
+
+There is no fourth, no BUY, no MARKET, and no flag that selects a symbol,
+quantity, or price. The set lives in `D2_BOUND_ORDERS`; the sealed payload is
+re-read at runtime and must match it exactly.
+
+## 2. Why a second entry point exists
+
+`scripts/binance_spot_demo_smoke.py` is the ROB-298 BUY round-trip and does not
+wire a SELL `--confirm`, so it cannot express these operations. The 2026-08-20
+execution attempt correctly refused to reach around it with an ad-hoc script,
+because that would have created an unreviewed execution surface. This module is
+the reviewed alternative.
+
+`tests/services/brokers/binance/spot_demo/test_spot_demo_submit_callers.py`
+enumerates every caller of `BinanceSpotDemoExecutionClient.submit_order` and
+fails on an unlisted one. Adding an execution surface is a reviewed change.
+
+## 3. Inherited boundaries — none relaxed
+
+| Boundary | Owner | State after this change |
+|---|---|---|
+| Host pinned to `demo-api.binance.com` | ROB-298 transport | unchanged; the writer re-asserts it before composing |
+| `submit_order(..., confirm=True)` per-call gate | ROB-298 execution client | unchanged; the writer's own default is `confirm=False` |
+| `BINANCE_SPOT_DEMO_ENABLED` | ROB-298 | unchanged, still default-off |
+| Ledger writes via `BinanceDemoLedgerService` | ROB-298 | unchanged; the repository is never imported here |
+| Lifecycle state machine | ROB-298 | unchanged; the writer only uses legal transitions |
+
+Added on top (all tightening):
+
+* `D2_REMEDIATION_SINGLE_ENABLED` — a second, independent, default-off gate.
+* A closed three-order set bound to one `pre_snapshot_hash`.
+* A J3A lease precondition, re-attested immediately before every submit.
+* One dispatch per `client_order_id`, enforced by a claim set.
+* Two independent post-dispatch proof epochs.
+
+## 4. Rehearsal
+
+`--plan-only` is pure: it binds the seal and prints the three request payloads
+with no HTTP, no DB, no lease, and no signing. It needs no env gate because it
+touches nothing.
+
+```bash
+uv run python -m scripts.binance_spot_demo_d2_remediation \
+  --plan-only \
+  --sealed-payload <path>/r7-snapshot/attempt-2/binding-payload-proposed.json
+```
+
+`--dry-run` walks the whole path — both env gates, host re-assertion, seal
+binding, J3A lease acquisition and attestation, request composition, and the
+non-mutating `POST /api/v3/order/test` shape check — and stops immediately
+before the signed POST. It needs both gates armed and a reachable database.
+
+```bash
+BINANCE_SPOT_DEMO_ENABLED=true D2_REMEDIATION_SINGLE_ENABLED=true \
+uv run python -m scripts.binance_spot_demo_d2_remediation \
+  --dry-run --sealed-payload <path>/binding-payload-proposed.json
+```
+
+## 5. Execution — not authorized by this document
+
+`--confirm` is the only mode that reaches `submit_order(..., confirm=True)`.
+Before it may be run, all of the following must hold, and none of them is
+established here:
+
+1. a fresh operator re-sign bound to the exact r7 `pre_snapshot_hash`;
+2. `operator_authorization` no longer `null` in the sealed object;
+3. both env gates armed by the operator, deliberately, for this run;
+4. the account-wide writer freeze in force per contract v2.1 §6.
+
+## 6. Failure behaviour
+
+* **Ambiguous submit** (timeout, reset, unclear response): one bounded
+  readback of the order by its client id. Never a re-send — a duplicate order
+  is the worst available outcome, so an unproven result is recorded as an
+  anomaly and the run halts before the next order.
+* **Broker echo mismatch**: a response describing a different symbol, side,
+  type, or quantity is a failure, not cosmetic drift.
+* **Lease lost**: refusal before the transport. Acquisition-time success is
+  never carried forward.
+
+## 7. Known limits
+
+* **The J3A lease is not broker-enforced fencing.** Binance never sees it. An
+  operator at a console or an out-of-repo process reaches the same shared Demo
+  account without contending for it. That is why the writer also re-attests per
+  submit and reads the *account-wide* open-order book in both proof epochs —
+  and why neither of those closes the hole, only narrows it.
+* **A resting SELL LIMIT is not a fill.** The writer records `submitted` and
+  proves the resting state; it does not wait for or assert a fill.
+* **No scheduler registration.** CLI-only, operator-driven, one shot.

--- a/docs/runbooks/binance-spot-demo-d2-remediation.md
+++ b/docs/runbooks/binance-spot-demo-d2-remediation.md
@@ -73,10 +73,12 @@ uv run python -m scripts.binance_spot_demo_d2_remediation \
   --sealed-payload <path>/r7-snapshot/attempt-2/binding-payload-proposed.json
 ```
 
-`--dry-run` walks the whole path — both env gates, host re-assertion, seal
-binding, J3A lease acquisition and attestation, request composition, and the
-non-mutating `POST /api/v3/order/test` shape check — and stops immediately
-before the signed POST. It needs both gates armed and a reachable database.
+`--dry-run` walks the whole path — both env gates, host re-assertion,
+credential-fingerprint match, writer freeze, seal verification, J3A lease
+acquisition and attestation, **pre-dispatch account truth**, request
+composition, and the non-mutating `POST /api/v3/order/test` shape check — and
+stops immediately before the signed POST. It needs both gates armed and a
+reachable database.
 
 ```bash
 BINANCE_SPOT_DEMO_ENABLED=true D2_REMEDIATION_SINGLE_ENABLED=true \
@@ -84,16 +86,57 @@ uv run python -m scripts.binance_spot_demo_d2_remediation \
   --dry-run --sealed-payload <path>/binding-payload-proposed.json
 ```
 
-## 5. Execution — not authorized by this document
+There is no flag to skip the order-shape check. It was optional in the first
+revision, which meant the mode that sends real orders could also be the mode
+that skipped the only broker-side proof that the sealed filters still describe
+the market.
+
+## 5. Execution — structurally unreachable today
 
 `--confirm` is the only mode that reaches `submit_order(..., confirm=True)`.
-Before it may be run, all of the following must hold, and none of them is
-established here:
+It is not merely "not authorized by this document" — it cannot run, and that is
+enforced at runtime rather than documented:
 
-1. a fresh operator re-sign bound to the exact r7 `pre_snapshot_hash`;
-2. `operator_authorization` no longer `null` in the sealed object;
-3. both env gates armed by the operator, deliberately, for this run;
-4. the account-wide writer freeze in force per contract v2.1 §6.
+| Gate | Where | Current state |
+|---|---|---|
+| Registered payload digest | `D2_KNOWN_SEALED_PAYLOADS` | one entry, `dispatch_authorized=false` |
+| `operator_authorization` non-null | `SealedAuthority.dispatch_block_reasons` | `null` |
+| `expiry` present and future | same | absent |
+| `mutation_authorized` on all three rows | same | `false` on all three |
+| Sealed credential fingerprint = signed J2A registry | `load_sealed_authority` | matches |
+| Live client credential fingerprint = sealed | writer constructor | checked per run |
+| Account-wide writer freeze | `assert_writer_freeze` | in force |
+
+`--dry-run` prints the whole blocker list; `--confirm` refuses on it *before*
+opening a client, a lease, or a database session. Both env gates being armed
+changes none of this.
+
+Authorizing dispatch takes two separate things, in this order:
+
+1. the operator's fresh re-sign bound to the exact r7 `pre_snapshot_hash`,
+   which produces a **different file with a different digest**; and
+2. a reviewed change that registers that digest with
+   `dispatch_authorized=True` — which also has to update the import-time
+   tripwire in `_assert_closed_order_set` that currently asserts no such entry
+   exists.
+
+Neither step is something this repository can do to itself.
+
+## 5a. The durable replay fence
+
+The `client_order_id` is derived from the seal and the order
+(`d2rem-<24 hex>`), not minted per run. Three consequences:
+
+- a restarted process computes the same id, so the ledger recognises the prior
+  attempt and the writer reads the broker instead of sending;
+- Binance rejects a duplicate `newClientOrderId` while the original is live, so
+  there is a second fence outside this repository;
+- a changed price or quantity is a different id, so the fence cannot be
+  confused by an unrelated order.
+
+A ledger row with no matching broker record is **unresolvable** and halts the
+run. "Never arrived" and "arrived then vanished" look identical from here, and
+only one of them is safe to act on.
 
 ## 6. Failure behaviour
 
@@ -102,17 +145,40 @@ established here:
   is the worst available outcome, so an unproven result is recorded as an
   anomaly and the run halts before the next order.
 * **Broker echo mismatch**: a response describing a different symbol, side,
-  type, or quantity is a failure, not cosmetic drift.
+  type, quantity, **price**, or **timeInForce** is a failure, not cosmetic
+  drift. A response that omits price or timeInForce is also a failure: it has
+  not proved the sealed values.
+* **Account drift**: a resting order this one-shot did not place, or any
+  balance that differs from the seal, stops the run before the first POST.
+  This writer has no cancel path, so clearing a foreign order is an operator
+  action.
 * **Lease lost**: refusal before the transport. Acquisition-time success is
-  never carried forward.
+  never carried forward, and the lease must be a real
+  `PostgresAdvisoryKeysetLease` — a duck-typed stand-in is rejected at
+  construction.
+* **Unreleased lease**: the CLI releases the lease last, after the proof
+  epochs, and exits 2 if the release could not be *proven*. A stuck lease is
+  reported with its hold id rather than swallowed.
 
 ## 7. Known limits
 
 * **The J3A lease is not broker-enforced fencing.** Binance never sees it. An
   operator at a console or an out-of-repo process reaches the same shared Demo
   account without contending for it. That is why the writer also re-attests per
-  submit and reads the *account-wide* open-order book in both proof epochs —
-  and why neither of those closes the hole, only narrows it.
+  submit and reads the *account-wide* open-order book before dispatching and in
+  both proof epochs — and why none of those closes the hole, only narrows it.
+* **Residual in-process bypasses.** The gates stop a mistaken caller and a
+  doctored file; they do not stop code running inside this process that is
+  determined to lie. Specifically: a caller can build a real
+  `PostgresAdvisoryKeysetLease` over a fabricated `LockAuthorityConnection`, can
+  subclass `BinanceDemoLedgerService` with no-op writes, can mutate `os.environ`,
+  and can monkeypatch module constants. Each of those is what the *tests* do,
+  which is the honest way to say it. Closing them would require the lease and
+  the ledger to prove themselves to something outside the process.
+* **Balance drift is checked by exact equality**, so any movement on the three
+  sealed assets since the snapshot stops the run. That is deliberate — the seal
+  either describes the account or it does not — but it means a stale seal fails
+  loudly rather than adapting.
 * **A resting SELL LIMIT is not a fill.** The writer records `submitted` and
   proves the resting state; it does not wait for or assert a fill.
 * **No scheduler registration.** CLI-only, operator-driven, one shot.

--- a/docs/runbooks/binance-spot-demo-d2-remediation.md
+++ b/docs/runbooks/binance-spot-demo-d2-remediation.md
@@ -91,21 +91,30 @@ revision, which meant the mode that sends real orders could also be the mode
 that skipped the only broker-side proof that the sealed filters still describe
 the market.
 
-## 5. Execution — structurally unreachable today
+## 5. Execution — refused, at runtime, on every registered payload
 
 `--confirm` is the only mode that reaches `submit_order(..., confirm=True)`.
-It is not merely "not authorized by this document" — it cannot run, and that is
-enforced at runtime rather than documented:
+For a caller entering through this module's functions, it is refused — not by
+convention but by checks that run, each named with where it lives:
 
-| Gate | Where | Current state |
+| Gate | Enforced at | Current state |
 |---|---|---|
-| Registered payload digest | `D2_KNOWN_SEALED_PAYLOADS` | one entry, `dispatch_authorized=false` |
+| Payload bytes hashed before parsing; unknown digest refused | `load_sealed_authority` | one registered digest |
+| Every registered digest is `dispatch_authorized=false`, and import fails if not | `_assert_closed_order_set` | holds |
 | `operator_authorization` non-null | `SealedAuthority.dispatch_block_reasons` | `null` |
-| `expiry` present and future | same | absent |
-| `mutation_authorized` on all three rows | same | `false` on all three |
-| Sealed credential fingerprint = signed J2A registry | `load_sealed_authority` | matches |
-| Live client credential fingerprint = sealed | writer constructor | checked per run |
+| `expiry` present and not past, read from the real clock | `SealedAuthority.dispatch_block_reasons`, `D2RemediationSingleWriter.dispatch_block_reasons` | absent |
+| `mutation_authorized` on all three rows | `SealedAuthority.dispatch_block_reasons` | `false` on all three |
+| Sealed credential fingerprint = signed J2A registry | `load_sealed_authority`, `assert_registry_credential_fingerprint` | matches |
+| Live client credential fingerprint = sealed | `D2RemediationSingleWriter._assert_client_account` | checked per run |
 | Account-wide writer freeze | `assert_writer_freeze` | in force |
+| Both env gates read only `os.environ` | `d2_remediation_enabled` | both off by default |
+| Claim committed before any send, then read back | `D2RemediationSingleWriter._dispatch_one`, `BinanceDemoLedgerService.commit_planned_claim` | enforced |
+| Broker identity / price / time-in-force echo | `D2RemediationSingleWriter._assert_echo`, `broker_identifier_problem` | enforced |
+
+Symbol names rather than line numbers on purpose: a line citation is a claim
+that goes stale on the next edit without anyone noticing, and
+`test_the_runbook_gate_table_names_symbols_that_exist` checks every name in the
+"Enforced at" column against the live modules.
 
 `--dry-run` prints the whole blocker list; `--confirm` refuses on it *before*
 opening a client, a lease, or a database session. Both env gates being armed
@@ -195,18 +204,21 @@ only one of them is safe to act on.
   account without contending for it. That is why the writer also re-attests per
   submit and reads the *account-wide* open-order book before dispatching and in
   both proof epochs — and why none of those closes the hole, only narrows it.
-* 🔴 **What these gates do and do not cover.** They stop accidental misuse, a
-  wrong parameter, a doctored payload file, a drifted account, a lying broker
-  response, and a re-send after a crash. They do **not** stop deliberate forgery
-  by code running inside the same process. A caller already executing in this
-  process can read `_AUTHORITY_TOKEN` and build a `SealedAuthority` that never
-  saw a file, can construct a real `PostgresAdvisoryKeysetLease` over a
-  fabricated lock authority, can subclass `BinanceDemoLedgerService`, and can
-  mutate `os.environ` or any module constant. No writer-level gate closes that
-  in Python — such a caller can simply call the broker client directly and skip
-  this module altogether. The threat-model question of whether that matters is
-  with the operator; this runbook states the limit rather than claiming a
-  guarantee that does not exist.
+* 🔴 **Threat model — confirmed by the operator, not pending.** These gates
+  cover **accidental misuse**: a wrong parameter, a doctored or unregistered
+  payload file, an account that has drifted from the seal, a malformed or
+  foreign broker response, and a re-send after a crash. They do **not** cover
+  **deliberate forgery by code running in the same process**, and that is
+  accepted as a documented limit rather than treated as a gap to close.
+
+  Concretely, an in-process caller can import `_AUTHORITY_TOKEN` and build a
+  `SealedAuthority` that never saw a file, construct a real
+  `PostgresAdvisoryKeysetLease` over a fabricated lock authority, subclass
+  `BinanceDemoLedgerService`, and rebind `os.environ` or any module constant.
+  It can also skip this module entirely and call
+  `BinanceSpotDemoExecutionClient` directly. No writer-level check closes any
+  of that in Python, and none in this repository claims to — the source
+  docstrings state the same limit.
 * **Balance drift is checked by exact equality**, so any movement on the three
   sealed assets since the snapshot stops the run. That is deliberate — the seal
   either describes the account or it does not — but it means a stale seal fails

--- a/scripts/binance_spot_demo_d2_remediation.py
+++ b/scripts/binance_spot_demo_d2_remediation.py
@@ -3,44 +3,54 @@
 Default-disabled, dry-run by default, and bound to the sealed r7 attempt-2
 snapshot.  It can express exactly three orders and no fourth:
 
-    BTCUSDT  SELL LIMIT 0.00015000 @ 69266.01000000
-    ETHUSDT  SELL LIMIT 0.00520000 @  2248.56000000
-    USDCUSDT SELL LIMIT 5000.00000000 @ 1.00072000
+    BTCUSDT  SELL LIMIT 0.00015000    @ 69266.01000000
+    ETHUSDT  SELL LIMIT 0.00520000    @  2248.56000000
+    USDCUSDT SELL LIMIT 5000.00000000 @     1.00072000
 
 There is no ``--symbol``, ``--side``, ``--quantity``, or ``--price`` flag,
-because there is nothing for them to select.  The order set comes from the
-sealed payload, is checked against the frozen constant in
-``app.services.brokers.binance.spot_demo.d2_remediation_single``, and any
-disagreement is a refusal.
+because there is nothing for them to select.  The orders come from the sealed
+payload file, whose **bytes are hashed and checked against a registered
+digest** before the JSON is even parsed.
+
+**``--confirm`` cannot dispatch today, and that is by construction.** Every
+registered sealed payload carries ``dispatch_authorized=false``, the current r7
+object has ``operator_authorization=null``, no expiry, and
+``mutation_authorized=false`` on all three rows. ``--dry-run`` prints that list;
+``--confirm`` refuses on it. Authorizing dispatch takes the operator's re-sign
+(which produces different bytes, and therefore a different digest) plus a
+reviewed change that registers it.
 
 **Relationship to ``scripts/binance_spot_demo_smoke.py``.**  That CLI is the
 ROB-298 BUY round-trip smoke path and remains exactly what it is; it does not
-wire a SELL ``--confirm``, so it cannot express these operations.  This file is
-the second — and last — approved Spot Demo entry point that places real Demo
-orders.  Both CLIs name each other so neither can be read as the sole one.
+wire a SELL ``--confirm``, so it cannot express these operations.  Both CLIs
+name each other so neither can be read as the sole one.
 
 Modes (mutually exclusive; the default prints guidance and exits 0):
 
   1. **default** — no flags: one guidance line, exit 0, zero HTTP / DB / lease.
-  2. ``--plan-only`` — bind the seal and print the three request payloads.
-     Pure: no HTTP, no DB, no lease, no signing.
+  2. ``--plan-only`` — verify the sealed file and print the three request
+     payloads with their deterministic client-order-ids. No HTTP, no DB, no
+     lease, no signing.
   3. ``--dry-run`` — the whole path, stopping immediately before the signed
-     POST: env gates, host re-assertion, seal binding, J3A lease acquisition
-     and attestation, request composition, and the non-mutating
+     POST: both env gates, host re-assertion, credential-fingerprint match,
+     writer freeze, seal verification, J3A lease acquisition and attestation,
+     pre-dispatch account truth, request composition, and the non-mutating
      ``POST /api/v3/order/test`` shape check.
-  4. ``--confirm`` — the real dispatch.  Requires ``--dry-run`` to have been
-     run first is *not* enforceable from here, so this mode instead requires
-     both env gates plus the explicit flag, and it is the only mode that can
-     reach ``submit_order(..., confirm=True)``.
+  4. ``--confirm`` — the real dispatch. Requires everything ``--dry-run`` does,
+     plus complete dispatch authority. The order-shape check is not optional
+     here; there is no flag to skip it.
 
-Env gates (both default-off; neither relaxes the other):
+Env gates (both default-off; neither relaxes the other, and both are read from
+the real process environment):
   * ``BINANCE_SPOT_DEMO_ENABLED`` — ROB-298's existing client gate.
   * ``D2_REMEDIATION_SINGLE_ENABLED`` — this one-shot's dedicated gate.
 
 Exit codes:
   0 — clean run (including the default-disabled exit).
-  1 — operator misconfiguration (gate off, missing payload, seal mismatch).
-  2 — runtime failure (lease unavailable, broker error, anomaly, halted run).
+  1 — operator misconfiguration (gate off, unregistered/mismatched seal,
+      dispatch not authorized).
+  2 — runtime failure (lease unavailable, account drift, broker error,
+      anomaly, halted run, unreleased lease).
 """
 
 from __future__ import annotations
@@ -63,13 +73,11 @@ from app.services.brokers.binance.spot_demo.d2_remediation_single import (
     WRITER_NAME,
     D2DryRunReport,
     D2ExecutionReport,
-    D2ReasonCode,
     D2RemediationError,
     D2RemediationSingleWriter,
-    D2SealBindingMismatch,
     acquire_d2_lease,
-    bind_sealed_orders,
     d2_remediation_enabled,
+    load_sealed_authority,
 )
 from app.services.brokers.binance.spot_demo.execution_client import (
     BinanceSpotDemoExecutionClient,
@@ -86,16 +94,6 @@ def _emit(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False))
 
 
-def load_sealed_payload(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise D2SealBindingMismatch(
-            D2ReasonCode.SEAL_MALFORMED,
-            f"{path}: sealed payload is not a JSON object",
-        )
-    return payload
-
-
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="binance_spot_demo_d2_remediation",
@@ -108,7 +106,8 @@ def build_parser() -> argparse.ArgumentParser:
     mode.add_argument(
         "--plan-only",
         action="store_true",
-        help="print the three bound requests; no HTTP, no DB, no lease",
+        help="verify the sealed file and print the three bound requests; "
+        "no HTTP, no DB, no lease",
     )
     mode.add_argument(
         "--dry-run",
@@ -124,11 +123,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--sealed-payload",
         type=Path,
         help="path to the sealed r7 attempt-2 binding payload JSON",
-    )
-    parser.add_argument(
-        "--no-order-test",
-        action="store_true",
-        help="skip the non-mutating POST /api/v3/order/test shape check",
     )
     return parser
 
@@ -165,22 +159,26 @@ async def _run(args: argparse.Namespace) -> int:
     if args.sealed_payload is None:
         logger.error("--sealed-payload is required for every mode")
         return 1
-    payload = load_sealed_payload(args.sealed_payload)
+    # Hashes the file bytes and refuses an unregistered digest before parsing.
+    authority = load_sealed_authority(args.sealed_payload)
 
     if args.plan_only:
-        # Pure: bind and print. No client, no lease, no socket, no DB.
-        bind_sealed_orders(payload)
+        # Pure: verify and print. No client, no lease, no socket, no DB.
         _emit(
             {
                 "schema_version": "d2-remediation-single-plan.v1",
                 "writer": WRITER_NAME,
                 "remediation_id": D2_REMEDIATION_ID,
                 "pre_snapshot_hash": D2_PRE_SNAPSHOT_HASH,
-                "sealed_payload_path": str(args.sealed_payload),
+                "authority": authority.as_evidence(),
+                "dispatch_block_reasons": list(
+                    authority.dispatch_block_reasons(now=_now())
+                ),
                 "broker_mutation_count": 0,
                 "operations": [
                     {
                         "operation_id": operation_id,
+                        "client_order_id": order.client_order_id,
                         "request_params": order.request_params(),
                     }
                     for order, operation_id in zip(
@@ -199,30 +197,100 @@ async def _run(args: argparse.Namespace) -> int:
         )
         return 1
 
-    from app.core.db import _get_engine  # local: avoids an import-time DBAPI load
+    if args.confirm:
+        # Refuse before opening a client, a lease, or a database session:
+        # nothing about a broker connection improves an unsigned seal.
+        blockers = authority.dispatch_block_reasons(now=_now())
+        if blockers:
+            logger.error(
+                "dispatch not authorized under this seal; nothing was opened. "
+                "Blockers: %s",
+                "; ".join(blockers),
+            )
+            _emit(
+                {
+                    "writer": WRITER_NAME,
+                    "status": "DISPATCH_NOT_AUTHORIZED",
+                    "authority": authority.as_evidence(),
+                    "dispatch_block_reasons": list(blockers),
+                    "broker_mutation_count": 0,
+                }
+            )
+            return 1
+
+    # Local imports: both pull the asyncpg DBAPI, which the offline modes above
+    # must not pay for.
+    from app.core.db import AsyncSessionLocal, _get_engine
+    from app.services.brokers.binance.demo.ledger.service import (
+        BinanceDemoLedgerService,
+    )
 
     execution = BinanceSpotDemoExecutionClient.from_env()
     lease = await acquire_d2_lease(engine=_get_engine())
+    lease_release_evidence: dict[str, Any] = {}
     try:
-        writer = D2RemediationSingleWriter(
-            execution_client=execution,
-            sealed_payload=payload,
-            lease=lease,
-            lease_grant=lease.grant,
-        )
-        report = await writer.execute(
-            confirm=bool(args.confirm),
-            include_order_test=not args.no_order_test,
-        )
+        async with AsyncSessionLocal() as session:
+            # The writer refuses a None ledger, so this is not optional wiring:
+            # there is no dispatch path that leaves no durable evidence.
+            ledger = BinanceDemoLedgerService(session)
+            writer = D2RemediationSingleWriter(
+                execution_client=execution,
+                authority=authority,
+                lease=lease,
+                lease_grant=lease.grant,
+                ledger=ledger,
+            )
+            report = await writer.execute(confirm=bool(args.confirm))
+            await session.commit()
     finally:
         await execution.aclose()
+        lease_release_evidence = await _release_lease(lease)
 
+    body = report.as_evidence()
+    body["lease_release"] = lease_release_evidence
+    _emit(body)
+    if not lease_release_evidence.get("released"):
+        # A lease that cannot be proven released leaves the account coordinated
+        # by a process that is exiting. That is fail-closed rather than
+        # fail-open, but it still needs an operator, so it is not exit 0.
+        return 2
     if isinstance(report, D2DryRunReport):
-        _emit(report.as_evidence())
         return 0
     assert isinstance(report, D2ExecutionReport)
-    _emit(report.as_evidence())
     return 2 if report.halted_reason else 0
+
+
+def _now() -> Any:
+    import datetime as dt
+
+    return dt.datetime.now(dt.UTC)
+
+
+async def _release_lease(lease: Any) -> dict[str, Any]:
+    """Release the J3A lease and say plainly whether it was proven released.
+
+    The lease outlives the execution client on purpose — it is still held
+    across the proof epochs — so it is released here, last, and the outcome is
+    reported rather than swallowed. An unreleased authority is recorded by the
+    coordination layer as a hold; surfacing its id is what lets an operator
+    find the stuck account instead of guessing.
+    """
+
+    try:
+        await lease.release(lease.grant)
+    except Exception as exc:
+        hold = getattr(lease, "unreleased_authority_hold", None)
+        return {
+            "released": False,
+            "error": repr(exc),
+            "unreleased_authority_hold": None if hold is None else str(hold),
+        }
+    hold = getattr(lease, "unreleased_authority_hold", None)
+    return {
+        "released": bool(getattr(lease, "released", False)),
+        "unlocked_keys": list(getattr(lease, "unlocked_keys", ()) or ()),
+        "unreleased_authority_hold": None if hold is None else str(hold),
+    }
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/binance_spot_demo_d2_remediation.py
+++ b/scripts/binance_spot_demo_d2_remediation.py
@@ -1,0 +1,242 @@
+"""D2 one-shot remediation CLI — the operator entry point for the writer.
+
+Default-disabled, dry-run by default, and bound to the sealed r7 attempt-2
+snapshot.  It can express exactly three orders and no fourth:
+
+    BTCUSDT  SELL LIMIT 0.00015000 @ 69266.01000000
+    ETHUSDT  SELL LIMIT 0.00520000 @  2248.56000000
+    USDCUSDT SELL LIMIT 5000.00000000 @ 1.00072000
+
+There is no ``--symbol``, ``--side``, ``--quantity``, or ``--price`` flag,
+because there is nothing for them to select.  The order set comes from the
+sealed payload, is checked against the frozen constant in
+``app.services.brokers.binance.spot_demo.d2_remediation_single``, and any
+disagreement is a refusal.
+
+**Relationship to ``scripts/binance_spot_demo_smoke.py``.**  That CLI is the
+ROB-298 BUY round-trip smoke path and remains exactly what it is; it does not
+wire a SELL ``--confirm``, so it cannot express these operations.  This file is
+the second — and last — approved Spot Demo entry point that places real Demo
+orders.  Both CLIs name each other so neither can be read as the sole one.
+
+Modes (mutually exclusive; the default prints guidance and exits 0):
+
+  1. **default** — no flags: one guidance line, exit 0, zero HTTP / DB / lease.
+  2. ``--plan-only`` — bind the seal and print the three request payloads.
+     Pure: no HTTP, no DB, no lease, no signing.
+  3. ``--dry-run`` — the whole path, stopping immediately before the signed
+     POST: env gates, host re-assertion, seal binding, J3A lease acquisition
+     and attestation, request composition, and the non-mutating
+     ``POST /api/v3/order/test`` shape check.
+  4. ``--confirm`` — the real dispatch.  Requires ``--dry-run`` to have been
+     run first is *not* enforceable from here, so this mode instead requires
+     both env gates plus the explicit flag, and it is the only mode that can
+     reach ``submit_order(..., confirm=True)``.
+
+Env gates (both default-off; neither relaxes the other):
+  * ``BINANCE_SPOT_DEMO_ENABLED`` — ROB-298's existing client gate.
+  * ``D2_REMEDIATION_SINGLE_ENABLED`` — this one-shot's dedicated gate.
+
+Exit codes:
+  0 — clean run (including the default-disabled exit).
+  1 — operator misconfiguration (gate off, missing payload, seal mismatch).
+  2 — runtime failure (lease unavailable, broker error, anomaly, halted run).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from app.services.brokers.binance.spot_demo.d2_remediation_single import (
+    D2_ALLOWED_OPERATION_IDS,
+    D2_BOUND_ORDERS,
+    D2_PRE_SNAPSHOT_HASH,
+    D2_REMEDIATION_ENABLED_ENV,
+    D2_REMEDIATION_ID,
+    WRITER_NAME,
+    D2DryRunReport,
+    D2ExecutionReport,
+    D2ReasonCode,
+    D2RemediationError,
+    D2RemediationSingleWriter,
+    D2SealBindingMismatch,
+    acquire_d2_lease,
+    bind_sealed_orders,
+    d2_remediation_enabled,
+)
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+)
+
+logger = logging.getLogger("binance_spot_demo_d2_remediation")
+
+_SPOT_DEMO_ENABLED_ENV = "BINANCE_SPOT_DEMO_ENABLED"
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    """One JSON object per run, on stdout, for the evidence file."""
+
+    print(json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False))
+
+
+def load_sealed_payload(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_MALFORMED,
+            f"{path}: sealed payload is not a JSON object",
+        )
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="binance_spot_demo_d2_remediation",
+        description=(
+            "D2 one-shot remediation writer (d2_remediation_single). "
+            "Default-disabled; dry-run by default."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="print the three bound requests; no HTTP, no DB, no lease",
+    )
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run the whole path and stop immediately before the signed POST",
+    )
+    mode.add_argument(
+        "--confirm",
+        action="store_true",
+        help="dispatch the three authorized SELL LIMIT orders for real",
+    )
+    parser.add_argument(
+        "--sealed-payload",
+        type=Path,
+        help="path to the sealed r7 attempt-2 binding payload JSON",
+    )
+    parser.add_argument(
+        "--no-order-test",
+        action="store_true",
+        help="skip the non-mutating POST /api/v3/order/test shape check",
+    )
+    return parser
+
+
+def _gates_armed() -> tuple[bool, list[str]]:
+    missing: list[str] = []
+    if os.environ.get(_SPOT_DEMO_ENABLED_ENV, "").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        missing.append(_SPOT_DEMO_ENABLED_ENV)
+    if not d2_remediation_enabled():
+        missing.append(D2_REMEDIATION_ENABLED_ENV)
+    return (not missing), missing
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if not (args.plan_only or args.dry_run or args.confirm):
+        _emit(
+            {
+                "writer": WRITER_NAME,
+                "status": "NO_MODE_SELECTED",
+                "detail": (
+                    "pass --plan-only, --dry-run, or --confirm. Nothing was "
+                    "read, locked, or dispatched."
+                ),
+                "broker_mutation_count": 0,
+            }
+        )
+        return 0
+
+    if args.sealed_payload is None:
+        logger.error("--sealed-payload is required for every mode")
+        return 1
+    payload = load_sealed_payload(args.sealed_payload)
+
+    if args.plan_only:
+        # Pure: bind and print. No client, no lease, no socket, no DB.
+        bind_sealed_orders(payload)
+        _emit(
+            {
+                "schema_version": "d2-remediation-single-plan.v1",
+                "writer": WRITER_NAME,
+                "remediation_id": D2_REMEDIATION_ID,
+                "pre_snapshot_hash": D2_PRE_SNAPSHOT_HASH,
+                "sealed_payload_path": str(args.sealed_payload),
+                "broker_mutation_count": 0,
+                "operations": [
+                    {
+                        "operation_id": operation_id,
+                        "request_params": order.request_params(),
+                    }
+                    for order, operation_id in zip(
+                        D2_BOUND_ORDERS, D2_ALLOWED_OPERATION_IDS, strict=True
+                    )
+                ],
+            }
+        )
+        return 0
+
+    armed, missing = _gates_armed()
+    if not armed:
+        logger.error(
+            "default-disabled: %s not armed; nothing was read, locked, or dispatched",
+            ", ".join(missing),
+        )
+        return 1
+
+    from app.core.db import _get_engine  # local: avoids an import-time DBAPI load
+
+    execution = BinanceSpotDemoExecutionClient.from_env()
+    lease = await acquire_d2_lease(engine=_get_engine())
+    try:
+        writer = D2RemediationSingleWriter(
+            execution_client=execution,
+            sealed_payload=payload,
+            lease=lease,
+            lease_grant=lease.grant,
+        )
+        report = await writer.execute(
+            confirm=bool(args.confirm),
+            include_order_test=not args.no_order_test,
+        )
+    finally:
+        await execution.aclose()
+
+    if isinstance(report, D2DryRunReport):
+        _emit(report.as_evidence())
+        return 0
+    assert isinstance(report, D2ExecutionReport)
+    _emit(report.as_evidence())
+    return 2 if report.halted_reason else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = build_parser().parse_args(argv)
+    try:
+        return asyncio.run(_run(args))
+    except D2RemediationError as exc:
+        logger.error("refused: %s", exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001 - CLI boundary
+        logger.error("runtime failure: %r", exc)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/binance_spot_demo_d2_remediation.py
+++ b/scripts/binance_spot_demo_d2_remediation.py
@@ -243,12 +243,27 @@ async def _run(args: argparse.Namespace) -> int:
             report = await writer.execute(confirm=bool(args.confirm))
             await session.commit()
     finally:
-        await execution.aclose()
+        # Two separate try/finally layers, not one block. Sharing a block meant
+        # a raising ``aclose()`` skipped the release entirely, so the one path
+        # where the lease is most likely to be stuck was also the one that
+        # produced no release evidence at all.
+        try:
+            await execution.aclose()
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+            close_error = repr(exc)
+        else:
+            close_error = None
         lease_release_evidence = await _release_lease(lease)
+        if close_error is not None:
+            lease_release_evidence["execution_client_close_error"] = close_error
 
     body = report.as_evidence()
     body["lease_release"] = lease_release_evidence
     _emit(body)
+    if lease_release_evidence.get("execution_client_close_error"):
+        # The lease evidence exists either way; a failed close is still a
+        # runtime failure an operator has to look at.
+        return 2
     if not lease_release_evidence.get("released"):
         # A lease that cannot be proven released leaves the account coordinated
         # by a process that is exiting. That is fail-closed rather than

--- a/scripts/binance_spot_demo_smoke.py
+++ b/scripts/binance_spot_demo_smoke.py
@@ -23,8 +23,23 @@ Hard invariants:
     routed for the ``--confirm`` mode.
   * Secret hygiene: api_key / api_secret never appear in any printed
     line; only fingerprints and redacted broker payloads are emitted.
-  * No scheduler activation; this CLI is the only Spot Demo entry point
-    that places real Demo orders.
+  * No scheduler activation.  Every caller that can place a real Spot Demo
+    order is named by a distinct operator authority, and the enumeration is
+    pinned by ``tests/services/brokers/binance/spot_demo/
+    test_spot_demo_submit_callers.py``:
+
+      - this CLI (ROB-298) — the BUY + close round-trip smoke;
+      - ``scripts/b0x/crypto/sidecar.py`` — ``b0x-adapter-orders-20260808``,
+        surface ``binance_spot_demo_sidecar_buy_side_only``;
+      - ``scripts/binance_spot_demo_d2_remediation.py`` —
+        ``binance-demo-remediation-20260820``, writer
+        ``d2_remediation_single``, three sealed SELL LIMIT orders only.
+
+    An unlisted caller of ``BinanceSpotDemoExecutionClient.submit_order`` is
+    an unreviewed execution surface and fails that test.  Its allowlist is
+    slightly wider than the three CLIs above: it also carries the D2 writer
+    module itself and the ROB-1270 J6B composition, whose call site exists but
+    is structurally unreachable.
 
 Exit codes:
   0 — clean run (or default-disabled exit, or reconciled-clean confirm).

--- a/tests/scripts/test_binance_spot_demo_d2_remediation_cli.py
+++ b/tests/scripts/test_binance_spot_demo_d2_remediation_cli.py
@@ -1,0 +1,125 @@
+"""The D2 remediation CLI — gates, modes, and the flags it deliberately lacks.
+
+The point of these tests is what the CLI *cannot* do. It has no way to name a
+symbol, a side, a quantity, or a price, so an operator holding this script
+cannot widen the one-shot even by typing carefully.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.services.brokers.binance.spot_demo.d2_remediation_single import (
+    D2_BOUND_ORDERS,
+    D2_PRE_SNAPSHOT_HASH,
+    D2_REMEDIATION_ENABLED_ENV,
+)
+from scripts.binance_spot_demo_d2_remediation import build_parser, main
+from tests.services.brokers.binance.spot_demo.test_d2_remediation_single import (
+    sealed_payload,
+)
+
+pytestmark = pytest.mark.unit
+
+_SPOT_DEMO_ENABLED_ENV = "BINANCE_SPOT_DEMO_ENABLED"
+
+
+@pytest.fixture(autouse=True)
+def _gates_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both gates start off in every test; a test that needs one arms it."""
+
+    monkeypatch.delenv(D2_REMEDIATION_ENABLED_ENV, raising=False)
+    monkeypatch.delenv(_SPOT_DEMO_ENABLED_ENV, raising=False)
+
+
+@pytest.fixture
+def payload_file(tmp_path: Path) -> Path:
+    path = tmp_path / "binding-payload-proposed.json"
+    path.write_text(json.dumps(sealed_payload()), encoding="utf-8")
+    return path
+
+
+def _stdout_json(capsys: pytest.CaptureFixture[str]) -> dict[str, Any]:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_no_mode_selected_exits_clean_and_does_nothing(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main([]) == 0
+    body = _stdout_json(capsys)
+    assert body["status"] == "NO_MODE_SELECTED"
+    assert body["broker_mutation_count"] == 0
+
+
+def test_plan_only_prints_the_sealed_values(
+    payload_file: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["--plan-only", "--sealed-payload", str(payload_file)]) == 0
+    body = _stdout_json(capsys)
+    assert body["pre_snapshot_hash"] == D2_PRE_SNAPSHOT_HASH
+    assert body["broker_mutation_count"] == 0
+    assert [op["request_params"] for op in body["operations"]] == [
+        order.request_params() for order in D2_BOUND_ORDERS
+    ]
+
+
+def test_plan_only_needs_no_env_gate_because_it_touches_nothing(
+    payload_file: Path,
+) -> None:
+    """No client, no lease, no socket — so the gates have nothing to guard."""
+
+    assert main(["--plan-only", "--sealed-payload", str(payload_file)]) == 0
+
+
+def test_plan_only_refuses_a_foreign_seal(tmp_path: Path) -> None:
+    mutant = sealed_payload()
+    mutant["pre_snapshot_hash"] = "sha256:" + "0" * 64
+    path = tmp_path / "mutant.json"
+    path.write_text(json.dumps(mutant), encoding="utf-8")
+    assert main(["--plan-only", "--sealed-payload", str(path)]) == 1
+
+
+def test_every_mode_requires_a_sealed_payload() -> None:
+    assert main(["--plan-only"]) == 1
+    assert main(["--dry-run"]) == 1
+    assert main(["--confirm"]) == 1
+
+
+def test_dry_run_refuses_while_the_gates_are_off(payload_file: Path) -> None:
+    assert main(["--dry-run", "--sealed-payload", str(payload_file)]) == 1
+
+
+def test_confirm_refuses_while_the_gates_are_off(payload_file: Path) -> None:
+    assert main(["--confirm", "--sealed-payload", str(payload_file)]) == 1
+
+
+def test_confirm_still_refuses_when_only_one_gate_is_armed(
+    payload_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neither gate stands in for the other."""
+
+    monkeypatch.setenv(_SPOT_DEMO_ENABLED_ENV, "true")
+    assert main(["--confirm", "--sealed-payload", str(payload_file)]) == 1
+    monkeypatch.delenv(_SPOT_DEMO_ENABLED_ENV)
+    monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
+    assert main(["--confirm", "--sealed-payload", str(payload_file)]) == 1
+
+
+@pytest.mark.parametrize(
+    "flag", ["--symbol", "--side", "--quantity", "--price", "--order-type"]
+)
+def test_the_cli_has_no_flag_that_could_widen_the_one_shot(flag: str) -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([flag, "SOLUSDT"])
+
+
+def test_the_three_modes_are_mutually_exclusive() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--dry-run", "--confirm"])

--- a/tests/scripts/test_binance_spot_demo_d2_remediation_cli.py
+++ b/tests/scripts/test_binance_spot_demo_d2_remediation_cli.py
@@ -1,8 +1,10 @@
 """The D2 remediation CLI — gates, modes, and the flags it deliberately lacks.
 
 The point of these tests is what the CLI *cannot* do. It has no way to name a
-symbol, a side, a quantity, or a price, so an operator holding this script
-cannot widen the one-shot even by typing carefully.
+symbol, a side, a quantity, or a price, no way to skip the broker-side
+order-shape check, and no way to reach ``--confirm`` under the current unsigned
+seal — so an operator holding this script cannot widen the one-shot even by
+typing carefully.
 """
 
 from __future__ import annotations
@@ -13,6 +15,7 @@ from typing import Any
 
 import pytest
 
+from app.services.brokers.binance.spot_demo import d2_remediation_single as d2
 from app.services.brokers.binance.spot_demo.d2_remediation_single import (
     D2_BOUND_ORDERS,
     D2_PRE_SNAPSHOT_HASH,
@@ -21,6 +24,7 @@ from app.services.brokers.binance.spot_demo.d2_remediation_single import (
 from scripts.binance_spot_demo_d2_remediation import build_parser, main
 from tests.services.brokers.binance.spot_demo.test_d2_remediation_single import (
     sealed_payload,
+    write_sealed,
 )
 
 pytestmark = pytest.mark.unit
@@ -37,10 +41,8 @@ def _gates_off(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def payload_file(tmp_path: Path) -> Path:
-    path = tmp_path / "binding-payload-proposed.json"
-    path.write_text(json.dumps(sealed_payload()), encoding="utf-8")
-    return path
+def payload_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    return write_sealed(tmp_path, monkeypatch, sealed_payload())
 
 
 def _stdout_json(capsys: pytest.CaptureFixture[str]) -> dict[str, Any]:
@@ -56,7 +58,7 @@ def test_no_mode_selected_exits_clean_and_does_nothing(
     assert body["broker_mutation_count"] == 0
 
 
-def test_plan_only_prints_the_sealed_values(
+def test_plan_only_prints_the_sealed_values_and_the_blockers(
     payload_file: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assert main(["--plan-only", "--sealed-payload", str(payload_file)]) == 0
@@ -66,6 +68,10 @@ def test_plan_only_prints_the_sealed_values(
     assert [op["request_params"] for op in body["operations"]] == [
         order.request_params() for order in D2_BOUND_ORDERS
     ]
+    assert [op["client_order_id"] for op in body["operations"]] == [
+        order.client_order_id for order in D2_BOUND_ORDERS
+    ]
+    assert body["dispatch_block_reasons"]
 
 
 def test_plan_only_needs_no_env_gate_because_it_touches_nothing(
@@ -76,11 +82,19 @@ def test_plan_only_needs_no_env_gate_because_it_touches_nothing(
     assert main(["--plan-only", "--sealed-payload", str(payload_file)]) == 0
 
 
-def test_plan_only_refuses_a_foreign_seal(tmp_path: Path) -> None:
+def test_plan_only_refuses_an_unregistered_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload(), register=False)
+    assert main(["--plan-only", "--sealed-payload", str(path)]) == 1
+
+
+def test_plan_only_refuses_a_foreign_seal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     mutant = sealed_payload()
     mutant["pre_snapshot_hash"] = "sha256:" + "0" * 64
-    path = tmp_path / "mutant.json"
-    path.write_text(json.dumps(mutant), encoding="utf-8")
+    path = write_sealed(tmp_path, monkeypatch, mutant)
     assert main(["--plan-only", "--sealed-payload", str(path)]) == 1
 
 
@@ -110,13 +124,81 @@ def test_confirm_still_refuses_when_only_one_gate_is_armed(
     assert main(["--confirm", "--sealed-payload", str(payload_file)]) == 1
 
 
+def test_confirm_with_both_gates_armed_still_refuses_the_unsigned_seal(
+    payload_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The B1 fix, end to end.
+
+    Arming both env gates was previously enough to walk a null-authorization
+    payload into the dispatch path. Now the refusal happens before a client, a
+    lease, or a database session is opened — so this test needs neither.
+    """
+
+    monkeypatch.setenv(_SPOT_DEMO_ENABLED_ENV, "true")
+    monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
+    assert main(["--confirm", "--sealed-payload", str(payload_file)]) == 1
+    body = _stdout_json(capsys)
+    assert body["status"] == "DISPATCH_NOT_AUTHORIZED"
+    assert body["broker_mutation_count"] == 0
+    reasons = " | ".join(body["dispatch_block_reasons"])
+    assert "operator_authorization is null" in reasons
+    assert "dispatch_authorized=false" in reasons
+
+
+def test_the_shipped_registry_leaves_confirm_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No registered payload authorizes dispatch, so there is nothing to run.
+
+    This is the structural version of "creates no execution authority": it
+    reads the shipped constant rather than a fixture.
+    """
+
+    assert not any(
+        record.dispatch_authorized for record in d2.D2_KNOWN_SEALED_PAYLOADS.values()
+    )
+
+
 @pytest.mark.parametrize(
-    "flag", ["--symbol", "--side", "--quantity", "--price", "--order-type"]
+    "flag",
+    ["--symbol", "--side", "--quantity", "--price", "--order-type"],
 )
 def test_the_cli_has_no_flag_that_could_widen_the_one_shot(flag: str) -> None:
     parser = build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args([flag, "SOLUSDT"])
+
+
+def test_the_order_shape_check_can_no_longer_be_skipped() -> None:
+    """SHOULD-1 from the adversarial review.
+
+    ``--no-order-test`` removed the only broker-side proof that the sealed
+    filters still describe the market, which mattered most in exactly the mode
+    that sends real orders. The flag is gone.
+    """
+
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--no-order-test"])
+    assert "--no-order-test" not in parser.format_help()
+
+
+def test_the_lease_is_released_in_a_finally_block() -> None:
+    """SHOULD-2 from the adversarial review.
+
+    The CLI previously closed the execution client and left the advisory lease
+    held. It now releases it last — after the proof epochs — and reports
+    whether the release was *proven*, exiting non-zero when it was not.
+    """
+
+    source = Path("scripts/binance_spot_demo_d2_remediation.py").read_text(
+        encoding="utf-8"
+    )
+    assert "_release_lease(lease)" in source
+    assert "finally:" in source
+    assert "unreleased_authority_hold" in source
 
 
 def test_the_three_modes_are_mutually_exclusive() -> None:

--- a/tests/services/brokers/binance/demo/test_ledger_durable_claim.py
+++ b/tests/services/brokers/binance/demo/test_ledger_durable_claim.py
@@ -1,0 +1,162 @@
+"""The D2 pre-send claim has to survive its author's transaction.
+
+``record_planned`` writes into the caller's transaction and only flushes, which
+is right for a caller that owns the whole lifecycle. It is wrong for a writer
+whose safety argument is "a restart must see the prior attempt": everything the
+caller had not committed disappears when the process dies, so a crash between
+the signed POST and the caller's own commit erased the fence.
+
+These tests run against the real database because that is the only place the
+distinction exists — an in-memory double cannot tell a flush from a commit.
+Each one opens its own session and abandons it without committing, which is
+what a dying process leaves behind, and then reads back through a fresh session,
+which is what the restarted process sees.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+
+from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def instrument_ids(db_session) -> tuple[int, int]:
+    """Two committed instrument identities.
+
+    Two, not one, because ``uq_binance_demo_ledger_open_root`` is unique on
+    ``(product, instrument_id)`` across the open lifecycle states: a flush-only
+    open root and a committed open root for the *same* instrument would have
+    the second waiting on the first's transaction lock rather than showing the
+    durability difference. The D2 writer never hits that — its three orders are
+    three different instruments — and the constraint is a useful extra fence,
+    but a test has to stay off it to measure anything.
+
+    Resolved through the service, which commits them in its own transaction; a
+    flush-only fixture would be invisible to the claim transaction and the
+    insert would fail on the foreign key.
+    """
+
+    ledger = BinanceDemoLedgerService(db_session)
+    return (
+        await ledger.resolve_or_create_instrument(
+            venue="binance",
+            product="spot",
+            venue_symbol="BTCUSDT",
+            base_asset="BTC",
+            quote_asset="USDT",
+        ),
+        await ledger.resolve_or_create_instrument(
+            venue="binance",
+            product="spot",
+            venue_symbol="ETHUSDT",
+            base_asset="ETH",
+            quote_asset="USDT",
+        ),
+    )
+
+
+_CID_PREFIX = "d2durable-"
+
+
+def _cid() -> str:
+    return f"{_CID_PREFIX}{uuid.uuid4().hex[:16]}"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _drop_committed_rows():
+    """Delete what this module commits.
+
+    These claims are committed on purpose — that is the whole property under
+    test — so they outlive the usual transaction rollback and would otherwise
+    be counted by the neighbouring ``test_ledger_service`` row-counting tests.
+    """
+
+    yield
+    from sqlalchemy import text
+
+    from app.core.db import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as cleanup:
+        await cleanup.execute(
+            text(
+                "DELETE FROM binance_demo_order_ledger "
+                "WHERE client_order_id LIKE :prefix"
+            ),
+            {"prefix": f"{_CID_PREFIX}%"},
+        )
+        await cleanup.commit()
+
+
+def _claim_kwargs(instrument_id: int, client_order_id: str) -> dict:
+    return {
+        "instrument_id": instrument_id,
+        "product": "spot",
+        "venue_host": "demo-api.binance.com",
+        "client_order_id": client_order_id,
+        "side": "SELL",
+        "order_type": "LIMIT",
+        "qty": Decimal("0.00015000"),
+        "price": Decimal("69266.01000000"),
+        "now": dt.datetime.now(dt.UTC),
+    }
+
+
+async def _read_from_a_fresh_session(client_order_id: str) -> str | None:
+    """What a restarted process sees: a new session, a new transaction, nothing
+    inherited from the writer that died."""
+
+    from app.core.db import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as fresh:
+        return await BinanceDemoLedgerService(fresh).committed_lifecycle_state(
+            client_order_id
+        )
+
+
+@pytest.mark.asyncio
+async def test_only_the_committed_claim_survives_the_writers_session_dying(
+    instrument_ids: tuple[int, int],
+) -> None:
+    """One session, two claims — the only difference is how they were written.
+
+    Kept as a single test on purpose: both claims share a session and a
+    lifetime, so nothing but the write method can explain the different
+    outcomes.
+    """
+
+    from app.core.db import AsyncSessionLocal
+
+    committed_instrument, flushed_instrument = instrument_ids
+    committed_cid, flushed_cid = _cid(), _cid()
+    async with AsyncSessionLocal() as owner:
+        ledger = BinanceDemoLedgerService(owner)
+
+        # The old path: written into this transaction, flushed, never committed.
+        await ledger.record_planned(**_claim_kwargs(flushed_instrument, flushed_cid))
+        # Its author can see it — which is exactly why reading through the owner
+        # session would be a useless durability check...
+        owned = await ledger.get_by_client_order_id(flushed_cid)
+        assert owned is not None and owned.lifecycle_state == "planned"
+        # ...and nobody else can.
+        assert await ledger.committed_lifecycle_state(flushed_cid) is None
+
+        # The fix: committed in its own transaction, before any broker call.
+        await ledger.commit_planned_claim(
+            **_claim_kwargs(committed_instrument, committed_cid),
+            extra_metadata={"writer": "d2_remediation_single"},
+        )
+        assert await ledger.committed_lifecycle_state(committed_cid) == "planned"
+
+        # The process dies here: this session never commits.
+
+    # What the restarted process sees.
+    assert await _read_from_a_fresh_session(committed_cid) == "planned"
+    assert await _read_from_a_fresh_session(flushed_cid) is None

--- a/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
+++ b/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
@@ -1860,8 +1860,8 @@ async def test_b3_effect_a_no_op_ledger_subclass_is_refused_before_any_send(
     ("override", "needle"),
     [
         ({"clientOrderId": "someone-elses-order"}, "clientOrderId"),
-        ({"clientOrderId": None}, "carries no clientOrderId"),
-        ({"orderId": ""}, "carries no orderId"),
+        ({"clientOrderId": None}, "clientOrderId is null"),
+        ({"orderId": ""}, "orderId is '', which is a spelling of absent"),
     ],
 )
 async def test_b5_identity_a_response_about_another_order_is_refused(
@@ -1940,3 +1940,189 @@ def test_the_lease_release_is_not_skipped_when_the_client_close_raises() -> None
     # after an unguarded await.
     assert close_at < guard_at < release_at, finally_block[:600]
     assert "execution_client_close_error" in source
+
+
+# --------------------------------------------------------------------------
+# Round 4 — a null orderId must not be laundered into evidence
+# --------------------------------------------------------------------------
+
+
+#: Every spelling of "absent" a broker, a serialiser, or an ``str()`` call can
+#: produce. Round 3 checked only that the *stringified* DTO field was non-blank,
+#: so ``None`` arrived as the four-character string ``'None'`` and passed.
+_ABSENT_ORDER_ID_SPELLINGS: list[Any] = [
+    None,
+    "None",
+    "none",
+    "null",
+    "NULL",
+    "nil",
+    "undefined",
+    "<none>",
+    "n/a",
+    "-",
+    "",
+    "   ",
+    "\t",
+    0,
+    -1,
+    True,
+    [],
+]
+
+
+@pytest.mark.parametrize("spelling", _ABSENT_ORDER_ID_SPELLINGS)
+def test_b5_every_spelling_of_an_absent_order_id_is_rejected(spelling: Any) -> None:
+    problem = d2.broker_identifier_problem(spelling, field="orderId")
+    assert problem is not None, f"{spelling!r} was accepted as an order id"
+    assert "orderId" in problem
+
+
+@pytest.mark.parametrize("value", ["12345", 12345, "  12345  ", "abc-123"])
+def test_b5_real_order_ids_are_still_accepted(value: Any) -> None:
+    """Control: the guard discriminates rather than refusing everything."""
+
+    assert d2.broker_identifier_problem(value, field="orderId") is None
+
+
+def test_b5_str_of_none_is_exactly_the_laundering_that_used_to_pass() -> None:
+    """The specific defect, named.
+
+    ``str(None)`` is ``'None'``: non-empty, non-blank, and indistinguishable
+    from an identifier to any presence check that runs after the coercion. The
+    fix is to read the raw value, not to add another string to a denylist —
+    though the denylist covers the serialiser-produced spellings too.
+    """
+
+    laundered = str(None)
+    assert laundered == "None"
+    assert bool(laundered.strip())  # the round-3 check saw this as present
+    assert d2.broker_identifier_problem(laundered, field="orderId") is not None
+    assert d2.broker_identifier_problem(None, field="orderId") is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("spelling", [None, "None", "null", "", "   ", 0])
+async def test_b5_a_null_order_id_stops_the_submit_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, spelling: Any
+) -> None:
+    client = FakeExecutionClient(echo_overrides={"orderId": spelling})
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2RemediationError) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.BROKER_ECHO_MISMATCH
+    assert "orderId" in str(exc.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("spelling", [None, "None", "null", "", 0])
+async def test_b5_a_null_order_id_stops_the_readback_path_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, spelling: Any
+) -> None:
+    """The readback converter used to ``str()`` the raw value on its way into
+    the DTO, so this path laundered the null before the check ever saw it."""
+
+    client = FakeExecutionClient(
+        submit_error=TimeoutError("reset"),
+        echo_overrides={"orderId": spelling},
+    )
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2RemediationError) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.BROKER_ECHO_MISMATCH
+    assert "orderId" in str(exc.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("spelling", [None, "None", "null", "", 0])
+async def test_b5_a_null_client_order_id_is_rejected_the_same_way(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, spelling: Any
+) -> None:
+    client = FakeExecutionClient(echo_overrides={"clientOrderId": spelling})
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2RemediationError) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.BROKER_ECHO_MISMATCH
+    assert "clientOrderId" in str(exc.value)
+
+
+def test_b5_the_readback_converter_no_longer_stringifies_a_null_order_id() -> None:
+    """Read at the source, not through a denylist: the converter must not
+    create the string in the first place."""
+
+    source = inspect.getsource(D2RemediationSingleWriter._echo_from_status)
+    assert 'str(status_body.get("orderId"' not in source
+    assert 'raw_oid = status_body.get("orderId")' in source
+
+
+def test_the_runbook_gate_table_names_symbols_that_exist() -> None:
+    """Every gate the runbook claims is enforced must resolve to real code.
+
+    A runbook that names a gate which no longer exists is worse than one that
+    names none: it reads as a verified guarantee. This walks the "Enforced at"
+    column and resolves each dotted name against the live modules.
+    """
+
+    runbook = Path("docs/runbooks/binance-spot-demo-d2-remediation.md").read_text(
+        encoding="utf-8"
+    )
+    table = runbook.split("| Gate | Enforced at | Current state |", 1)[1]
+    table = table.split("\n\n", 1)[0]
+
+    named: set[str] = set()
+    for row in table.splitlines():
+        cells = [c.strip() for c in row.split("|")]
+        if len(cells) < 4 or cells[2].startswith("---"):
+            continue
+        named.update(re.findall(r"`([A-Za-z_][A-Za-z0-9_.]*)`", cells[2]))
+    assert len(named) >= 10, named
+
+    from app.services.brokers.binance.demo.ledger.service import (
+        BinanceDemoLedgerService as _Ledger,
+    )
+
+    roots: dict[str, Any] = {
+        "BinanceDemoLedgerService": _Ledger,
+        "D2RemediationSingleWriter": D2RemediationSingleWriter,
+        "SealedAuthority": d2.SealedAuthority,
+    }
+    for dotted in sorted(named):
+        head, _, tail = dotted.partition(".")
+        owner = roots.get(head, d2) if head in roots else d2
+        if head in roots:
+            assert tail and hasattr(owner, tail), dotted
+        else:
+            assert hasattr(d2, head), dotted
+
+
+def test_the_source_does_not_claim_guarantees_it_does_not_provide() -> None:
+    """Anti-regression on wording, not on behaviour.
+
+    The operator-confirmed threat model is that these gates cover accidental
+    misuse and not deliberate same-process forgery. A docstring that calls
+    something "unforgeable" or "impossible" contradicts that, and a reader who
+    trusts it makes a worse decision than one who reads nothing.
+    """
+
+    banned = ("unforgeable", "impossible to", "cannot be forged", "tamper-proof")
+    for path in (
+        Path("app/services/brokers/binance/spot_demo/d2_remediation_single.py"),
+        Path("scripts/binance_spot_demo_d2_remediation.py"),
+        Path("docs/runbooks/binance-spot-demo-d2-remediation.md"),
+    ):
+        text = path.read_text(encoding="utf-8").lower()
+        for phrase in banned:
+            assert phrase not in text, f"{path}: overclaims with {phrase!r}"
+
+    # ...and the limit is stated where a reader will meet it.
+    module = Path(
+        "app/services/brokers/binance/spot_demo/d2_remediation_single.py"
+    ).read_text(encoding="utf-8")
+    assert "Threat model (operator-confirmed)" in module
+    assert "do **not** cover" in module
+
+    runbook = Path("docs/runbooks/binance-spot-demo-d2-remediation.md").read_text(
+        encoding="utf-8"
+    )
+    assert "confirmed by the operator, not pending" in runbook
+    assert "deliberate forgery by code running in the same process" in runbook

--- a/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
+++ b/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
@@ -280,7 +280,7 @@ class FakeExecutionClient:
         }
 
     def _echo(self, order: Any, cid: str, index: int) -> dict[str, Any]:
-        body = {
+        body: dict[str, Any] = {
             "symbol": order.symbol,
             "side": order.side,
             "type": order.order_type,
@@ -362,8 +362,17 @@ class FakeLedger(BinanceDemoLedgerService):
             return None
         return type("Row", (), {"lifecycle_state": state})()
 
+    async def committed_lifecycle_state(self, client_order_id: str) -> str | None:
+        return self.states.get(client_order_id)
+
     async def resolve_or_create_instrument(self, **kwargs: Any) -> int:
         return 1
+
+    async def commit_planned_claim(self, **kwargs: Any) -> str:
+        cid = kwargs["client_order_id"]
+        self.states[cid] = "planned"
+        self.calls.append(("planned", cid))
+        return str(cid)
 
     async def record_planned(self, **kwargs: Any) -> Any:
         cid = kwargs["client_order_id"]
@@ -393,6 +402,42 @@ class FakeLedger(BinanceDemoLedgerService):
         cid = kwargs["client_order_id"]
         self.states[cid] = "anomaly"
         self.calls.append(("anomaly", cid))
+        return None
+
+
+class NoOpLedger(BinanceDemoLedgerService):
+    """A real subclass whose writes go nowhere.
+
+    The verifier's B3 point: requiring the *type* is not requiring the
+    *effect*. This is the object the round-2 isinstance guard happily accepted.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def committed_lifecycle_state(self, client_order_id: str) -> str | None:
+        return None
+
+    async def get_by_client_order_id(self, client_order_id: str) -> Any:
+        return None
+
+    async def resolve_or_create_instrument(self, **kwargs: Any) -> int:
+        return 1
+
+    async def commit_planned_claim(self, **kwargs: Any) -> str:
+        self.calls.append("commit_planned_claim")
+        return str(kwargs["client_order_id"])
+
+    async def record_previewed(self, **kwargs: Any) -> Any:
+        return None
+
+    async def record_validated(self, **kwargs: Any) -> Any:
+        return None
+
+    async def record_submitted(self, **kwargs: Any) -> Any:
+        return None
+
+    async def record_anomaly(self, **kwargs: Any) -> Any:
         return None
 
 
@@ -476,6 +521,27 @@ class FakeLockAuthority:
         raise AssertionError("termination must not be needed in these tests")
 
 
+#: A grant carries the loop its session is bound to. Sync tests have no running
+#: loop, and ``asyncio.get_event_loop()`` outside one is order-dependent — it
+#: succeeds or raises depending on whether an earlier async test happened to
+#: leave a loop set on the thread. One inert loop keeps these tests independent
+#: of collection order.
+_SENTINEL_LOOP = asyncio.new_event_loop()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _close_sentinel_loop() -> Any:
+    yield
+    _SENTINEL_LOOP.close()
+
+
+def _bound_loop() -> asyncio.AbstractEventLoop:
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return _SENTINEL_LOOP
+
+
 def make_lease(
     keys: tuple[int, ...] | None = None,
 ) -> tuple[PostgresAdvisoryKeysetLease, AdvisoryLeaseGrant]:
@@ -488,7 +554,7 @@ def make_lease(
         backend_pid=authority.backend_pid,
         database_oid=authority.database_oid,
         connection_token="lockconn:test",
-        event_loop=asyncio.get_event_loop(),
+        event_loop=_bound_loop(),
     )
     lease = PostgresAdvisoryKeysetLease(connection=authority, grant=grant)  # type: ignore[arg-type]
     return lease, grant
@@ -1700,3 +1766,177 @@ async def test_a_backdated_now_fn_cannot_revive_an_expired_authority(
     with pytest.raises(D2DispatchNotAuthorized):
         await writer.execute(confirm=True)
     assert client.submit_calls == []
+
+
+# --------------------------------------------------------------------------
+# Round 3 — B2-durable, B3-effect, B5-identity, B6-env
+# --------------------------------------------------------------------------
+
+
+class SequencedLedger(FakeLedger):
+    """Records the global order of ledger writes against broker calls."""
+
+    def __init__(self, sequence: list[str]) -> None:
+        super().__init__()
+        self.sequence = sequence
+
+    async def commit_planned_claim(self, **kwargs: Any) -> str:
+        self.sequence.append(f"claim_committed:{kwargs['client_order_id']}")
+        return await super().commit_planned_claim(**kwargs)
+
+    async def committed_lifecycle_state(self, client_order_id: str) -> str | None:
+        self.sequence.append(f"claim_read_back:{client_order_id}")
+        return await super().committed_lifecycle_state(client_order_id)
+
+
+class SequencedClient(FakeExecutionClient):
+    def __init__(self, sequence: list[str], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.sequence = sequence
+
+    async def submit_order(self, **kwargs: Any) -> SpotDemoOrderSubmitResult:
+        self.sequence.append(f"submit:{kwargs['client_order_id']}")
+        return await super().submit_order(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_b2_durable_the_claim_is_committed_before_the_broker_is_called(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Record, then execute — not the other way round.
+
+    Round 2 wrote the claim into the caller's transaction and let the CLI commit
+    after ``execute()`` returned, so the whole send happened inside a window
+    where nothing was durable yet.
+    """
+
+    sequence: list[str] = []
+    client = SequencedClient(sequence)
+    writer = build_writer(
+        tmp_path,
+        monkeypatch,
+        client=client,  # type: ignore[arg-type]
+        ledger=SequencedLedger(sequence),
+        authorized=True,
+    )
+    await writer.execute(confirm=True)
+
+    for order in D2_BOUND_ORDERS:
+        cid = order.client_order_id
+        commit_at = sequence.index(f"claim_committed:{cid}")
+        submit_at = sequence.index(f"submit:{cid}")
+        readbacks = [i for i, e in enumerate(sequence) if e == f"claim_read_back:{cid}"]
+        assert commit_at < submit_at, sequence
+        # The durability read-back also precedes the send.
+        assert any(commit_at < i < submit_at for i in readbacks), sequence
+
+
+@pytest.mark.asyncio
+async def test_b3_effect_a_no_op_ledger_subclass_is_refused_before_any_send(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The verifier's B3: an isinstance guard checks the type, not the effect.
+
+    ``NoOpLedger`` is a genuine ``BinanceDemoLedgerService`` subclass whose
+    writes go nowhere. Round 2 accepted it. It is now caught by reading the
+    claim back out of an independent transaction, before the broker is touched.
+    """
+
+    client = FakeExecutionClient()
+    ledger = NoOpLedger()
+    writer = build_writer(
+        tmp_path, monkeypatch, client=client, ledger=ledger, authorized=True
+    )
+    with pytest.raises(d2.D2ClaimNotDurable) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.CLAIM_NOT_DURABLE
+    assert "commit_planned_claim" in ledger.calls  # it was asked
+    assert client.submit_calls == []  # and nothing was sent
+    assert client.order_test_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("override", "needle"),
+    [
+        ({"clientOrderId": "someone-elses-order"}, "clientOrderId"),
+        ({"clientOrderId": None}, "carries no clientOrderId"),
+        ({"orderId": ""}, "carries no orderId"),
+    ],
+)
+async def test_b5_identity_a_response_about_another_order_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    override: dict[str, Any],
+    needle: str,
+) -> None:
+    """The verifier's ``MUTANT_BROKER_CLIENT_ORDER_ID_ECHO``.
+
+    Matching contents are not identity. The shared Demo account can hold another
+    order with the same symbol, side, quantity, and price, so a response is only
+    ours if it says so.
+    """
+
+    client = FakeExecutionClient(echo_overrides=override)
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2RemediationError) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.BROKER_ECHO_MISMATCH
+    assert needle in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_b5_identity_readback_no_longer_supplies_the_id_it_should_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Round 2's readback converter defaulted a missing ``clientOrderId`` to the
+    id it was looking for, manufacturing the evidence the check demanded."""
+
+    client = FakeExecutionClient(
+        submit_error=TimeoutError("reset"),
+        echo_overrides={"clientOrderId": None},
+    )
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2RemediationError) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.BROKER_ECHO_MISMATCH
+    assert "clientOrderId" in str(exc.value)
+
+
+def test_b6_env_no_gate_helper_accepts_an_injected_environment() -> None:
+    """Sweep, not a spot check: nothing on the gate path takes an env mapping."""
+
+    import scripts.binance_spot_demo_d2_remediation as cli
+
+    for module in (d2, cli):
+        for name, obj in vars(module).items():
+            if not inspect.isfunction(obj) or obj.__module__ != module.__name__:
+                continue
+            params = set(inspect.signature(obj).parameters)
+            assert not params & {"environ", "env", "environment"}, (
+                f"{module.__name__}.{name} takes an injectable environment"
+            )
+    assert inspect.signature(d2.d2_remediation_enabled).parameters == {}
+    assert "os.environ" in inspect.getsource(d2.d2_remediation_enabled)
+    assert "os.environ" in inspect.getsource(cli._gates_armed)
+
+
+def test_the_lease_release_is_not_skipped_when_the_client_close_raises() -> None:
+    """SHOULD from round 2's review.
+
+    ``aclose()`` and the lease release shared one ``finally``, so a raising
+    close skipped the release and emitted no release evidence — on exactly the
+    path where the lease is most likely to be stuck.
+    """
+
+    source = Path("scripts/binance_spot_demo_d2_remediation.py").read_text(
+        encoding="utf-8"
+    )
+    finally_block = source.split("    finally:", 1)[1]
+    close_at = finally_block.index("await execution.aclose()")
+    release_at = finally_block.index("_release_lease(lease)")
+    guard_at = finally_block.index("except Exception")
+    # The close is wrapped, and the release comes after the guard rather than
+    # after an unguarded await.
+    assert close_at < guard_at < release_at, finally_block[:600]
+    assert "execution_client_close_error" in source

--- a/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
+++ b/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
@@ -1,46 +1,73 @@
 """``d2_remediation_single`` — the closed three-order D2 writer.
 
-The interesting question about this writer is not "does it place an order"
-but "what can it be talked into placing". These tests answer that by mutation:
-each of the nine cases below takes the real sealed r7 attempt-2 payload, makes
-one change a mistaken or hostile caller might make, and proves the writer
-refuses. Every mutant is paired with the unmutated original so a refusal that
-came from something unrelated would show up as the control failing too.
+The interesting question about this writer is not "does it place an order" but
+"what can it be talked into placing". These tests answer that by mutation: each
+case takes a valid sealed payload, makes one change a mistaken or hostile
+caller might make, and proves the writer refuses.
+
+Round 2 exists because an adversarial verifier got five of these past the first
+version by injecting mutants directly. Those mutants are reproduced here by
+name, so a regression that reopens any of them fails CI rather than waiting for
+another review:
+
+    B1  unregistered / altered payload bytes, null operator_authorization,
+        absent expiry, wrong credential fingerprint, mutation_authorized=false
+    B2  replay under a fresh process (new client_order_id)
+    B3  a ledger-less dispatch path
+    B4  wrong credential, unfrozen writer lane, no pre-dispatch account truth
+    B5  a broker echo whose price or timeInForce is not the sealed one
+    B6  a fabricated lease object, and an injected ``environ`` that arms the
+        gate the operator left off
 
 Checks are closed equality against the frozen constant, never a name match:
-``0.00016`` is refused because it is not ``0.00015``, not because a string
-did or did not contain a substring.
+``0.00016`` is refused because it is not ``0.00015``, not because a string did
+or did not contain a substring.
 """
 
 from __future__ import annotations
 
 import asyncio
 import copy
+import hashlib
+import inspect
+import json
 import re
+from dataclasses import replace
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl
 
 import pytest
 
 from app.services.brokers.binance.demo.errors import BinanceDemoOrderNotFound
+from app.services.brokers.binance.demo.ledger.service import BinanceDemoLedgerService
+from app.services.brokers.binance.spot_demo import d2_remediation_single as d2
 from app.services.brokers.binance.spot_demo.d2_remediation_single import (
     D2_ALLOWED_OPERATION_IDS,
     D2_BOUND_ORDERS,
+    D2_CREDENTIAL_FINGERPRINT,
     D2_PRE_SNAPSHOT_HASH,
     D2_REMEDIATION_ENABLED_ENV,
     D2_REMEDIATION_ID,
     D2_VENUE_HOST,
     WRITER_NAME,
+    D2AccountTruthDrift,
     D2BlindRetryRefused,
+    D2DispatchNotAuthorized,
     D2LeaseNotHeld,
+    D2LedgerRequired,
+    D2PriorAttemptUnresolved,
     D2ReasonCode,
     D2RemediationDisabled,
+    D2RemediationError,
     D2RemediationSingleWriter,
     D2SealBindingMismatch,
     D2UnauthorizedOperation,
+    SealedPayloadRecord,
     bind_sealed_orders,
     d2_advisory_keyset,
+    load_sealed_authority,
 )
 from app.services.brokers.binance.spot_demo.dto import (
     SpotDemoAssetBalance,
@@ -52,7 +79,11 @@ from app.services.brokers.binance.spot_demo.dto import (
 from app.services.brokers.binance.spot_demo.execution_client import (
     BinanceSpotDemoExecutionClient,
 )
-from app.services.mock_integration.coordination import AdvisoryLeaseGrant
+from app.services.mock_integration.coordination import (
+    AdvisoryLeaseGrant,
+    PostgresAdvisoryKeysetLease,
+    split_advisory_key,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -62,27 +93,37 @@ pytestmark = pytest.mark.unit
 # --------------------------------------------------------------------------
 
 
-def _actionable(symbol: str, asset: str, quantity: str, price: str) -> dict[str, Any]:
+def _actionable(
+    symbol: str,
+    asset: str,
+    quantity: str,
+    price: str,
+    free: str,
+    *,
+    mutation_authorized: bool = False,
+) -> dict[str, Any]:
     return {
         "symbol": symbol,
         "asset": asset,
         "product": "spot",
         "disposition": "REVIEWED_SCOPE_LIMIT_CANDIDATE",
-        "mutation_authorized": False,
+        "mutation_authorized": mutation_authorized,
         "proposed_one_step": {
             "side": "SELL",
             "order_type": "LIMIT",
             "time_in_force": None,
             "proposed_quantity_floor": quantity,
             "proposed_limit_price_floor": price,
+            "raw_free_quantity": free,
+            "raw_locked_quantity": "0E-8",
             "rounding_direction": "floor_only_no_uplift",
         },
     }
 
 
 def _dust(symbol: str, asset: str) -> dict[str, Any]:
-    """A floor-zero attestation row. It authorizes no order and must never
-    be picked up as one."""
+    """A floor-zero attestation row. It authorizes no order and must never be
+    picked up as one."""
 
     return {
         "symbol": symbol,
@@ -94,23 +135,50 @@ def _dust(symbol: str, asset: str) -> dict[str, Any]:
     }
 
 
-def sealed_payload() -> dict[str, Any]:
-    """The exact bound object: three actionable rows, three dust rows, one
-    quote-cash row."""
+def sealed_payload(*, authorized: bool = False) -> dict[str, Any]:
+    """The bound object: three actionable rows, three dust rows, one quote row.
 
-    return {
+    ``authorized=False`` mirrors the real r7 attempt-2 file — it binds, but
+    authorizes nothing. ``authorized=True`` is the shape a re-signed payload
+    would have, and exists so the tests can show the dispatch gate is
+    discriminating rather than a blanket refusal.
+    """
+
+    payload: dict[str, Any] = {
         "remediation_id": D2_REMEDIATION_ID,
         "product_domain": "both",
         "pre_snapshot_hash": D2_PRE_SNAPSHOT_HASH,
         "operator_authorization": None,
+        "expiry": None,
+        "physical_account_identity": {
+            "credential_fingerprint": D2_CREDENTIAL_FINGERPRINT,
+            "spot_host": D2_VENUE_HOST,
+        },
         "authorized_symbols": {
             "spot": {
                 "BTCUSDT": _actionable(
-                    "BTCUSDT", "BTC", "0.00015000", "69266.01000000"
+                    "BTCUSDT",
+                    "BTC",
+                    "0.00015000",
+                    "69266.01000000",
+                    "0.00015957",
+                    mutation_authorized=authorized,
                 ),
-                "ETHUSDT": _actionable("ETHUSDT", "ETH", "0.00520000", "2248.56000000"),
+                "ETHUSDT": _actionable(
+                    "ETHUSDT",
+                    "ETH",
+                    "0.00520000",
+                    "2248.56000000",
+                    "0.00529470",
+                    mutation_authorized=authorized,
+                ),
                 "USDCUSDT": _actionable(
-                    "USDCUSDT", "USDC", "5000.00000000", "1.00072000"
+                    "USDCUSDT",
+                    "USDC",
+                    "5000.00000000",
+                    "1.00072000",
+                    "5000.00000000",
+                    mutation_authorized=authorized,
                 ),
                 "SOLUSDT": _dust("SOLUSDT", "SOL"),
                 "XRPUSDT": _dust("XRPUSDT", "XRP"),
@@ -122,6 +190,45 @@ def sealed_payload() -> dict[str, Any]:
             }
         },
     }
+    if authorized:
+        payload["operator_authorization"] = {
+            "section": "§125차",
+            "signature": "operator-resign-fixture",
+        }
+        payload["expiry"] = "2099-01-01T00:00:00Z"
+    return payload
+
+
+def write_sealed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, Any],
+    *,
+    register: bool = True,
+    dispatch_authorized: bool = False,
+    name: str = "binding-payload-proposed.json",
+) -> Path:
+    """Write a payload and (optionally) register its exact-byte digest.
+
+    Registration is monkeypatched module state, not a production seam: nothing
+    in ``app/`` or ``scripts/`` can add an entry at runtime, and the shipped map
+    has exactly one entry with ``dispatch_authorized=False``.
+    """
+
+    path = tmp_path / name
+    raw = json.dumps(payload).encode("utf-8")
+    path.write_bytes(raw)
+    digest = hashlib.sha256(raw).hexdigest()
+    registry = dict(d2.D2_KNOWN_SEALED_PAYLOADS)
+    if register:
+        registry[digest] = SealedPayloadRecord(
+            sha256=digest,
+            pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+            dispatch_authorized=dispatch_authorized,
+            note="test fixture",
+        )
+    monkeypatch.setattr(d2, "D2_KNOWN_SEALED_PAYLOADS", registry)
+    return path
 
 
 # --------------------------------------------------------------------------
@@ -132,21 +239,26 @@ def sealed_payload() -> dict[str, Any]:
 class FakeExecutionClient:
     """Counts everything that crosses the transport boundary.
 
-    ``submit_calls`` is the number that matters: a duplicate order is the
-    worst available failure of this writer, so the tests assert on the count,
-    not on whether a retry loop is visible in the source.
+    ``submit_calls`` is the number that matters: a duplicate order is the worst
+    available failure of this writer, so the tests assert on the count, not on
+    whether a retry loop is visible in the source.
     """
 
     def __init__(
         self,
         *,
         base_url: str = f"https://{D2_VENUE_HOST}",
+        credential_fingerprint: str = D2_CREDENTIAL_FINGERPRINT,
         submit_error: Exception | None = None,
         status_body: dict[str, Any] | None = None,
         status_error: Exception | None = None,
         submit_status: str = "NEW",
+        echo_overrides: dict[str, Any] | None = None,
+        open_orders: list[SpotDemoOpenOrder] | None = None,
+        balances: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         self._base_url = base_url
+        self.credential_fingerprint = credential_fingerprint
         self.submit_calls: list[dict[str, Any]] = []
         self.order_test_calls: list[dict[str, Any]] = []
         self.status_calls: list[dict[str, Any]] = []
@@ -156,6 +268,32 @@ class FakeExecutionClient:
         self._status_body = status_body
         self._status_error = status_error
         self._submit_status = submit_status
+        self._echo_overrides = echo_overrides or {}
+        self._open_orders = open_orders if open_orders is not None else []
+        # Default: the account is exactly what the seal observed.
+        self._balances = balances or {
+            order.asset: (
+                format(order.sealed_free_quantity, "f"),
+                format(order.sealed_locked_quantity, "f"),
+            )
+            for order in D2_BOUND_ORDERS
+        }
+
+    def _echo(self, order: Any, cid: str, index: int) -> dict[str, Any]:
+        body = {
+            "symbol": order.symbol,
+            "side": order.side,
+            "type": order.order_type,
+            "origQty": format(order.quantity, "f"),
+            "executedQty": "0",
+            "price": format(order.price, "f"),
+            "timeInForce": order.time_in_force,
+            "status": self._submit_status,
+            "orderId": f"bid-{index}",
+            "clientOrderId": cid,
+        }
+        body.update(self._echo_overrides)
+        return body
 
     async def order_test(self, **kwargs: Any) -> SpotDemoOrderTestResult:
         self.order_test_calls.append(kwargs)
@@ -170,16 +308,19 @@ class FakeExecutionClient:
         self.submit_calls.append(kwargs)
         if self._submit_error is not None:
             raise self._submit_error
+        order = next(o for o in D2_BOUND_ORDERS if o.symbol == kwargs["symbol"])
+        body = self._echo(order, kwargs["client_order_id"], len(self.submit_calls))
         return SpotDemoOrderSubmitResult(
-            client_order_id=kwargs["client_order_id"],
-            broker_order_id=f"bid-{len(self.submit_calls)}",
-            symbol=kwargs["symbol"],
-            side=kwargs["side"],
-            order_type=kwargs["order_type"],
-            qty=kwargs["qty"],
-            executed_qty=Decimal("0"),
+            client_order_id=str(body["clientOrderId"]),
+            broker_order_id=str(body["orderId"]),
+            symbol=str(body["symbol"]),
+            side=str(body["side"]),
+            order_type=str(body["type"]),
+            qty=Decimal(str(body["origQty"])),
+            executed_qty=Decimal(str(body["executedQty"])),
             cummulative_quote_qty=Decimal("0"),
-            status=self._submit_status,
+            status=str(body["status"]),
+            raw_response_redacted=body,
         )
 
     async def get_order_status(self, **kwargs: Any) -> dict[str, Any]:
@@ -188,114 +329,205 @@ class FakeExecutionClient:
             raise self._status_error
         if self._status_body is not None:
             return dict(self._status_body)
-        # Default: the venue faithfully echoes the order that was authorized.
         order = next(o for o in D2_BOUND_ORDERS if o.symbol == kwargs["symbol"])
-        return {
-            "symbol": order.symbol,
-            "side": order.side,
-            "type": order.order_type,
-            "origQty": format(order.quantity, "f"),
-            "executedQty": "0",
-            "status": "NEW",
-            "orderId": f"readback-{len(self.status_calls)}",
-            "clientOrderId": kwargs["client_order_id"],
-        }
+        return self._echo(order, kwargs["client_order_id"], len(self.status_calls))
 
     async def get_all_open_orders(self) -> SpotDemoOpenOrdersResult:
         self.open_order_reads += 1
-        return SpotDemoOpenOrdersResult(
-            orders=[
-                SpotDemoOpenOrder(
-                    client_order_id="cid",
-                    broker_order_id="bid",
-                    symbol="BTCUSDT",
-                    side="SELL",
-                    qty=Decimal("0.00015"),
-                    status="NEW",
-                )
-            ]
-        )
+        return SpotDemoOpenOrdersResult(orders=list(self._open_orders))
 
     async def get_asset_balance(self, *, asset: str) -> SpotDemoAssetBalance:
         self.balance_reads += 1
-        return SpotDemoAssetBalance(asset=asset, free=Decimal("0"), locked=Decimal("0"))
+        free, locked = self._balances.get(asset, ("0", "0"))
+        return SpotDemoAssetBalance(
+            asset=asset, free=Decimal(free), locked=Decimal(locked)
+        )
 
 
-class FakeLease:
-    """A stand-in for ``PostgresAdvisoryKeysetLease`` with the same use-time
-    contract: ownership is re-proved on demand and never cached."""
+class FakeLedger(BinanceDemoLedgerService):
+    """A real ``BinanceDemoLedgerService`` subclass with in-memory rows.
+
+    A subclass, not a look-alike: the writer's ``isinstance`` guard exists to
+    reject an *unrelated* object being passed as a ledger, not to reject a test
+    double of the right type.
+    """
+
+    def __init__(self, *, existing: dict[str, str] | None = None) -> None:
+        self.states: dict[str, str] = dict(existing or {})
+        self.calls: list[tuple[str, str]] = []
+
+    async def get_by_client_order_id(self, client_order_id: str) -> Any:
+        state = self.states.get(client_order_id)
+        if state is None:
+            return None
+        return type("Row", (), {"lifecycle_state": state})()
+
+    async def resolve_or_create_instrument(self, **kwargs: Any) -> int:
+        return 1
+
+    async def record_planned(self, **kwargs: Any) -> Any:
+        cid = kwargs["client_order_id"]
+        self.states[cid] = "planned"
+        self.calls.append(("planned", cid))
+        return None
+
+    async def record_previewed(self, **kwargs: Any) -> Any:
+        cid = kwargs["client_order_id"]
+        self.states[cid] = "previewed"
+        self.calls.append(("previewed", cid))
+        return None
+
+    async def record_validated(self, **kwargs: Any) -> Any:
+        cid = kwargs["client_order_id"]
+        self.states[cid] = "validated"
+        self.calls.append(("validated", cid))
+        return None
+
+    async def record_submitted(self, **kwargs: Any) -> Any:
+        cid = kwargs["client_order_id"]
+        self.states[cid] = "submitted"
+        self.calls.append(("submitted", cid))
+        return None
+
+    async def record_anomaly(self, **kwargs: Any) -> Any:
+        cid = kwargs["client_order_id"]
+        self.states[cid] = "anomaly"
+        self.calls.append(("anomaly", cid))
+        return None
+
+
+class _Rows:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> _Rows:
+        return self
+
+    def one(self) -> dict[str, Any]:
+        return self._rows[0]
+
+    def all(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class FakeLockAuthority:
+    """A ``LockAuthorityConnection`` that answers the real attestation SQL.
+
+    Built so the tests can construct a **real** ``PostgresAdvisoryKeysetLease``
+    rather than a duck-typed stand-in — which the writer now rejects — and so
+    the genuine ``pg_locks`` ownership logic runs instead of being stubbed out.
+    """
 
     def __init__(
-        self,
-        grant: AdvisoryLeaseGrant,
-        *,
-        released: bool = False,
-        attest_error: Exception | None = None,
+        self, *, keys: tuple[int, ...], backend_pid: int = 4242, database_oid: int = 99
     ) -> None:
-        self._grant = grant
-        self.released = released
-        self.attest_calls = 0
-        self._attest_error = attest_error
+        self.keys = keys
+        self.backend_pid = backend_pid
+        self.database_oid = database_oid
+        self.unlocked: set[int] = set()
 
-    async def assert_owned(self, expected_grant: AdvisoryLeaseGrant) -> None:
-        self.attest_calls += 1
-        if self._attest_error is not None:
-            raise self._attest_error
-        if expected_grant is not self._grant:
-            raise RuntimeError("lease_lost")
+    async def execute(self, statement: Any, parameters: Any = None, /) -> _Rows:
+        sql = str(statement)
+        if "pg_backend_pid" in sql:
+            return _Rows(
+                [
+                    {
+                        "backend_pid": self.backend_pid,
+                        "database_oid": self.database_oid,
+                    }
+                ]
+            )
+        if "pg_locks" in sql:
+            rows = []
+            for key in self.keys:
+                if key in self.unlocked:
+                    continue
+                classid, objid = split_advisory_key(key)
+                rows.append(
+                    {
+                        "locktype": "advisory",
+                        "mode": "ExclusiveLock",
+                        "granted": True,
+                        "database_oid": self.database_oid,
+                        "pid": self.backend_pid,
+                        "objsubid": 1,
+                        "classid": classid,
+                        "objid": objid,
+                    }
+                )
+            return _Rows(rows)
+        if "pg_advisory_unlock" in sql:
+            self.unlocked.add(int((parameters or {})["key"]))
+            return _Rows([{"released": True}])
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+    async def commit(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    def can_prove_backend_session_termination(self) -> bool:
+        return True
+
+    async def terminate_backend_session(
+        self, *, expected_pid: int, owner_token: str
+    ) -> Any:  # pragma: no cover - not reached by these tests
+        raise AssertionError("termination must not be needed in these tests")
 
 
-#: A grant carries the loop its session is bound to. Sync tests have no running
-#: loop, and ``asyncio.get_event_loop()`` outside one is order-dependent — it
-#: succeeds or raises depending on whether an earlier async test happened to
-#: leave a loop set on the thread. One inert loop keeps these tests independent
-#: of collection order.
-_SENTINEL_LOOP = asyncio.new_event_loop()
+def make_lease(
+    keys: tuple[int, ...] | None = None,
+) -> tuple[PostgresAdvisoryKeysetLease, AdvisoryLeaseGrant]:
+    """A real lease over a fake authority, bound to the running loop."""
 
-
-@pytest.fixture(scope="session", autouse=True)
-def _close_sentinel_loop() -> Any:
-    yield
-    _SENTINEL_LOOP.close()
-
-
-def make_grant(keys: tuple[int, ...] | None = None) -> AdvisoryLeaseGrant:
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = _SENTINEL_LOOP
-    return AdvisoryLeaseGrant(
-        keys=keys if keys is not None else d2_advisory_keyset(),
-        backend_pid=4242,
-        database_oid=99,
+    resolved = keys if keys is not None else d2_advisory_keyset()
+    authority = FakeLockAuthority(keys=resolved)
+    grant = AdvisoryLeaseGrant(
+        keys=resolved,
+        backend_pid=authority.backend_pid,
+        database_oid=authority.database_oid,
         connection_token="lockconn:test",
-        event_loop=loop,
+        event_loop=asyncio.get_event_loop(),
     )
+    lease = PostgresAdvisoryKeysetLease(connection=authority, grant=grant)  # type: ignore[arg-type]
+    return lease, grant
 
 
 @pytest.fixture(autouse=True)
 def _arm_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     """The env gate is default-off; every test that expects the writer to
-    construct has to arm it explicitly, and one test below removes it again."""
+    construct has to arm it, and one test below removes it again."""
 
     monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
 
 
 def build_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     *,
     payload: dict[str, Any] | None = None,
     client: FakeExecutionClient | None = None,
-    lease: FakeLease | None = None,
-    grant: AdvisoryLeaseGrant | None = None,
     ledger: Any = None,
+    authorized: bool = False,
+    lease: Any = None,
+    grant: Any = None,
 ) -> D2RemediationSingleWriter:
-    the_grant = grant if grant is not None else make_grant()
+    path = write_sealed(
+        tmp_path,
+        monkeypatch,
+        payload if payload is not None else sealed_payload(authorized=authorized),
+        dispatch_authorized=authorized,
+    )
+    authority = load_sealed_authority(path)
+    if lease is None:
+        lease, grant = make_lease()
     return D2RemediationSingleWriter(
         execution_client=client or FakeExecutionClient(),  # type: ignore[arg-type]
-        sealed_payload=payload if payload is not None else sealed_payload(),
-        lease=lease if lease is not None else FakeLease(the_grant),  # type: ignore[arg-type]
-        lease_grant=the_grant,
-        ledger=ledger,
+        authority=authority,
+        lease=lease,
+        lease_grant=grant,
+        ledger=ledger if ledger is not None else FakeLedger(),
     )
 
 
@@ -311,8 +543,7 @@ def test_unmutated_seal_binds_to_the_frozen_constant() -> None:
 
 
 def test_dust_and_quote_cash_rows_never_become_orders() -> None:
-    bound = bind_sealed_orders(sealed_payload())
-    symbols = {order.symbol for order in bound}
+    symbols = {order.symbol for order in bind_sealed_orders(sealed_payload())}
     assert symbols.isdisjoint({"SOLUSDT", "XRPUSDT", "DOGEUSDT", "USDT"})
 
 
@@ -323,10 +554,11 @@ def test_bound_set_is_exactly_three_sell_limits() -> None:
     assert len(D2_ALLOWED_OPERATION_IDS) == 3
 
 
-def test_request_params_equal_the_sealed_values_exactly() -> None:
-    writer = build_writer()
-    params = [op.request_params for op in writer.plan()]
-    assert params == [
+def test_request_params_equal_the_sealed_values_exactly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    writer = build_writer(tmp_path, monkeypatch)
+    assert [op.request_params for op in writer.plan()] == [
         {
             "symbol": "BTCUSDT",
             "side": "SELL",
@@ -355,7 +587,7 @@ def test_request_params_equal_the_sealed_values_exactly() -> None:
 
 
 # --------------------------------------------------------------------------
-# M1 — a different symbol
+# Round-1 mutants M1-M8 — payload shape
 # --------------------------------------------------------------------------
 
 
@@ -365,16 +597,11 @@ def test_m1_foreign_symbol_is_refused() -> None:
 
     mutant = copy.deepcopy(control)
     mutant["authorized_symbols"]["spot"]["SOLUSDT"] = _actionable(
-        "SOLUSDT", "SOL", "1.00000000", "100.00000000"
+        "SOLUSDT", "SOL", "1.00000000", "100.00000000", "1.00000000"
     )
     with pytest.raises(D2SealBindingMismatch) as exc:
         bind_sealed_orders(mutant)
     assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
-
-
-# --------------------------------------------------------------------------
-# M2 — side flipped to BUY
-# --------------------------------------------------------------------------
 
 
 def test_m2_buy_side_is_refused() -> None:
@@ -383,11 +610,6 @@ def test_m2_buy_side_is_refused() -> None:
     with pytest.raises(D2SealBindingMismatch) as exc:
         bind_sealed_orders(mutant)
     assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
-
-
-# --------------------------------------------------------------------------
-# M3 — one digit of quantity
-# --------------------------------------------------------------------------
 
 
 def test_m3_quantity_one_digit_changed_is_refused() -> None:
@@ -411,25 +633,14 @@ def test_m3_trailing_zero_difference_is_not_a_mutation() -> None:
     assert bind_sealed_orders(same_value) is D2_BOUND_ORDERS
 
 
-# --------------------------------------------------------------------------
-# M4 — one tick of price
-# --------------------------------------------------------------------------
-
-
 def test_m4_price_one_tick_changed_is_refused() -> None:
     mutant = copy.deepcopy(sealed_payload())
     step = mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
     assert step["proposed_limit_price_floor"] == "69266.01000000"
-    # PRICE_FILTER tickSize for BTCUSDT is 0.01.
-    step["proposed_limit_price_floor"] = "69266.02000000"
+    step["proposed_limit_price_floor"] = "69266.02000000"  # tickSize is 0.01
     with pytest.raises(D2SealBindingMismatch) as exc:
         bind_sealed_orders(mutant)
     assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
-
-
-# --------------------------------------------------------------------------
-# M5 — a different seal
-# --------------------------------------------------------------------------
 
 
 def test_m5_foreign_pre_snapshot_hash_is_refused() -> None:
@@ -443,81 +654,11 @@ def test_m5_foreign_pre_snapshot_hash_is_refused() -> None:
     assert exc.value.reason_code is D2ReasonCode.SEAL_HASH_MISMATCH
 
 
-def test_m5_hash_mismatch_is_caught_before_the_writer_constructs() -> None:
-    client = FakeExecutionClient()
-    mutant = copy.deepcopy(sealed_payload())
-    mutant["pre_snapshot_hash"] = "sha256:" + "0" * 64
-    with pytest.raises(D2SealBindingMismatch):
-        build_writer(payload=mutant, client=client)
-    assert client.submit_calls == []
-    assert client.order_test_calls == []
-
-
-# --------------------------------------------------------------------------
-# M6 — no lease
-# --------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_m6_released_lease_blocks_the_order_path() -> None:
-    client = FakeExecutionClient()
-    grant = make_grant()
-    writer = build_writer(
-        client=client, lease=FakeLease(grant, released=True), grant=grant
-    )
-    with pytest.raises(D2LeaseNotHeld) as exc:
-        await writer.execute(confirm=True)
-    assert exc.value.reason_code is D2ReasonCode.LEASE_NOT_HELD
-    assert client.submit_calls == []
-    assert client.order_test_calls == []
-
-
-@pytest.mark.asyncio
-async def test_m6_lease_over_the_wrong_keyset_blocks_the_order_path() -> None:
-    client = FakeExecutionClient()
-    wrong = make_grant(keys=(1234567890,))
-    writer = build_writer(client=client, lease=FakeLease(wrong), grant=wrong)
-    with pytest.raises(D2LeaseNotHeld) as exc:
-        await writer.execute(confirm=True)
-    assert exc.value.reason_code is D2ReasonCode.LEASE_SCOPE_MISMATCH
-    assert client.submit_calls == []
-
-
-@pytest.mark.asyncio
-async def test_m6_unattestable_lease_blocks_the_order_path() -> None:
-    client = FakeExecutionClient()
-    grant = make_grant()
-    lease = FakeLease(grant, attest_error=RuntimeError("lock_authority_unavailable"))
-    writer = build_writer(client=client, lease=lease, grant=grant)
-    with pytest.raises(D2LeaseNotHeld):
-        await writer.execute(confirm=True)
-    assert client.submit_calls == []
-
-
-@pytest.mark.asyncio
-async def test_lease_is_reattested_immediately_before_each_submit() -> None:
-    """Acquisition-time success is not carried forward: there is one
-    attestation for the run and one more per order, plus one per proof epoch."""
-
-    client = FakeExecutionClient()
-    grant = make_grant()
-    lease = FakeLease(grant)
-    writer = build_writer(client=client, lease=lease, grant=grant)
-    await writer.execute(confirm=True)
-    assert len(client.submit_calls) == 3
-    # 1 run entry + 3 pre-submit + 2 proof epochs
-    assert lease.attest_calls == 6
-
-
-# --------------------------------------------------------------------------
-# M7 — MARKET
-# --------------------------------------------------------------------------
-
-
 def test_m7_market_order_type_is_refused() -> None:
     mutant = copy.deepcopy(sealed_payload())
-    step = mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
-    step["order_type"] = "MARKET"
+    mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"][
+        "order_type"
+    ] = "MARKET"
     with pytest.raises(D2SealBindingMismatch) as exc:
         bind_sealed_orders(mutant)
     assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
@@ -527,15 +668,10 @@ def test_m7_no_bound_order_is_a_market_order() -> None:
     assert all(order.order_type == "LIMIT" for order in D2_BOUND_ORDERS)
 
 
-# --------------------------------------------------------------------------
-# M8 — a fourth order
-# --------------------------------------------------------------------------
-
-
 def test_m8_fourth_order_is_refused() -> None:
     mutant = copy.deepcopy(sealed_payload())
     mutant["authorized_symbols"]["spot"]["XRPUSDT"] = _actionable(
-        "XRPUSDT", "XRP", "10.00000000", "0.50000000"
+        "XRPUSDT", "XRP", "10.00000000", "0.50000000", "10.00000000"
     )
     with pytest.raises(D2SealBindingMismatch) as exc:
         bind_sealed_orders(mutant)
@@ -554,22 +690,272 @@ def test_m8_a_missing_third_order_is_also_refused() -> None:
     assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
 
 
+def test_sealed_observed_balance_is_part_of_the_bound_identity() -> None:
+    """Rewriting only the observed free balance keeps every order field intact,
+    and must still be refused — the pre-dispatch drift check compares against
+    it, so a payload that lies about it is a different object."""
+
+    mutant = copy.deepcopy(sealed_payload())
+    mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"][
+        "raw_free_quantity"
+    ] = "9.99999999"
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
 # --------------------------------------------------------------------------
-# M9 — re-sending after a failure
+# B1 — sealed bytes, operator authorization, expiry, mutation_authorized
 # --------------------------------------------------------------------------
+
+
+def test_b1_unregistered_payload_digest_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload(), register=False)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_UNKNOWN_DIGEST
+
+
+def test_b1_altering_the_file_changes_its_digest_and_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The verifier's ``MUTANT_BINDING_PAYLOAD_SHA256_MISMATCH``.
+
+    Round 1 carried the expected digest as metadata and never compared it to
+    anything, so any file whose *contents* parsed was accepted. Now the digest
+    is computed over the bytes before the JSON is parsed, so editing the file at
+    all — even in a field the parser ignores — changes the digest and fails.
+    """
+
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload())
+    assert load_sealed_authority(path) is not None  # control
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["a_field_the_parser_never_reads"] = "tampered"
+    path.write_bytes(json.dumps(payload).encode("utf-8"))
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_UNKNOWN_DIGEST
 
 
 @pytest.mark.asyncio
-async def test_m9_ambiguous_submit_is_resolved_by_readback_not_resend() -> None:
-    """Every submit fails locally after the POST, so every outcome is
-    ambiguous. Each one is settled by asking the venue exactly once; no symbol
-    is ever POSTed twice."""
+async def test_b1_null_operator_authorization_blocks_confirm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = FakeExecutionClient()
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=False)
+    reasons = writer.dispatch_block_reasons()
+    assert any("operator_authorization is null" in r for r in reasons)
+    with pytest.raises(D2DispatchNotAuthorized) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.DISPATCH_NOT_AUTHORIZED
+    assert client.submit_calls == []
 
+
+@pytest.mark.asyncio
+async def test_b1_absent_and_past_expiry_both_block_confirm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    absent = sealed_payload(authorized=True)
+    absent["expiry"] = None
+    writer = build_writer(
+        tmp_path,
+        monkeypatch,
+        payload=absent,
+        authorized=True,
+        client=FakeExecutionClient(),
+    )
+    assert any("expiry is absent" in r for r in writer.dispatch_block_reasons())
+
+    expired = sealed_payload(authorized=True)
+    expired["expiry"] = "2020-01-01T00:00:00Z"
+    writer2 = build_writer(
+        tmp_path,
+        monkeypatch,
+        payload=expired,
+        authorized=True,
+        client=FakeExecutionClient(),
+    )
+    assert any("expired at" in r for r in writer2.dispatch_block_reasons())
+    with pytest.raises(D2DispatchNotAuthorized):
+        await writer2.execute(confirm=True)
+
+
+@pytest.mark.asyncio
+async def test_b1_mutation_authorized_false_blocks_confirm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = sealed_payload(authorized=True)
+    payload["authorized_symbols"]["spot"]["ETHUSDT"]["mutation_authorized"] = False
+    client = FakeExecutionClient()
+    writer = build_writer(
+        tmp_path, monkeypatch, payload=payload, authorized=True, client=client
+    )
+    reasons = writer.dispatch_block_reasons()
+    assert any("mutation_authorized is not true for ['ETHUSDT']" in r for r in reasons)
+    with pytest.raises(D2DispatchNotAuthorized):
+        await writer.execute(confirm=True)
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b1_registered_dispatch_authorized_false_blocks_confirm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even a fully signed payload cannot dispatch until a reviewed change
+    registers its digest as dispatch-authorized."""
+
+    path = write_sealed(
+        tmp_path,
+        monkeypatch,
+        sealed_payload(authorized=True),
+        dispatch_authorized=False,
+    )
+    authority = load_sealed_authority(path)
+    lease, grant = make_lease()
+    writer = D2RemediationSingleWriter(
+        execution_client=FakeExecutionClient(),  # type: ignore[arg-type]
+        authority=authority,
+        lease=lease,
+        lease_grant=grant,
+        ledger=FakeLedger(),
+    )
+    reasons = writer.dispatch_block_reasons()
+    assert any("dispatch_authorized=false" in r for r in reasons)
+    with pytest.raises(D2DispatchNotAuthorized):
+        await writer.execute(confirm=True)
+
+
+def test_b1_every_shipped_sealed_payload_is_dispatch_blocked() -> None:
+    """The structural claim: this repository grants no dispatch authority.
+
+    Not "we checked once" — the shipped map is asserted empty of authorized
+    entries here and again by an import-time tripwire in the module.
+    """
+
+    assert d2.D2_KNOWN_SEALED_PAYLOADS
+    assert not any(
+        record.dispatch_authorized for record in d2.D2_KNOWN_SEALED_PAYLOADS.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_b1_a_fully_authorized_seal_does_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate discriminates; it is not a blanket refusal.
+
+    Without this the five B1 refusals above would be satisfied by a writer that
+    simply never runs, which would prove nothing about the gate.
+    """
+
+    client = FakeExecutionClient()
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    assert writer.dispatch_block_reasons() == ()
+    report = await writer.execute(confirm=True)
+    assert len(client.submit_calls) == 3
+    assert report.halted_reason is None
+
+
+# --------------------------------------------------------------------------
+# B2 — durable replay fence
+# --------------------------------------------------------------------------
+
+
+def test_b2_client_order_ids_are_deterministic_across_processes() -> None:
+    """The verifier's ``REPLAY_WITH_NEW_CLIENT_ORDER_ID``.
+
+    Round 1 minted a UUID per ``plan()`` call, so a restarted process believed
+    it was making a first attempt and would re-send. The id is now derived from
+    the seal and the order, so it is the same everywhere.
+    """
+
+    first = [order.client_order_id for order in D2_BOUND_ORDERS]
+    second = [order.client_order_id for order in D2_BOUND_ORDERS]
+    assert first == second
+    assert not any(re.fullmatch(r"[0-9a-f]{32}", cid) for cid in first)
+    assert all(cid.startswith("d2rem-") and len(cid) <= 36 for cid in first)
+    assert len(set(first)) == 3
+
+
+def test_b2_ids_change_when_the_order_changes() -> None:
+    """Derivation, not a constant: a different price is a different id."""
+
+    order = D2_BOUND_ORDERS[0]
+    other = replace(order, price=order.price + Decimal("0.01"))
+    assert other.client_order_id != order.client_order_id
+
+
+@pytest.mark.asyncio
+async def test_b2_a_prior_ledger_row_prevents_a_second_send(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Simulates the restart the process-local claim set cannot see: the ledger
+    already knows this exact bound order was attempted."""
+
+    prior_cid = D2_BOUND_ORDERS[0].client_order_id
+    client = FakeExecutionClient()
+    ledger = FakeLedger(existing={prior_cid: "submitted"})
+    writer = build_writer(
+        tmp_path, monkeypatch, client=client, ledger=ledger, authorized=True
+    )
+    report = await writer.execute(confirm=True)
+
+    submitted_symbols = [call["symbol"] for call in client.submit_calls]
+    assert "BTCUSDT" not in submitted_symbols  # never re-sent
+    assert submitted_symbols == ["ETHUSDT", "USDCUSDT"]
+    assert report.outcomes[0].readback_used is True
+    assert report.outcomes[0].ledger_state == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_b2_prior_row_with_no_broker_record_halts_instead_of_resending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The genuinely ambiguous case: a ledger row exists, the broker denies it.
+
+    "Never arrived" and "arrived then vanished" are indistinguishable from
+    here, and only one of them is safe to act on — so neither is acted on.
+    """
+
+    prior_cid = D2_BOUND_ORDERS[0].client_order_id
+    client = FakeExecutionClient(status_error=BinanceDemoOrderNotFound("nope"))
+    ledger = FakeLedger(existing={prior_cid: "validated"})
+    writer = build_writer(
+        tmp_path, monkeypatch, client=client, ledger=ledger, authorized=True
+    )
+    with pytest.raises(D2PriorAttemptUnresolved) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.PRIOR_ATTEMPT_UNRESOLVED
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b2_in_process_second_dispatch_is_still_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The inner fence still holds even with the ledger check bypassed."""
+
+    client = FakeExecutionClient()
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    op = writer.plan()[0]
+    writer._claims.claim(op.client_order_id)
+    with pytest.raises(D2BlindRetryRefused) as exc:
+        writer._claims.claim(op.client_order_id)
+    assert exc.value.reason_code is D2ReasonCode.BLIND_RETRY_REFUSED
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b2_ambiguous_submit_is_resolved_by_readback_not_resend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     client = FakeExecutionClient(
         submit_error=TimeoutError("connection reset after POST")
     )
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
     report = await writer.execute(confirm=True)
 
     assert [call["symbol"] for call in client.submit_calls] == [
@@ -580,41 +966,446 @@ async def test_m9_ambiguous_submit_is_resolved_by_readback_not_resend() -> None:
     assert len(client.status_calls) == 3
     assert all(outcome.readback_used for outcome in report.outcomes)
     assert report.broker_submit_count == 3
-    assert report.halted_reason is None
 
 
 @pytest.mark.asyncio
-async def test_m9_unresolvable_outcome_halts_the_run_as_an_anomaly() -> None:
+async def test_b2_unresolvable_outcome_halts_the_run_as_an_anomaly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     client = FakeExecutionClient(
         submit_error=TimeoutError("connection reset after POST"),
         status_error=BinanceDemoOrderNotFound("not found"),
     )
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    ledger = FakeLedger()
+    writer = build_writer(
+        tmp_path, monkeypatch, client=client, ledger=ledger, authorized=True
+    )
     report = await writer.execute(confirm=True)
 
     assert len(client.submit_calls) == 1
     assert report.halted_reason is not None
     assert report.outcomes[0].status == "anomaly"
     assert len(report.outcomes) == 1  # ETH and USDC were never dispatched
-    assert report.broker_submit_count == 1
+    assert ("anomaly", D2_BOUND_ORDERS[0].client_order_id) in ledger.calls
+
+
+# --------------------------------------------------------------------------
+# B3 — the ledger is mandatory
+# --------------------------------------------------------------------------
+
+
+def test_b3_ledger_has_no_default_and_is_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signature = inspect.signature(D2RemediationSingleWriter.__init__)
+    assert signature.parameters["ledger"].default is inspect.Parameter.empty
+
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload())
+    authority = load_sealed_authority(path)
+    lease, grant = make_lease()
+    with pytest.raises(TypeError):
+        D2RemediationSingleWriter(  # type: ignore[call-arg]
+            execution_client=FakeExecutionClient(),  # type: ignore[arg-type]
+            authority=authority,
+            lease=lease,
+            lease_grant=grant,
+        )
+
+
+def test_b3_a_non_ledger_object_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload())
+    authority = load_sealed_authority(path)
+    lease, grant = make_lease()
+    with pytest.raises(D2LedgerRequired) as exc:
+        D2RemediationSingleWriter(
+            execution_client=FakeExecutionClient(),  # type: ignore[arg-type]
+            authority=authority,
+            lease=lease,
+            lease_grant=grant,
+            ledger=object(),  # type: ignore[arg-type]
+        )
+    assert exc.value.reason_code is D2ReasonCode.LEDGER_REQUIRED
 
 
 @pytest.mark.asyncio
-async def test_m9_second_dispatch_of_one_client_order_id_is_refused() -> None:
-    """The no-retry rule is a claim set, not the absence of a loop: even a
-    direct second dispatch of the same id fails before the transport."""
+async def test_b3_every_dispatch_writes_the_full_lifecycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger = FakeLedger()
+    writer = build_writer(tmp_path, monkeypatch, ledger=ledger, authorized=True)
+    await writer.execute(confirm=True)
+    for order in D2_BOUND_ORDERS:
+        cid = order.client_order_id
+        assert [state for state, c in ledger.calls if c == cid] == [
+            "planned",
+            "previewed",
+            "validated",
+            "submitted",
+        ]
+
+
+def test_b3_the_cli_constructs_a_ledger_service() -> None:
+    source = Path("scripts/binance_spot_demo_d2_remediation.py").read_text(
+        encoding="utf-8"
+    )
+    assert "BinanceDemoLedgerService(session)" in source
+    assert "ledger=ledger" in source
+
+
+# --------------------------------------------------------------------------
+# B4 — physical account, writer freeze, pre-dispatch account truth
+# --------------------------------------------------------------------------
+
+
+def test_b4_a_foreign_credential_fingerprint_in_the_seal_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mutant = sealed_payload()
+    mutant["physical_account_identity"]["credential_fingerprint"] = "sha256:" + "a" * 64
+    path = write_sealed(tmp_path, monkeypatch, mutant)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ACCOUNT_MISMATCH
+
+
+def test_b4_a_client_on_a_different_account_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Demo host is shared: the right host proves nothing about whose
+    balances are about to be sold."""
+
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload())
+    authority = load_sealed_authority(path)
+    lease, grant = make_lease()
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        D2RemediationSingleWriter(
+            execution_client=FakeExecutionClient(  # type: ignore[arg-type]
+                credential_fingerprint="sha256:" + "b" * 64
+            ),
+            authority=authority,
+            lease=lease,
+            lease_grant=grant,
+            ledger=FakeLedger(),
+        )
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ACCOUNT_MISMATCH
+
+
+def test_b4_an_unfrozen_writer_lane_blocks_construction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.mock_lane_registry import CANONICAL_LANE_REGISTRY
+
+    account = d2.d2_physical_account_id()
+    unfrozen = tuple(
+        replace(entry, writer=True) if entry.physical_account_id == account else entry
+        for entry in CANONICAL_LANE_REGISTRY
+    )
+    monkeypatch.setattr(d2, "CANONICAL_LANE_REGISTRY", unfrozen)
+    with pytest.raises(D2RemediationError) as exc:
+        build_writer(tmp_path, monkeypatch)
+    assert exc.value.reason_code is D2ReasonCode.WRITER_FREEZE_VIOLATED
+
+
+def test_b4_the_shipped_registry_is_frozen_for_this_account() -> None:
+    d2.assert_writer_freeze()
+    d2.assert_registry_credential_fingerprint()
+
+
+@pytest.mark.asyncio
+async def test_b4_a_foreign_resting_order_stops_the_run_before_any_submit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Round 1 read the open-order book only in the post-dispatch proof epochs,
+    so a foreign resting order was discovered after the sells were on the
+    book."""
+
+    client = FakeExecutionClient(
+        open_orders=[
+            SpotDemoOpenOrder(
+                client_order_id="someone-elses-bot",
+                broker_order_id="9",
+                symbol="XRPUSDT",
+                side="BUY",
+                qty=Decimal("10"),
+                status="NEW",
+            )
+        ]
+    )
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2AccountTruthDrift) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.ACCOUNT_TRUTH_DRIFT
+    assert client.submit_calls == []
+    assert client.order_test_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b4_balance_drift_stops_the_run_before_any_submit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    drifted = {
+        order.asset: (format(order.sealed_free_quantity, "f"), "0")
+        for order in D2_BOUND_ORDERS
+    }
+    drifted["BTC"] = ("0.00009000", "0")  # someone spent it since the snapshot
+    client = FakeExecutionClient(balances=drifted)
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2AccountTruthDrift) as exc:
+        await writer.execute(confirm=True)
+    assert "BTC free" in str(exc.value)
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b4_account_truth_is_read_before_the_first_submit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = FakeExecutionClient()
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    report = await writer.execute(confirm=True)
+    assert report.account_truth is not None
+    # 1 pre-dispatch read + 2 proof epochs.
+    assert client.open_order_reads == 3
+    # 3 sealed assets pre-dispatch + (3 + USDT) x 2 epochs.
+    assert client.balance_reads == 11
+
+
+# --------------------------------------------------------------------------
+# B5 — the broker echo must prove the sealed price and TIF
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("override", "needle"),
+    [
+        ({"price": "69266.02000000"}, "price"),
+        ({"timeInForce": "IOC"}, "timeInForce"),
+        ({"price": None}, "carries no price"),
+        ({"timeInForce": None}, "carries no timeInForce"),
+        ({"origQty": "0.00099000"}, "qty"),
+        ({"side": "BUY"}, "side"),
+    ],
+)
+async def test_b5_broker_echo_mismatch_is_not_treated_as_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    override: dict[str, Any],
+    needle: str,
+) -> None:
+    """The verifier's ``MUTANT_BROKER_PRICE_ECHO``.
+
+    Round 1 compared symbol, side, type, and quantity, so a response that
+    echoed a different *price* was accepted as ``submitted``. Absence is a
+    failure too: a response that cannot prove the sealed price has not proved
+    it.
+    """
+
+    client = FakeExecutionClient(echo_overrides=override)
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2RemediationError) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.BROKER_ECHO_MISMATCH
+    assert needle in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_b5_a_faithful_echo_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Control: the echo check is discriminating, not always-fail."""
 
     client = FakeExecutionClient()
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
-    op = writer.plan()[0]
-    await writer._dispatch_one(op, include_order_test=False)
-    assert len(client.submit_calls) == 1
-    with pytest.raises(D2BlindRetryRefused) as exc:
-        await writer._dispatch_one(op, include_order_test=False)
-    assert exc.value.reason_code is D2ReasonCode.BLIND_RETRY_REFUSED
-    assert len(client.submit_calls) == 1  # no second POST
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    report = await writer.execute(confirm=True)
+    assert report.halted_reason is None
+    assert len(report.outcomes) == 3
+
+
+@pytest.mark.asyncio
+async def test_b5_readback_echo_is_checked_just_as_hard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A drifted price is not laundered by arriving through the readback path."""
+
+    client = FakeExecutionClient(
+        submit_error=TimeoutError("reset"),
+        echo_overrides={"price": "1.00000000"},
+    )
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
+    with pytest.raises(D2RemediationError) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.BROKER_ECHO_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# B6 — lease capability and env bypass
+# --------------------------------------------------------------------------
+
+
+def test_b6_a_fabricated_lease_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The verifier injected an object with ``.released`` and ``.assert_owned``
+    and it satisfied every later check while proving nothing."""
+
+    class FabricatedLease:
+        released = False
+
+        async def assert_owned(self, grant: Any) -> None:
+            return None
+
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload())
+    authority = load_sealed_authority(path)
+    _, grant = make_lease()
+    with pytest.raises(D2LeaseNotHeld) as exc:
+        D2RemediationSingleWriter(
+            execution_client=FakeExecutionClient(),  # type: ignore[arg-type]
+            authority=authority,
+            lease=FabricatedLease(),  # type: ignore[arg-type]
+            lease_grant=grant,
+            ledger=FakeLedger(),
+        )
+    assert exc.value.reason_code is D2ReasonCode.LEASE_NOT_A_CAPABILITY
+
+
+def test_b6_there_is_no_environ_seam_to_arm_the_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The verifier's ``INJECTED_ENV_BYPASSES_OS_D2_GATE``.
+
+    Round 1 accepted an ``environ`` mapping "for testability", which let an
+    in-process caller arm the gate the operator had deliberately left off.
+    """
+
+    assert (
+        "environ"
+        not in inspect.signature(D2RemediationSingleWriter.__init__).parameters
+    )
+    assert inspect.signature(d2.d2_remediation_enabled).parameters == {}
+
+    monkeypatch.delenv(D2_REMEDIATION_ENABLED_ENV, raising=False)
+    path = write_sealed(tmp_path, monkeypatch, sealed_payload())
+    authority = load_sealed_authority(path)
+    lease, grant = make_lease()
+    with pytest.raises(D2RemediationDisabled) as exc:
+        D2RemediationSingleWriter(
+            execution_client=FakeExecutionClient(),  # type: ignore[arg-type]
+            authority=authority,
+            lease=lease,
+            lease_grant=grant,
+            ledger=FakeLedger(),
+        )
+    assert exc.value.reason_code is D2ReasonCode.DISABLED
+
+
+def test_b6_a_raw_payload_cannot_be_passed_instead_of_an_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lease, grant = make_lease()
+    with pytest.raises(D2SealBindingMismatch):
+        D2RemediationSingleWriter(
+            execution_client=FakeExecutionClient(),  # type: ignore[arg-type]
+            authority=sealed_payload(),  # type: ignore[arg-type]
+            lease=lease,
+            lease_grant=grant,
+            ledger=FakeLedger(),
+        )
+
+
+def test_b6_a_sealed_authority_cannot_be_hand_built() -> None:
+    """Only ``load_sealed_authority`` may mint one, so the digest check cannot
+    be skipped by constructing the result object directly."""
+
+    with pytest.raises(D2SealBindingMismatch):
+        d2.SealedAuthority(
+            source_path="/dev/null",
+            payload_sha256="0" * 64,
+            record=SealedPayloadRecord(
+                sha256="0" * 64,
+                pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+                dispatch_authorized=True,
+                note="forged",
+            ),
+            orders=D2_BOUND_ORDERS,
+            credential_fingerprint=D2_CREDENTIAL_FINGERPRINT,
+            operator_authorization={"forged": True},
+            expiry=None,
+            mutation_authorized_symbols=frozenset(
+                order.symbol for order in D2_BOUND_ORDERS
+            ),
+            _token=object(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_b6_a_released_lease_blocks_the_order_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = FakeExecutionClient()
+    lease, grant = make_lease()
+    writer = build_writer(
+        tmp_path,
+        monkeypatch,
+        client=client,
+        authorized=True,
+        lease=lease,
+        grant=grant,
+    )
+    lease._released = True
+    with pytest.raises(D2LeaseNotHeld) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.LEASE_NOT_HELD
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b6_a_lease_over_the_wrong_keyset_blocks_the_order_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = FakeExecutionClient()
+    lease, grant = make_lease(keys=(1234567890,))
+    writer = build_writer(
+        tmp_path,
+        monkeypatch,
+        client=client,
+        authorized=True,
+        lease=lease,
+        grant=grant,
+    )
+    with pytest.raises(D2LeaseNotHeld) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.LEASE_SCOPE_MISMATCH
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_b6_lease_ownership_is_reproved_before_each_submit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lease that stops attesting mid-run stops the run.
+
+    Uses the real ``pg_locks`` attestation: dropping the lock rows is what a
+    lost session looks like to PostgreSQL.
+    """
+
+    client = FakeExecutionClient()
+    lease, grant = make_lease()
+    writer = build_writer(
+        tmp_path,
+        monkeypatch,
+        client=client,
+        authorized=True,
+        lease=lease,
+        grant=grant,
+    )
+    authority: FakeLockAuthority = lease._connection  # type: ignore[assignment]
+    authority.unlocked.update(grant.keys)  # the backend no longer holds them
+    with pytest.raises(D2LeaseNotHeld):
+        await writer.execute(confirm=True)
+    assert client.submit_calls == []
 
 
 # --------------------------------------------------------------------------
@@ -623,10 +1414,11 @@ async def test_m9_second_dispatch_of_one_client_order_id_is_refused() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dry_run_is_the_default_and_submits_nothing() -> None:
+async def test_dry_run_is_the_default_and_submits_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     client = FakeExecutionClient()
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    writer = build_writer(tmp_path, monkeypatch, client=client)
     report = await writer.execute()  # no confirm= at all
     assert client.submit_calls == []
     assert report.broker_mutation_count == 0
@@ -636,20 +1428,27 @@ async def test_dry_run_is_the_default_and_submits_nothing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dry_run_can_skip_even_the_non_mutating_order_test() -> None:
-    client = FakeExecutionClient()
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
-    await writer.execute(confirm=False, include_order_test=False)
-    assert client.order_test_calls == []
-    assert client.submit_calls == []
+async def test_dry_run_reports_every_dispatch_blocker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rehearsal lists all the blockers at once, rather than making the
+    operator discover them one run at a time."""
+
+    writer = build_writer(tmp_path, monkeypatch, client=FakeExecutionClient())
+    evidence = (await writer.execute(confirm=False)).as_evidence()
+    assert evidence["dispatch_authorized"] is False
+    reasons = " | ".join(evidence["dispatch_block_reasons"])
+    assert "dispatch_authorized=false" in reasons
+    assert "operator_authorization is null" in reasons
+    assert "expiry is absent" in reasons
+    assert "mutation_authorized is not true" in reasons
 
 
 @pytest.mark.asyncio
-async def test_dry_run_evidence_prints_the_sealed_values() -> None:
-    client = FakeExecutionClient()
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+async def test_dry_run_evidence_prints_the_sealed_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    writer = build_writer(tmp_path, monkeypatch, client=FakeExecutionClient())
     evidence = (await writer.execute(confirm=False)).as_evidence()
     assert evidence["writer"] == WRITER_NAME
     assert evidence["pre_snapshot_hash"] == D2_PRE_SNAPSHOT_HASH
@@ -657,18 +1456,6 @@ async def test_dry_run_evidence_prints_the_sealed_values() -> None:
     assert [op["request_params"] for op in evidence["operations"]] == [
         order.request_params() for order in D2_BOUND_ORDERS
     ]
-
-
-# --------------------------------------------------------------------------
-# Inherited boundaries are still boundaries
-# --------------------------------------------------------------------------
-
-
-def test_env_gate_is_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv(D2_REMEDIATION_ENABLED_ENV, raising=False)
-    with pytest.raises(D2RemediationDisabled) as exc:
-        build_writer()
-    assert exc.value.reason_code is D2ReasonCode.DISABLED
 
 
 @pytest.mark.parametrize(
@@ -679,47 +1466,25 @@ def test_env_gate_is_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
         "https://demo-api.binance.com.evil.example",
     ],
 )
-def test_non_spot_demo_host_is_refused(base_url: str) -> None:
+def test_non_spot_demo_host_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, base_url: str
+) -> None:
     with pytest.raises(D2UnauthorizedOperation) as exc:
-        build_writer(client=FakeExecutionClient(base_url=base_url))
+        build_writer(
+            tmp_path, monkeypatch, client=FakeExecutionClient(base_url=base_url)
+        )
     assert exc.value.reason_code is D2ReasonCode.HOST_NOT_SPOT_DEMO
 
 
 @pytest.mark.asyncio
-async def test_broker_echo_mismatch_is_not_treated_as_success() -> None:
-    class DriftingClient(FakeExecutionClient):
-        async def submit_order(self, **kwargs: Any) -> SpotDemoOrderSubmitResult:
-            self.submit_calls.append(kwargs)
-            return SpotDemoOrderSubmitResult(
-                client_order_id=kwargs["client_order_id"],
-                broker_order_id="bid",
-                symbol=kwargs["symbol"],
-                side=kwargs["side"],
-                order_type=kwargs["order_type"],
-                qty=Decimal("0.00099"),  # not what was authorized
-                executed_qty=Decimal("0"),
-                cummulative_quote_qty=Decimal("0"),
-                status="NEW",
-            )
-
-    client = DriftingClient()
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
-    with pytest.raises(Exception) as exc:
-        await writer.execute(confirm=True)
-    assert getattr(exc.value, "reason_code", None) is D2ReasonCode.BROKER_ECHO_MISMATCH
-
-
-@pytest.mark.asyncio
-async def test_two_independent_proof_epochs_are_produced() -> None:
+async def test_two_independent_proof_epochs_are_produced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     client = FakeExecutionClient()
-    grant = make_grant()
-    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    writer = build_writer(tmp_path, monkeypatch, client=client, authorized=True)
     report = await writer.execute(confirm=True)
     assert [epoch.epoch_index for epoch in report.proof_epochs] == [1, 2]
-    # Each epoch issued its own reads; neither reused the other's bytes.
-    assert client.open_order_reads == 2
-    assert client.balance_reads == 8  # (3 assets + USDT) x 2 epochs
+    assert all(epoch.ledger_states for epoch in report.proof_epochs)
 
 
 def test_writer_name_matches_the_operator_contract() -> None:
@@ -753,6 +1518,29 @@ def real_client(monkeypatch: pytest.MonkeyPatch) -> BinanceSpotDemoExecutionClie
     return BinanceSpotDemoExecutionClient.from_env()
 
 
+def _sealed_payload_for(client: BinanceSpotDemoExecutionClient) -> dict[str, Any]:
+    """The seal has to name the account the live client actually holds."""
+
+    payload = sealed_payload(authorized=True)
+    payload["physical_account_identity"]["credential_fingerprint"] = (
+        client.credential_fingerprint
+    )
+    return payload
+
+
+def _account_balances_json() -> dict[str, Any]:
+    return {
+        "balances": [
+            {
+                "asset": order.asset,
+                "free": format(order.sealed_free_quantity, "f"),
+                "locked": format(order.sealed_locked_quantity, "f"),
+            }
+            for order in D2_BOUND_ORDERS
+        ]
+    }
+
+
 def _sent_order_fields(request: Any) -> dict[str, str]:
     params = dict(parse_qsl(str(request.url).split("?", 1)[1]))
     return {
@@ -762,67 +1550,102 @@ def _sent_order_fields(request: Any) -> dict[str, str]:
     }
 
 
-@pytest.mark.asyncio
-async def test_dry_run_sends_only_order_test_with_the_sealed_fields(
-    real_client: BinanceSpotDemoExecutionClient, httpx_mock: Any
-) -> None:
-    for _ in D2_BOUND_ORDERS:
-        httpx_mock.add_response(method="POST", url=_ORDER_TEST_RE, json={})
-    grant = make_grant()
-    writer = D2RemediationSingleWriter(
-        execution_client=real_client,
-        sealed_payload=sealed_payload(),
-        lease=FakeLease(grant),  # type: ignore[arg-type]
+def _wire_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    client: BinanceSpotDemoExecutionClient,
+) -> D2RemediationSingleWriter:
+    monkeypatch.setattr(d2, "D2_CREDENTIAL_FINGERPRINT", client.credential_fingerprint)
+    monkeypatch.setattr(
+        d2,
+        "assert_registry_credential_fingerprint",
+        lambda: None,
+    )
+    path = write_sealed(
+        tmp_path, monkeypatch, _sealed_payload_for(client), dispatch_authorized=True
+    )
+    authority = load_sealed_authority(path)
+    lease, grant = make_lease()
+    return D2RemediationSingleWriter(
+        execution_client=client,
+        authority=authority,
+        lease=lease,
         lease_grant=grant,
+        ledger=FakeLedger(),
     )
 
+
+@pytest.mark.asyncio
+async def test_dry_run_sends_only_reads_and_order_test_with_the_sealed_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    real_client: BinanceSpotDemoExecutionClient,
+    httpx_mock: Any,
+) -> None:
+    httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
+    for _ in D2_BOUND_ORDERS:
+        httpx_mock.add_response(
+            method="GET", url=_ACCOUNT_RE, json=_account_balances_json()
+        )
+        httpx_mock.add_response(method="POST", url=_ORDER_TEST_RE, json={})
+
+    writer = _wire_writer(tmp_path, monkeypatch, real_client)
     await writer.execute(confirm=False)
 
     requests = httpx_mock.get_requests()
-    assert [str(r.url).split("?", 1)[0] for r in requests] == [
-        f"{_BASE}/api/v3/order/test"
-    ] * 3
-    assert [_sent_order_fields(r) for r in requests] == [
+    order_tests = [
+        r
+        for r in requests
+        if str(r.url).split("?", 1)[0] == f"{_BASE}/api/v3/order/test"
+    ]
+    assert [_sent_order_fields(r) for r in order_tests] == [
         order.request_params() for order in D2_BOUND_ORDERS
     ]
+    assert not [
+        r for r in requests if str(r.url).split("?", 1)[0] == f"{_BASE}/api/v3/order"
+    ]
+    assert {r.url.host for r in requests} == {D2_VENUE_HOST}
 
 
 @pytest.mark.asyncio
 async def test_confirm_posts_exactly_the_sealed_fields(
-    real_client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    real_client: BinanceSpotDemoExecutionClient,
+    httpx_mock: Any,
 ) -> None:
+    httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
     for _ in D2_BOUND_ORDERS:
-        httpx_mock.add_response(method="POST", url=_ORDER_TEST_RE, json={})
+        httpx_mock.add_response(
+            method="GET", url=_ACCOUNT_RE, json=_account_balances_json()
+        )
     for index, order in enumerate(D2_BOUND_ORDERS):
+        httpx_mock.add_response(method="POST", url=_ORDER_TEST_RE, json={})
         httpx_mock.add_response(
             method="POST",
             url=_ORDER_RE,
             json={
                 "symbol": order.symbol,
                 "orderId": 1000 + index,
-                "clientOrderId": "echoed",
+                "clientOrderId": order.client_order_id,
                 "side": order.side,
                 "type": order.order_type,
                 "origQty": format(order.quantity, "f"),
                 "executedQty": "0",
                 "cummulativeQuoteQty": "0",
+                "price": format(order.price, "f"),
+                "timeInForce": order.time_in_force,
                 "status": "NEW",
             },
         )
-    # Proof-epoch reads: 2 account-wide open-order reads and 4 balance reads
-    # per epoch.
     for _ in range(2):
         httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
     for _ in range(8):
-        httpx_mock.add_response(method="GET", url=_ACCOUNT_RE, json={"balances": []})
+        httpx_mock.add_response(
+            method="GET", url=_ACCOUNT_RE, json=_account_balances_json()
+        )
 
-    grant = make_grant()
-    writer = D2RemediationSingleWriter(
-        execution_client=real_client,
-        sealed_payload=sealed_payload(),
-        lease=FakeLease(grant),  # type: ignore[arg-type]
-        lease_grant=grant,
-    )
+    writer = _wire_writer(tmp_path, monkeypatch, real_client)
     await writer.execute(confirm=True)
 
     posts = [
@@ -833,5 +1656,47 @@ async def test_confirm_posts_exactly_the_sealed_fields(
     assert [_sent_order_fields(r) for r in posts] == [
         order.request_params() for order in D2_BOUND_ORDERS
     ]
-    # Every request went to the Spot Demo host and nowhere else.
+    # The deterministic ids go on the wire, not a UUID.
+    sent_ids = [
+        dict(parse_qsl(str(r.url).split("?", 1)[1]))["newClientOrderId"] for r in posts
+    ]
+    assert sent_ids == [order.client_order_id for order in D2_BOUND_ORDERS]
     assert {r.url.host for r in httpx_mock.get_requests()} == {D2_VENUE_HOST}
+
+
+# --------------------------------------------------------------------------
+# Bypass enumeration — the seams I went looking for myself
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_backdated_now_fn_cannot_revive_an_expired_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``now_fn`` exists for reproducible evidence timestamps.
+
+    Wiring it into the expiry comparison would have made it a bypass: a caller
+    passing a clock fixed before the expiry could run an authority that has
+    already lapsed. The expiry check reads the real clock.
+    """
+
+    import datetime as real_dt
+
+    expired = sealed_payload(authorized=True)
+    expired["expiry"] = "2020-01-01T00:00:00Z"
+    path = write_sealed(tmp_path, monkeypatch, expired, dispatch_authorized=True)
+    authority = load_sealed_authority(path)
+    lease, grant = make_lease()
+    client = FakeExecutionClient()
+    writer = D2RemediationSingleWriter(
+        execution_client=client,  # type: ignore[arg-type]
+        authority=authority,
+        lease=lease,
+        lease_grant=grant,
+        ledger=FakeLedger(),
+        now_fn=lambda: real_dt.datetime(2019, 1, 1, tzinfo=real_dt.UTC),
+    )
+    assert any("expired at" in r for r in writer.dispatch_block_reasons())
+    with pytest.raises(D2DispatchNotAuthorized):
+        await writer.execute(confirm=True)
+    assert client.submit_calls == []

--- a/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
+++ b/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
@@ -1,0 +1,837 @@
+"""``d2_remediation_single`` — the closed three-order D2 writer.
+
+The interesting question about this writer is not "does it place an order"
+but "what can it be talked into placing". These tests answer that by mutation:
+each of the nine cases below takes the real sealed r7 attempt-2 payload, makes
+one change a mistaken or hostile caller might make, and proves the writer
+refuses. Every mutant is paired with the unmutated original so a refusal that
+came from something unrelated would show up as the control failing too.
+
+Checks are closed equality against the frozen constant, never a name match:
+``0.00016`` is refused because it is not ``0.00015``, not because a string
+did or did not contain a substring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import re
+from decimal import Decimal
+from typing import Any
+from urllib.parse import parse_qsl
+
+import pytest
+
+from app.services.brokers.binance.demo.errors import BinanceDemoOrderNotFound
+from app.services.brokers.binance.spot_demo.d2_remediation_single import (
+    D2_ALLOWED_OPERATION_IDS,
+    D2_BOUND_ORDERS,
+    D2_PRE_SNAPSHOT_HASH,
+    D2_REMEDIATION_ENABLED_ENV,
+    D2_REMEDIATION_ID,
+    D2_VENUE_HOST,
+    WRITER_NAME,
+    D2BlindRetryRefused,
+    D2LeaseNotHeld,
+    D2ReasonCode,
+    D2RemediationDisabled,
+    D2RemediationSingleWriter,
+    D2SealBindingMismatch,
+    D2UnauthorizedOperation,
+    bind_sealed_orders,
+    d2_advisory_keyset,
+)
+from app.services.brokers.binance.spot_demo.dto import (
+    SpotDemoAssetBalance,
+    SpotDemoOpenOrder,
+    SpotDemoOpenOrdersResult,
+    SpotDemoOrderSubmitResult,
+    SpotDemoOrderTestResult,
+)
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+)
+from app.services.mock_integration.coordination import AdvisoryLeaseGrant
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# The sealed payload, transcribed from r7 attempt-2
+# --------------------------------------------------------------------------
+
+
+def _actionable(symbol: str, asset: str, quantity: str, price: str) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "asset": asset,
+        "product": "spot",
+        "disposition": "REVIEWED_SCOPE_LIMIT_CANDIDATE",
+        "mutation_authorized": False,
+        "proposed_one_step": {
+            "side": "SELL",
+            "order_type": "LIMIT",
+            "time_in_force": None,
+            "proposed_quantity_floor": quantity,
+            "proposed_limit_price_floor": price,
+            "rounding_direction": "floor_only_no_uplift",
+        },
+    }
+
+
+def _dust(symbol: str, asset: str) -> dict[str, Any]:
+    """A floor-zero attestation row. It authorizes no order and must never
+    be picked up as one."""
+
+    return {
+        "symbol": symbol,
+        "asset": asset,
+        "product": "spot",
+        "disposition": "LOT_SIZE_FLOOR_ZERO_V1_2",
+        "mutation_authorized": False,
+        "planned_quantity": "0",
+    }
+
+
+def sealed_payload() -> dict[str, Any]:
+    """The exact bound object: three actionable rows, three dust rows, one
+    quote-cash row."""
+
+    return {
+        "remediation_id": D2_REMEDIATION_ID,
+        "product_domain": "both",
+        "pre_snapshot_hash": D2_PRE_SNAPSHOT_HASH,
+        "operator_authorization": None,
+        "authorized_symbols": {
+            "spot": {
+                "BTCUSDT": _actionable(
+                    "BTCUSDT", "BTC", "0.00015000", "69266.01000000"
+                ),
+                "ETHUSDT": _actionable("ETHUSDT", "ETH", "0.00520000", "2248.56000000"),
+                "USDCUSDT": _actionable(
+                    "USDCUSDT", "USDC", "5000.00000000", "1.00072000"
+                ),
+                "SOLUSDT": _dust("SOLUSDT", "SOL"),
+                "XRPUSDT": _dust("XRPUSDT", "XRP"),
+                "DOGEUSDT": _dust("DOGEUSDT", "DOGE"),
+                "USDT": {
+                    "asset": "USDT",
+                    "disposition": "QUOTE_CASH_ATTESTATION_ONLY_KEEP",
+                },
+            }
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+class FakeExecutionClient:
+    """Counts everything that crosses the transport boundary.
+
+    ``submit_calls`` is the number that matters: a duplicate order is the
+    worst available failure of this writer, so the tests assert on the count,
+    not on whether a retry loop is visible in the source.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = f"https://{D2_VENUE_HOST}",
+        submit_error: Exception | None = None,
+        status_body: dict[str, Any] | None = None,
+        status_error: Exception | None = None,
+        submit_status: str = "NEW",
+    ) -> None:
+        self._base_url = base_url
+        self.submit_calls: list[dict[str, Any]] = []
+        self.order_test_calls: list[dict[str, Any]] = []
+        self.status_calls: list[dict[str, Any]] = []
+        self.open_order_reads = 0
+        self.balance_reads = 0
+        self._submit_error = submit_error
+        self._status_body = status_body
+        self._status_error = status_error
+        self._submit_status = submit_status
+
+    async def order_test(self, **kwargs: Any) -> SpotDemoOrderTestResult:
+        self.order_test_calls.append(kwargs)
+        return SpotDemoOrderTestResult(
+            symbol=kwargs["symbol"],
+            side=kwargs["side"],
+            order_type=kwargs["order_type"],
+            qty=kwargs["qty"],
+        )
+
+    async def submit_order(self, **kwargs: Any) -> SpotDemoOrderSubmitResult:
+        self.submit_calls.append(kwargs)
+        if self._submit_error is not None:
+            raise self._submit_error
+        return SpotDemoOrderSubmitResult(
+            client_order_id=kwargs["client_order_id"],
+            broker_order_id=f"bid-{len(self.submit_calls)}",
+            symbol=kwargs["symbol"],
+            side=kwargs["side"],
+            order_type=kwargs["order_type"],
+            qty=kwargs["qty"],
+            executed_qty=Decimal("0"),
+            cummulative_quote_qty=Decimal("0"),
+            status=self._submit_status,
+        )
+
+    async def get_order_status(self, **kwargs: Any) -> dict[str, Any]:
+        self.status_calls.append(kwargs)
+        if self._status_error is not None:
+            raise self._status_error
+        if self._status_body is not None:
+            return dict(self._status_body)
+        # Default: the venue faithfully echoes the order that was authorized.
+        order = next(o for o in D2_BOUND_ORDERS if o.symbol == kwargs["symbol"])
+        return {
+            "symbol": order.symbol,
+            "side": order.side,
+            "type": order.order_type,
+            "origQty": format(order.quantity, "f"),
+            "executedQty": "0",
+            "status": "NEW",
+            "orderId": f"readback-{len(self.status_calls)}",
+            "clientOrderId": kwargs["client_order_id"],
+        }
+
+    async def get_all_open_orders(self) -> SpotDemoOpenOrdersResult:
+        self.open_order_reads += 1
+        return SpotDemoOpenOrdersResult(
+            orders=[
+                SpotDemoOpenOrder(
+                    client_order_id="cid",
+                    broker_order_id="bid",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    qty=Decimal("0.00015"),
+                    status="NEW",
+                )
+            ]
+        )
+
+    async def get_asset_balance(self, *, asset: str) -> SpotDemoAssetBalance:
+        self.balance_reads += 1
+        return SpotDemoAssetBalance(asset=asset, free=Decimal("0"), locked=Decimal("0"))
+
+
+class FakeLease:
+    """A stand-in for ``PostgresAdvisoryKeysetLease`` with the same use-time
+    contract: ownership is re-proved on demand and never cached."""
+
+    def __init__(
+        self,
+        grant: AdvisoryLeaseGrant,
+        *,
+        released: bool = False,
+        attest_error: Exception | None = None,
+    ) -> None:
+        self._grant = grant
+        self.released = released
+        self.attest_calls = 0
+        self._attest_error = attest_error
+
+    async def assert_owned(self, expected_grant: AdvisoryLeaseGrant) -> None:
+        self.attest_calls += 1
+        if self._attest_error is not None:
+            raise self._attest_error
+        if expected_grant is not self._grant:
+            raise RuntimeError("lease_lost")
+
+
+#: A grant carries the loop its session is bound to. Sync tests have no running
+#: loop, and ``asyncio.get_event_loop()`` outside one is order-dependent — it
+#: succeeds or raises depending on whether an earlier async test happened to
+#: leave a loop set on the thread. One inert loop keeps these tests independent
+#: of collection order.
+_SENTINEL_LOOP = asyncio.new_event_loop()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _close_sentinel_loop() -> Any:
+    yield
+    _SENTINEL_LOOP.close()
+
+
+def make_grant(keys: tuple[int, ...] | None = None) -> AdvisoryLeaseGrant:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = _SENTINEL_LOOP
+    return AdvisoryLeaseGrant(
+        keys=keys if keys is not None else d2_advisory_keyset(),
+        backend_pid=4242,
+        database_oid=99,
+        connection_token="lockconn:test",
+        event_loop=loop,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _arm_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The env gate is default-off; every test that expects the writer to
+    construct has to arm it explicitly, and one test below removes it again."""
+
+    monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
+
+
+def build_writer(
+    *,
+    payload: dict[str, Any] | None = None,
+    client: FakeExecutionClient | None = None,
+    lease: FakeLease | None = None,
+    grant: AdvisoryLeaseGrant | None = None,
+    ledger: Any = None,
+) -> D2RemediationSingleWriter:
+    the_grant = grant if grant is not None else make_grant()
+    return D2RemediationSingleWriter(
+        execution_client=client or FakeExecutionClient(),  # type: ignore[arg-type]
+        sealed_payload=payload if payload is not None else sealed_payload(),
+        lease=lease if lease is not None else FakeLease(the_grant),  # type: ignore[arg-type]
+        lease_grant=the_grant,
+        ledger=ledger,
+    )
+
+
+# --------------------------------------------------------------------------
+# Control — the unmutated seal binds, and binds to the frozen constant
+# --------------------------------------------------------------------------
+
+
+def test_unmutated_seal_binds_to_the_frozen_constant() -> None:
+    bound = bind_sealed_orders(sealed_payload())
+    assert bound is D2_BOUND_ORDERS
+    assert [order.symbol for order in bound] == ["BTCUSDT", "ETHUSDT", "USDCUSDT"]
+
+
+def test_dust_and_quote_cash_rows_never_become_orders() -> None:
+    bound = bind_sealed_orders(sealed_payload())
+    symbols = {order.symbol for order in bound}
+    assert symbols.isdisjoint({"SOLUSDT", "XRPUSDT", "DOGEUSDT", "USDT"})
+
+
+def test_bound_set_is_exactly_three_sell_limits() -> None:
+    assert len(D2_BOUND_ORDERS) == 3
+    assert {order.side for order in D2_BOUND_ORDERS} == {"SELL"}
+    assert {order.order_type for order in D2_BOUND_ORDERS} == {"LIMIT"}
+    assert len(D2_ALLOWED_OPERATION_IDS) == 3
+
+
+def test_request_params_equal_the_sealed_values_exactly() -> None:
+    writer = build_writer()
+    params = [op.request_params for op in writer.plan()]
+    assert params == [
+        {
+            "symbol": "BTCUSDT",
+            "side": "SELL",
+            "type": "LIMIT",
+            "quantity": "0.00015000",
+            "price": "69266.01000000",
+            "timeInForce": "GTC",
+        },
+        {
+            "symbol": "ETHUSDT",
+            "side": "SELL",
+            "type": "LIMIT",
+            "quantity": "0.00520000",
+            "price": "2248.56000000",
+            "timeInForce": "GTC",
+        },
+        {
+            "symbol": "USDCUSDT",
+            "side": "SELL",
+            "type": "LIMIT",
+            "quantity": "5000.00000000",
+            "price": "1.00072000",
+            "timeInForce": "GTC",
+        },
+    ]
+
+
+# --------------------------------------------------------------------------
+# M1 — a different symbol
+# --------------------------------------------------------------------------
+
+
+def test_m1_foreign_symbol_is_refused() -> None:
+    control = sealed_payload()
+    assert bind_sealed_orders(control) is D2_BOUND_ORDERS  # control passes
+
+    mutant = copy.deepcopy(control)
+    mutant["authorized_symbols"]["spot"]["SOLUSDT"] = _actionable(
+        "SOLUSDT", "SOL", "1.00000000", "100.00000000"
+    )
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# M2 — side flipped to BUY
+# --------------------------------------------------------------------------
+
+
+def test_m2_buy_side_is_refused() -> None:
+    mutant = copy.deepcopy(sealed_payload())
+    mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]["side"] = "BUY"
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# M3 — one digit of quantity
+# --------------------------------------------------------------------------
+
+
+def test_m3_quantity_one_digit_changed_is_refused() -> None:
+    mutant = copy.deepcopy(sealed_payload())
+    step = mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
+    assert step["proposed_quantity_floor"] == "0.00015000"
+    step["proposed_quantity_floor"] = "0.00016000"
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+def test_m3_trailing_zero_difference_is_not_a_mutation() -> None:
+    """The check is decimal value equality, not string equality: a differently
+    spelled but identical quantity must still bind, or the guard would be
+    rejecting for the wrong reason."""
+
+    same_value = copy.deepcopy(sealed_payload())
+    step = same_value["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
+    step["proposed_quantity_floor"] = "0.00015"
+    assert bind_sealed_orders(same_value) is D2_BOUND_ORDERS
+
+
+# --------------------------------------------------------------------------
+# M4 — one tick of price
+# --------------------------------------------------------------------------
+
+
+def test_m4_price_one_tick_changed_is_refused() -> None:
+    mutant = copy.deepcopy(sealed_payload())
+    step = mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
+    assert step["proposed_limit_price_floor"] == "69266.01000000"
+    # PRICE_FILTER tickSize for BTCUSDT is 0.01.
+    step["proposed_limit_price_floor"] = "69266.02000000"
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# M5 — a different seal
+# --------------------------------------------------------------------------
+
+
+def test_m5_foreign_pre_snapshot_hash_is_refused() -> None:
+    mutant = copy.deepcopy(sealed_payload())
+    # The superseded attempt-1 hash: a real, adjacent, wrong seal.
+    mutant["pre_snapshot_hash"] = (
+        "sha256:df50c7c0acfaf059e9f97ee27826520cf7bfa9b71d9f0c2316c16d8dcadecdfe"
+    )
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_HASH_MISMATCH
+
+
+def test_m5_hash_mismatch_is_caught_before_the_writer_constructs() -> None:
+    client = FakeExecutionClient()
+    mutant = copy.deepcopy(sealed_payload())
+    mutant["pre_snapshot_hash"] = "sha256:" + "0" * 64
+    with pytest.raises(D2SealBindingMismatch):
+        build_writer(payload=mutant, client=client)
+    assert client.submit_calls == []
+    assert client.order_test_calls == []
+
+
+# --------------------------------------------------------------------------
+# M6 — no lease
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m6_released_lease_blocks_the_order_path() -> None:
+    client = FakeExecutionClient()
+    grant = make_grant()
+    writer = build_writer(
+        client=client, lease=FakeLease(grant, released=True), grant=grant
+    )
+    with pytest.raises(D2LeaseNotHeld) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.LEASE_NOT_HELD
+    assert client.submit_calls == []
+    assert client.order_test_calls == []
+
+
+@pytest.mark.asyncio
+async def test_m6_lease_over_the_wrong_keyset_blocks_the_order_path() -> None:
+    client = FakeExecutionClient()
+    wrong = make_grant(keys=(1234567890,))
+    writer = build_writer(client=client, lease=FakeLease(wrong), grant=wrong)
+    with pytest.raises(D2LeaseNotHeld) as exc:
+        await writer.execute(confirm=True)
+    assert exc.value.reason_code is D2ReasonCode.LEASE_SCOPE_MISMATCH
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_m6_unattestable_lease_blocks_the_order_path() -> None:
+    client = FakeExecutionClient()
+    grant = make_grant()
+    lease = FakeLease(grant, attest_error=RuntimeError("lock_authority_unavailable"))
+    writer = build_writer(client=client, lease=lease, grant=grant)
+    with pytest.raises(D2LeaseNotHeld):
+        await writer.execute(confirm=True)
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_lease_is_reattested_immediately_before_each_submit() -> None:
+    """Acquisition-time success is not carried forward: there is one
+    attestation for the run and one more per order, plus one per proof epoch."""
+
+    client = FakeExecutionClient()
+    grant = make_grant()
+    lease = FakeLease(grant)
+    writer = build_writer(client=client, lease=lease, grant=grant)
+    await writer.execute(confirm=True)
+    assert len(client.submit_calls) == 3
+    # 1 run entry + 3 pre-submit + 2 proof epochs
+    assert lease.attest_calls == 6
+
+
+# --------------------------------------------------------------------------
+# M7 — MARKET
+# --------------------------------------------------------------------------
+
+
+def test_m7_market_order_type_is_refused() -> None:
+    mutant = copy.deepcopy(sealed_payload())
+    step = mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
+    step["order_type"] = "MARKET"
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+def test_m7_no_bound_order_is_a_market_order() -> None:
+    assert all(order.order_type == "LIMIT" for order in D2_BOUND_ORDERS)
+
+
+# --------------------------------------------------------------------------
+# M8 — a fourth order
+# --------------------------------------------------------------------------
+
+
+def test_m8_fourth_order_is_refused() -> None:
+    mutant = copy.deepcopy(sealed_payload())
+    mutant["authorized_symbols"]["spot"]["XRPUSDT"] = _actionable(
+        "XRPUSDT", "XRP", "10.00000000", "0.50000000"
+    )
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+    assert "XRPUSDT" in str(exc.value)
+
+
+def test_m8_a_missing_third_order_is_also_refused() -> None:
+    """The set is closed in both directions: silently shrinking it would let a
+    truncated payload look like a clean partial run."""
+
+    mutant = copy.deepcopy(sealed_payload())
+    del mutant["authorized_symbols"]["spot"]["USDCUSDT"]
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        bind_sealed_orders(mutant)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# M9 — re-sending after a failure
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m9_ambiguous_submit_is_resolved_by_readback_not_resend() -> None:
+    """Every submit fails locally after the POST, so every outcome is
+    ambiguous. Each one is settled by asking the venue exactly once; no symbol
+    is ever POSTed twice."""
+
+    client = FakeExecutionClient(
+        submit_error=TimeoutError("connection reset after POST")
+    )
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    report = await writer.execute(confirm=True)
+
+    assert [call["symbol"] for call in client.submit_calls] == [
+        "BTCUSDT",
+        "ETHUSDT",
+        "USDCUSDT",
+    ]  # each exactly once
+    assert len(client.status_calls) == 3
+    assert all(outcome.readback_used for outcome in report.outcomes)
+    assert report.broker_submit_count == 3
+    assert report.halted_reason is None
+
+
+@pytest.mark.asyncio
+async def test_m9_unresolvable_outcome_halts_the_run_as_an_anomaly() -> None:
+    client = FakeExecutionClient(
+        submit_error=TimeoutError("connection reset after POST"),
+        status_error=BinanceDemoOrderNotFound("not found"),
+    )
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    report = await writer.execute(confirm=True)
+
+    assert len(client.submit_calls) == 1
+    assert report.halted_reason is not None
+    assert report.outcomes[0].status == "anomaly"
+    assert len(report.outcomes) == 1  # ETH and USDC were never dispatched
+    assert report.broker_submit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_m9_second_dispatch_of_one_client_order_id_is_refused() -> None:
+    """The no-retry rule is a claim set, not the absence of a loop: even a
+    direct second dispatch of the same id fails before the transport."""
+
+    client = FakeExecutionClient()
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    op = writer.plan()[0]
+    await writer._dispatch_one(op, include_order_test=False)
+    assert len(client.submit_calls) == 1
+    with pytest.raises(D2BlindRetryRefused) as exc:
+        await writer._dispatch_one(op, include_order_test=False)
+    assert exc.value.reason_code is D2ReasonCode.BLIND_RETRY_REFUSED
+    assert len(client.submit_calls) == 1  # no second POST
+
+
+# --------------------------------------------------------------------------
+# Dry run is the default and reaches no mutation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_is_the_default_and_submits_nothing() -> None:
+    client = FakeExecutionClient()
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    report = await writer.execute()  # no confirm= at all
+    assert client.submit_calls == []
+    assert report.broker_mutation_count == 0
+    assert report.lease_attested is True
+    assert len(report.operations) == 3
+    assert len(client.order_test_calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_dry_run_can_skip_even_the_non_mutating_order_test() -> None:
+    client = FakeExecutionClient()
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    await writer.execute(confirm=False, include_order_test=False)
+    assert client.order_test_calls == []
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_dry_run_evidence_prints_the_sealed_values() -> None:
+    client = FakeExecutionClient()
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    evidence = (await writer.execute(confirm=False)).as_evidence()
+    assert evidence["writer"] == WRITER_NAME
+    assert evidence["pre_snapshot_hash"] == D2_PRE_SNAPSHOT_HASH
+    assert evidence["broker_mutation_count"] == 0
+    assert [op["request_params"] for op in evidence["operations"]] == [
+        order.request_params() for order in D2_BOUND_ORDERS
+    ]
+
+
+# --------------------------------------------------------------------------
+# Inherited boundaries are still boundaries
+# --------------------------------------------------------------------------
+
+
+def test_env_gate_is_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(D2_REMEDIATION_ENABLED_ENV, raising=False)
+    with pytest.raises(D2RemediationDisabled) as exc:
+        build_writer()
+    assert exc.value.reason_code is D2ReasonCode.DISABLED
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.binance.com",
+        "https://testnet.binance.vision",
+        "https://demo-api.binance.com.evil.example",
+    ],
+)
+def test_non_spot_demo_host_is_refused(base_url: str) -> None:
+    with pytest.raises(D2UnauthorizedOperation) as exc:
+        build_writer(client=FakeExecutionClient(base_url=base_url))
+    assert exc.value.reason_code is D2ReasonCode.HOST_NOT_SPOT_DEMO
+
+
+@pytest.mark.asyncio
+async def test_broker_echo_mismatch_is_not_treated_as_success() -> None:
+    class DriftingClient(FakeExecutionClient):
+        async def submit_order(self, **kwargs: Any) -> SpotDemoOrderSubmitResult:
+            self.submit_calls.append(kwargs)
+            return SpotDemoOrderSubmitResult(
+                client_order_id=kwargs["client_order_id"],
+                broker_order_id="bid",
+                symbol=kwargs["symbol"],
+                side=kwargs["side"],
+                order_type=kwargs["order_type"],
+                qty=Decimal("0.00099"),  # not what was authorized
+                executed_qty=Decimal("0"),
+                cummulative_quote_qty=Decimal("0"),
+                status="NEW",
+            )
+
+    client = DriftingClient()
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    with pytest.raises(Exception) as exc:
+        await writer.execute(confirm=True)
+    assert getattr(exc.value, "reason_code", None) is D2ReasonCode.BROKER_ECHO_MISMATCH
+
+
+@pytest.mark.asyncio
+async def test_two_independent_proof_epochs_are_produced() -> None:
+    client = FakeExecutionClient()
+    grant = make_grant()
+    writer = build_writer(client=client, lease=FakeLease(grant), grant=grant)
+    report = await writer.execute(confirm=True)
+    assert [epoch.epoch_index for epoch in report.proof_epochs] == [1, 2]
+    # Each epoch issued its own reads; neither reused the other's bytes.
+    assert client.open_order_reads == 2
+    assert client.balance_reads == 8  # (3 assets + USDT) x 2 epochs
+
+
+def test_writer_name_matches_the_operator_contract() -> None:
+    assert WRITER_NAME == "d2_remediation_single"
+    assert D2RemediationSingleWriter.writer_name == "d2_remediation_single"
+
+
+# --------------------------------------------------------------------------
+# Wire-level proof: what would actually be sent
+# --------------------------------------------------------------------------
+#
+# The tests above use a fake client, so they prove the writer's decisions but
+# not the bytes. These use the real ``BinanceSpotDemoExecutionClient`` over a
+# mocked transport, so the assertions are on the query string that Binance
+# would receive — signing, param building, and host pinning all included.
+
+
+_BASE = f"https://{D2_VENUE_HOST}"
+_ORDER_RE = re.compile(r"^https://demo-api\.binance\.com/api/v3/order\?.*$")
+_ORDER_TEST_RE = re.compile(r"^https://demo-api\.binance\.com/api/v3/order/test\?.*$")
+_OPEN_ORDERS_RE = re.compile(r"^https://demo-api\.binance\.com/api/v3/openOrders\?.*$")
+_ACCOUNT_RE = re.compile(r"^https://demo-api\.binance\.com/api/v3/account\?.*$")
+
+
+@pytest.fixture
+def real_client(monkeypatch: pytest.MonkeyPatch) -> BinanceSpotDemoExecutionClient:
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "DUMMY_KEY")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "DUMMY_SECRET")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_BASE_URL", _BASE)
+    return BinanceSpotDemoExecutionClient.from_env()
+
+
+def _sent_order_fields(request: Any) -> dict[str, str]:
+    params = dict(parse_qsl(str(request.url).split("?", 1)[1]))
+    return {
+        key: params[key]
+        for key in ("symbol", "side", "type", "quantity", "price", "timeInForce")
+        if key in params
+    }
+
+
+@pytest.mark.asyncio
+async def test_dry_run_sends_only_order_test_with_the_sealed_fields(
+    real_client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    for _ in D2_BOUND_ORDERS:
+        httpx_mock.add_response(method="POST", url=_ORDER_TEST_RE, json={})
+    grant = make_grant()
+    writer = D2RemediationSingleWriter(
+        execution_client=real_client,
+        sealed_payload=sealed_payload(),
+        lease=FakeLease(grant),  # type: ignore[arg-type]
+        lease_grant=grant,
+    )
+
+    await writer.execute(confirm=False)
+
+    requests = httpx_mock.get_requests()
+    assert [str(r.url).split("?", 1)[0] for r in requests] == [
+        f"{_BASE}/api/v3/order/test"
+    ] * 3
+    assert [_sent_order_fields(r) for r in requests] == [
+        order.request_params() for order in D2_BOUND_ORDERS
+    ]
+
+
+@pytest.mark.asyncio
+async def test_confirm_posts_exactly_the_sealed_fields(
+    real_client: BinanceSpotDemoExecutionClient, httpx_mock: Any
+) -> None:
+    for _ in D2_BOUND_ORDERS:
+        httpx_mock.add_response(method="POST", url=_ORDER_TEST_RE, json={})
+    for index, order in enumerate(D2_BOUND_ORDERS):
+        httpx_mock.add_response(
+            method="POST",
+            url=_ORDER_RE,
+            json={
+                "symbol": order.symbol,
+                "orderId": 1000 + index,
+                "clientOrderId": "echoed",
+                "side": order.side,
+                "type": order.order_type,
+                "origQty": format(order.quantity, "f"),
+                "executedQty": "0",
+                "cummulativeQuoteQty": "0",
+                "status": "NEW",
+            },
+        )
+    # Proof-epoch reads: 2 account-wide open-order reads and 4 balance reads
+    # per epoch.
+    for _ in range(2):
+        httpx_mock.add_response(method="GET", url=_OPEN_ORDERS_RE, json=[])
+    for _ in range(8):
+        httpx_mock.add_response(method="GET", url=_ACCOUNT_RE, json={"balances": []})
+
+    grant = make_grant()
+    writer = D2RemediationSingleWriter(
+        execution_client=real_client,
+        sealed_payload=sealed_payload(),
+        lease=FakeLease(grant),  # type: ignore[arg-type]
+        lease_grant=grant,
+    )
+    await writer.execute(confirm=True)
+
+    posts = [
+        r
+        for r in httpx_mock.get_requests()
+        if str(r.url).split("?", 1)[0] == f"{_BASE}/api/v3/order"
+    ]
+    assert [_sent_order_fields(r) for r in posts] == [
+        order.request_params() for order in D2_BOUND_ORDERS
+    ]
+    # Every request went to the Spot Demo host and nowhere else.
+    assert {r.url.host for r in httpx_mock.get_requests()} == {D2_VENUE_HOST}

--- a/tests/services/brokers/binance/spot_demo/test_spot_demo_submit_callers.py
+++ b/tests/services/brokers/binance/spot_demo/test_spot_demo_submit_callers.py
@@ -1,0 +1,125 @@
+"""Every caller that can place a real Spot Demo order is enumerated here.
+
+``BinanceSpotDemoExecutionClient.submit_order`` is the single signed-POST
+chokepoint for ``demo-api.binance.com``. Each caller of it consumes a distinct,
+separately reviewed operator authority, so a *new* caller is not a refactor —
+it is a new execution surface. This test makes adding one a CI failure rather
+than a discovery.
+
+It also stops the docstrings from drifting into a false "sole entry point"
+claim, which is exactly what happened before: the ROB-298 smoke CLI kept
+calling itself the only one after the b0x sidecar had already joined it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _repo_root() -> Path:
+    """Walk up to the marker rather than counting directories.
+
+    A hard-coded parent depth silently resolves to the wrong directory when the
+    file moves, and every rglob below then finds nothing — which reads as a
+    clean pass.
+    """
+
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    raise AssertionError("repository root not found")
+
+
+_REPO_ROOT = _repo_root()
+
+#: path -> the operator authority that permits it to mutate the Demo account.
+APPROVED_SUBMIT_CALLERS: dict[str, str] = {
+    "scripts/binance_spot_demo_smoke.py": "ROB-298 Spot Demo smoke (BUY round-trip)",
+    "scripts/b0x/crypto/sidecar.py": (
+        "b0x-adapter-orders-20260808 / binance_spot_demo_sidecar_buy_side_only"
+    ),
+    "scripts/binance_spot_demo_d2_remediation.py": (
+        "binance-demo-remediation-20260820 / writer d2_remediation_single"
+    ),
+    "app/services/brokers/binance/spot_demo/d2_remediation_single.py": (
+        "binance-demo-remediation-20260820 / the writer itself"
+    ),
+    "app/services/brokers/binance/spot_demo/mock_auto_limit.py": (
+        "ROB-1270 J6B lane composition — structurally undispatchable: the "
+        "signed registry makes assert_entry_execution_ready unsatisfiable for "
+        "this lane, so the call site exists but no configuration reaches it"
+    ),
+}
+
+#: Searched for callers. ``tests/`` is excluded on purpose: a test that fakes a
+#: submit is not an execution surface.
+_SEARCH_ROOTS = ("app", "scripts", "research")
+
+
+def _calls_submit_order(path: Path) -> bool:
+    """True when the file calls ``<something>.submit_order(...)``.
+
+    AST rather than grep so a mention inside a docstring or a comment does not
+    count as a call — the D2 CLI's own docstring names the method.
+    """
+
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - defensive
+        return False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "submit_order":
+            return True
+    return False
+
+
+def _mentions_spot_demo_client(path: Path) -> bool:
+    return "BinanceSpotDemoExecutionClient" in path.read_text(encoding="utf-8")
+
+
+def test_no_unapproved_caller_can_place_a_spot_demo_order() -> None:
+    found: dict[str, str] = {}
+    scanned = 0
+    for root in _SEARCH_ROOTS:
+        search_root = _REPO_ROOT / root
+        assert search_root.is_dir(), search_root
+        for path in sorted(search_root.rglob("*.py")):
+            scanned += 1
+            if not _mentions_spot_demo_client(path):
+                continue
+            if _calls_submit_order(path):
+                found[str(path.relative_to(_REPO_ROOT))] = "calls submit_order"
+
+    # An empty scan would pass vacuously; prove the sweep actually ran.
+    assert scanned > 100, scanned
+    assert found, "no Spot Demo submit caller found at all — the sweep is broken"
+
+    unapproved = sorted(set(found) - set(APPROVED_SUBMIT_CALLERS))
+    assert not unapproved, (
+        "new Spot Demo execution surface(s) with no named operator authority: "
+        f"{unapproved}. Adding a caller of submit_order is a reviewed change, "
+        "not a refactor — name its authority in APPROVED_SUBMIT_CALLERS."
+    )
+
+
+def test_every_approved_caller_still_exists() -> None:
+    """A stale allowlist entry would quietly widen the check."""
+
+    for relative in APPROVED_SUBMIT_CALLERS:
+        assert (_REPO_ROOT / relative).is_file(), relative
+
+
+def test_the_d2_writer_is_the_only_new_caller_this_change_added() -> None:
+    d2_callers = {path for path in APPROVED_SUBMIT_CALLERS if "d2_remediation" in path}
+    assert d2_callers == {
+        "scripts/binance_spot_demo_d2_remediation.py",
+        "app/services/brokers/binance/spot_demo/d2_remediation_single.py",
+    }


### PR DESCRIPTION
## What this is

`operator_contract.yaml` names `writer: d2_remediation_single` for the one-shot
`binance-demo-remediation-20260820` exception. No such writer existed — the
2026-08-20 execution attempt stopped at `D2_DUAL_ATTESTATION=FAIL` after a static
search returned zero matches. This PR is that writer.

**No sealed payload in this repository authorizes a dispatch.** Every entry in
`D2_KNOWN_SEALED_PAYLOADS` carries `dispatch_authorized=false`, an import-time
tripwire fails the build if one does not, and the current r7 object also has
`operator_authorization=null`, no expiry, and `mutation_authorized=false` on all
three rows. A caller entering through this module's functions — both env gates
armed, live lease in hand — reaches `--confirm` and is refused.

Broker mutation 0, `--confirm` runs 0, env arm direction 0, scheduler 0,
migration 0.

## Round 4 — the last two items

### B5 — a null `orderId` was laundered into evidence

The readback converter wrapped the raw value in `str()`, so `None` arrived as
the four-character string `'None'`; the check that followed only asked whether
the *stringified* field was non-blank. A malformed broker response passed the
identity check and would have been booked as proof an order exists.

Both identifiers are now read from the **raw** body through a shared
`broker_identifier_problem`, on the submit and readback paths alike, and the
converter no longer creates the string in the first place.

Measured by evaluating the round-3 and round-4 checks on the same inputs:

| raw `orderId` | r3 (before) | r4 (after) |
|---|---|---|
| `None` | REJECTED | REJECTED: is null |
| `'None'` | **ACCEPTED** | REJECTED: spelling of absent |
| `'none'` / `'null'` / `'NULL'` | **ACCEPTED** | REJECTED: spelling of absent |
| `'nil'` / `'undefined'` / `'<none>'` | **ACCEPTED** | REJECTED: spelling of absent |
| `'n/a'` / `'-'` | **ACCEPTED** | REJECTED: spelling of absent |
| `''` / `'   '` / `'\t'` | REJECTED | REJECTED: spelling of absent |
| `0` / `-1` | **ACCEPTED** | REJECTED: not a positive id |
| `True` | **ACCEPTED** | REJECTED: boolean, not an identifier |
| `[]` | **ACCEPTED** | REJECTED: non-identifier type |
| `'12345'`, `12345`, `'  12345  '`, `'abc-123'` | ACCEPTED | ACCEPTED (controls) |

12 of 17 absent-spellings went ACCEPTED → REJECTED; the four controls are
unchanged. End-to-end through the writer, both paths:

```text
submit path:   orderId=None/'None'/'null'/''/0 -> REJECTED:d2_broker_echo_mismatch
readback path: orderId=None/'None'/'null'/''/0 -> REJECTED:d2_broker_echo_mismatch
```

Note what this does and does not do: the order was already sent when the
malformed response arrives (`submits=1`). The writer cannot un-send it. What
changed is that it refuses to **book** that response as evidence, and halts.

### Threat model — confirmed, so now stated rather than deferred

Per the operator's ruling: these gates cover **accidental misuse** — a wrong
parameter, a doctored or unregistered payload, a drifted account, a malformed or
foreign broker response, a re-send after a crash. They do **not** cover
**deliberate forgery by code running in the same process**, and that is an
accepted limit, not a gap to close.

Claims that contradicted it are gone:

- the lease is no longer an "unforgeable capability" — `isinstance` rejects a
  wrong *type*, not a determined caller, who can construct the real class over a
  fabricated lock authority;
- `SealedAuthority` no longer says an in-process caller "cannot" hand the writer
  a hand-built authority — the token is private by convention, which is all
  Python offers;
- the runbook's execution-gate table now cites **symbols, not line numbers**: a
  line citation goes stale on the next edit and reads as a verified guarantee
  afterwards. (I found this the honest way — my first draft cited lines I had
  since shifted.)

Two guards keep both honest:

- `test_the_runbook_gate_table_names_symbols_that_exist` resolves every symbol
  the runbook names as an enforcement point against the live modules. Verified
  non-vacuous by injecting a bogus name and watching it fail.
- `test_the_source_does_not_claim_guarantees_it_does_not_provide` fails if
  "unforgeable", "impossible to", "cannot be forged", or "tamper-proof"
  reappears, and asserts the limit is stated where a reader will meet it.

## Not attempted, by upstream instruction

In-process forging of the sealed authority or the lease. No writer-level gate
closes it in Python — such a caller can call `BinanceSpotDemoExecutionClient`
directly and never enter this file.

## Regression

Every round-1/2/3 mutant re-run at this HEAD, unchanged: seal digest, operator
authorization, expiry, `mutation_authorized`, fingerprint, deterministic replay
id, required ledger, no-op ledger subclass, price/TIF/identity echo, duck-typed
lease, raw payload as authority, env seam. Controls still ACCEPTED. Real payload
SHA unchanged.

One stale *harness* fixture surfaced and was fixed: the round-1 harness built a
hand-made echo body with no `orderId` at all, so the new check correctly
rejected it as a control. A real Binance response always carries one; the
fixture now does too. The test-suite control (`CONTROL_FAITHFUL_IDENTITY_ECHO`)
was passing throughout.

## Evidence

- `make lint`: ruff check, ruff format --check, `ty check app/ --error-on-warning` — clean.
- Targeted: **341 passed** (writer, CLI, submit-caller enumeration, the demo
  ledger suite, and the ROB-1271 boundary contract).
- Full suite: **21725 passed, 0 failed, 13 skipped.**
- `alembic heads`: single head `20260820_rob1290_reconcile`. No migration.
- `ci_shards`: **unchanged** — no new test files this round. All four still
  `LC_ALL=C sort -c` clean; `exact-cover OK: 1677 file(s), 0 missing, 0
  duplicate, 0 unexpected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a default-disabled, dry-run-first D2 remediation workflow for exactly three sealed Binance Spot Demo orders.
  - Added validation for authorization, credentials, account state, leases, replay protection, broker responses, and durable execution claims.
  - Added CLI modes for guidance, planning, dry runs, and authorized execution.

- **Documentation**
  - Added an operational runbook covering setup, safeguards, execution, and failure handling.

- **Tests**
  - Added comprehensive coverage for CLI behavior, validation, safety controls, durable claims, and approved order-placement callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->