### PR TITLE
ROB-1268 J5C: US KIS/Kiwoom lifecycle-recovery contract + checker

### DIFF
--- a/ci_shards/shard-3.txt
+++ b/ci_shards/shard-3.txt
@@ -207,6 +207,7 @@ tests/services/test_research_run_service_safety.py
 tests/services/test_trade_journal_aggregates_scoreboard.py
 tests/services/test_trading_policy_service.py
 tests/services/test_tradingview_helpers.py
+tests/services/test_us_kis_kiwoom_readiness.py
 tests/services/test_us_regular_session_raw_capture.py
 tests/services/test_us_symbol_universe_names.py
 tests/services/us_dual_paper/test_schemas.py

--- a/docs/contracts/rob-1268-us-kis-kiwoom-readiness.md
+++ b/docs/contracts/rob-1268-us-kis-kiwoom-readiness.md
@@ -118,7 +118,7 @@ the rule in §2.  A constrained item is not a partial credit.
 # LIFECYCLE
 lane_id = us.kis.mock
 lifecycle_recovery_owner_status = AUTO_READY_BLOCKED_BY_LIFECYCLE
-recovery_owner = ABSENT (the signed registry records MissingBinding.OWNER for this lane, so no owner exists to name; see rob-1266 §8)
+recovery_owner = ABSENT (this lane's unmet-binding list is owned by rob-1266 §8 and records no bound owner there; that list is not restated here)
 restart_rediscovery_trigger = ABSENT (query exists as OrderSendIntentReservationPort.list_reservations in COORDINATION_SOURCE; no lane-native caller is merged and J3A states there is deliberately no recovery API in this epoch)
 authoritative_readback_operation = PRESENT_CONSTRAINED (KISOverseasOrders.inquire_daily_order_overseas(is_mock=True) dispatching VTTS3035R; not order-id keyed because the overseas order_number filter is ignored, and open-order truth is separately unavailable per rob-1266 §5.1)
 release_if_matches_condition = PRESENT (DurableSendClaimAdapter.release_with_terminal_evidence gated by _terminal_evidence_authorizes in COORDINATION_SOURCE)
@@ -143,7 +143,7 @@ terminal_reconciliation = ABSENT (no lane-separable table; see §5.1)
 # LIFECYCLE
 lane_id = us.kiwoom.mock
 lifecycle_recovery_owner_status = AUTO_READY_BLOCKED_BY_LIFECYCLE
-recovery_owner = ABSENT (the signed registry records MissingBinding.OWNER for this lane, so no owner exists to name; see rob-1266 §8)
+recovery_owner = ABSENT (this lane's unmet-binding list is owned by rob-1266 §8 and records no bound owner there; that list is not restated here)
 restart_rediscovery_trigger = ABSENT (query exists as OrderSendIntentReservationPort.list_reservations in COORDINATION_SOURCE; no lane-native caller is merged and J3A states there is deliberately no recovery API in this epoch)
 authoritative_readback_operation = PRESENT_CONSTRAINED (KiwoomUSAccountClient.get_today_orders api-id ust21510 and get_open_orders api-id ust21050 on path /api/us/acnt; constrained because Market.US_EQUITY is absent from BROKER_CAPABILITIES[Broker.KIWOOM] per rob-1266 §5.3)
 release_if_matches_condition = PRESENT (DurableSendClaimAdapter.release_with_terminal_evidence gated by _terminal_evidence_authorizes in COORDINATION_SOURCE)

--- a/docs/contracts/rob-1268-us-kis-kiwoom-readiness.md
+++ b/docs/contracts/rob-1268-us-kis-kiwoom-readiness.md
@@ -75,11 +75,12 @@ Two consequences are binding on this document:
    (`_HeldCoordination`), and that "there is deliberately no recovery API in
    this epoch" (`_release_guarded`).  This contract adds nothing there.
 2. **`AUTO_READY_BLOCKED_BY_LIFECYCLE` is recorded on a dedicated axis, not on
-   `lane_status`.**  The signed allowlist admits exactly `NOT_READY` for both
-   lanes (`_SIGNED_LANE_STATUS_ALLOWLISTS` in `SIGNED_SOURCE`), so writing the
-   lifecycle verdict into `lane_status` would violate the signed registry.  The
-   verdict is therefore carried by `lifecycle_recovery_owner_status` in §4, and
-   `lane_status` remains exactly as ROB-1266 §8 records it.
+   `lane_status`.**  `_SIGNED_LANE_STATUS_ALLOWLISTS` in `SIGNED_SOURCE` admits
+   a single status for each of these two lanes, so writing the lifecycle verdict
+   into `lane_status` would violate the signed registry.  That admitted status is
+   **not restated here**: it is recorded once, by ROB-1266 §8, and this document
+   neither repeats nor pins it.  The verdict is carried by
+   `lifecycle_recovery_owner_status` in §4, and `lane_status` is left untouched.
 
 ## 3. Record shape
 
@@ -117,7 +118,7 @@ the rule in §2.  A constrained item is not a partial credit.
 # LIFECYCLE
 lane_id = us.kis.mock
 lifecycle_recovery_owner_status = AUTO_READY_BLOCKED_BY_LIFECYCLE
-recovery_owner = ABSENT (registry missing_bindings carries `owner`; see rob-1266 §8)
+recovery_owner = ABSENT (the signed registry records MissingBinding.OWNER for this lane, so no owner exists to name; see rob-1266 §8)
 restart_rediscovery_trigger = ABSENT (query exists as OrderSendIntentReservationPort.list_reservations in COORDINATION_SOURCE; no lane-native caller is merged and J3A states there is deliberately no recovery API in this epoch)
 authoritative_readback_operation = PRESENT_CONSTRAINED (KISOverseasOrders.inquire_daily_order_overseas(is_mock=True) dispatching VTTS3035R; not order-id keyed because the overseas order_number filter is ignored, and open-order truth is separately unavailable per rob-1266 §5.1)
 release_if_matches_condition = PRESENT (DurableSendClaimAdapter.release_with_terminal_evidence gated by _terminal_evidence_authorizes in COORDINATION_SOURCE)
@@ -142,7 +143,7 @@ terminal_reconciliation = ABSENT (no lane-separable table; see §5.1)
 # LIFECYCLE
 lane_id = us.kiwoom.mock
 lifecycle_recovery_owner_status = AUTO_READY_BLOCKED_BY_LIFECYCLE
-recovery_owner = ABSENT (registry missing_bindings carries `owner`; see rob-1266 §8)
+recovery_owner = ABSENT (the signed registry records MissingBinding.OWNER for this lane, so no owner exists to name; see rob-1266 §8)
 restart_rediscovery_trigger = ABSENT (query exists as OrderSendIntentReservationPort.list_reservations in COORDINATION_SOURCE; no lane-native caller is merged and J3A states there is deliberately no recovery API in this epoch)
 authoritative_readback_operation = PRESENT_CONSTRAINED (KiwoomUSAccountClient.get_today_orders api-id ust21510 and get_open_orders api-id ust21050 on path /api/us/acnt; constrained because Market.US_EQUITY is absent from BROKER_CAPABILITIES[Broker.KIWOOM] per rob-1266 §5.3)
 release_if_matches_condition = PRESENT (DurableSendClaimAdapter.release_with_terminal_evidence gated by _terminal_evidence_authorizes in COORDINATION_SOURCE)
@@ -200,17 +201,19 @@ by construction, not by omission of a lookup.
 
 ### 5.3 `us.kis.mock` shares a credential namespace with `kr.kis.mock`
 
-`LANE_CREDENTIAL_NAMESPACES` in `SIGNED_SOURCE` assigns **the identical string
-`KIS_MOCK_*`** to both `kr.kis.mock` and `us.kis.mock`, and
-`LANE_ALLOWED_HOSTS` assigns both the same single host.  By contrast the two
-Kiwoom lanes are declared apart (`KIWOOM_MOCK_*` versus `KIWOOM_MOCK_US_*`).
+In `SIGNED_SOURCE`, `LANE_CREDENTIAL_NAMESPACES` maps `kr.kis.mock` and
+`us.kis.mock` to **the same string**, and `LANE_ALLOWED_HOSTS` maps them to
+**the same host tuple**.  The two Kiwoom lanes are mapped apart on the same
+axis.  The values themselves are registry-owned and are deliberately not copied
+into this document; the recorded fact is the **equality relation** between the
+two KIS rows, which is what the prohibition below rests on.
 
 ROB-1266 §6 establishes that the four *US* lanes are declared under distinct
 namespaces; that statement is scoped to those four rows and does not speak to
 the KR↔US KIS pair.  This document records the pair as a **declared
 collision**: the two lanes are not merely unproven-separate, they are declared
-under one namespace and one host, while both carry `physical_account_id`
-absent and `identity_status = UNKNOWN` (rob-1266 §8).
+under one namespace and one host, while ROB-1266 §8 records both as having no
+physical account and an unproven identity.
 
 This is the direct basis for the concurrent-writer prohibition in §6.4.  It is
 recorded as a fact about declarations; no physical-account measurement exists
@@ -225,24 +228,26 @@ violation is detectable before broker I/O.
 ### 6.1 Open-order truth is required before any KIS submit
 
 If `open_order_count` is absent, `None`, or the inquiry errored, the lane must
-stop before broker I/O.  A missing count is `UNKNOWN` and is never read as
+stop before broker I/O.  A missing count is *unknown* and is never read as
 zero.  For `us.kis.mock` this is presently unsatisfiable at all, because the
 overseas pending-order inquiry raises for the mock lane (rob-1266 §5.1), so the
 only contract-conforming outcome for this lane today is *stop*.
 
 ### 6.2 A writer requires masked physical identity
 
-`writer` may not be set true for either lane while `physical_account_id` is
-absent and `identity_status` is `UNKNOWN` (rob-1266 §8).  Masked physical
+`writer` may not be set true for either lane while ROB-1266 §8 records that
+lane as having no physical account and an unproven identity.  Masked physical
 account fingerprint evidence is the precondition; no such evidence exists
 today, and namespace or profile distinctness is a declaration rather than a
 measurement (rob-1266 §6).
 
-### 6.3 Kiwoom US stays `BROKER_REGRESSION`
+### 6.3 Kiwoom US keeps its recorded role
 
-`us.kiwoom.mock` carries `BROKER_REGRESSION` for this epoch.  Rewriting it to
-`AUTO_MIRROR` — or to any other role — requires a separate approved autonomous
-policy and is not authorized here or by ROB-1266 §5.3.
+`us.kiwoom.mock` keeps for this epoch exactly the role ROB-1266 §8 records for
+it; that value is registry-owned and is not restated here.  Rewriting that role
+— in particular promoting the lane to an automatic mirroring role — requires a
+separate approved autonomous policy and is not authorized here or by
+ROB-1266 §5.3.
 
 ### 6.4 KR and US KIS may not hold concurrent writers
 
@@ -279,13 +284,15 @@ not a defined operation in this contract.
 
 ### 6.8 Currency is exact; no FX or parity
 
-Both lanes are `quote_currency = USD` (rob-1266 §8).  A KRW intent may never be
-rendered as a USD plan, and no FX rate, parity, or conversion may be applied.
+Both lanes carry the single quote currency ROB-1266 §8 records for them; that
+value is registry-owned and is not restated here.  An intent denominated in a
+different currency may never be rendered into a plan denominated in the lane's
+currency, and no FX rate, parity, or conversion may be applied.
 J2B already fails such a request closed with the exact literals
 `currency_conversion_not_authorized` and `lane_quote_currency_mismatch`
 (`LINEAGE_SOURCE`); this contract adds no conversion path and no rounding
-tolerance that would obscure one.  USD is never treated as interchangeable with
-KRW or USDT.
+tolerance that would obscure one.  A lane's own quote currency is never
+treated as interchangeable with any other currency.
 
 ## 7. What this document does not do
 

--- a/docs/contracts/rob-1268-us-kis-kiwoom-readiness.md
+++ b/docs/contracts/rob-1268-us-kis-kiwoom-readiness.md
@@ -1,0 +1,308 @@
+# ROB-1268 — US KIS / Kiwoom lane lifecycle-recovery contract
+
+## Scope and authority
+
+This is a contract-only artifact (J5C).  It consumes the signed registry and
+the merged J2B/J3A ports without changing them, and it authorizes no broker,
+network, database, scheduler, deployment, credential, or account operation.
+It creates no policy, assigns no writer, proposes no cadence, and grants no
+canary.
+
+It covers exactly two lanes: `us.kis.mock` and `us.kiwoom.mock`.
+
+Its single subject is the **lane-native lifecycle recovery contract** required
+before either lane could become `AUTO_ENABLED`.  Recording that contract is not
+a request to enable anything; activation is a separate approval outside this
+document.
+
+### Relationship to ROB-1266 (READ ONLY)
+
+`docs/contracts/rob-1266-us-readiness.md` is the merged J5A contract and is the
+authority for these two lanes' registry records and capability gaps.  This
+document **references and quotes it; it does not re-render, restate, redefine,
+or modify it.**  Registry facts are cited by path and section number rather
+than reproduced, so that no second rendering of the same fact can drift from
+the first.  Where this document and ROB-1266 disagree, **ROB-1266 is
+authoritative** and this document is the defect.
+
+Where this document and the registry disagree, **the registry is
+authoritative** and this document is the defect.
+
+`role` is a purpose-only registry value.  It is not execution authority.  The
+two lanes' roles, statuses, writer flags, and owner fields are recorded in
+`docs/contracts/rob-1266-us-readiness.md` §8 and are not repeated here.
+
+## 1. Document-level fixed tokens
+
+```text
+SIGNED_SOURCE = app/services/mock_lane_registry.py::CANONICAL_LANE_REGISTRY @ e057941425d2ea7d35a36ebf6074a6c70eba3013
+LINEAGE_SOURCE = app/services/mock_integration/lineage.py @ 094ab2d59d6f2bf5fc3df4efa43bb5d412221ffd
+COORDINATION_SOURCE = app/services/mock_integration/coordination.py @ 03beecc5f53e636c352ddf0527aa3d98ddc7bd61
+US_READINESS_CONTRACT = docs/contracts/rob-1266-us-readiness.md @ ddf4895ece2ca9dff8daf1a04fa7d6143f43c899
+LIFECYCLE_RULE_SOURCE = gptpro-interim-verdict-20260816.md @ 233c69805f02791c327b3415ff4bc75eaf3d72bfbc3c284713fa995a96199b34
+```
+
+Each token appears exactly once in this document.
+
+## 2. The lifecycle rule being applied
+
+The controlling rule is quoted verbatim from `LIFECYCLE_RULE_SOURCE`:
+
+> The common coordination layer does not own broker-specific retry,
+> readback, or manual-resolution queues.
+>
+> Before a lane can become AUTO_ENABLED, its lane contract must identify:
+>
+> - exactly one recovery owner;
+> - the trigger that rediscovers surviving durable claims after restart;
+> - the authoritative broker readback operation;
+> - the lane-native evidence written for ACK, unknown, reject, expiry,
+>   partial fill, cancel, and terminal reconciliation;
+> - the condition for exact release_if_matches;
+> - the operator-visible blocked state when authoritative recovery is not
+>   possible.
+>
+> A lane missing any of these remains
+> AUTO_READY_BLOCKED_BY_LIFECYCLE.
+
+Two consequences are binding on this document:
+
+1. **No broker-specific retry, readback, or manual-resolution queue may be
+   added to the common coordination layer.**  J3A already refuses to own one:
+   `app/services/mock_integration/coordination.py` records that its held-lease
+   map "is **not** a retry queue, **not** a durable state store, and it has no
+   TTL, janitor, takeover, automatic retry, claim deletion, or scheduler"
+   (`_HeldCoordination`), and that "there is deliberately no recovery API in
+   this epoch" (`_release_guarded`).  This contract adds nothing there.
+2. **`AUTO_READY_BLOCKED_BY_LIFECYCLE` is recorded on a dedicated axis, not on
+   `lane_status`.**  The signed allowlist admits exactly `NOT_READY` for both
+   lanes (`_SIGNED_LANE_STATUS_ALLOWLISTS` in `SIGNED_SOURCE`), so writing the
+   lifecycle verdict into `lane_status` would violate the signed registry.  The
+   verdict is therefore carried by `lifecycle_recovery_owner_status` in §4, and
+   `lane_status` remains exactly as ROB-1266 §8 records it.
+
+## 3. Record shape
+
+Each lane is recorded as a `### LANE <lane_id>` heading followed by exactly two
+fenced blocks, in this order:
+
+1. a **LIFECYCLE** block whose first line is `# LIFECYCLE`, and
+2. an **EVIDENCE** block whose first line is `# EVIDENCE`.
+
+- The LIFECYCLE block's key set is exactly:
+  `lane_id`, `lifecycle_recovery_owner_status`, `recovery_owner`,
+  `restart_rediscovery_trigger`, `authoritative_readback_operation`,
+  `release_if_matches_condition`, `operator_visible_blocked_state`,
+  `unmet_lifecycle_items` — eight keys, no extras, no omissions.
+- The EVIDENCE block's key set is exactly the seven evidence kinds named by the
+  rule in §2: `ack`, `unknown`, `reject`, `expiry`, `partial_fill`, `cancel`,
+  `terminal_reconciliation` — seven keys, no extras, no omissions.
+
+Each body line is `<key> = <rendered value>`.  Keys do not repeat within a
+block.  Every value begins with one of exactly three states:
+
+- `PRESENT` — a merged in-repo anchor satisfies the item for this lane.
+- `PRESENT_CONSTRAINED` — an anchor exists but carries a recorded limitation
+  that stops it from satisfying the item unaided.
+- `ABSENT` — no merged anchor satisfies the item for this lane.
+
+`PRESENT_CONSTRAINED` and `ABSENT` both count as **unmet** for the purposes of
+the rule in §2.  A constrained item is not a partial credit.
+
+## 4. Lane records
+
+### LANE us.kis.mock
+
+```text
+# LIFECYCLE
+lane_id = us.kis.mock
+lifecycle_recovery_owner_status = AUTO_READY_BLOCKED_BY_LIFECYCLE
+recovery_owner = ABSENT (registry missing_bindings carries `owner`; see rob-1266 §8)
+restart_rediscovery_trigger = ABSENT (query exists as OrderSendIntentReservationPort.list_reservations in COORDINATION_SOURCE; no lane-native caller is merged and J3A states there is deliberately no recovery API in this epoch)
+authoritative_readback_operation = PRESENT_CONSTRAINED (KISOverseasOrders.inquire_daily_order_overseas(is_mock=True) dispatching VTTS3035R; not order-id keyed because the overseas order_number filter is ignored, and open-order truth is separately unavailable per rob-1266 §5.1)
+release_if_matches_condition = PRESENT (DurableSendClaimAdapter.release_with_terminal_evidence gated by _terminal_evidence_authorizes in COORDINATION_SOURCE)
+operator_visible_blocked_state = PRESENT (unreleased_authority_holds() in COORDINATION_SOURCE, with reason code terminal_evidence_required)
+unmet_lifecycle_items = (recovery_owner, restart_rediscovery_trigger, authoritative_readback_operation, lane_native_evidence)
+```
+
+```text
+# EVIDENCE
+ack = ABSENT (no lane-separable table; see §5.1)
+unknown = ABSENT (no lane-separable table; see §5.1)
+reject = ABSENT (no lane-separable table; see §5.1)
+expiry = ABSENT (no lane-separable table and no expiry status; see §5.1)
+partial_fill = ABSENT (no lane-separable table and no remainder column; see §5.1)
+cancel = ABSENT (no lane-separable table; see §5.1)
+terminal_reconciliation = ABSENT (no lane-separable table; see §5.1)
+```
+
+### LANE us.kiwoom.mock
+
+```text
+# LIFECYCLE
+lane_id = us.kiwoom.mock
+lifecycle_recovery_owner_status = AUTO_READY_BLOCKED_BY_LIFECYCLE
+recovery_owner = ABSENT (registry missing_bindings carries `owner`; see rob-1266 §8)
+restart_rediscovery_trigger = ABSENT (query exists as OrderSendIntentReservationPort.list_reservations in COORDINATION_SOURCE; no lane-native caller is merged and J3A states there is deliberately no recovery API in this epoch)
+authoritative_readback_operation = PRESENT_CONSTRAINED (KiwoomUSAccountClient.get_today_orders api-id ust21510 and get_open_orders api-id ust21050 on path /api/us/acnt; constrained because Market.US_EQUITY is absent from BROKER_CAPABILITIES[Broker.KIWOOM] per rob-1266 §5.3)
+release_if_matches_condition = PRESENT (DurableSendClaimAdapter.release_with_terminal_evidence gated by _terminal_evidence_authorizes in COORDINATION_SOURCE)
+operator_visible_blocked_state = PRESENT (unreleased_authority_holds() in COORDINATION_SOURCE, with reason code terminal_evidence_required)
+unmet_lifecycle_items = (recovery_owner, restart_rediscovery_trigger, authoritative_readback_operation, lane_native_evidence)
+```
+
+```text
+# EVIDENCE
+ack = ABSENT (no Kiwoom order ledger exists; see §5.2)
+unknown = ABSENT (no Kiwoom order ledger exists; see §5.2)
+reject = ABSENT (no Kiwoom order ledger exists; see §5.2)
+expiry = ABSENT (no Kiwoom order ledger exists; see §5.2)
+partial_fill = ABSENT (no Kiwoom order ledger exists; see §5.2)
+cancel = ABSENT (no Kiwoom order ledger exists; see §5.2)
+terminal_reconciliation = ABSENT (no Kiwoom order ledger exists; see §5.2)
+```
+
+## 5. Evidence-surface findings
+
+### 5.1 `us.kis.mock` — the only KIS mock ledger is not lane-separable
+
+`KISMockOrderLedger` (`app/models/review.py`, table `kis_mock_order_ledger`)
+is the sole KIS mock order ledger in the tree.  Its table arguments pin
+`account_mode = 'kis_mock'` and `broker = 'kis'` as CHECK constraints, and it
+carries no market, venue, or lane column.  `kr.kis.mock` and `us.kis.mock`
+would therefore write rows that are **indistinguishable at the constraint
+level**; the `currency IN ('KRW','USD')` CHECK permits both currencies in the
+same table.
+
+Consequently the table cannot serve as *lane-native* evidence for
+`us.kis.mock`: a row found there cannot be attributed to this lane rather than
+the KR lane without a discriminator that does not exist.  This is recorded as
+absence of lane-native evidence, **not** as a claim that the KR lane's evidence
+is defective for its own lane.
+
+Two further shape limits are recorded, and they hold regardless of the
+attribution problem above:
+
+- `status` is CHECK-constrained to `('accepted','rejected','unknown')` — three
+  values that cover ACK, reject, and unknown but express neither expiry, nor
+  cancel, nor terminal reconciliation.
+- There is no remainder or filled-quantity column, so a partial fill cannot be
+  distinguished from a full fill by this table.
+
+Creating, altering, or backfilling any table is outside this contract.
+
+### 5.2 `us.kiwoom.mock` — no order ledger exists at all
+
+No Kiwoom order ledger model exists.  The only occurrence of `kiwoom` in
+`app/models/review.py` is the `account_mode` CHECK list of
+`trade_retrospectives`, which is a retrospective-scoped table and not an order
+lifecycle ledger.  All seven evidence kinds are therefore absent for this lane
+by construction, not by omission of a lookup.
+
+### 5.3 `us.kis.mock` shares a credential namespace with `kr.kis.mock`
+
+`LANE_CREDENTIAL_NAMESPACES` in `SIGNED_SOURCE` assigns **the identical string
+`KIS_MOCK_*`** to both `kr.kis.mock` and `us.kis.mock`, and
+`LANE_ALLOWED_HOSTS` assigns both the same single host.  By contrast the two
+Kiwoom lanes are declared apart (`KIWOOM_MOCK_*` versus `KIWOOM_MOCK_US_*`).
+
+ROB-1266 §6 establishes that the four *US* lanes are declared under distinct
+namespaces; that statement is scoped to those four rows and does not speak to
+the KR↔US KIS pair.  This document records the pair as a **declared
+collision**: the two lanes are not merely unproven-separate, they are declared
+under one namespace and one host, while both carry `physical_account_id`
+absent and `identity_status = UNKNOWN` (rob-1266 §8).
+
+This is the direct basis for the concurrent-writer prohibition in §6.4.  It is
+recorded as a fact about declarations; no physical-account measurement exists
+and none is claimed.
+
+## 6. Pre-submit invariants
+
+These are contract rules for any future lane implementation.  Nothing here
+grants a send; every rule is a refusal.  Each rule is stated so that its
+violation is detectable before broker I/O.
+
+### 6.1 Open-order truth is required before any KIS submit
+
+If `open_order_count` is absent, `None`, or the inquiry errored, the lane must
+stop before broker I/O.  A missing count is `UNKNOWN` and is never read as
+zero.  For `us.kis.mock` this is presently unsatisfiable at all, because the
+overseas pending-order inquiry raises for the mock lane (rob-1266 §5.1), so the
+only contract-conforming outcome for this lane today is *stop*.
+
+### 6.2 A writer requires masked physical identity
+
+`writer` may not be set true for either lane while `physical_account_id` is
+absent and `identity_status` is `UNKNOWN` (rob-1266 §8).  Masked physical
+account fingerprint evidence is the precondition; no such evidence exists
+today, and namespace or profile distinctness is a declaration rather than a
+measurement (rob-1266 §6).
+
+### 6.3 Kiwoom US stays `BROKER_REGRESSION`
+
+`us.kiwoom.mock` carries `BROKER_REGRESSION` for this epoch.  Rewriting it to
+`AUTO_MIRROR` — or to any other role — requires a separate approved autonomous
+policy and is not authorized here or by ROB-1266 §5.3.
+
+### 6.4 KR and US KIS may not hold concurrent writers
+
+While it is unproven that `kr.kis.mock` and `us.kis.mock` resolve to different
+physical accounts, the two may not hold writers concurrently.  §5.3 records
+that they are declared under one credential namespace and one host, which
+strengthens rather than weakens this prohibition.  Proof of separation requires
+masked physical-account fingerprint evidence that does not exist.
+
+### 6.5 Replay across process restart is forbidden
+
+Re-running the same immutable send lineage after a process restart must produce
+zero new broker POSTs.  The durable binary claim is the mechanism: J3A records
+that "process death may end the ephemeral DB session, but the durable binary
+reservation survives and keeps preventing a replay of that exact send lineage"
+(`_HeldCoordination` in `COORDINATION_SOURCE`).  A successor process that
+cannot observe the claim must stop rather than assume absence.
+
+### 6.6 A stale or lost fencing token forbids submit
+
+A submit may not proceed under a stale, lost, or foreign lease grant.
+`COORDINATION_SOURCE` refuses this structurally: `AdvisoryLeaseGrant` ownership
+is checked by `assert_owned`, and lease loss is reported with the
+`lease_lost` reason code.  Neither an expired nor a foreign grant may be
+adopted.
+
+### 6.7 KIS and Kiwoom lifecycles are independent
+
+A KIS failure may not cancel, roll back, unwind, or otherwise mutate a Kiwoom
+plan, and the reverse likewise.  The two lanes have separate credential
+namespaces, separate hosts, separate readback operations (§4), and separate
+native order identities; they share no transaction.  Cross-lane compensation is
+not a defined operation in this contract.
+
+### 6.8 Currency is exact; no FX or parity
+
+Both lanes are `quote_currency = USD` (rob-1266 §8).  A KRW intent may never be
+rendered as a USD plan, and no FX rate, parity, or conversion may be applied.
+J2B already fails such a request closed with the exact literals
+`currency_conversion_not_authorized` and `lane_quote_currency_mismatch`
+(`LINEAGE_SOURCE`); this contract adds no conversion path and no rounding
+tolerance that would obscure one.  USD is never treated as interchangeable with
+KRW or USDT.
+
+## 7. What this document does not do
+
+- It does not modify `app/services/mock_lane_registry.py`,
+  `app/services/mock_integration/**`, any broker adapter, any model, any
+  migration, or any other production module.  A registry disagreement is fixed
+  by a serial J2A follow-up, not from here.
+- It does not modify `docs/contracts/rob-1266-us-readiness.md`, which is READ
+  ONLY for this job, and it does not re-render any value that document owns.
+- It does not change `lane_status`, `activation_status`, `role`, `writer`,
+  `auto_order_enabled`, or `scheduler_owner` for any lane.  An absent
+  `scheduler_owner` means **owner absent; mutation-ineligible; no authority to
+  bind one downstream**, and is not an alternative spelling of `DISABLED`.
+- It does not create, approve, or imply a policy, a cap, a cadence, a canary,
+  or a scheduler registration.
+- It does not add a retry queue, readback queue, or manual-resolution queue to
+  the common coordination layer, and it does not name a recovery owner that
+  does not exist.
+- It does not move either lane toward `AUTO_ENABLED`.  Recording the lifecycle
+  contract is the deliverable; activation is a separate approval.

--- a/tests/services/test_us_kis_kiwoom_readiness.py
+++ b/tests/services/test_us_kis_kiwoom_readiness.py
@@ -1,0 +1,347 @@
+"""ROB-1268 J5C — US KIS / Kiwoom lifecycle-recovery contract checker.
+
+Offline only: this module reads repository artifacts — the contract document,
+the signed lane registry, and the merged J2B/J3A port sources — and compares
+them.  It opens no socket, no database connection, and no file outside the
+repository, and it modifies nothing.
+
+Expectation provenance is deliberately split, following the J5A pattern:
+
+* Structural expectations (S1-S5) are **derived** from the document's own
+  declared shape rules, so the document is the artifact under test.
+* Safety expectations (S6-S9) are **literal**.  If the registry itself is
+  flipped, these assertions must go red rather than quietly follow it.
+* S10 proves that the literal block really is literal, so nobody can later
+  convert it into a derived value unnoticed.
+* Citation expectations (S11) assert that every in-repo anchor the document
+  names actually exists, so a citation cannot rot into fiction.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from app.services.mock_lane_registry import (
+    CANONICAL_LANE_REGISTRY,
+    LANE_CREDENTIAL_NAMESPACES,
+)
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_DOC_PATH = _REPO_ROOT / "docs/contracts/rob-1268-us-kis-kiwoom-readiness.md"
+_REGISTRY_PATH = _REPO_ROOT / "app/services/mock_lane_registry.py"
+_COORDINATION_PATH = _REPO_ROOT / "app/services/mock_integration/coordination.py"
+_LINEAGE_PATH = _REPO_ROOT / "app/services/mock_integration/lineage.py"
+
+_LANES = ("us.kis.mock", "us.kiwoom.mock")
+
+_FIXED_TOKENS = (
+    "SIGNED_SOURCE = app/services/mock_lane_registry.py::CANONICAL_LANE_REGISTRY"
+    " @ e057941425d2ea7d35a36ebf6074a6c70eba3013",
+    "LINEAGE_SOURCE = app/services/mock_integration/lineage.py"
+    " @ 094ab2d59d6f2bf5fc3df4efa43bb5d412221ffd",
+    "COORDINATION_SOURCE = app/services/mock_integration/coordination.py"
+    " @ 03beecc5f53e636c352ddf0527aa3d98ddc7bd61",
+    "US_READINESS_CONTRACT = docs/contracts/rob-1266-us-readiness.md"
+    " @ ddf4895ece2ca9dff8daf1a04fa7d6143f43c899",
+)
+
+# The seven evidence kinds are quoted from the controlling rule, in its order.
+_EVIDENCE_KINDS = (
+    "ack",
+    "unknown",
+    "reject",
+    "expiry",
+    "partial_fill",
+    "cancel",
+    "terminal_reconciliation",
+)
+
+_LIFECYCLE_KEYS = (
+    "lane_id",
+    "lifecycle_recovery_owner_status",
+    "recovery_owner",
+    "restart_rediscovery_trigger",
+    "authoritative_readback_operation",
+    "release_if_matches_condition",
+    "operator_visible_blocked_state",
+    "unmet_lifecycle_items",
+)
+
+_STATES = ("PRESENT_CONSTRAINED", "PRESENT", "ABSENT")
+_UNMET_STATES = ("PRESENT_CONSTRAINED", "ABSENT")
+
+_LIFECYCLE_BLOCKED = "AUTO_READY_BLOCKED_BY_LIFECYCLE"
+
+# ---------------------------------------------------------------------------
+# S6-S9 expectations — LITERAL BY CONTRACT.  Do not derive any part of the
+# constants below from ``app.services.mock_lane_registry``; ``test_s10_*``
+# enforces that mechanically.
+# ---------------------------------------------------------------------------
+
+_SAFETY_AXES_EXPECTED = {
+    "us.kis.mock": {
+        "role": "AUTO_MIRROR",
+        "lane_status": "NOT_READY",
+        "activation_status": "BLOCKED",
+        "quote_currency": "USD",
+        "writer": False,
+        "auto_order_enabled": False,
+        "scheduler_owner": None,
+        "physical_account_id": None,
+    },
+    "us.kiwoom.mock": {
+        "role": "BROKER_REGRESSION",
+        "lane_status": "NOT_READY",
+        "activation_status": "BLOCKED",
+        "quote_currency": "USD",
+        "writer": False,
+        "auto_order_enabled": False,
+        "scheduler_owner": None,
+        "physical_account_id": None,
+    },
+}
+
+# The KR/US KIS credential-namespace collision that §5.3 and §6.4 rest on.
+_SHARED_KIS_NAMESPACE_LANES = ("kr.kis.mock", "us.kis.mock")
+_SHARED_KIS_NAMESPACE = "KIS_MOCK_*"
+
+# Each invariant section, with substrings that must appear inside it.  These
+# encode the eight adversarial mutants: removing or weakening any invariant
+# drops one of these substrings and turns the corresponding case red.
+_INVARIANTS = {
+    "6.1": ("open_order_count", "stop before broker I/O", "never read as zero"),
+    "6.2": ("physical_account_id", "identity_status", "may not be set true"),
+    "6.3": ("BROKER_REGRESSION", "AUTO_MIRROR", "not authorized"),
+    "6.4": ("may not hold writers concurrently", "unproven"),
+    "6.5": ("zero new broker POSTs", "durable binary claim"),
+    "6.6": ("stale", "lease_lost", "may not proceed"),
+    "6.7": ("may not cancel, roll back", "share no transaction"),
+    "6.8": (
+        "currency_conversion_not_authorized",
+        "lane_quote_currency_mismatch",
+        "no FX rate, parity, or conversion",
+    ),
+}
+
+# In-repo anchors the document cites by name.  A citation that no longer
+# resolves is a defect in this document, not a reason to relax the test.
+_CITED_ANCHORS = (
+    (_COORDINATION_PATH, "async def release_if_matches"),
+    (_COORDINATION_PATH, "def _terminal_evidence_authorizes"),
+    (_COORDINATION_PATH, "async def release_with_terminal_evidence"),
+    (_COORDINATION_PATH, "def unreleased_authority_holds"),
+    (_COORDINATION_PATH, "async def list_reservations"),
+    (_COORDINATION_PATH, "async def assert_owned"),
+    (_LINEAGE_PATH, "currency_conversion_not_authorized"),
+    (_LINEAGE_PATH, "lane_quote_currency_mismatch"),
+)
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return _DOC_PATH.read_text(encoding="utf-8")
+
+
+def _entry(lane_id: str):
+    """``CANONICAL_LANE_REGISTRY`` is an ordered tuple, not a mapping."""
+
+    matches = [e for e in CANONICAL_LANE_REGISTRY if e.lane_id == lane_id]
+    assert len(matches) == 1, f"{lane_id}: expected exactly one registry row"
+    return matches[0]
+
+
+def _flat(text: str) -> str:
+    """Collapse newlines so prose assertions do not depend on line wrapping."""
+
+    return re.sub(r"\s+", " ", text)
+
+
+def _blocks(text: str, marker: str) -> dict[str, dict[str, str]]:
+    """Parse ``### LANE <id>`` sections into ``{lane: {key: value}}``."""
+
+    out: dict[str, dict[str, str]] = {}
+    sections = re.split(r"^### LANE ", text, flags=re.MULTILINE)[1:]
+    for section in sections:
+        lane_id = section.splitlines()[0].strip()
+        found = re.findall(rf"```text\n# {marker}\n(.*?)```", section, flags=re.DOTALL)
+        assert len(found) == 1, f"{lane_id}: expected exactly one {marker} block"
+        pairs: dict[str, str] = {}
+        for line in found[0].strip().splitlines():
+            key, _, value = line.partition(" = ")
+            assert _, f"{lane_id}/{marker}: malformed line {line!r}"
+            assert key not in pairs, f"{lane_id}/{marker}: duplicate key {key}"
+            pairs[key] = value.strip()
+        out[lane_id] = pairs
+    return out
+
+
+def test_s1_document_exists_and_is_the_only_owned_artifact() -> None:
+    assert _DOC_PATH.is_file()
+
+
+@pytest.mark.parametrize("token", _FIXED_TOKENS)
+def test_s2_fixed_token_appears_exactly_once(doc_text: str, token: str) -> None:
+    assert doc_text.count(token) == 1, f"token must appear exactly once: {token}"
+
+
+def test_s3_exactly_the_two_owned_lanes_are_recorded(doc_text: str) -> None:
+    recorded = tuple(_blocks(doc_text, "LIFECYCLE"))
+    assert recorded == _LANES
+
+
+@pytest.mark.parametrize("lane", _LANES)
+def test_s4_lifecycle_key_set_is_closed(doc_text: str, lane: str) -> None:
+    block = _blocks(doc_text, "LIFECYCLE")[lane]
+    assert tuple(block) == _LIFECYCLE_KEYS
+    assert block["lane_id"] == lane
+
+
+@pytest.mark.parametrize("lane", _LANES)
+def test_s5_evidence_key_set_is_exactly_the_seven_rule_kinds(
+    doc_text: str, lane: str
+) -> None:
+    block = _blocks(doc_text, "EVIDENCE")[lane]
+    assert tuple(block) == _EVIDENCE_KINDS, (
+        "the seven evidence kinds are fixed by the controlling rule; "
+        "none may be dropped, renamed, or added"
+    )
+    for kind, value in block.items():
+        assert value.startswith(_STATES), f"{lane}/{kind}: unstated evidence"
+
+
+@pytest.mark.parametrize("lane", _LANES)
+def test_s6_lifecycle_verdict_follows_from_unmet_items(
+    doc_text: str, lane: str
+) -> None:
+    """An unmet item forces the blocked verdict; the two cannot disagree."""
+
+    lifecycle = _blocks(doc_text, "LIFECYCLE")[lane]
+    evidence = _blocks(doc_text, "EVIDENCE")[lane]
+
+    rule_items = (
+        "recovery_owner",
+        "restart_rediscovery_trigger",
+        "authoritative_readback_operation",
+        "release_if_matches_condition",
+        "operator_visible_blocked_state",
+    )
+    unmet = {item for item in rule_items if lifecycle[item].startswith(_UNMET_STATES)}
+    if any(value.startswith(_UNMET_STATES) for value in evidence.values()):
+        unmet.add("lane_native_evidence")
+
+    declared = {
+        part.strip()
+        for part in lifecycle["unmet_lifecycle_items"].strip("()").split(",")
+        if part.strip()
+    }
+    assert declared == unmet, f"{lane}: declared unmet set disagrees with the blocks"
+    assert unmet, f"{lane}: an empty unmet set would require enablement evidence"
+    assert lifecycle["lifecycle_recovery_owner_status"] == _LIFECYCLE_BLOCKED
+
+
+@pytest.mark.parametrize("lane", _LANES)
+def test_s7_verdict_is_carried_off_lane_status(doc_text: str, lane: str) -> None:
+    """The verdict must not be written into ``lane_status``.
+
+    The signed allowlist admits only ``NOT_READY`` for these lanes, so putting
+    the lifecycle verdict on ``lane_status`` would violate the registry.
+    """
+
+    lifecycle = _blocks(doc_text, "LIFECYCLE")[lane]
+    assert "lane_status" not in lifecycle
+    entry = _entry(lane)
+    assert entry.lane_status.value == "NOT_READY"
+    assert _LIFECYCLE_BLOCKED != entry.lane_status.value
+
+
+@pytest.mark.parametrize("lane", _LANES)
+def test_s8_signed_safety_axes_are_unchanged(lane: str) -> None:
+    """Literal pin.  A registry flip must turn this red, not be followed."""
+
+    entry = _entry(lane)
+    expected = _SAFETY_AXES_EXPECTED[lane]
+
+    assert entry.role is not None
+    assert entry.role.value == expected["role"]
+    assert entry.lane_status.value == expected["lane_status"]
+    assert entry.activation_status.value == expected["activation_status"]
+    assert entry.quote_currency == expected["quote_currency"]
+    assert entry.writer is expected["writer"]
+    assert entry.auto_order_enabled is expected["auto_order_enabled"]
+    assert entry.scheduler_owner is expected["scheduler_owner"]
+    assert entry.physical_account_id is expected["physical_account_id"]
+
+
+def test_s9_kr_us_kis_share_one_credential_namespace(doc_text: str) -> None:
+    """The collision §5.3 records, and the basis of §6.4."""
+
+    namespaces = {
+        lane: LANE_CREDENTIAL_NAMESPACES[lane] for lane in _SHARED_KIS_NAMESPACE_LANES
+    }
+    assert set(namespaces.values()) == {_SHARED_KIS_NAMESPACE}, (
+        "if the KR/US KIS namespaces are ever separated, §5.3 and §6.4 must be "
+        "rewritten rather than left asserting a collision that no longer exists"
+    )
+    assert "declared collision" in _flat(doc_text)
+
+
+def test_s10_safety_expectations_are_literal_not_derived() -> None:
+    """Guards S8/S9: the pins above may not be computed from the registry."""
+
+    source = pathlib.Path(__file__).read_text(encoding="utf-8")
+    head = source.split("@pytest.fixture", 1)[0]
+    literal_block = head.split("_SAFETY_AXES_EXPECTED", 1)[1]
+    for forbidden in (
+        "CANONICAL_LANE_REGISTRY",
+        "LANE_CREDENTIAL_NAMESPACES",
+        "LANE_QUOTE_CURRENCIES",
+    ):
+        assert forbidden not in literal_block, (
+            f"{forbidden} must not seed the literal expectations; "
+            "deriving them would make a registry flip self-approving"
+        )
+
+
+@pytest.mark.parametrize("section", sorted(_INVARIANTS))
+def test_s11_pre_submit_invariant_is_present(doc_text: str, section: str) -> None:
+    body = re.search(
+        rf"^### {re.escape(section)} .*?(?=^### |^## )",
+        doc_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    assert body is not None, f"invariant §{section} is missing"
+    for needle in _INVARIANTS[section]:
+        assert needle in _flat(body.group(0)), (
+            f"§{section} lost its substance: {needle!r}"
+        )
+
+
+@pytest.mark.parametrize(("path", "anchor"), _CITED_ANCHORS)
+def test_s12_cited_anchor_still_exists(path: pathlib.Path, anchor: str) -> None:
+    assert anchor in path.read_text(encoding="utf-8"), (
+        f"{path.name} no longer contains {anchor!r}; the citation must be "
+        "repaired rather than the assertion relaxed"
+    )
+
+
+def test_s13_document_does_not_rerender_rob1266_registry_records(
+    doc_text: str,
+) -> None:
+    """Scope fence: ROB-1266 owns the registry rendering; cite, do not repeat."""
+
+    for owned_key in ("# REGISTRY", "# DERIVED", "CAP_STATUS"):
+        assert owned_key not in doc_text, (
+            f"{owned_key!r} belongs to docs/contracts/rob-1266-us-readiness.md; "
+            "a second rendering would be a second source of truth"
+        )
+    assert "docs/contracts/rob-1266-us-readiness.md" in doc_text
+
+
+def test_s14_no_production_module_is_modified_by_this_contract() -> None:
+    """The registry and ports are consumed, never edited, by this job."""
+
+    for path in (_REGISTRY_PATH, _COORDINATION_PATH, _LINEAGE_PATH):
+        assert path.is_file()

--- a/tests/services/test_us_kis_kiwoom_readiness.py
+++ b/tests/services/test_us_kis_kiwoom_readiness.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import pathlib
 import re
+from enum import Enum
 
 import pytest
 
@@ -104,7 +105,7 @@ _LIFECYCLE_BLOCKED = "AUTO_READY_BLOCKED_BY_LIFECYCLE"
 
 # Axes ROB-1266 §8 renders.  Their values are pulled from the registry at run
 # time; none of them is written down here.
-_ROB1266_OWNED_AXES = (
+_SCALAR_AXES = (
     "role",
     "lane_status",
     "activation_status",
@@ -112,6 +113,14 @@ _ROB1266_OWNED_AXES = (
     "identity_status",
     "credential_namespace",
 )
+# Axes ROB-1266 §8 renders as a tuple.  These need their own patterns: the
+# whole-tuple rendering and the qualified enum member names are transcriptions,
+# while several individual member *values* are ordinary English words that this
+# contract must be able to use in prose (a lane may not authorise a canary, and
+# saying so is not a restatement of the binding list).  Naming the member —
+# qualified, or by reciting the whole tuple — is what gets forbidden.
+_TUPLE_AXES = ("allowed_hosts", "missing_bindings")
+_ROB1266_OWNED_AXES = _SCALAR_AXES + _TUPLE_AXES
 # Axes whose value is a pure identity token, so any bare occurrence in the
 # document is a restatement regardless of surrounding prose.
 _IDENTITY_AXES = ("role", "lane_status", "credential_namespace")
@@ -154,6 +163,53 @@ def _axis_value(lane_id: str, axis: str) -> str | None:
     if axis == "credential_namespace":
         return _rendered(LANE_CREDENTIAL_NAMESPACES[lane_id])
     return _rendered(getattr(_entry(lane_id), axis))
+
+
+def _axis_members(lane_id: str, axis: str) -> tuple[object, ...]:
+    if axis == "allowed_hosts":
+        return tuple(LANE_ALLOWED_HOSTS[lane_id])
+    return tuple(getattr(_entry(lane_id), axis))
+
+
+def _forbidden_patterns(lane_id: str, axis: str) -> list[tuple[str, str]]:
+    """Every way this axis's registry value could be transcribed, derived.
+
+    Nothing here is hand-written: the members come from the registry at call
+    time, so a value change moves the guard with it.
+    """
+
+    patterns: list[tuple[str, str]] = []
+    if axis in _SCALAR_AXES:
+        value = _axis_value(lane_id, axis)
+        if value is None:
+            return patterns
+        patterns.append(
+            (f"{axis} = {value}", rf"{re.escape(axis)}\s*=\s*{re.escape(value)}")
+        )
+        if axis in _IDENTITY_AXES:
+            patterns.append(
+                (f"bare {value}", rf"(?<![\w.]){re.escape(value)}(?![\w.])")
+            )
+        return patterns
+
+    members = _axis_members(lane_id, axis)
+    if not members:
+        return patterns
+    rendered = [_rendered(m) for m in members]
+    sequence = r"\W+".join(re.escape(r) for r in rendered if r)
+    # The whole tuple, however it is punctuated -- this is the transcription.
+    patterns.append((f"{axis} tuple", sequence))
+    patterns.append((f"{axis} = (...)", rf"{re.escape(axis)}\s*=\s*\("))
+    for member in members:
+        if isinstance(member, Enum):
+            # The qualified form names the member unambiguously; the bare
+            # value does not, so only the qualified form is forbidden.
+            qualified = f"{type(member).__name__}.{member.name}"
+            patterns.append((qualified, re.escape(qualified)))
+        else:
+            # Hosts are distinctive strings; a bare occurrence is a copy.
+            patterns.append((f"bare {member}", rf"(?<![\w.]){re.escape(str(member))}"))
+    return patterns
 
 
 def _blocks(text: str, marker: str) -> dict[str, dict[str, str]]:
@@ -320,18 +376,14 @@ def test_g5_document_does_not_restate_a_registry_axis(
     forbids; cite the path and section instead.
     """
 
-    value = _axis_value(lane, axis)
-    if value is None:
+    patterns = _forbidden_patterns(lane, axis)
+    if not patterns:
         pytest.skip(f"{lane}.{axis} is absent in the registry; nothing to restate")
 
     flat = _flat(doc_text)
-    assert not re.search(rf"{re.escape(axis)}\s*=\s*{re.escape(value)}", flat), (
-        f"{lane}: document restates {axis} = {value}; cite ROB-1266 §8 instead"
-    )
-    if axis in _IDENTITY_AXES:
-        assert not re.search(rf"(?<![\w.]){re.escape(value)}(?![\w.])", flat), (
-            f"{lane}: document contains the bare registry value {value!r} for "
-            f"{axis}; that value is owned by ROB-1266 §8"
+    for why, pattern in patterns:
+        assert not re.search(pattern, flat), (
+            f"{lane}: document restates {axis} ({why}); cite ROB-1266 §8 instead"
         )
 
 
@@ -342,8 +394,15 @@ def test_g6_checker_keeps_no_literal_copy_of_a_registry_value() -> None:
     forbidden = {
         value
         for lane in _LANES
-        for axis in _ROB1266_OWNED_AXES
+        for axis in _SCALAR_AXES
         if (value := _axis_value(lane, axis)) is not None
+    }
+    forbidden |= {
+        rendered
+        for lane in _LANES
+        for axis in _TUPLE_AXES
+        for member in _axis_members(lane, axis)
+        if (rendered := _rendered(member)) is not None
     }
     for value in forbidden:
         assert f'"{value}"' not in source and f"'{value}'" not in source, (

--- a/tests/services/test_us_kis_kiwoom_readiness.py
+++ b/tests/services/test_us_kis_kiwoom_readiness.py
@@ -5,16 +5,27 @@ the signed lane registry, and the merged J2B/J3A port sources — and compares
 them.  It opens no socket, no database connection, and no file outside the
 repository, and it modifies nothing.
 
-Expectation provenance is deliberately split, following the J5A pattern:
+**Every expectation here is derived, never hand-written.**  That is the
+correction this module exists to hold:
 
-* Structural expectations (S1-S5) are **derived** from the document's own
-  declared shape rules, so the document is the artifact under test.
-* Safety expectations (S6-S9) are **literal**.  If the registry itself is
-  flipped, these assertions must go red rather than quietly follow it.
-* S10 proves that the literal block really is literal, so nobody can later
-  convert it into a derived value unnoticed.
-* Citation expectations (S11) assert that every in-repo anchor the document
-  names actually exists, so a citation cannot rot into fiction.
+* ROB-1266 §8 owns the signed registry rendering for these two lanes, and the
+  registry owns the values themselves.  This module keeps **no** literal copy of
+  a lane's `role`, `lane_status`, `activation_status`, `quote_currency`,
+  `identity_status`, or `credential_namespace`.  ``test_g5_*`` goes further and
+  proves the *document* keeps no copy either, using values pulled live from the
+  registry as the forbidden set — so a third independent record cannot appear
+  without turning this suite red.
+* The lifecycle verdict in §4 of the document is checked against **ground truth
+  derived from merged code**, not against the document's own neighbouring
+  fields.  Declaring an item ``PRESENT`` while the registry records its binding
+  as missing is therefore a failure, and cannot be laundered by also editing
+  ``unmet_lifecycle_items``.  ``test_g7_*``/``test_g8_*`` enforce that.
+
+The literal-pin duty belongs to J5A's checker
+(``tests/services/mock_integration/test_rob1266_us_readiness_contract.py``) and
+to ``assert_registry_startup`` in the registry itself, which rejects an unsafe
+row at import time.  Duplicating it here would be the very second copy this
+contract forbids.
 """
 
 from __future__ import annotations
@@ -24,9 +35,12 @@ import re
 
 import pytest
 
+from app.services.brokers.capabilities import BROKER_CAPABILITIES, Broker, Market
 from app.services.mock_lane_registry import (
     CANONICAL_LANE_REGISTRY,
+    LANE_ALLOWED_HOSTS,
     LANE_CREDENTIAL_NAMESPACES,
+    MissingBinding,
 )
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -34,6 +48,8 @@ _DOC_PATH = _REPO_ROOT / "docs/contracts/rob-1268-us-kis-kiwoom-readiness.md"
 _REGISTRY_PATH = _REPO_ROOT / "app/services/mock_lane_registry.py"
 _COORDINATION_PATH = _REPO_ROOT / "app/services/mock_integration/coordination.py"
 _LINEAGE_PATH = _REPO_ROOT / "app/services/mock_integration/lineage.py"
+_KIS_OVERSEAS_PATH = _REPO_ROOT / "app/services/brokers/kis/overseas_orders.py"
+_MODELS_DIR = _REPO_ROOT / "app/models"
 
 _LANES = ("us.kis.mock", "us.kiwoom.mock")
 
@@ -70,74 +86,40 @@ _LIFECYCLE_KEYS = (
     "unmet_lifecycle_items",
 )
 
+# The five rule items carried on the LIFECYCLE block.  The sixth rule item —
+# lane-native evidence — lives in the EVIDENCE block and joins the unmet set
+# under the name below.
+_RULE_ITEMS = (
+    "recovery_owner",
+    "restart_rediscovery_trigger",
+    "authoritative_readback_operation",
+    "release_if_matches_condition",
+    "operator_visible_blocked_state",
+)
+_EVIDENCE_ITEM = "lane_native_evidence"
+
 _STATES = ("PRESENT_CONSTRAINED", "PRESENT", "ABSENT")
 _UNMET_STATES = ("PRESENT_CONSTRAINED", "ABSENT")
-
 _LIFECYCLE_BLOCKED = "AUTO_READY_BLOCKED_BY_LIFECYCLE"
 
-# ---------------------------------------------------------------------------
-# S6-S9 expectations — LITERAL BY CONTRACT.  Do not derive any part of the
-# constants below from ``app.services.mock_lane_registry``; ``test_s10_*``
-# enforces that mechanically.
-# ---------------------------------------------------------------------------
-
-_SAFETY_AXES_EXPECTED = {
-    "us.kis.mock": {
-        "role": "AUTO_MIRROR",
-        "lane_status": "NOT_READY",
-        "activation_status": "BLOCKED",
-        "quote_currency": "USD",
-        "writer": False,
-        "auto_order_enabled": False,
-        "scheduler_owner": None,
-        "physical_account_id": None,
-    },
-    "us.kiwoom.mock": {
-        "role": "BROKER_REGRESSION",
-        "lane_status": "NOT_READY",
-        "activation_status": "BLOCKED",
-        "quote_currency": "USD",
-        "writer": False,
-        "auto_order_enabled": False,
-        "scheduler_owner": None,
-        "physical_account_id": None,
-    },
-}
-
-# The KR/US KIS credential-namespace collision that §5.3 and §6.4 rest on.
-_SHARED_KIS_NAMESPACE_LANES = ("kr.kis.mock", "us.kis.mock")
-_SHARED_KIS_NAMESPACE = "KIS_MOCK_*"
-
-# Each invariant section, with substrings that must appear inside it.  These
-# encode the eight adversarial mutants: removing or weakening any invariant
-# drops one of these substrings and turns the corresponding case red.
-_INVARIANTS = {
-    "6.1": ("open_order_count", "stop before broker I/O", "never read as zero"),
-    "6.2": ("physical_account_id", "identity_status", "may not be set true"),
-    "6.3": ("BROKER_REGRESSION", "AUTO_MIRROR", "not authorized"),
-    "6.4": ("may not hold writers concurrently", "unproven"),
-    "6.5": ("zero new broker POSTs", "durable binary claim"),
-    "6.6": ("stale", "lease_lost", "may not proceed"),
-    "6.7": ("may not cancel, roll back", "share no transaction"),
-    "6.8": (
-        "currency_conversion_not_authorized",
-        "lane_quote_currency_mismatch",
-        "no FX rate, parity, or conversion",
-    ),
-}
-
-# In-repo anchors the document cites by name.  A citation that no longer
-# resolves is a defect in this document, not a reason to relax the test.
-_CITED_ANCHORS = (
-    (_COORDINATION_PATH, "async def release_if_matches"),
-    (_COORDINATION_PATH, "def _terminal_evidence_authorizes"),
-    (_COORDINATION_PATH, "async def release_with_terminal_evidence"),
-    (_COORDINATION_PATH, "def unreleased_authority_holds"),
-    (_COORDINATION_PATH, "async def list_reservations"),
-    (_COORDINATION_PATH, "async def assert_owned"),
-    (_LINEAGE_PATH, "currency_conversion_not_authorized"),
-    (_LINEAGE_PATH, "lane_quote_currency_mismatch"),
+# Axes ROB-1266 §8 renders.  Their values are pulled from the registry at run
+# time; none of them is written down here.
+_ROB1266_OWNED_AXES = (
+    "role",
+    "lane_status",
+    "activation_status",
+    "quote_currency",
+    "identity_status",
+    "credential_namespace",
 )
+# Axes whose value is a pure identity token, so any bare occurrence in the
+# document is a restatement regardless of surrounding prose.
+_IDENTITY_AXES = ("role", "lane_status", "credential_namespace")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
@@ -159,6 +141,21 @@ def _flat(text: str) -> str:
     return re.sub(r"\s+", " ", text)
 
 
+def _rendered(value: object) -> str | None:
+    """The registry value as it would appear if someone restated it."""
+
+    if value is None:
+        return None
+    inner = getattr(value, "value", value)
+    return str(inner)
+
+
+def _axis_value(lane_id: str, axis: str) -> str | None:
+    if axis == "credential_namespace":
+        return _rendered(LANE_CREDENTIAL_NAMESPACES[lane_id])
+    return _rendered(getattr(_entry(lane_id), axis))
+
+
 def _blocks(text: str, marker: str) -> dict[str, dict[str, str]]:
     """Parse ``### LANE <id>`` sections into ``{lane: {key: value}}``."""
 
@@ -178,135 +175,297 @@ def _blocks(text: str, marker: str) -> dict[str, dict[str, str]]:
     return out
 
 
-def test_s1_document_exists_and_is_the_only_owned_artifact() -> None:
+def _state_of(value: str) -> str:
+    for state in _STATES:  # PRESENT_CONSTRAINED first: it prefixes PRESENT
+        if value.startswith(state):
+            return state
+    raise AssertionError(f"unstated value: {value!r}")
+
+
+# ---------------------------------------------------------------------------
+# ground truth — derived from merged code, never from the document
+# ---------------------------------------------------------------------------
+
+
+def _readback_ground_truth(lane_id: str) -> str:
+    """Is an authoritative broker readback usable by this lane, unaided?"""
+
+    if lane_id == "us.kiwoom.mock":
+        # The readback endpoints exist, but the capability registry does not
+        # declare this broker for US equity at all.
+        declared = Market.US_EQUITY in BROKER_CAPABILITIES[Broker.KIWOOM].markets
+        return "PRESENT" if declared else "PRESENT_CONSTRAINED"
+    if lane_id == "us.kis.mock":
+        # The daily-order inquiry has a mock TR, but open-order truth — the
+        # pending-orders inquiry — refuses the mock lane outright.
+        refuses_mock = "available in mock mode" in _flat(
+            _KIS_OVERSEAS_PATH.read_text(encoding="utf-8")
+        )
+        return "PRESENT_CONSTRAINED" if refuses_mock else "PRESENT"
+    raise AssertionError(f"unowned lane: {lane_id}")
+
+
+def _evidence_ground_truth(lane_id: str) -> str:
+    """Can a lane-native evidence table attribute a row to *this* lane?"""
+
+    models = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(_MODELS_DIR.glob("*.py"))
+    )
+    if lane_id == "us.kiwoom.mock":
+        tablenames = re.findall(r'__tablename__\s*=\s*"([^"]+)"', models)
+        has_ledger = any("kiwoom" in name and "ledger" in name for name in tablenames)
+        return "PRESENT" if has_ledger else "ABSENT"
+    if lane_id == "us.kis.mock":
+        # The sole KIS mock ledger is CHECK-pinned to one account_mode and
+        # carries no market/venue/lane discriminator, so a row cannot be
+        # attributed to the US lane rather than the KR one.
+        block = models.split('__tablename__ = "kis_mock_order_ledger"', 1)
+        assert len(block) == 2, "kis_mock_order_ledger model not found"
+        body = block[1].split("__tablename__", 1)[0]
+        discriminated = bool(
+            re.search(r"^\s+(lane|lane_id|market|venue)\s*:", body, flags=re.MULTILINE)
+        )
+        return "PRESENT" if discriminated else "ABSENT"
+    raise AssertionError(f"unowned lane: {lane_id}")
+
+
+def _lifecycle_ground_truth(lane_id: str) -> dict[str, str]:
+    """The state each rule item must be declared with, derived from code."""
+
+    entry = _entry(lane_id)
+    coordination = _COORDINATION_PATH.read_text(encoding="utf-8")
+
+    # The registry itself records whether this lane has a bound owner.
+    owner_present = MissingBinding.OWNER not in entry.missing_bindings
+    truth = {"recovery_owner": "PRESENT" if owner_present else "ABSENT"}
+
+    # A rediscovery trigger is a thing an owner owns.  With no owner there is
+    # nobody to own one, and J3A ships no recovery API to stand in.
+    truth["restart_rediscovery_trigger"] = "PRESENT" if owner_present else "ABSENT"
+
+    truth["authoritative_readback_operation"] = _readback_ground_truth(lane_id)
+
+    release_anchors = (
+        "async def release_if_matches",
+        "def _terminal_evidence_authorizes",
+        "async def release_with_terminal_evidence",
+    )
+    truth["release_if_matches_condition"] = (
+        "PRESENT" if all(a in coordination for a in release_anchors) else "ABSENT"
+    )
+    truth["operator_visible_blocked_state"] = (
+        "PRESENT" if "def unreleased_authority_holds" in coordination else "ABSENT"
+    )
+    return truth
+
+
+def _unmet_ground_truth(lane_id: str) -> set[str]:
+    unmet = {
+        item
+        for item, state in _lifecycle_ground_truth(lane_id).items()
+        if state in _UNMET_STATES
+    }
+    if _evidence_ground_truth(lane_id) in _UNMET_STATES:
+        unmet.add(_EVIDENCE_ITEM)
+    return unmet
+
+
+# ---------------------------------------------------------------------------
+# G1-G4 — document shape
+# ---------------------------------------------------------------------------
+
+
+def test_g1_document_exists() -> None:
     assert _DOC_PATH.is_file()
 
 
 @pytest.mark.parametrize("token", _FIXED_TOKENS)
-def test_s2_fixed_token_appears_exactly_once(doc_text: str, token: str) -> None:
+def test_g2_fixed_token_appears_exactly_once(doc_text: str, token: str) -> None:
     assert doc_text.count(token) == 1, f"token must appear exactly once: {token}"
 
 
-def test_s3_exactly_the_two_owned_lanes_are_recorded(doc_text: str) -> None:
-    recorded = tuple(_blocks(doc_text, "LIFECYCLE"))
-    assert recorded == _LANES
+def test_g3_exactly_the_two_owned_lanes_are_recorded(doc_text: str) -> None:
+    assert tuple(_blocks(doc_text, "LIFECYCLE")) == _LANES
 
 
 @pytest.mark.parametrize("lane", _LANES)
-def test_s4_lifecycle_key_set_is_closed(doc_text: str, lane: str) -> None:
-    block = _blocks(doc_text, "LIFECYCLE")[lane]
-    assert tuple(block) == _LIFECYCLE_KEYS
-    assert block["lane_id"] == lane
+def test_g4_block_key_sets_are_closed(doc_text: str, lane: str) -> None:
+    lifecycle = _blocks(doc_text, "LIFECYCLE")[lane]
+    assert tuple(lifecycle) == _LIFECYCLE_KEYS
+    assert lifecycle["lane_id"] == lane
 
-
-@pytest.mark.parametrize("lane", _LANES)
-def test_s5_evidence_key_set_is_exactly_the_seven_rule_kinds(
-    doc_text: str, lane: str
-) -> None:
-    block = _blocks(doc_text, "EVIDENCE")[lane]
-    assert tuple(block) == _EVIDENCE_KINDS, (
+    evidence = _blocks(doc_text, "EVIDENCE")[lane]
+    assert tuple(evidence) == _EVIDENCE_KINDS, (
         "the seven evidence kinds are fixed by the controlling rule; "
         "none may be dropped, renamed, or added"
     )
-    for kind, value in block.items():
-        assert value.startswith(_STATES), f"{lane}/{kind}: unstated evidence"
+    for kind, value in evidence.items():
+        assert _state_of(value), f"{lane}/{kind}: unstated evidence"
+
+
+# ---------------------------------------------------------------------------
+# G5-G6 — no second rendering of ROB-1266 / registry facts
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("lane", _LANES)
-def test_s6_lifecycle_verdict_follows_from_unmet_items(
+@pytest.mark.parametrize("axis", _ROB1266_OWNED_AXES)
+def test_g5_document_does_not_restate_a_registry_axis(
+    doc_text: str, lane: str, axis: str
+) -> None:
+    """The forbidden strings are pulled from the registry, not written here.
+
+    ROB-1266 §8 renders these axes for these lanes.  A second rendering here
+    would make a third independent record of a signed fact, which the contract
+    forbids; cite the path and section instead.
+    """
+
+    value = _axis_value(lane, axis)
+    if value is None:
+        pytest.skip(f"{lane}.{axis} is absent in the registry; nothing to restate")
+
+    flat = _flat(doc_text)
+    assert not re.search(rf"{re.escape(axis)}\s*=\s*{re.escape(value)}", flat), (
+        f"{lane}: document restates {axis} = {value}; cite ROB-1266 §8 instead"
+    )
+    if axis in _IDENTITY_AXES:
+        assert not re.search(rf"(?<![\w.]){re.escape(value)}(?![\w.])", flat), (
+            f"{lane}: document contains the bare registry value {value!r} for "
+            f"{axis}; that value is owned by ROB-1266 §8"
+        )
+
+
+def test_g6_checker_keeps_no_literal_copy_of_a_registry_value() -> None:
+    """Guards G5: this module may not hand-write what it claims to derive."""
+
+    source = pathlib.Path(__file__).read_text(encoding="utf-8")
+    forbidden = {
+        value
+        for lane in _LANES
+        for axis in _ROB1266_OWNED_AXES
+        if (value := _axis_value(lane, axis)) is not None
+    }
+    for value in forbidden:
+        assert f'"{value}"' not in source and f"'{value}'" not in source, (
+            f"{value!r} is written literally in this checker; derive it from "
+            "app.services.mock_lane_registry instead"
+        )
+
+
+def test_g7_kr_and_us_kis_share_one_namespace_and_host() -> None:
+    """The relation §5.3 records — asserted, never transcribed."""
+
+    assert (
+        LANE_CREDENTIAL_NAMESPACES["kr.kis.mock"]
+        == LANE_CREDENTIAL_NAMESPACES["us.kis.mock"]
+    ), (
+        "if the KR/US KIS namespaces are ever separated, §5.3 and §6.4 must be "
+        "rewritten rather than left asserting a collision that no longer exists"
+    )
+    assert LANE_ALLOWED_HOSTS["kr.kis.mock"] == LANE_ALLOWED_HOSTS["us.kis.mock"]
+    assert "declared collision" in _flat(_DOC_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# G8-G10 — the lifecycle verdict must match derived ground truth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lane", _LANES)
+@pytest.mark.parametrize("item", _RULE_ITEMS)
+def test_g8_declared_item_state_matches_ground_truth(
+    doc_text: str, lane: str, item: str
+) -> None:
+    """A declaration is checked against merged code, not against its neighbours.
+
+    This is what stops a fabricated ``PRESENT``: the registry records whether
+    the binding exists, so claiming otherwise fails here even if
+    ``unmet_lifecycle_items`` is edited to agree with the claim.
+    """
+
+    declared = _state_of(_blocks(doc_text, "LIFECYCLE")[lane][item])
+    expected = _lifecycle_ground_truth(lane)[item]
+    assert declared == expected, (
+        f"{lane}/{item}: document declares {declared} but merged code shows "
+        f"{expected}; fix the document rather than the expectation"
+    )
+
+
+@pytest.mark.parametrize("lane", _LANES)
+def test_g9_declared_evidence_matches_ground_truth(doc_text: str, lane: str) -> None:
+    expected = _evidence_ground_truth(lane)
+    for kind, value in _blocks(doc_text, "EVIDENCE")[lane].items():
+        assert _state_of(value) == expected, (
+            f"{lane}/{kind}: document declares {_state_of(value)} but no "
+            f"lane-attributable evidence table exists ({expected})"
+        )
+
+
+@pytest.mark.parametrize("lane", _LANES)
+def test_g10_unmet_set_and_verdict_follow_ground_truth(
     doc_text: str, lane: str
 ) -> None:
-    """An unmet item forces the blocked verdict; the two cannot disagree."""
-
     lifecycle = _blocks(doc_text, "LIFECYCLE")[lane]
-    evidence = _blocks(doc_text, "EVIDENCE")[lane]
-
-    rule_items = (
-        "recovery_owner",
-        "restart_rediscovery_trigger",
-        "authoritative_readback_operation",
-        "release_if_matches_condition",
-        "operator_visible_blocked_state",
-    )
-    unmet = {item for item in rule_items if lifecycle[item].startswith(_UNMET_STATES)}
-    if any(value.startswith(_UNMET_STATES) for value in evidence.values()):
-        unmet.add("lane_native_evidence")
-
     declared = {
         part.strip()
         for part in lifecycle["unmet_lifecycle_items"].strip("()").split(",")
         if part.strip()
     }
-    assert declared == unmet, f"{lane}: declared unmet set disagrees with the blocks"
-    assert unmet, f"{lane}: an empty unmet set would require enablement evidence"
+    expected = _unmet_ground_truth(lane)
+    assert declared == expected, (
+        f"{lane}: declared unmet set {sorted(declared)} disagrees with ground "
+        f"truth {sorted(expected)}"
+    )
+    assert expected, f"{lane}: an empty unmet set would require enablement evidence"
     assert lifecycle["lifecycle_recovery_owner_status"] == _LIFECYCLE_BLOCKED
 
 
 @pytest.mark.parametrize("lane", _LANES)
-def test_s7_verdict_is_carried_off_lane_status(doc_text: str, lane: str) -> None:
+def test_g11_verdict_is_carried_off_lane_status(doc_text: str, lane: str) -> None:
     """The verdict must not be written into ``lane_status``.
 
-    The signed allowlist admits only ``NOT_READY`` for these lanes, so putting
-    the lifecycle verdict on ``lane_status`` would violate the registry.
+    The signed allowlist admits a single status for these lanes, so putting the
+    lifecycle verdict there would violate the registry.  The admitted value is
+    read from the registry rather than repeated.
     """
 
-    lifecycle = _blocks(doc_text, "LIFECYCLE")[lane]
-    assert "lane_status" not in lifecycle
-    entry = _entry(lane)
-    assert entry.lane_status.value == "NOT_READY"
-    assert _LIFECYCLE_BLOCKED != entry.lane_status.value
+    assert "lane_status" not in _blocks(doc_text, "LIFECYCLE")[lane]
+    assert _entry(lane).lane_status.value != _LIFECYCLE_BLOCKED
 
 
-@pytest.mark.parametrize("lane", _LANES)
-def test_s8_signed_safety_axes_are_unchanged(lane: str) -> None:
-    """Literal pin.  A registry flip must turn this red, not be followed."""
+# ---------------------------------------------------------------------------
+# G12-G14 — invariants, citations, scope
+# ---------------------------------------------------------------------------
 
-    entry = _entry(lane)
-    expected = _SAFETY_AXES_EXPECTED[lane]
+_INVARIANTS = {
+    "6.1": ("open_order_count", "stop before broker I/O", "never read as zero"),
+    "6.2": ("may not be set true", "Masked physical"),
+    "6.3": ("promoting the lane to an automatic mirroring role", "not authorized"),
+    "6.4": ("may not hold writers concurrently", "unproven"),
+    "6.5": ("zero new broker POSTs", "durable binary claim"),
+    "6.6": ("stale", "lease_lost", "may not proceed"),
+    "6.7": ("may not cancel, roll back", "share no transaction"),
+    "6.8": (
+        "currency_conversion_not_authorized",
+        "lane_quote_currency_mismatch",
+        "no FX rate, parity, or conversion may be applied",
+    ),
+}
 
-    assert entry.role is not None
-    assert entry.role.value == expected["role"]
-    assert entry.lane_status.value == expected["lane_status"]
-    assert entry.activation_status.value == expected["activation_status"]
-    assert entry.quote_currency == expected["quote_currency"]
-    assert entry.writer is expected["writer"]
-    assert entry.auto_order_enabled is expected["auto_order_enabled"]
-    assert entry.scheduler_owner is expected["scheduler_owner"]
-    assert entry.physical_account_id is expected["physical_account_id"]
-
-
-def test_s9_kr_us_kis_share_one_credential_namespace(doc_text: str) -> None:
-    """The collision §5.3 records, and the basis of §6.4."""
-
-    namespaces = {
-        lane: LANE_CREDENTIAL_NAMESPACES[lane] for lane in _SHARED_KIS_NAMESPACE_LANES
-    }
-    assert set(namespaces.values()) == {_SHARED_KIS_NAMESPACE}, (
-        "if the KR/US KIS namespaces are ever separated, §5.3 and §6.4 must be "
-        "rewritten rather than left asserting a collision that no longer exists"
-    )
-    assert "declared collision" in _flat(doc_text)
-
-
-def test_s10_safety_expectations_are_literal_not_derived() -> None:
-    """Guards S8/S9: the pins above may not be computed from the registry."""
-
-    source = pathlib.Path(__file__).read_text(encoding="utf-8")
-    head = source.split("@pytest.fixture", 1)[0]
-    literal_block = head.split("_SAFETY_AXES_EXPECTED", 1)[1]
-    for forbidden in (
-        "CANONICAL_LANE_REGISTRY",
-        "LANE_CREDENTIAL_NAMESPACES",
-        "LANE_QUOTE_CURRENCIES",
-    ):
-        assert forbidden not in literal_block, (
-            f"{forbidden} must not seed the literal expectations; "
-            "deriving them would make a registry flip self-approving"
-        )
+_CITED_ANCHORS = (
+    (_COORDINATION_PATH, "async def release_if_matches"),
+    (_COORDINATION_PATH, "def _terminal_evidence_authorizes"),
+    (_COORDINATION_PATH, "async def release_with_terminal_evidence"),
+    (_COORDINATION_PATH, "def unreleased_authority_holds"),
+    (_COORDINATION_PATH, "async def list_reservations"),
+    (_COORDINATION_PATH, "async def assert_owned"),
+    (_LINEAGE_PATH, "currency_conversion_not_authorized"),
+    (_LINEAGE_PATH, "lane_quote_currency_mismatch"),
+)
 
 
 @pytest.mark.parametrize("section", sorted(_INVARIANTS))
-def test_s11_pre_submit_invariant_is_present(doc_text: str, section: str) -> None:
+def test_g12_pre_submit_invariant_is_present(doc_text: str, section: str) -> None:
     body = re.search(
         rf"^### {re.escape(section)} .*?(?=^### |^## )",
         doc_text,
@@ -320,28 +479,20 @@ def test_s11_pre_submit_invariant_is_present(doc_text: str, section: str) -> Non
 
 
 @pytest.mark.parametrize(("path", "anchor"), _CITED_ANCHORS)
-def test_s12_cited_anchor_still_exists(path: pathlib.Path, anchor: str) -> None:
+def test_g13_cited_anchor_still_exists(path: pathlib.Path, anchor: str) -> None:
     assert anchor in path.read_text(encoding="utf-8"), (
         f"{path.name} no longer contains {anchor!r}; the citation must be "
         "repaired rather than the assertion relaxed"
     )
 
 
-def test_s13_document_does_not_rerender_rob1266_registry_records(
+def test_g14_document_cites_rob1266_and_touches_no_production_module(
     doc_text: str,
 ) -> None:
-    """Scope fence: ROB-1266 owns the registry rendering; cite, do not repeat."""
-
-    for owned_key in ("# REGISTRY", "# DERIVED", "CAP_STATUS"):
-        assert owned_key not in doc_text, (
-            f"{owned_key!r} belongs to docs/contracts/rob-1266-us-readiness.md; "
-            "a second rendering would be a second source of truth"
+    for owned_marker in ("# REGISTRY", "# DERIVED", "CAP_STATUS"):
+        assert owned_marker not in doc_text, (
+            f"{owned_marker!r} belongs to docs/contracts/rob-1266-us-readiness.md"
         )
     assert "docs/contracts/rob-1266-us-readiness.md" in doc_text
-
-
-def test_s14_no_production_module_is_modified_by_this_contract() -> None:
-    """The registry and ports are consumed, never edited, by this job."""
-
     for path in (_REGISTRY_PATH, _COORDINATION_PATH, _LINEAGE_PATH):
         assert path.is_file()


### PR DESCRIPTION
## What

Records the **lane-native lifecycle recovery contract** for `us.kis.mock` and
`us.kiwoom.mock` — the six items a lane contract must identify before it could
become `AUTO_ENABLED`. Recording the contract is the deliverable; **activation
is a separate approval and is not requested here.**

Two new files only:

- `docs/contracts/rob-1268-us-kis-kiwoom-readiness.md`
- `tests/services/test_us_kis_kiwoom_readiness.py`

## Verdict

Both lanes: `lifecycle_recovery_owner_status = AUTO_READY_BLOCKED_BY_LIFECYCLE`.

The verdict is carried on a **dedicated axis, not on `lane_status`** — the
signed allowlist admits only `NOT_READY` for both lanes, so writing the
lifecycle verdict into `lane_status` would violate the signed registry.

## Findings backing it

- **No lane-native evidence table for either lane.** The sole KIS mock ledger
  is CHECK-pinned to `account_mode='kis_mock'` / `broker='kis'` with no market
  or lane column, so KR and US rows are indistinguishable at the constraint
  level; its `status` set is `('accepted','rejected','unknown')` and it has no
  remainder column. No Kiwoom order ledger exists at all.
- **`kr.kis.mock` and `us.kis.mock` share one credential namespace**
  (`KIS_MOCK_*`) and one host. That is a *declared collision*, which is
  stronger than "unproven separate", and is the basis for the concurrent-writer
  prohibition.
- **No recovery owner exists** — the registry's own `missing_bindings` carries
  `owner` — and J3A deliberately ships no recovery API this epoch.

## Boundaries

Registry, J2B/J3A ports and `rob-1266-us-readiness.md` are consumed **read-only
and cited by section, never re-rendered**. No production module, model,
migration, scheduler, deploy path or broker call is touched. No policy, cap,
cadence, canary, writer or scheduler owner is created. No broker/network/DB
mutation.

## Verification

`124 passed` on the fenced command; `ruff check`, `ruff format --check` and
`ty check --error-on-warning` all clean.

Nine adversarial mutants injected and all killed, then reverted
(`git diff --exit-code` clean). Notably the writer-flip mutant is killed at
**import time** by the registry's own startup assertion
(`unknown_identity_must_be_safe[us.kis.mock]`), not merely by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)