### PR TITLE
fix: attribute native alpaca lab executions

### DIFF
--- a/docs/runbooks/alpaca-paper-lab-cleanup-prep.md
+++ b/docs/runbooks/alpaca-paper-lab-cleanup-prep.md
@@ -21,7 +21,9 @@ R2 counter: submit=0, cancel=0, modify=0, close_or_liquidate=0, total=0. No code
 
 The filled row matches the bounded broker position on `account_mode=alpaca_paper_lab`, symbol UBER, quantity 1, average entry price 69.65, and broker order ID. Ledger net long is `0 + 1 = 1`, exactly the broker quantity. `derive_client_order_id` in `app/services/alpaca_paper_submit_service.py` emits `dlab-rob73-…` for the lab account. Thus this is **ledger-linked / B0-X-lane-unattributed**, not foreign or generally unattributed.
 
-`scripts/b0x/us/alpaca.py::_b0xu_executions` intentionally filters to `b0xu-` correlations before `_attribute_positions`. It answers B0-X experiment-lane ownership, not account-wide provenance. The former document incorrectly promoted its zero-result for `dlab-` rows to “not ours.” The reader is not changed here: expanding a B0-X ownership boundary is a separate design/code task; this round corrects the account-wide interpretation only.
+The original reader intentionally filtered to `b0xu-` correlations before `_attribute_positions`, which incorrectly promoted a known `dlab-` lab row to “not ours.” The follow-up attribution repair accepts `b0xu-` and `dlab-` execution evidence for **positions** only. Open-order ownership remains `b0xu-` only, preserving the B0-X cancellation boundary; `dlab-` does not become a B0-X pending order.
+
+This correction does **not** make UBER generally tradeable: the canceled row has no fill price, so cumulative deployment remains unreadable and blocks additional buys; its two execution events also fail the single-native-buy requirement for an automated sell source.
 
 The recorded cycle `/Users/mgh3326/work/herdr-artifacts/b0x/alpaca_paper_lab/20260814T224344-us-cycle.json` has the same `foreign_position_symbols=["UBER"]` / no-`b0xu-` evidence and `submission_skipped="contaminated lab account state — foreign/unlinked residue blocks submit"`. The stated skip cause is therefore confirmed for that recorded cycle. It proves an attribution-scope defect in the decision input, not that liquidation is necessary.
 

--- a/docs/runbooks/b0x-us-cycle.md
+++ b/docs/runbooks/b0x-us-cycle.md
@@ -82,10 +82,11 @@ open-order 또는 bounded ledger 응답이 limit에 닿으면 완전성을 증�
 
 - `lifecycle_correlation_id`가 `b0xu-`로 시작하는 lab execution evidence가 broker
   order id와 정확히 하나로 연결될 때만 open order를 자기 것으로 본다.
-- position은 symbol별 b0xu fill의 순수량이 broker 수량과 정확히 일치할 때만 자기
-  position이다. fill이 없거나 수량 evidence가 불완전하면 foreign/linkage failure다.
-  매수가 fill price만 불완전한 경우에는 소유권을 꾸며 바꾸지 않고 cumulative deployment를
-  unreadable로 표시하여 추가매수를 막는다.
+- position은 symbol별 `b0xu-` 또는 native-lab `dlab-` execution fill의 순수량이 broker
+  수량과 정확히 일치할 때만 자기 position이다. 이 확장은 contamination 오탐만 제거하며,
+  open-order 소유권·취소 사정권을 넓히지 않는다. fill이 없거나 수량 evidence가 불완전하면
+  foreign/linkage failure다. 매수가 fill price만 불완전한 경우에는 소유권을 꾸며 바꾸지
+  않고 cumulative deployment를 unreadable로 표시하여 추가매수를 막는다.
 - 그 밖의 open order/position은 foreign으로 기록하고 `CONTAMINATED`로 분리한다.
   관측은 남기되 submit은 막으며, foreign 주문/포지션을 취소·청산하지 않는다.
 

--- a/scripts/b0x/us/alpaca.py
+++ b/scripts/b0x/us/alpaca.py
@@ -4,10 +4,11 @@ This module deliberately has two sharply separated halves:
 
 * :func:`read_fresh_truth` uses the existing read-only ``alpaca_paper_*``
   surfaces for the *lab* account only.  It reads the whole positions/open
-  order snapshot plus the existing Alpaca ledger, then attributes residual
-  state by an evidence-bearing ``b0xu-`` lifecycle correlation.  Nothing is
-  inferred from an account name, a client-order-id prefix, or a plausible
-  history.
+  order snapshot plus the existing Alpaca ledger.  Position attribution accepts
+  evidence-bearing ``b0xu-`` and native-lab ``dlab-`` lifecycle correlations;
+  open-order ownership remains ``b0xu-`` only, so its cancellation scope does
+  not expand.  Nothing is inferred from an account name, a client-order-id
+  prefix, or a plausible history.
 * planning/submission is pure.  There is deliberately no production mutation
   default until an approved lab-aware automated boundary exists.  Tests inject
   fakes/stubs at that seam; no test needs an Alpaca account, preview call,
@@ -86,7 +87,7 @@ class LabTruthReadError(RuntimeError):
 
 
 class RealizedPnlUnavailable(RuntimeError):
-    """A B0-X execution exists today but no realized-P&L source is available."""
+    """A recognized lab execution exists today but no realized-P&L source exists."""
 
 
 class LabMutationNotWired(RuntimeError):
@@ -294,11 +295,11 @@ class FreshTruth:
             "own_pending_readable": True,
             "cumulative_deployment_readable": self.cumulative_deployment_readable,
             "realized_pnl_source": (
-                "no B0-X US execution observed in the current UTC day in the "
+                "no recognized lab execution observed in the current UTC day in the "
                 "bounded, complete recent ledger snapshot"
                 if self.realized_pnl_today == Decimal("0")
-                else "unavailable: B0-X US execution exists today but no realized-P&L "
-                "read model is wired"
+                else "unavailable: recognized lab execution exists today but no "
+                "realized-P&L read model is wired"
             ),
         }
 
@@ -359,7 +360,14 @@ def _classify_open_orders(
 ) -> tuple[tuple[RawOpenOrder, ...], tuple[RawOpenOrder, ...]]:
     correlations_by_broker_id: dict[str, set[str]] = defaultdict(set)
     for execution in executions:
-        if execution.broker_order_id:
+        # Position provenance recognizes native lab smoke rows as well, but
+        # open-order ownership reaches the cancellation path.  Preserve that
+        # mutation scope: only B0-X's own lifecycle prefix can own a resting
+        # broker order.
+        if (
+            execution.correlation_id.startswith(B0XU_CORRELATION_PREFIX)
+            and execution.broker_order_id
+        ):
             correlations_by_broker_id[execution.broker_order_id].add(
                 execution.correlation_id
             )
@@ -475,12 +483,12 @@ def _attribute_positions(
 def _realized_pnl_today(
     executions: tuple[LedgerExecution, ...], *, now: dt.datetime
 ) -> Decimal | None:
-    """Return a provable zero only when no B0-X execution exists today.
+    """Return a provable zero only when no recognized lab execution exists today.
 
     The current ledger exposes fills and positions, not a dedicated realized
     P&L read model.  A made-up zero would disable a NAV-ratio kill.  The
     bounded complete ledger snapshot can, however, prove the bootstrap case:
-    no B0-X execution at all means there is no B0-X realized P&L today.
+    no recognized lab execution at all means there is no lab realized P&L today.
     """
 
     if not executions:
@@ -537,7 +545,7 @@ async def read_fresh_truth(
         )
     if int(ledger_response.get("count", -1)) >= _LEDGER_READ_LIMIT:
         raise LabTruthReadError(
-            "ledger read reached its limit; b0xu attribution incomplete"
+            "ledger read reached its limit; lab attribution incomplete"
         )
 
     account = account_response.get("account")
@@ -969,6 +977,8 @@ async def cancel_own_open_orders(
 
 __all__ = [
     "B0XU_CORRELATION_PREFIX",
+    "DLAB_CORRELATION_PREFIX",
+    "LAB_EXECUTION_CORRELATION_PREFIXES",
     "LANE",
     "MARKET",
     "QUOTE_CURRENCY",

--- a/scripts/b0x/us/alpaca.py
+++ b/scripts/b0x/us/alpaca.py
@@ -57,6 +57,14 @@ LANE: Final[str] = ALPACA_PAPER_LAB_ACCOUNT_MODE
 MARKET: Final[str] = "us"
 QUOTE_CURRENCY: Final[str] = "USD"
 B0XU_CORRELATION_PREFIX: Final[str] = "b0xu-"
+# The Alpaca lab profile prefixes server-issued manual and automated IDs with
+# ``dlab-``.  These IDs predate B0-X, but are native evidence for the same
+# explicitly selected lab account when stored as lifecycle correlations.
+DLAB_CORRELATION_PREFIX: Final[str] = "dlab-"
+LAB_EXECUTION_CORRELATION_PREFIXES: Final[tuple[str, ...]] = (
+    B0XU_CORRELATION_PREFIX,
+    DLAB_CORRELATION_PREFIX,
+)
 
 # Contract §4 US column.  The locked envelope holds the $450 ceiling; these
 # two values are the signed lower edge and B0's selected point within the band.
@@ -310,19 +318,19 @@ def _parse_datetime(value: Any) -> dt.datetime | None:
     return parsed.astimezone(dt.UTC)
 
 
-def _b0xu_executions(items: list[dict[str, Any]]) -> tuple[LedgerExecution, ...]:
+def _lab_executions(items: list[dict[str, Any]]) -> tuple[LedgerExecution, ...]:
     parsed: list[LedgerExecution] = []
     for row in items:
         correlation = str(row.get("lifecycle_correlation_id") or "").strip()
-        if not correlation.startswith(B0XU_CORRELATION_PREFIX):
+        if not correlation.startswith(LAB_EXECUTION_CORRELATION_PREFIXES):
             continue
         if row.get("account_mode") != LANE:
-            raise LabTruthReadError("b0xu ledger row is not bound to alpaca_paper_lab")
+            raise LabTruthReadError("lab ledger row is not bound to alpaca_paper_lab")
         if str(row.get("record_kind") or "") != "execution":
             continue
         side = str(row.get("side") or "").strip().lower()
         if side not in {"buy", "sell"}:
-            raise LabTruthReadError("b0xu execution has an unknown side")
+            raise LabTruthReadError("lab execution has an unknown side")
         parsed.append(
             LedgerExecution(
                 correlation_id=correlation,
@@ -390,11 +398,13 @@ def _attribute_positions(
         events = events_by_symbol.get(position.symbol, [])
         if not events:
             foreign.append(position.symbol)
-            failures.append(f"{position.symbol}: no b0xu execution correlation")
+            failures.append(
+                f"{position.symbol}: no recognized lab execution correlation"
+            )
             continue
         if any(event.filled_qty is None for event in events):
             foreign.append(position.symbol)
-            failures.append(f"{position.symbol}: b0xu fill quantity unavailable")
+            failures.append(f"{position.symbol}: lab fill quantity unavailable")
             continue
 
         signed_qty = sum(
@@ -408,7 +418,7 @@ def _attribute_positions(
         if signed_qty != position.quantity or signed_qty <= 0:
             foreign.append(position.symbol)
             failures.append(
-                f"{position.symbol}: broker quantity does not exactly match b0xu fills"
+                f"{position.symbol}: broker quantity does not exactly match lab fills"
             )
             continue
 
@@ -581,7 +591,7 @@ async def read_fresh_truth(
     ledger_items = ledger_response.get("items")
     if not isinstance(ledger_items, list):
         raise LabTruthReadError("ledger items malformed")
-    executions = _b0xu_executions(ledger_items)
+    executions = _lab_executions(ledger_items)
     positions = tuple(sorted(raw_positions, key=lambda position: position.symbol))
     open_orders = tuple(sorted(raw_orders, key=lambda order: order.broker_order_id))
     own_open_orders, foreign_open_orders = _classify_open_orders(

--- a/scripts/b0x/us/cycle.py
+++ b/scripts/b0x/us/cycle.py
@@ -46,8 +46,8 @@ MISSING_NAV_FOR_RATIO_KILL_REASON = "missing_nav_for_ratio_kill"
 INVALID_US_TABLE_SIZING_REASON = "invalid_us_table_sizing"
 
 US_REALIZED_PNL_UNAVAILABLE = (
-    "realized_pnl_today has no dedicated source when a b0xu execution exists "
-    "today; this cycle fails closed rather than treating it as a measured zero."
+    "realized_pnl_today has no dedicated source when a recognized lab execution "
+    "exists today; this cycle fails closed rather than treating it as a measured zero."
 )
 
 

--- a/tests/scripts/b0x/us/test_alpaca.py
+++ b/tests/scripts/b0x/us/test_alpaca.py
@@ -109,7 +109,9 @@ def _table() -> PolicyTable:
 
 
 @pytest.mark.asyncio
-async def test_fresh_truth_uses_lab_only_and_attributes_by_b0xu_correlation() -> None:
+async def test_fresh_truth_uses_lab_only_and_attributes_by_known_correlation_prefix() -> (
+    None
+):
     readers, calls = _readers(
         positions=[
             {
@@ -139,7 +141,7 @@ async def test_fresh_truth_uses_lab_only_and_attributes_by_b0xu_correlation() ->
             {
                 "account_mode": alpaca.LANE,
                 "record_kind": "execution",
-                "lifecycle_correlation_id": "b0xu-aapl-buy",
+                "lifecycle_correlation_id": "dlab-rob73-aapl",
                 "client_order_id": "dlab-rob842a-aapl",
                 "broker_order_id": "b0xu-open",
                 "execution_symbol": "AAPL",
@@ -175,9 +177,46 @@ async def test_fresh_truth_uses_lab_only_and_attributes_by_b0xu_correlation() ->
     assert [order.broker_order_id for order in fresh.foreign_open_orders] == [
         "foreign-open"
     ]
-    # No b0xu execution exists on NOW's UTC day, which is a provable bootstrap
-    # zero—not an inferred P&L calculation.
+    # No recognized lab execution exists on NOW's UTC day, which is a provable
+    # bootstrap zero—not an inferred P&L calculation.
     assert fresh.realized_pnl_today == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_unlinked_fake_lab_position_remains_contaminated() -> None:
+    """A position without a recognized ledger link must still block submission."""
+
+    readers, _ = _readers(
+        positions=[
+            {
+                "symbol": "FAKE",
+                "qty": "1",
+                "qty_available": "1",
+                "avg_entry_price": "100",
+            }
+        ],
+        ledger=[
+            {
+                "account_mode": alpaca.LANE,
+                "record_kind": "execution",
+                "lifecycle_correlation_id": "not-a-recognized-lab-prefix",
+                "client_order_id": "not-a-recognized-lab-prefix",
+                "broker_order_id": "unrelated-order",
+                "execution_symbol": "FAKE",
+                "side": "buy",
+                "filled_qty": "1",
+                "filled_avg_price": "100",
+                "created_at": "2026-08-09T15:00:00+00:00",
+            }
+        ],
+    )
+
+    fresh = await alpaca.read_fresh_truth(now=NOW, readers=readers)
+
+    assert fresh.foreign_position_symbols == ("FAKE",)
+    assert fresh.position_linkage_failures == (
+        "FAKE: no recognized lab execution correlation",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/us/test_alpaca.py
+++ b/tests/scripts/b0x/us/test_alpaca.py
@@ -18,6 +18,7 @@ from scripts.b0x.derivation import DerivedOrder
 from scripts.b0x.envelope import US_ALPACA_PAPER_LAB_ENVELOPE
 from scripts.b0x.table_source import PolicyTable
 from scripts.b0x.us import alpaca
+from scripts.b0x.us import cycle as us_cycle
 
 pytestmark = pytest.mark.unit
 
@@ -141,7 +142,7 @@ async def test_fresh_truth_uses_lab_only_and_attributes_by_known_correlation_pre
             {
                 "account_mode": alpaca.LANE,
                 "record_kind": "execution",
-                "lifecycle_correlation_id": "dlab-rob73-aapl",
+                "lifecycle_correlation_id": "b0xu-aapl-buy",
                 "client_order_id": "dlab-rob842a-aapl",
                 "broker_order_id": "b0xu-open",
                 "execution_symbol": "AAPL",
@@ -217,6 +218,223 @@ async def test_unlinked_fake_lab_position_remains_contaminated() -> None:
     assert fresh.position_linkage_failures == (
         "FAKE: no recognized lab execution correlation",
     )
+
+
+@pytest.mark.asyncio
+async def test_dlab_execution_does_not_expand_open_order_ownership() -> None:
+    """Native lab provenance may own a position, never a B0-X resting order."""
+
+    readers, _ = _readers(
+        positions=[
+            {
+                "symbol": "UBER",
+                "qty": "1",
+                "qty_available": "1",
+                "avg_entry_price": "69.65",
+            }
+        ],
+        orders=[{"id": "dlab-resting", "symbol": "UBER"}],
+        ledger=[
+            {
+                "account_mode": alpaca.LANE,
+                "record_kind": "execution",
+                "lifecycle_correlation_id": "dlab-rob73-uber",
+                "client_order_id": "dlab-rob73-uber",
+                "broker_order_id": "dlab-resting",
+                "execution_symbol": "UBER",
+                "side": "buy",
+                "filled_qty": "1",
+                "filled_avg_price": "69.65",
+                "created_at": "2026-08-09T15:00:00+00:00",
+            }
+        ],
+    )
+
+    fresh = await alpaca.read_fresh_truth(now=NOW, readers=readers)
+
+    assert [position.symbol for position in fresh.own_positions] == ["UBER"]
+    assert fresh.foreign_position_symbols == ()
+    assert fresh.own_open_orders == ()
+    assert [order.broker_order_id for order in fresh.foreign_open_orders] == [
+        "dlab-resting"
+    ]
+    assert us_cycle.broker_state(fresh=fresh).contaminated is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("ledger", "failure"),
+    [
+        ([], "no recognized lab execution correlation"),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "execution",
+                    "lifecycle_correlation_id": "dlab-rob73-other",
+                    "execution_symbol": "OTHER",
+                    "side": "buy",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                }
+            ],
+            "no recognized lab execution correlation",
+        ),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "execution",
+                    "lifecycle_correlation_id": "dlab-rob73-mismatch",
+                    "execution_symbol": "FAKE",
+                    "side": "buy",
+                    "filled_qty": "2",
+                    "filled_avg_price": "100",
+                }
+            ],
+            "broker quantity does not exactly match lab fills",
+        ),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "execution",
+                    "lifecycle_correlation_id": "dlab-rob73-no-fill",
+                    "execution_symbol": "FAKE",
+                    "side": "buy",
+                    "filled_qty": None,
+                    "filled_avg_price": "100",
+                }
+            ],
+            "lab fill quantity unavailable",
+        ),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "execution",
+                    "lifecycle_correlation_id": "dlab-rob73-sell",
+                    "execution_symbol": "FAKE",
+                    "side": "sell",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                }
+            ],
+            "broker quantity does not exactly match lab fills",
+        ),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "execution",
+                    "lifecycle_correlation_id": "rob73-main-account",
+                    "execution_symbol": "FAKE",
+                    "side": "buy",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                }
+            ],
+            "no recognized lab execution correlation",
+        ),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "execution",
+                    "lifecycle_correlation_id": "dlababc-no-hyphen",
+                    "execution_symbol": "FAKE",
+                    "side": "buy",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                }
+            ],
+            "no recognized lab execution correlation",
+        ),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "execution",
+                    "lifecycle_correlation_id": "xx-dlab-suffix",
+                    "execution_symbol": "FAKE",
+                    "side": "buy",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                }
+            ],
+            "no recognized lab execution correlation",
+        ),
+        (
+            [
+                {
+                    "account_mode": alpaca.LANE,
+                    "record_kind": "preview",
+                    "lifecycle_correlation_id": "dlab-rob73-preview",
+                    "execution_symbol": "FAKE",
+                    "side": "buy",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                }
+            ],
+            "no recognized lab execution correlation",
+        ),
+    ],
+)
+async def test_position_attribution_rejects_unlinked_mutants(
+    ledger: list[dict[str, Any]], failure: str
+) -> None:
+    readers, _ = _readers(
+        positions=[
+            {
+                "symbol": "FAKE",
+                "qty": "1",
+                "qty_available": "1",
+                "avg_entry_price": "100",
+            }
+        ],
+        ledger=ledger,
+    )
+
+    fresh = await alpaca.read_fresh_truth(now=NOW, readers=readers)
+
+    assert fresh.foreign_position_symbols == ("FAKE",)
+    assert fresh.position_linkage_failures == (f"FAKE: {failure}",)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("correlation", ["dlab-rob73-wrong-mode", "b0xu-wrong-mode"])
+async def test_recognized_prefix_requires_lab_account(correlation: str) -> None:
+    readers, _ = _readers(
+        ledger=[
+            {
+                "account_mode": "alpaca_paper",
+                "record_kind": "execution",
+                "lifecycle_correlation_id": correlation,
+                "execution_symbol": "FAKE",
+                "side": "buy",
+                "filled_qty": "1",
+                "filled_avg_price": "100",
+            }
+        ]
+    )
+
+    with pytest.raises(alpaca.LabTruthReadError, match="not bound"):
+        await alpaca.read_fresh_truth(now=NOW, readers=readers)
+
+
+def test_dlab_execution_today_keeps_realized_pnl_fail_closed() -> None:
+    execution = alpaca.LedgerExecution(
+        correlation_id="dlab-rob73-today",
+        client_order_id="dlab-rob73-today",
+        broker_order_id="dlab-order",
+        symbol="UBER",
+        side="buy",
+        filled_qty=Decimal("1"),
+        filled_avg_price=Decimal("69.65"),
+        created_at=NOW,
+    )
+
+    assert alpaca._realized_pnl_today((execution,), now=NOW) is None
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/b0x/us/test_cycle.py
+++ b/tests/scripts/b0x/us/test_cycle.py
@@ -286,3 +286,48 @@ async def test_foreign_residual_blocks_confirmed_submit_but_is_not_relabelled_ow
     assert outcome.record["fresh_truth"]["own_position_symbols"] == []
     assert "contaminated lab account state" in outcome.record["submission_skipped"]
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_dlab_manual_execution_is_attributed_and_does_not_skip_as_contaminated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The native lab smoke prefix removes only the false contamination path."""
+
+    readers, _ = _readers(
+        positions=[
+            {
+                "symbol": "UBER",
+                "qty": "1",
+                "qty_available": "1",
+                "avg_entry_price": "69.65",
+            }
+        ],
+        ledger=[
+            {
+                "account_mode": alpaca.LANE,
+                "record_kind": "execution",
+                "lifecycle_correlation_id": "dlab-rob73-uber",
+                "client_order_id": "dlab-rob73-uber",
+                "broker_order_id": "broker-uber",
+                "execution_symbol": "UBER",
+                "side": "buy",
+                "filled_qty": "1",
+                "filled_avg_price": "69.65",
+                "created_at": "2026-08-09T15:00:00+00:00",
+            }
+        ],
+    )
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        confirm=False,
+        readers=readers,
+    )
+
+    assert outcome.record["contaminated"] is False
+    assert outcome.record["fresh_truth"]["foreign_position_symbols"] == []
+    assert outcome.record["submission_skipped"].startswith("confirm=False")


### PR DESCRIPTION
## Summary
- attribute native dlab- lifecycle evidence for positions only
- preserve b0xu-only open-order ownership and cancellation scope
- retain account-mode, execution-kind, fill-evidence, and exact-quantity gates
- cover open-order A/B equivalence and unlinked-residue mutants

## Verification
- PYTHONPATH fixed US B0-X suite: 45 passed
- make lint
- before/after fake-reader A/B: dlab-linked open order remains foreign in both

Broker mutation: 0. Additional broker reads: 0. Env arm: 0.