### PR TITLE
research(uwtrim): underwater spike-trim historical backtest (crypto · KR · US)

### DIFF
--- a/research/underwater_spike_trim_study/README.md
+++ b/research/underwater_spike_trim_study/README.md
@@ -1,0 +1,106 @@
+# underwater_spike_trim_study
+
+Offline historical backtest of the §128차 `underwater_spike_trim` shadow, run
+across three markets (Upbit KRW crypto, KR equities, US equities) under one
+pre-registered specification.
+
+**Observation only.** Nothing in this package imports `app`, opens a socket,
+or touches a database. `tests/test_offline_boundary.py` proves that as a
+property of the import graph rather than as a claim.
+
+## The question
+
+An underwater position prints a big up-day with no resistance overhead. Is it
+better to
+
+1. keep holding,
+2. trim 10% into the spike, or
+3. trim 10% and rebid that 10% at support?
+
+## Pre-registration
+
+`spec.py` **is** the pre-registration and was frozen before any P&L was
+computed. Event definition, the three payoff formulas, the horizons, the
+cost-basis grid and the control design are all constants there. Changing one
+after seeing a result is a new round and must be labelled as such.
+
+Two proxy arms were added after observing *event counts only* (never P&L), and
+both are declared in `spec.py`:
+
+* `resistance_rule` — `named` (headline) vs `any` (literal). On a bar that
+  closes at a new window high, the production clustering reports exactly one
+  "resistance": `fib_0`, which is that same bar's own intraday high. The
+  literal rule therefore fires on ~1% of spike days, so the headline arm
+  ignores single-source `weak` clusters.
+* `rebid_strength` — `strong` (as written) vs `moderate_plus`. `strong`
+  requires three independent sources inside one 2% band and exists below the
+  price on only ~7% of crypto events, which would leave option (3) mostly
+  "unavailable". Both are reported; neither replaces the other.
+
+## Running
+
+```bash
+# scan one market's frozen corpus -> observations.jsonl + scan-summary.json
+uv run python -m research.underwater_spike_trim_study.run --market crypto
+uv run python -m research.underwater_spike_trim_study.run --market kr
+uv run python -m research.underwater_spike_trim_study.run --market us
+
+# sensitivity: the production get_support_resistance tool fetches 60 bars,
+# the pre-registered primary is 120
+uv run python -m research.underwater_spike_trim_study.run --market crypto --level-window 60
+
+# aggregate (never re-reads a corpus)
+uv run python -m research.underwater_spike_trim_study.report \
+  --observations <out>/crypto/observations.jsonl --out <out>/crypto/report.json
+
+# the one real underwater lot
+uv run python -m research.underwater_spike_trim_study.case_study \
+  --observations <out>/crypto/observations.jsonl --out <out>/crypto/xrp-case.json
+```
+
+Tests live under `tests/` and are **not** collected by CI (`testpaths =
+["tests"]` in `pyproject.toml`). Run them explicitly:
+
+```bash
+uv run pytest research/underwater_spike_trim_study/tests/ -q
+```
+
+## Data
+
+| Market | Corpus | Exploration span | Universe | Sealed |
+|---|---|---|---|---|
+| crypto | `crypto-corpus-v1` `dataset-labeled/venue=upbit_krw` | 2017-10-24 → 2024-12-31 | 139 KRW markets, `SURVIVORSHIP_BIASED` | 2025-01-01 → 2026-08-01 |
+| kr | `kr-corpus-v1` run `20260803-1001` | 2015-01-01 → 2024-12-31 | KOSPI + KOSDAQ, `BUILT_WITH_GAPS` | 2025-01-01 → 2026-07-31 |
+| us | `us-corpus-v1` `dataset/market=us` | 2016-01-01 → 2024-12-31 | 5,355 frozen active common stocks, `SURVIVORSHIP_BIASED=TRUE` | 2025-01-01 → 2026-07-31 |
+
+Every sealed holdout is refused through that corpus's own guard
+(`crypto_corpus.loader`, `kr_corpus.backtest.holdout_guard`,
+`us_corpus.holdout_gate`). No result here covers 2025 or later.
+
+## Market-specific honesty rules
+
+* **KR ceiling locks.** A zero-range bar whose close-to-close move sits at the
+  statutory daily cap (±30% from 2015-06-15, ±15% before) is treated as
+  price-unreachable: the trim is recorded as non-executable and the bar is
+  removed from the rebid fill window. `fill_used_locked_bar` records whether
+  that removal actually changed a fill verdict, so the exclusion's cost is
+  measured rather than assumed.
+* **Gaps.** Every observation is valued twice — `event_close` (trim at the
+  event bar's close) and `next_open` (trim at the following bar's open, exit
+  at the open `H` sessions later). `gap_next_open` is reported per market.
+* **Missing sessions.** A close-to-close return that silently bridges a
+  dropped session is not a 24h return. Bars whose predecessor is not the
+  immediately preceding calendar session are excluded from the event and
+  control pools entirely.
+
+## Files
+
+| File | Role |
+|---|---|
+| `spec.py` | the frozen pre-registration |
+| `levels.py` | pure port of the production S/R + RSI arithmetic |
+| `corpora.py` | the three corpus readers, normalised to one bar schema |
+| `events.py` | event detection and seeded control sampling |
+| `simulate.py` | the three options' payoffs (no data access) |
+| `report.py` | aggregation into arms |
+| `case_study.py` | the real Upbit KRW-XRP lot |

--- a/research/underwater_spike_trim_study/__init__.py
+++ b/research/underwater_spike_trim_study/__init__.py
@@ -1,0 +1,11 @@
+"""Offline historical backtest of the §128 underwater-spike-trim shadow.
+
+The package answers one pre-registered question — is it better to (1) keep
+holding, (2) trim 10%, or (3) trim 10% and rebid at support — when an
+underwater position prints a >=+12% day with RSI(14) >= 75 and no named
+resistance overhead.
+
+Everything here reads frozen corpus Parquet files only.  There is no network
+call, no database session, no broker adapter, and no credential lookup on any
+code path, so the study can never move a real position.
+"""

--- a/research/underwater_spike_trim_study/case_study.py
+++ b/research/underwater_spike_trim_study/case_study.py
@@ -1,0 +1,133 @@
+"""The one real underwater lot: Upbit KRW-XRP.
+
+The lot facts below are a *literal input*, transcribed from a read-only
+holdings snapshot taken on 2026-08-21 outside this package.  Keeping them as
+constants is what lets the study stay offline — nothing here calls a broker.
+
+    quantity        2758.02569914
+    avg_buy_price   2,118.736 KRW
+    current_price   1,738 KRW
+    profit_rate     -17.97%
+
+The average cost therefore sits +21.90% above the market, between the
+pre-registered +20% and +30% grid points.
+
+🔴 Scope limit: crypto-corpus-v1's exploration tree ends 2024-12-31 and
+2025-01-01 onward is a sealed holdout.  The live 2026 lot cannot be replayed
+against its own forward data.  What this case study answers is narrower and
+stated as such: *given KRW-XRP's own historical spike events, what would the
+three options have produced for a holder whose cost sat +21.90% above the
+event price?*
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .report import Arm, load_observations, summarise
+from .simulate import cost_basis_view, option_values
+from .spec import BASES, HORIZONS
+
+XRP_SYMBOL = "KRW-XRP"
+XRP_QUANTITY = 2758.02569914
+XRP_AVG_BUY_PRICE = 2118.73604672
+XRP_SNAPSHOT_PRICE = 1738.0
+XRP_SNAPSHOT_DATE = "2026-08-21"
+XRP_COST_PREMIUM = XRP_AVG_BUY_PRICE / XRP_SNAPSHOT_PRICE - 1.0
+
+
+def case_study(
+    observations: list[dict[str, Any]],
+    *,
+    symbol: str = XRP_SYMBOL,
+    cost_premium: float = XRP_COST_PREMIUM,
+) -> dict[str, Any]:
+    subset = [o for o in observations if o["symbol"] == symbol]
+    events = [o for o in subset if o["kind"] == "event"]
+
+    per_event: list[dict[str, Any]] = []
+    for observation in events:
+        row: dict[str, Any] = {
+            "session": observation["session"],
+            "ret_24h": observation["ret_24h"],
+            "rsi": observation["rsi"],
+            "resistance_count": observation["resistance_count"],
+            "named_resistance_count": observation["named_resistance_count"],
+            "rebuy_price_strong": observation["rebuy_price"],
+            "rebuy_price_moderate_plus": observation["rebuy_price_moderate_plus"],
+        }
+        for horizon in HORIZONS:
+            block = observation["forward"][f"event_close:{horizon}"]
+            rebuy = observation["rebuy_price_moderate_plus"]
+            if rebuy is not None and rebuy >= block["p0"]:
+                rebuy = None
+            values = option_values(
+                p0=block["p0"],
+                pt=block["exit_price"],
+                rebuy_price=rebuy,
+                window_low=block["window_low"],
+            )
+            view = cost_basis_view(values, p0=block["p0"], cost_premium=cost_premium)
+            row[f"d{horizon}"] = {
+                "p0": block["p0"],
+                "exit_price": block["exit_price"],
+                "hold_return": values.hold / block["p0"] - 1.0,
+                "trim_minus_hold": (values.trim - values.hold) / block["p0"],
+                "rebid_minus_hold": (
+                    None
+                    if values.rebid is None
+                    else (values.rebid - values.hold) / block["p0"]
+                ),
+                "rebuy_filled": values.rebuy_filled,
+                "hold_still_underwater": bool(view["hold_still_underwater"]),
+                "trim_still_underwater": bool(view["trim_still_underwater"]),
+            }
+        per_event.append(row)
+
+    aggregate = {
+        f"{basis}:{horizon}": summarise(
+            subset, Arm("named", "moderate_plus", basis, horizon, "event")
+        )
+        for basis in BASES
+        for horizon in HORIZONS
+    }
+    return {
+        "symbol": symbol,
+        "lot": {
+            "snapshot_date": XRP_SNAPSHOT_DATE,
+            "quantity": XRP_QUANTITY,
+            "avg_buy_price": XRP_AVG_BUY_PRICE,
+            "snapshot_price": XRP_SNAPSHOT_PRICE,
+            "cost_premium": cost_premium,
+            "trim_10pct_quantity": XRP_QUANTITY * 0.10,
+            "trim_10pct_proceeds_at_snapshot": XRP_QUANTITY * 0.10 * XRP_SNAPSHOT_PRICE,
+            "realised_loss_on_that_trim": XRP_QUANTITY
+            * 0.10
+            * (XRP_SNAPSHOT_PRICE - XRP_AVG_BUY_PRICE),
+        },
+        "events": per_event,
+        "aggregate": aggregate,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--observations", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--symbol", default=XRP_SYMBOL)
+    args = parser.parse_args(argv)
+
+    payload = case_study(load_observations(args.observations), symbol=args.symbol)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(json.dumps({"symbol": payload["symbol"], "events": len(payload["events"])}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/underwater_spike_trim_study/corpora.py
+++ b/research/underwater_spike_trim_study/corpora.py
@@ -1,0 +1,359 @@
+"""Frozen-corpus readers for the three markets, normalised to one bar schema.
+
+Every reader is offline: it opens Parquet files under
+``/Users/mgh3326/work/herdr-artifacts`` and nothing else.  Sealed holdout
+trees are refused through each corpus's own guard, so a mistake raises
+instead of silently shrinking the sample.
+
+Normalised frame per symbol, ascending by session, index reset:
+
+    session (datetime64[ns]) | open | high | low | close | volume
+
+plus two derived columns the market adapters own:
+
+    contiguous_prev  bool   previous row is the immediately preceding
+                            trading session of this market's calendar
+    limit_locked     int    -1 limit-down lock, 0 none, +1 limit-up lock
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+
+from research.crypto_corpus.loader import load_labeled_parquet_files
+from research.kr_corpus.backtest.holdout_guard import assert_path_not_holdout
+from research.us_corpus.holdout_gate import guard_read
+
+CRYPTO_DATASET = Path(
+    "/Users/mgh3326/work/herdr-artifacts/crypto-corpus-v1/dataset-labeled/venue=upbit_krw"
+)
+KR_RUN_DATASET = Path(
+    "/Users/mgh3326/work/herdr-artifacts/kr-corpus-v1/runs/"
+    "kr-corpus-v1-20260803-1001/dataset"
+)
+US_DATASET = Path("/Users/mgh3326/work/herdr-artifacts/us-corpus-v1/dataset/market=us")
+
+BAR_COLUMNS = ["session", "open", "high", "low", "close", "volume"]
+
+# KRX daily price limit: +-15% until 2015-06-14, +-30% from 2015-06-15.
+KR_LIMIT_CHANGE_DATE = pd.Timestamp("2015-06-15")
+KR_LIMIT_BEFORE = 0.15
+KR_LIMIT_AFTER = 0.30
+# Adjusted prices and tick rounding move the realised cap off the nominal one.
+KR_LIMIT_TOLERANCE = 0.02
+
+
+@dataclass(frozen=True)
+class SymbolBars:
+    """One symbol's cleaned daily history plus the rows that were dropped."""
+
+    market: str
+    symbol: str
+    frame: pd.DataFrame
+    dropped_invalid_rows: int
+    inconsistent_ohlc_rows: int
+    group: str = ""
+    segment: str = ""
+
+
+@dataclass(frozen=True)
+class CorpusCoverage:
+    market: str
+    symbols: int
+    rows: int
+    first_session: str | None
+    last_session: str | None
+    dropped_invalid_rows: int
+    inconsistent_ohlc_rows: int
+    non_contiguous_rows: int
+
+
+def _clean(frame: pd.DataFrame) -> tuple[pd.DataFrame, int, int]:
+    """Drop unusable bars and count the OHLC-consistency violations kept."""
+    frame = frame.loc[:, BAR_COLUMNS].copy()
+    for column in ("open", "high", "low", "close", "volume"):
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+    before = len(frame)
+    positive = (
+        frame[["open", "high", "low", "close"]].gt(0).all(axis=1)
+        & frame["volume"].notna()
+        & frame["session"].notna()
+    )
+    frame = frame.loc[positive]
+    dropped = before - len(frame)
+
+    frame = frame.sort_values("session").drop_duplicates("session", keep="last")
+    inconsistent = int(
+        (
+            (frame["high"] < frame[["open", "close"]].max(axis=1))
+            | (frame["low"] > frame[["open", "close"]].min(axis=1))
+            | (frame["high"] < frame["low"])
+        ).sum()
+    )
+    return frame.reset_index(drop=True), dropped, inconsistent
+
+
+def _mark_contiguity(
+    frame: pd.DataFrame, calendar: pd.DatetimeIndex | None
+) -> pd.DataFrame:
+    """Flag rows whose previous bar is the previous *calendar* session.
+
+    A close-to-close return that silently bridges a missing session is not a
+    24h return.  KR's corpus drops 171k main-scope sessions and the drops skew
+    to strong up-closes, so this flag is load-bearing there, not cosmetic.
+    """
+    frame = frame.copy()
+    if calendar is None:
+        # Crypto: every UTC day is a session.
+        delta = frame["session"].diff()
+        frame["contiguous_prev"] = delta == pd.Timedelta(days=1)
+    else:
+        rank = pd.Series(np.arange(len(calendar)), index=calendar)
+        positions = frame["session"].map(rank)
+        frame["contiguous_prev"] = positions.diff() == 1
+    frame.loc[frame.index[:1], "contiguous_prev"] = False
+    frame["contiguous_prev"] = frame["contiguous_prev"].fillna(False).astype(bool)
+    return frame
+
+
+def _mark_no_limit(frame: pd.DataFrame) -> pd.DataFrame:
+    frame = frame.copy()
+    frame["limit_locked"] = 0
+    return frame
+
+
+# --------------------------------------------------------------------------
+# Crypto — Upbit KRW daily, crypto-corpus-v1 exploration tree (2017-2024).
+# --------------------------------------------------------------------------
+
+_CRYPTO_FILE = re.compile(r"^(?P<symbol>[^/]+)__1d__")
+
+
+def crypto_symbol_files() -> dict[str, list[Path]]:
+    files: dict[str, list[Path]] = {}
+    for path_str in sorted(
+        glob.glob(str(CRYPTO_DATASET / "year=*" / "*__1d__*.parquet"))
+    ):
+        path = Path(path_str)
+        match = _CRYPTO_FILE.match(path.name)
+        if match is None:
+            continue
+        files.setdefault(match.group("symbol"), []).append(path)
+    return files
+
+
+def load_crypto(symbols: list[str] | None = None) -> Iterator[SymbolBars]:
+    """Load Upbit KRW daily bars through the corpus's fail-closed loader.
+
+    ``consumer_intent="time_series"`` is correct and deliberate: every symbol
+    is loaded and evaluated on its own timeline, and no ranking or selection
+    is ever made across symbols on a shared date.  That is what keeps the
+    Upbit XSEC survivorship opt-in from being required — the survivor bias is
+    still disclosed in the report.
+    """
+    per_symbol = crypto_symbol_files()
+    for symbol, paths in per_symbol.items():
+        if symbols is not None and symbol not in symbols:
+            continue
+        corpus = load_labeled_parquet_files(tuple(paths), consumer_intent="time_series")
+        frame = corpus.table.to_pandas()
+        frame = frame.rename(columns={"base_volume": "volume"})
+        frame["session"] = pd.to_datetime(
+            frame["open_time_utc"], utc=True
+        ).dt.tz_localize(None)
+        cleaned, dropped, inconsistent = _clean(frame)
+        cleaned = _mark_no_limit(_mark_contiguity(cleaned, calendar=None))
+        yield SymbolBars(
+            market="crypto",
+            symbol=symbol,
+            frame=cleaned,
+            dropped_invalid_rows=dropped,
+            inconsistent_ohlc_rows=inconsistent,
+            group="upbit_krw",
+            segment="upbit_krw",
+        )
+
+
+# --------------------------------------------------------------------------
+# KR — kr-corpus-v1 immutable run snapshot (2015-2024, BUILT_WITH_GAPS).
+# --------------------------------------------------------------------------
+
+
+def kr_symbol_files() -> dict[tuple[str, str], list[Path]]:
+    files: dict[tuple[str, str], list[Path]] = {}
+    for path_str in sorted(
+        glob.glob(str(KR_RUN_DATASET / "market=*" / "year=*" / "ticker=*.parquet"))
+    ):
+        path = Path(path_str)
+        assert_path_not_holdout(path)
+        market = path.parts[-3].split("=", 1)[1]
+        ticker = path.stem.split("=", 1)[1]
+        files.setdefault((market, ticker), []).append(path)
+    return files
+
+
+def kr_trading_calendar(
+    market_files: dict[tuple[str, str], list[Path]],
+) -> pd.DatetimeIndex:
+    """Union of every session that survives in the snapshot, per KRX overall.
+
+    Built from the membership partition names rather than the bar rows, so a
+    ticker's own missing session is still measured against a real calendar.
+    """
+    membership_root = KR_RUN_DATASET.parent / "membership"
+    sessions = {
+        Path(p).stem.split("=", 1)[1]
+        for p in glob.glob(
+            str(membership_root / "market=*" / "year=*" / "session=*.parquet")
+        )
+    }
+    if not sessions:
+        raise FileNotFoundError(f"no KR membership sessions under {membership_root}")
+    return pd.DatetimeIndex(sorted(pd.to_datetime(sorted(sessions))))
+
+
+def _kr_limit_flags(frame: pd.DataFrame) -> pd.Series:
+    """+1 limit-up lock, -1 limit-down lock, 0 otherwise.
+
+    A lock is a zero-range bar (``high == low``) whose close-to-close move sits
+    at the statutory daily cap.  Both conditions are required: a zero-range bar
+    at a normal price move is an illiquid no-trade day, not a lock.
+    """
+    prev_close = frame["close"].shift(1)
+    ret = frame["close"] / prev_close - 1.0
+    cap = np.where(
+        frame["session"] >= KR_LIMIT_CHANGE_DATE, KR_LIMIT_AFTER, KR_LIMIT_BEFORE
+    )
+    zero_range = frame["high"] <= frame["low"]
+    locked_up = zero_range & (ret >= cap - KR_LIMIT_TOLERANCE)
+    locked_down = zero_range & (ret <= -(cap - KR_LIMIT_TOLERANCE))
+    return pd.Series(
+        np.where(locked_up, 1, np.where(locked_down, -1, 0)),
+        index=frame.index,
+        dtype=int,
+    )
+
+
+def load_kr(symbols: list[str] | None = None) -> Iterator[SymbolBars]:
+    per_symbol = kr_symbol_files()
+    calendar = kr_trading_calendar(per_symbol)
+    for (market, ticker), paths in per_symbol.items():
+        if symbols is not None and ticker not in symbols:
+            continue
+        frames = []
+        for path in paths:
+            table = pq.ParquetFile(assert_path_not_holdout(path)).read()
+            part = table.to_pandas()
+            part["session"] = pd.to_datetime(part["session"])
+            frames.append(part)
+        frame = pd.concat(frames, ignore_index=True)
+        cleaned, dropped, inconsistent = _clean(frame)
+        cleaned = _mark_contiguity(cleaned, calendar=calendar)
+        cleaned["limit_locked"] = _kr_limit_flags(cleaned)
+        yield SymbolBars(
+            market="kr",
+            symbol=ticker,
+            frame=cleaned,
+            dropped_invalid_rows=dropped,
+            inconsistent_ohlc_rows=inconsistent,
+            # No proven common-stock classification exists in kr-corpus-v1
+            # (``NO_PROVEN_COMMON_STOCK_ROWS``).  The KRX code convention —
+            # common issues end in 0 — is recorded as a *label* so the report
+            # can slice on it; it never filters the primary sample.
+            group="code_suffix_0" if ticker.endswith("0") else "code_suffix_other",
+            segment=market,
+        )
+
+
+# --------------------------------------------------------------------------
+# US — us-corpus-v1 exploration tree (2016-2024, SURVIVORSHIP_BIASED=TRUE).
+# --------------------------------------------------------------------------
+
+
+def us_year_files() -> list[Path]:
+    paths = [
+        guard_read(Path(p), reason="underwater-spike-trim backtest, exploration only")
+        for p in sorted(glob.glob(str(US_DATASET / "year=*" / "*.parquet")))
+    ]
+    if not paths:
+        raise FileNotFoundError(f"no US exploration partitions under {US_DATASET}")
+    return paths
+
+
+def load_us(symbols: list[str] | None = None) -> Iterator[SymbolBars]:
+    """Load the whole US exploration tree once, then yield per symbol.
+
+    The corpus is stored one Parquet part per year rather than per symbol, so
+    a per-symbol read would rescan every year file.  Peak memory is ~7.5M rows
+    x 6 numeric columns, which fits comfortably.
+    """
+    frames = []
+    for path in us_year_files():
+        part = pq.ParquetFile(path).read(
+            columns=["symbol", "session_date", "open", "high", "low", "close", "volume"]
+        )
+        frames.append(part.to_pandas())
+    everything = pd.concat(frames, ignore_index=True)
+    everything["session"] = pd.to_datetime(everything["session_date"])
+    if symbols is not None:
+        everything = everything[everything["symbol"].isin(symbols)]
+    calendar = pd.DatetimeIndex(sorted(everything["session"].unique()))
+    for symbol, group in everything.groupby("symbol", sort=True):
+        cleaned, dropped, inconsistent = _clean(group)
+        cleaned = _mark_no_limit(_mark_contiguity(cleaned, calendar=calendar))
+        yield SymbolBars(
+            market="us",
+            symbol=str(symbol),
+            frame=cleaned,
+            dropped_invalid_rows=dropped,
+            inconsistent_ohlc_rows=inconsistent,
+            group="common_stock_frozen_universe",
+            segment="us",
+        )
+
+
+LOADERS = {"crypto": load_crypto, "kr": load_kr, "us": load_us}
+
+
+def load_market(market: str, symbols: list[str] | None = None) -> Iterator[SymbolBars]:
+    try:
+        loader = LOADERS[market]
+    except KeyError as exc:  # pragma: no cover - CLI validates first
+        raise ValueError(f"unsupported market {market!r}") from exc
+    return loader(symbols)
+
+
+def assert_offline_environment() -> None:
+    """Cheap belt-and-braces check that nothing here needs a network or DB.
+
+    The real guarantee is structural (no client import anywhere in the
+    package); this only catches an operator who exported a proxy expecting the
+    study to phone out.
+    """
+    for variable in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        if os.environ.get(variable):
+            raise RuntimeError(
+                f"{variable} is set; this study makes no network calls and a proxy "
+                "expectation means the run was configured wrongly"
+            )
+
+
+__all__ = [
+    "BAR_COLUMNS",
+    "CorpusCoverage",
+    "SymbolBars",
+    "assert_offline_environment",
+    "load_crypto",
+    "load_kr",
+    "load_market",
+    "load_us",
+]

--- a/research/underwater_spike_trim_study/events.py
+++ b/research/underwater_spike_trim_study/events.py
@@ -1,0 +1,299 @@
+"""Event detection and matched-control sampling over one symbol's bars.
+
+Look-ahead discipline
+---------------------
+Every field that decides whether a bar is an event is computed from bars at
+index <= i:
+
+  * ``ret_24h``  = close[i] / close[i-1] - 1
+  * ``rsi``      = Wilder RSI over close[:i+1]
+  * ``levels``   = S/R proxy over bars [i-119 .. i]
+
+Fields read from bars after i (``exit_price``, ``window_low``, the next
+open) are named ``fwd_*`` or live on the outcome side, never in the gate.
+``tests/test_no_lookahead.py`` truncates each frame at the event bar and
+re-derives the gate fields to prove it.
+"""
+
+from __future__ import annotations
+
+import zlib
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .corpora import SymbolBars
+from .levels import compute_levels, rsi_series
+from .spec import (
+    BASIS_EVENT_CLOSE,
+    BASIS_NEXT_OPEN,
+    CONTROLS_PER_EVENT,
+    HORIZONS,
+    LEVEL_WINDOW,
+    RANDOM_SEED,
+    REBUY_STRENGTH,
+    REBUY_STRENGTH_FALLBACK,
+    RESISTANCE_COUNT_MAX,
+    RSI_MIN,
+    RSI_PERIOD,
+    SPIKE_RETURN_MIN,
+)
+
+
+@dataclass
+class Observation:
+    """One decision point — an event or one of its matched controls."""
+
+    market: str
+    segment: str
+    group: str
+    symbol: str
+    kind: str  # "event" | "control"
+    index: int
+    session: str
+    prev_close: float
+    close: float
+    ret_24h: float
+    rsi: float
+    resistance_count: int
+    named_resistance_count: int
+    rebuy_price: float | None
+    rebuy_price_moderate_plus: float | None
+    nearest_support_any: float | None
+    limit_locked: int
+    next_open_limit_locked: int
+    gap_next_open: float | None
+    forward: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def _max_lookahead(horizons: tuple[int, ...]) -> int:
+    """Bars needed after the event bar so both bases and both horizons exist."""
+    return max(horizons) + 1
+
+
+def eligible_mask(
+    frame: pd.DataFrame,
+    horizons: tuple[int, ...] = HORIZONS,
+    level_window: int = LEVEL_WINDOW,
+) -> np.ndarray:
+    """Bars with a full trailing window, a real 24h step, and a full forward window."""
+    n = len(frame)
+    mask = np.zeros(n, dtype=bool)
+    if n == 0:
+        return mask
+    first = level_window - 1
+    last = n - 1 - _max_lookahead(horizons)
+    if last < first:
+        return mask
+    mask[first : last + 1] = True
+    return mask & frame["contiguous_prev"].to_numpy(dtype=bool)
+
+
+def _forward_block(
+    frame: pd.DataFrame,
+    i: int,
+    horizon: int,
+    basis: str,
+    rebuy_price: float | None,
+) -> dict[str, Any]:
+    """Decision price, exit price and the rebid fill test for one basis.
+
+    The rebid fill window is bars ``i+1 .. i+horizon`` under both bases: the
+    trim lands at ``close[i]`` (continuous markets) or ``open[i+1]`` (gap
+    basis), and in either case bar ``i+1`` onwards is live for the rebid.
+
+    KR limit-up locked bars are removed from the fill window: their whole
+    range collapses to the ceiling, so a printed touch is not a reachable
+    price.  ``fill_used_locked_bar`` records whether that removal changed the
+    answer, so the exclusion's real cost is measurable rather than assumed.
+    """
+    opens = frame["open"].to_numpy(dtype=float)
+    lows = frame["low"].to_numpy(dtype=float)
+    closes = frame["close"].to_numpy(dtype=float)
+    locked = frame["limit_locked"].to_numpy(dtype=int)
+
+    if basis == BASIS_EVENT_CLOSE:
+        p0 = float(closes[i])
+        pt = float(closes[i + horizon])
+        executable = locked[i] != 1
+    elif basis == BASIS_NEXT_OPEN:
+        p0 = float(opens[i + 1])
+        pt = float(opens[i + 1 + horizon])
+        executable = locked[i + 1] != 1
+    else:  # pragma: no cover - callers pass literals from spec
+        raise ValueError(f"unsupported basis {basis!r}")
+
+    window = slice(i + 1, i + horizon + 1)
+    window_lows = lows[window]
+    window_locked_up = locked[window] == 1
+    low_all = float(window_lows.min()) if window_lows.size else None
+    tradable = window_lows[~window_locked_up]
+    low_tradable = float(tradable.min()) if tradable.size else None
+
+    fill_used_locked_bar = False
+    if rebuy_price is not None and low_all is not None:
+        would_fill_all = low_all <= rebuy_price
+        would_fill_tradable = low_tradable is not None and low_tradable <= rebuy_price
+        fill_used_locked_bar = bool(would_fill_all and not would_fill_tradable)
+
+    return {
+        "basis": basis,
+        "horizon": horizon,
+        "p0": p0,
+        "exit_price": pt,
+        "window_low": low_tradable,
+        "window_low_including_locked": low_all,
+        "trim_executable": bool(executable),
+        "fill_used_locked_bar": fill_used_locked_bar,
+    }
+
+
+def _observation(
+    bars: SymbolBars,
+    frame: pd.DataFrame,
+    i: int,
+    kind: str,
+    rsi: np.ndarray,
+    ret: np.ndarray,
+    price_decimals: int | None,
+    level_window: int,
+) -> Observation | None:
+    window = frame.iloc[i - level_window + 1 : i + 1]
+    try:
+        view = compute_levels(window, price_decimals=price_decimals)
+    except ValueError:
+        # A degenerate window (zero traded volume across 120 sessions) cannot
+        # produce levels.  Dropping the bar is the fail-closed answer; the
+        # count is reported.
+        return None
+
+    opens = frame["open"].to_numpy(dtype=float)
+    closes = frame["close"].to_numpy(dtype=float)
+    locked = frame["limit_locked"].to_numpy(dtype=int)
+    rebuy_price = view.nearest_support(REBUY_STRENGTH)
+    rebuy_price_moderate_plus = view.nearest_support(REBUY_STRENGTH_FALLBACK)
+
+    observation = Observation(
+        market=bars.market,
+        segment=bars.segment,
+        group=bars.group,
+        symbol=bars.symbol,
+        kind=kind,
+        index=i,
+        session=str(frame["session"].iloc[i].date()),
+        prev_close=float(closes[i - 1]),
+        close=float(closes[i]),
+        ret_24h=float(ret[i]),
+        rsi=float(rsi[i]),
+        resistance_count=view.resistance_count,
+        named_resistance_count=view.named_resistance_count,
+        rebuy_price=rebuy_price,
+        rebuy_price_moderate_plus=rebuy_price_moderate_plus,
+        nearest_support_any=view.nearest_support(None),
+        limit_locked=int(locked[i]),
+        next_open_limit_locked=int(locked[i + 1]),
+        gap_next_open=float(opens[i + 1] / closes[i] - 1.0),
+    )
+    for horizon in HORIZONS:
+        for basis in (BASIS_EVENT_CLOSE, BASIS_NEXT_OPEN):
+            block = _forward_block(frame, i, horizon, basis, rebuy_price)
+            fallback = _forward_block(
+                frame, i, horizon, basis, rebuy_price_moderate_plus
+            )
+            block["fill_used_locked_bar_moderate_plus"] = fallback[
+                "fill_used_locked_bar"
+            ]
+            observation.forward[f"{basis}:{horizon}"] = block
+    return observation
+
+
+def _symbol_rng(market: str, symbol: str) -> np.random.Generator:
+    """Deterministic per-symbol stream.
+
+    ``zlib.crc32`` rather than ``hash()``: Python's string hash is salted per
+    process, which would make control sampling irreproducible across runs.
+    """
+    key = f"{market}:{symbol}".encode()
+    return np.random.default_rng(RANDOM_SEED + zlib.crc32(key))
+
+
+@dataclass
+class ScanResult:
+    observations: list[Observation]
+    bars_scanned: int
+    eligible_bars: int
+    prefilter_hits: int
+    events: int
+    events_dropped_degenerate_window: int
+    events_rejected_resistance: int
+    control_candidates: int
+
+
+def scan_symbol(
+    bars: SymbolBars,
+    *,
+    price_decimals: int | None = None,
+    level_window: int = LEVEL_WINDOW,
+) -> ScanResult:
+    """Find the symbol's events and draw its matched controls."""
+    frame = bars.frame
+    n = len(frame)
+    empty = ScanResult([], n, 0, 0, 0, 0, 0, 0)
+    if n < level_window + _max_lookahead(HORIZONS) + 1:
+        return empty
+
+    closes = frame["close"]
+    ret = (closes / closes.shift(1) - 1.0).to_numpy(dtype=float)
+    rsi = rsi_series(closes, period=RSI_PERIOD).to_numpy(dtype=float)
+
+    eligible = eligible_mask(frame, level_window=level_window)
+    if not eligible.any():
+        return empty
+
+    with np.errstate(invalid="ignore"):
+        prefilter = eligible & (ret >= SPIKE_RETURN_MIN) & (rsi >= RSI_MIN)
+    prefilter_indices = np.flatnonzero(prefilter)
+
+    observations: list[Observation] = []
+    degenerate = 0
+    rejected_resistance = 0
+    for i in prefilter_indices:
+        observation = _observation(
+            bars, frame, int(i), "event", rsi, ret, price_decimals, level_window
+        )
+        if observation is None:
+            degenerate += 1
+            continue
+        # Gate on the looser "named" rule.  The strict arm
+        # (``resistance_count == 0``) is a strict subset of what passes here,
+        # so one scan serves both arms and the report slices between them.
+        if observation.named_resistance_count > RESISTANCE_COUNT_MAX:
+            rejected_resistance += 1
+            continue
+        observations.append(observation)
+
+    events = len(observations)
+    control_pool = np.flatnonzero(eligible & ~prefilter)
+    if events and control_pool.size:
+        rng = _symbol_rng(bars.market, bars.symbol)
+        wanted = min(events * CONTROLS_PER_EVENT, control_pool.size)
+        picks = rng.choice(control_pool, size=wanted, replace=False)
+        for i in np.sort(picks):
+            observation = _observation(
+                bars, frame, int(i), "control", rsi, ret, price_decimals, level_window
+            )
+            if observation is not None:
+                observations.append(observation)
+
+    return ScanResult(
+        observations=observations,
+        bars_scanned=n,
+        eligible_bars=int(eligible.sum()),
+        prefilter_hits=int(prefilter.sum()),
+        events=events,
+        events_dropped_degenerate_window=degenerate,
+        events_rejected_resistance=rejected_resistance,
+        control_candidates=int(control_pool.size),
+    )

--- a/research/underwater_spike_trim_study/levels.py
+++ b/research/underwater_spike_trim_study/levels.py
@@ -1,0 +1,437 @@
+"""Pure port of the repository's support/resistance and RSI arithmetic.
+
+Why a port and not an import
+----------------------------
+``app.mcp_server.tooling.market_data_indicators`` holds the production
+clustering logic, but importing it pulls ``app.core.config.settings`` in
+through the broker clients, which raises unless KIS/Upbit/OpenDART
+credentials and ``DATABASE_URL`` are present in the environment.  The
+pre-registered spec requires this study to run with zero network, zero
+database and no credentials, so the arithmetic is reproduced here instead.
+
+The port is not an approximation.  ``tests/test_levels_match_repo.py``
+imports the production functions (under throw-away dummy settings) and
+asserts value-for-value equality on randomised frames.  That test is opt-in
+and skips when the import fails; the study itself never imports ``app``.
+
+One deliberate deviation: the production helpers ``round(price, 2)`` because
+they feed a JSON display surface.  Two decimals silently destroys sub-KRW
+crypto prices, so ``price_decimals`` defaults to ``None`` (full precision)
+here.  Passing ``price_decimals=2`` reproduces production byte-for-byte.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+
+# Mirrors app.mcp_server.tooling.market_data_indicators.
+FIBONACCI_LEVELS = [0.0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0]
+DEFAULT_RSI_PERIOD = 14
+DEFAULT_BOLLINGER_PERIOD = 20
+DEFAULT_BOLLINGER_STD = 2.0
+DEFAULT_VOLUME_PROFILE_BINS = 20
+DEFAULT_CLUSTER_TOLERANCE_PCT = 0.02
+
+Strength = Literal["weak", "moderate", "strong"]
+
+
+def _maybe_round(value: float, decimals: int | None) -> float:
+    return float(value) if decimals is None else round(float(value), decimals)
+
+
+def rsi_series(close: pd.Series, period: int = DEFAULT_RSI_PERIOD) -> pd.Series:
+    """Wilder RSI, identical recursion to ``_calculate_rsi``.
+
+    The production helper returns only the last value; a full series is needed
+    here because every bar in a symbol is a candidate event day.  The EWM
+    recursion is causal, so ``rsi_series(close)[i]`` uses ``close[:i + 1]``
+    only — see ``tests/test_no_lookahead.py``.
+    """
+    close = close.astype(float)
+    delta = close.diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = (-delta).where(delta < 0, 0.0)
+    avg_gain = gain.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    return 100 - (100 / (1 + rs))
+
+
+def calculate_fibonacci(
+    df: pd.DataFrame,
+    current_price: float,
+    *,
+    price_decimals: int | None = None,
+) -> dict[str, Any]:
+    """Port of ``_calculate_fibonacci`` (date strings dropped as unused)."""
+    high = df["high"].astype(float)
+    low = df["low"].astype(float)
+
+    swing_high_price = _maybe_round(float(high.max()), price_decimals)
+    swing_low_price = _maybe_round(float(low.min()), price_decimals)
+    swing_high_pos = int(high.values.argmax())
+    swing_low_pos = int(low.values.argmin())
+
+    span = swing_high_price - swing_low_price
+    if swing_high_pos > swing_low_pos:
+        trend = "retracement_from_high"
+        levels = {
+            str(lvl): _maybe_round(swing_high_price - lvl * span, price_decimals)
+            for lvl in FIBONACCI_LEVELS
+        }
+    else:
+        trend = "bounce_from_low"
+        levels = {
+            str(lvl): _maybe_round(swing_low_price + lvl * span, price_decimals)
+            for lvl in FIBONACCI_LEVELS
+        }
+
+    return {
+        "swing_high": {"price": swing_high_price},
+        "swing_low": {"price": swing_low_price},
+        "trend": trend,
+        "current_price": current_price,
+        "levels": levels,
+    }
+
+
+def calculate_bollinger(
+    close: pd.Series,
+    period: int = DEFAULT_BOLLINGER_PERIOD,
+    std: float = DEFAULT_BOLLINGER_STD,
+) -> dict[str, float | None]:
+    """Port of ``_calculate_bollinger`` (pandas sample stddev, ddof=1)."""
+    close = close.astype(float)
+    if len(close) < period:
+        return {"upper": None, "middle": None, "lower": None}
+    sma = close.rolling(window=period).mean()
+    rolling_std = close.rolling(window=period).std()
+    upper = sma + (rolling_std * std)
+    lower = sma - (rolling_std * std)
+    sma_val = sma.iloc[-1]
+    upper_val = upper.iloc[-1]
+    lower_val = lower.iloc[-1]
+    return {
+        "upper": float(upper_val) if pd.notna(upper_val) else None,
+        "middle": float(sma_val) if pd.notna(sma_val) else None,
+        "lower": float(lower_val) if pd.notna(lower_val) else None,
+    }
+
+
+def _normalize_number(value: float, decimals: int = 6) -> float | int:
+    rounded = round(float(value), decimals)
+    if abs(rounded - round(rounded)) < 10 ** (-decimals):
+        return int(round(rounded))
+    return rounded
+
+
+def calculate_volume_profile(
+    df: pd.DataFrame,
+    bins: int = DEFAULT_VOLUME_PROFILE_BINS,
+    value_area_ratio: float = 0.70,
+) -> dict[str, Any]:
+    """Port of ``_calculate_volume_profile`` (POC + value area only).
+
+    The per-bin ``profile`` list of the production helper is dropped: the
+    caller only ever consumed ``poc.price`` and the two value-area edges.
+    """
+    if bins < 2:
+        raise ValueError("bins must be >= 2")
+    if not 0 < value_area_ratio <= 1:
+        raise ValueError("value_area_ratio must be between 0 and 1")
+
+    low = pd.to_numeric(df["low"], errors="coerce")
+    high = pd.to_numeric(df["high"], errors="coerce")
+    volume = pd.to_numeric(df["volume"], errors="coerce")
+    valid_mask = low.notna() & high.notna() & volume.notna()
+    if not valid_mask.any():
+        raise ValueError("No valid OHLCV rows with low/high/volume")
+
+    low_values = low[valid_mask].astype(float).to_numpy()
+    high_values = high[valid_mask].astype(float).to_numpy()
+    candle_low = np.minimum(low_values, high_values)
+    candle_high = np.maximum(low_values, high_values)
+    candle_volume = volume[valid_mask].astype(float).to_numpy()
+
+    price_low = float(candle_low.min())
+    price_high = float(candle_high.max())
+    if price_high <= price_low:
+        epsilon = max(abs(price_low) * 1e-6, 1e-6)
+        bin_edges = np.linspace(
+            price_low - epsilon / 2, price_high + epsilon / 2, bins + 1
+        )
+    else:
+        bin_edges = np.linspace(price_low, price_high, bins + 1)
+
+    bin_volumes = np.zeros(bins, dtype=float)
+    for low_i, high_i, vol_i in zip(
+        candle_low, candle_high, candle_volume, strict=False
+    ):
+        if vol_i <= 0:
+            continue
+        if high_i <= low_i:
+            idx = int(
+                np.clip(
+                    np.searchsorted(bin_edges, low_i, side="right") - 1, 0, bins - 1
+                )
+            )
+            bin_volumes[idx] += vol_i
+            continue
+        overlaps = np.minimum(bin_edges[1:], high_i) - np.maximum(bin_edges[:-1], low_i)
+        overlaps = np.clip(overlaps, 0.0, None)
+        overlap_sum = float(overlaps.sum())
+        if overlap_sum <= 0:
+            mid_price = (low_i + high_i) / 2
+            idx = int(
+                np.clip(
+                    np.searchsorted(bin_edges, mid_price, side="right") - 1, 0, bins - 1
+                )
+            )
+            bin_volumes[idx] += vol_i
+            continue
+        bin_volumes += vol_i * (overlaps / overlap_sum)
+
+    total_volume = float(bin_volumes.sum())
+    if total_volume <= 0:
+        raise ValueError("Total volume is zero for the selected period")
+
+    poc_index = int(np.argmax(bin_volumes))
+    target_volume = total_volume * value_area_ratio
+    covered_volume = float(bin_volumes[poc_index])
+    left_index = poc_index
+    right_index = poc_index
+    while covered_volume < target_volume and (left_index > 0 or right_index < bins - 1):
+        left_vol = bin_volumes[left_index - 1] if left_index > 0 else -np.inf
+        right_vol = bin_volumes[right_index + 1] if right_index < bins - 1 else -np.inf
+        if right_vol > left_vol:
+            right_index += 1
+            covered_volume += float(bin_volumes[right_index])
+        else:
+            if left_index > 0:
+                left_index -= 1
+                covered_volume += float(bin_volumes[left_index])
+            elif right_index < bins - 1:
+                right_index += 1
+                covered_volume += float(bin_volumes[right_index])
+            else:
+                break
+
+    return {
+        "poc": {
+            "price": _normalize_number(
+                (bin_edges[poc_index] + bin_edges[poc_index + 1]) / 2, decimals=6
+            )
+        },
+        "value_area": {
+            "high": _normalize_number(bin_edges[right_index + 1], decimals=6),
+            "low": _normalize_number(bin_edges[left_index], decimals=6),
+        },
+    }
+
+
+def format_fibonacci_source(level_key: str) -> str:
+    """Port of ``_format_fibonacci_source``."""
+    try:
+        level = float(level_key)
+    except (TypeError, ValueError):
+        return f"fib_{level_key}"
+    pct = level * 100
+    if abs(pct - round(pct)) < 1e-9:
+        pct_str = str(int(round(pct)))
+    else:
+        pct_str = f"{pct:.1f}".rstrip("0").rstrip(".")
+    return f"fib_{pct_str}"
+
+
+def cluster_price_levels(
+    levels: list[tuple[float, str]],
+    tolerance_pct: float = DEFAULT_CLUSTER_TOLERANCE_PCT,
+    *,
+    price_decimals: int | None = None,
+) -> list[dict[str, Any]]:
+    """Port of ``_cluster_price_levels``.
+
+    Strength is source *diversity*, not hit count: >=3 distinct sources is
+    ``strong``, exactly 2 is ``moderate``, 1 is ``weak``.  Option (3)'s rebid
+    price is the nearest ``strong`` support, so this threshold is load-bearing.
+    """
+    if not levels:
+        return []
+
+    clusters: list[dict[str, Any]] = []
+    for price, source in sorted(levels, key=lambda item: item[0]):
+        if price <= 0:
+            continue
+        matched_cluster: dict[str, Any] | None = None
+        for cluster in clusters:
+            center = float(cluster.get("center") or 0.0)
+            if center <= 0:
+                continue
+            if abs(price - center) / center <= tolerance_pct:
+                matched_cluster = cluster
+                break
+        if matched_cluster is None:
+            clusters.append({"prices": [price], "sources": [source], "center": price})
+            continue
+        prices = matched_cluster["prices"]
+        sources = matched_cluster["sources"]
+        prices.append(price)
+        if source not in sources:
+            sources.append(source)
+        matched_cluster["center"] = sum(prices) / len(prices)
+
+    clustered: list[dict[str, Any]] = []
+    for cluster in clusters:
+        prices = cluster.get("prices", [])
+        if not prices:
+            continue
+        level_sources = cluster.get("sources", [])
+        source_count = len(level_sources)
+        if source_count >= 3:
+            strength = "strong"
+        elif source_count == 2:
+            strength = "moderate"
+        else:
+            strength = "weak"
+        clustered.append(
+            {
+                "price": _maybe_round(sum(prices) / len(prices), price_decimals),
+                "strength": strength,
+                "sources": level_sources,
+            }
+        )
+    return clustered
+
+
+def split_support_resistance_levels(
+    clustered_levels: list[dict[str, Any]],
+    current_price: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Port of ``_split_support_resistance_levels``."""
+    supports: list[dict[str, Any]] = []
+    resistances: list[dict[str, Any]] = []
+    for level in clustered_levels:
+        price = float(level.get("price") or 0.0)
+        if price <= 0:
+            continue
+        level = dict(level)
+        level["distance_pct"] = round((price - current_price) / current_price * 100, 2)
+        if price < current_price:
+            supports.append(level)
+        elif price > current_price:
+            resistances.append(level)
+    supports.sort(key=lambda item: float(item["price"]), reverse=True)
+    resistances.sort(key=lambda item: float(item["price"]))
+    return supports, resistances
+
+
+@dataclass(frozen=True)
+class LevelView:
+    """One bar's overhead/underfoot structure, computed from that bar back."""
+
+    current_price: float
+    supports: tuple[dict[str, Any], ...]
+    resistances: tuple[dict[str, Any], ...]
+
+    @property
+    def resistance_count(self) -> int:
+        return len(self.resistances)
+
+    @property
+    def named_resistance_count(self) -> int:
+        """Resistances corroborated by at least two independent sources.
+
+        A ``weak`` cluster carries exactly one source.  On a bar closing at a
+        new window high that lone source is ``fib_0`` — the bar's own high —
+        so counting it as overhead resistance would make "no resistance
+        overhead" almost unreachable by construction.
+        """
+        return sum(1 for level in self.resistances if level.get("strength") != "weak")
+
+    def nearest_support(
+        self, strength: Strength | tuple[Strength, ...] | None = None
+    ) -> float | None:
+        """Highest support strictly below price, optionally filtered by strength.
+
+        ``supports`` is already sorted descending by price, so the first match
+        is the nearest one below.
+        """
+        if isinstance(strength, str):
+            allowed: tuple[str, ...] | None = (strength,)
+        else:
+            allowed = strength
+        for level in self.supports:
+            if allowed is not None and level.get("strength") not in allowed:
+                continue
+            return float(level["price"])
+        return None
+
+
+def compute_levels(
+    window: pd.DataFrame,
+    *,
+    current_price: float | None = None,
+    bins: int = DEFAULT_VOLUME_PROFILE_BINS,
+    tolerance_pct: float = DEFAULT_CLUSTER_TOLERANCE_PCT,
+    price_decimals: int | None = None,
+) -> LevelView:
+    """Port of ``get_support_resistance_impl``'s pure core.
+
+    ``window`` must be the trailing bars **ending at and including** the
+    decision bar, with ``high``/``low``/``close``/``volume`` columns.  Nothing
+    after the last row is read, which is what makes the study look-ahead free.
+    """
+    if window.empty:
+        raise ValueError("window is empty")
+    price = (
+        float(window["close"].iloc[-1])
+        if current_price is None
+        else float(current_price)
+    )
+    if price <= 0:
+        raise ValueError("current price must be positive")
+
+    fib = calculate_fibonacci(window, price, price_decimals=price_decimals)
+    volume_profile = calculate_volume_profile(window, bins=bins)
+    bollinger = calculate_bollinger(window["close"])
+
+    price_levels: list[tuple[float, str]] = []
+    for level_key, level_price in fib["levels"].items():
+        if level_price is not None and level_price > 0:
+            price_levels.append(
+                (float(level_price), format_fibonacci_source(str(level_key)))
+            )
+
+    poc_price = volume_profile["poc"]["price"]
+    if poc_price is not None and poc_price > 0:
+        price_levels.append((float(poc_price), "volume_poc"))
+    value_area = volume_profile["value_area"]
+    for key, source in (
+        ("high", "volume_value_area_high"),
+        ("low", "volume_value_area_low"),
+    ):
+        edge = value_area.get(key)
+        if edge is not None and edge > 0:
+            price_levels.append((float(edge), source))
+    for key, source in (
+        ("upper", "bb_upper"),
+        ("middle", "bb_middle"),
+        ("lower", "bb_lower"),
+    ):
+        band = bollinger.get(key)
+        if band is not None and band > 0:
+            price_levels.append((float(band), source))
+
+    clustered = cluster_price_levels(
+        price_levels, tolerance_pct=tolerance_pct, price_decimals=price_decimals
+    )
+    supports, resistances = split_support_resistance_levels(clustered, price)
+    return LevelView(
+        current_price=price,
+        supports=tuple(supports),
+        resistances=tuple(resistances),
+    )

--- a/research/underwater_spike_trim_study/report.py
+++ b/research/underwater_spike_trim_study/report.py
@@ -1,0 +1,263 @@
+"""Aggregate scanned observations into the tables the answer file carries.
+
+Reads only ``observations.jsonl`` written by ``run.py``; it never touches a
+corpus, so a table can be re-cut without re-scanning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .simulate import cost_basis_view, deltas_vs_hold, normalised, option_values
+from .spec import BASES, COST_BASIS_GRID, HORIZONS
+
+
+def load_observations(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def _pct(values: Sequence[float]) -> dict[str, float | None]:
+    if not values:
+        return {"n": 0, "median": None, "mean": None, "p25": None, "p75": None}
+    ordered = sorted(values)
+    return {
+        "n": len(values),
+        "median": statistics.median(ordered),
+        "mean": statistics.fmean(ordered),
+        "p25": ordered[max(0, int(0.25 * (len(ordered) - 1)))],
+        "p75": ordered[min(len(ordered) - 1, int(0.75 * (len(ordered) - 1)))],
+    }
+
+
+def _share(flags: Sequence[bool]) -> float | None:
+    return None if not flags else sum(1 for flag in flags if flag) / len(flags)
+
+
+@dataclass(frozen=True)
+class Arm:
+    """One fully specified way of reading the same scan."""
+
+    resistance_rule: str  # "named" | "strict"
+    rebid_strength: str  # "strong" | "moderate_plus"
+    basis: str
+    horizon: int
+    cohort: str  # "event" | "control"
+
+
+def _passes_resistance(observation: dict[str, Any], rule: str) -> bool:
+    if rule == "unfiltered":
+        # Controls drawn without matching on overhead structure — the cleaner
+        # answer to "is the spike day special?".  For events this is identical
+        # to "named", because the scan already gated on that rule.
+        return True
+    if rule == "named":
+        return observation["named_resistance_count"] == 0
+    if rule == "strict":
+        return observation["resistance_count"] == 0
+    raise ValueError(f"unsupported resistance rule {rule!r}")
+
+
+def _rebuy_price(observation: dict[str, Any], strength: str) -> float | None:
+    if strength == "strong":
+        return observation["rebuy_price"]
+    if strength == "moderate_plus":
+        return observation["rebuy_price_moderate_plus"]
+    raise ValueError(f"unsupported rebid strength {strength!r}")
+
+
+def summarise(observations: Iterable[dict[str, Any]], arm: Arm) -> dict[str, Any]:
+    """Compute one arm's option comparison, plus the cost-basis grid."""
+    hold_returns: list[float] = []
+    trim_deltas: list[float] = []
+    rebid_deltas: list[float] = []
+    rebid_vs_trim: list[float] = []
+    fill_flags: list[bool] = []
+    available_flags: list[bool] = []
+    locked_fill_flags: list[bool] = []
+    excluded_not_executable = 0
+    considered = 0
+    grid: dict[str, dict[str, list[float]]] = {
+        f"{int(premium * 100)}pct": {
+            "hold_pnl_vs_cost": [],
+            "trim_pnl_vs_cost": [],
+            "rebid_pnl_vs_cost": [],
+            "hold_still_underwater": [],
+            "trim_still_underwater": [],
+            "rebid_still_underwater": [],
+        }
+        for premium in COST_BASIS_GRID
+    }
+
+    for observation in observations:
+        if observation["kind"] != arm.cohort:
+            continue
+        if not _passes_resistance(observation, arm.resistance_rule):
+            continue
+        block = observation["forward"].get(f"{arm.basis}:{arm.horizon}")
+        if block is None:
+            continue
+        considered += 1
+        if not block["trim_executable"]:
+            # KR limit-up lock on the bar the trim would have used.
+            excluded_not_executable += 1
+            continue
+
+        p0 = block["p0"]
+        rebuy_price = _rebuy_price(observation, arm.rebid_strength)
+        if rebuy_price is not None and rebuy_price >= p0:
+            # The level view is anchored on close[i]; under the next-open basis
+            # p0 can gap below a support that was underfoot at the close.  The
+            # rebid is then not a rebid at all, so option (3) is unavailable.
+            rebuy_price = None
+        values = option_values(
+            p0=p0,
+            pt=block["exit_price"],
+            rebuy_price=rebuy_price,
+            window_low=block["window_low"],
+        )
+        returns = normalised(values, p0)
+        deltas = deltas_vs_hold(values, p0)
+        hold_returns.append(returns["hold"])
+        trim_deltas.append(deltas["trim"])
+        available_flags.append(values.rebid is not None)
+        if values.rebid is not None:
+            rebid_deltas.append(deltas["rebid"])
+            rebid_vs_trim.append((values.rebid - values.trim) / p0)
+            fill_flags.append(values.rebuy_filled)
+            key = (
+                "fill_used_locked_bar"
+                if arm.rebid_strength == "strong"
+                else "fill_used_locked_bar_moderate_plus"
+            )
+            locked_fill_flags.append(bool(block.get(key)))
+
+        for premium in COST_BASIS_GRID:
+            view = cost_basis_view(values, p0=p0, cost_premium=premium)
+            bucket = grid[f"{int(premium * 100)}pct"]
+            for metric in (
+                "hold_pnl_vs_cost",
+                "trim_pnl_vs_cost",
+                "hold_still_underwater",
+                "trim_still_underwater",
+            ):
+                bucket[metric].append(view[metric])
+            if view["rebid_pnl_vs_cost"] is not None:
+                bucket["rebid_pnl_vs_cost"].append(view["rebid_pnl_vs_cost"])
+                bucket["rebid_still_underwater"].append(view["rebid_still_underwater"])
+
+    return {
+        "arm": arm.__dict__,
+        "considered": considered,
+        "excluded_trim_not_executable": excluded_not_executable,
+        "n": len(hold_returns),
+        "hold_return": _pct(hold_returns),
+        "trim_minus_hold": _pct(trim_deltas),
+        "trim_beats_hold_rate": _share([d > 0 for d in trim_deltas]),
+        "rebid_available_rate": _share(available_flags),
+        "rebid_fill_rate": _share(fill_flags),
+        "rebid_fill_needed_locked_bar_rate": _share(locked_fill_flags),
+        "rebid_minus_hold": _pct(rebid_deltas),
+        "rebid_beats_hold_rate": _share([d > 0 for d in rebid_deltas]),
+        "rebid_minus_trim": _pct(rebid_vs_trim),
+        "cost_basis_grid": {
+            premium: {
+                "median_hold_pnl_vs_cost": _pct(bucket["hold_pnl_vs_cost"])["median"],
+                "median_trim_pnl_vs_cost": _pct(bucket["trim_pnl_vs_cost"])["median"],
+                "median_rebid_pnl_vs_cost": _pct(bucket["rebid_pnl_vs_cost"])["median"],
+                "hold_still_underwater_rate": _share(
+                    [bool(v) for v in bucket["hold_still_underwater"]]
+                ),
+                "trim_still_underwater_rate": _share(
+                    [bool(v) for v in bucket["trim_still_underwater"]]
+                ),
+                "rebid_still_underwater_rate": _share(
+                    [bool(v) for v in bucket["rebid_still_underwater"]]
+                ),
+            }
+            for premium, bucket in grid.items()
+        },
+    }
+
+
+def full_report(
+    observations: list[dict[str, Any]],
+    *,
+    bases: Sequence[str] = BASES,
+    rules: Sequence[str] = ("named", "strict", "unfiltered"),
+    strengths: Sequence[str] = ("strong", "moderate_plus"),
+) -> dict[str, Any]:
+    out: dict[str, Any] = {"arms": []}
+    for rule in rules:
+        for strength in strengths:
+            for basis in bases:
+                for horizon in HORIZONS:
+                    for cohort in ("event", "control"):
+                        arm = Arm(rule, strength, basis, horizon, cohort)
+                        out["arms"].append(summarise(observations, arm))
+    return out
+
+
+def descriptive(observations: list[dict[str, Any]]) -> dict[str, Any]:
+    events = [o for o in observations if o["kind"] == "event"]
+    controls = [o for o in observations if o["kind"] == "control"]
+    strict = [o for o in events if o["resistance_count"] == 0]
+    gaps = [o["gap_next_open"] for o in events if o["gap_next_open"] is not None]
+    return {
+        "events_named_rule": len(events),
+        "events_strict_rule": len(strict),
+        "controls": len(controls),
+        "distinct_event_symbols": len({o["symbol"] for o in events}),
+        "event_years": sorted({o["session"][:4] for o in events}),
+        "top_symbols": sorted(
+            (
+                (s, sum(1 for o in events if o["symbol"] == s))
+                for s in {o["symbol"] for o in events}
+            ),
+            key=lambda item: (-item[1], item[0]),
+        )[:10],
+        "event_limit_locked_up": sum(1 for o in events if o["limit_locked"] == 1),
+        "event_next_open_limit_locked_up": sum(
+            1 for o in events if o["next_open_limit_locked"] == 1
+        ),
+        "gap_next_open": _pct(gaps),
+        "gap_nonzero_rate": _share([abs(g) > 1e-9 for g in gaps]),
+        "median_ret_24h": _pct([o["ret_24h"] for o in events])["median"],
+        "median_rsi": _pct([o["rsi"] for o in events])["median"],
+        "strong_support_available_rate": _share(
+            [o["rebuy_price"] is not None for o in events]
+        ),
+        "moderate_plus_support_available_rate": _share(
+            [o["rebuy_price_moderate_plus"] is not None for o in events]
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--observations", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    observations = load_observations(args.observations)
+    payload = {
+        "source": str(args.observations),
+        "descriptive": descriptive(observations),
+        **full_report(observations),
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(json.dumps(payload["descriptive"], indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/underwater_spike_trim_study/run.py
+++ b/research/underwater_spike_trim_study/run.py
@@ -1,0 +1,151 @@
+"""CLI: scan one market's frozen corpus and persist every observation.
+
+    uv run python -m research.underwater_spike_trim_study.run --market crypto
+
+Writes ``observations.jsonl`` plus a ``scan-summary.json`` under the output
+directory.  Aggregation lives in ``report.py`` so a re-cut of the tables never
+re-reads the corpora.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+from .corpora import assert_offline_environment, load_market
+from .events import scan_symbol
+from .spec import LEVEL_WINDOW
+
+DEFAULT_OUT = Path("/Users/mgh3326/work/herdr-artifacts/uwtrim-backtest-20260821")
+MARKETS = ("crypto", "kr", "us")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", required=True, choices=MARKETS)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--symbols", nargs="*", default=None)
+    parser.add_argument(
+        "--max-symbols",
+        type=int,
+        default=None,
+        help="smoke-test cap; a capped run is labelled partial in the summary",
+    )
+    parser.add_argument(
+        "--level-window",
+        type=int,
+        default=LEVEL_WINDOW,
+        help=(
+            "trailing sessions for the S/R proxy; 120 is the pre-registered primary, "
+            "60 matches what the production get_support_resistance tool actually fetches"
+        ),
+    )
+    parser.add_argument(
+        "--price-decimals",
+        type=int,
+        default=None,
+        help="round level prices like the production tool does (2); default is full precision",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    assert_offline_environment()
+
+    suffix = "" if args.level_window == LEVEL_WINDOW else f"-w{args.level_window}"
+    out_dir = args.out / f"{args.market}{suffix}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    observations_path = out_dir / "observations.jsonl"
+
+    started = time.monotonic()
+    totals = {
+        "symbols_loaded": 0,
+        "symbols_with_events": 0,
+        "bars_scanned": 0,
+        "eligible_bars": 0,
+        "prefilter_hits": 0,
+        "events": 0,
+        "events_dropped_degenerate_window": 0,
+        "events_rejected_resistance": 0,
+        "controls": 0,
+        "dropped_invalid_rows": 0,
+        "inconsistent_ohlc_rows": 0,
+    }
+    first_session: str | None = None
+    last_session: str | None = None
+    segments: dict[str, int] = {}
+
+    with observations_path.open("w", encoding="utf-8") as handle:
+        for bars in load_market(args.market, args.symbols):
+            if (
+                args.max_symbols is not None
+                and totals["symbols_loaded"] >= args.max_symbols
+            ):
+                break
+            totals["symbols_loaded"] += 1
+            totals["dropped_invalid_rows"] += bars.dropped_invalid_rows
+            totals["inconsistent_ohlc_rows"] += bars.inconsistent_ohlc_rows
+            segments[bars.segment] = segments.get(bars.segment, 0) + 1
+            if not bars.frame.empty:
+                low = str(bars.frame["session"].iloc[0].date())
+                high = str(bars.frame["session"].iloc[-1].date())
+                first_session = (
+                    low if first_session is None else min(first_session, low)
+                )
+                last_session = high if last_session is None else max(last_session, high)
+
+            result = scan_symbol(
+                bars,
+                price_decimals=args.price_decimals,
+                level_window=args.level_window,
+            )
+            totals["bars_scanned"] += result.bars_scanned
+            totals["eligible_bars"] += result.eligible_bars
+            totals["prefilter_hits"] += result.prefilter_hits
+            totals["events"] += result.events
+            totals["events_dropped_degenerate_window"] += (
+                result.events_dropped_degenerate_window
+            )
+            totals["events_rejected_resistance"] += result.events_rejected_resistance
+            totals["controls"] += sum(
+                1 for o in result.observations if o.kind == "control"
+            )
+            if result.events:
+                totals["symbols_with_events"] += 1
+            for observation in result.observations:
+                handle.write(json.dumps(asdict(observation), ensure_ascii=False) + "\n")
+
+            if totals["symbols_loaded"] % 200 == 0:
+                elapsed = time.monotonic() - started
+                print(
+                    f"  {args.market}: {totals['symbols_loaded']} symbols, "
+                    f"{totals['events']} events, {elapsed:.0f}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+    summary = {
+        "market": args.market,
+        "level_window": args.level_window,
+        "price_decimals": args.price_decimals,
+        "partial_run": args.max_symbols is not None or args.symbols is not None,
+        "first_session": first_session,
+        "last_session": last_session,
+        "segments": segments,
+        "elapsed_seconds": round(time.monotonic() - started, 1),
+        **totals,
+    }
+    (out_dir / "scan-summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/underwater_spike_trim_study/simulate.py
+++ b/research/underwater_spike_trim_study/simulate.py
@@ -1,0 +1,124 @@
+"""The three options' payoffs — pure arithmetic, no data access.
+
+Accounting convention
+---------------------
+The position is normalised to 1.0 unit of the asset held at the decision
+price ``p0``, with no cash.  Every option is valued at the end of the window
+as ``coin * exit_price + cash``.  Dividing by ``p0`` makes the three
+comparable across symbols and price scales.
+
+  (1) hold   : 1.0 unit                       -> pt
+  (2) trim   : sell f at p0                   -> (1-f)*pt + f*p0
+  (3) rebid  : (2) plus buy f back at L if the window low reaches L
+               -> pt + f*(p0 - L)   when filled, otherwise identical to (2)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .spec import TRIM_FRACTION
+
+
+@dataclass(frozen=True)
+class OptionValues:
+    """Window-end portfolio value per unit of the initial position value."""
+
+    hold: float
+    trim: float
+    rebid: float | None
+    rebuy_filled: bool
+    rebuy_price: float | None
+
+
+def option_values(
+    *,
+    p0: float,
+    pt: float,
+    rebuy_price: float | None,
+    window_low: float | None,
+    trim_fraction: float = TRIM_FRACTION,
+) -> OptionValues:
+    """Value the three options for one observation.
+
+    ``rebuy_price=None`` means no strong support existed below the decision
+    price, i.e. option (3) was not available.  That is recorded as ``None``
+    rather than silently falling back to option (2) — the pre-registration
+    calls for "③ 불가 기록".
+    """
+    if p0 <= 0:
+        raise ValueError("decision price must be positive")
+    if not 0 < trim_fraction < 1:
+        raise ValueError("trim fraction must be strictly between 0 and 1")
+
+    hold = pt
+    trim = (1.0 - trim_fraction) * pt + trim_fraction * p0
+
+    if rebuy_price is None:
+        return OptionValues(hold, trim, None, False, None)
+    if rebuy_price >= p0:
+        raise ValueError(
+            "a rebid support level must sit strictly below the decision price"
+        )
+
+    filled = window_low is not None and window_low <= rebuy_price
+    rebid = pt + trim_fraction * (p0 - rebuy_price) if filled else trim
+    return OptionValues(hold, trim, rebid, filled, rebuy_price)
+
+
+def normalised(values: OptionValues, p0: float) -> dict[str, float | None]:
+    """Window return per option, as a fraction of the initial position value."""
+    return {
+        "hold": values.hold / p0 - 1.0,
+        "trim": values.trim / p0 - 1.0,
+        "rebid": None if values.rebid is None else values.rebid / p0 - 1.0,
+    }
+
+
+def deltas_vs_hold(values: OptionValues, p0: float) -> dict[str, float | None]:
+    """Each option minus option (1), in units of the initial position value.
+
+    🔴 Cost-basis invariance: both differences are functions of ``p0``, ``pt``
+    and ``L`` only.  An underwater average cost ``C`` enters every option as
+    the same additive constant and cancels here.  The +10/+20/+30% grid can
+    therefore not reorder the three options — it only changes how much loss
+    the trim books and whether the position is still underwater at the end.
+    ``tests/test_simulate.py::test_cost_basis_does_not_change_ranking`` pins
+    this, and the report states it instead of implying a sensitivity that
+    does not exist.
+    """
+    return {
+        "trim": (values.trim - values.hold) / p0,
+        "rebid": None if values.rebid is None else (values.rebid - values.hold) / p0,
+    }
+
+
+def cost_basis_view(
+    values: OptionValues,
+    *,
+    p0: float,
+    cost_premium: float,
+    trim_fraction: float = TRIM_FRACTION,
+) -> dict[str, float | None]:
+    """Metrics that *do* depend on the underwater average cost.
+
+    ``cost_premium`` is how far the average cost sits above the event price,
+    so ``C = p0 * (1 + cost_premium)``.
+    """
+    cost = p0 * (1.0 + cost_premium)
+    booked_loss = trim_fraction * (p0 - cost) / cost  # negative: a realised loss
+    out: dict[str, float | None] = {
+        "cost": cost,
+        "realised_loss_on_trim_pct_of_cost": booked_loss,
+        "hold_pnl_vs_cost": values.hold / cost - 1.0,
+        "trim_pnl_vs_cost": values.trim / cost - 1.0,
+        "rebid_pnl_vs_cost": None
+        if values.rebid is None
+        else values.rebid / cost - 1.0,
+    }
+    out["hold_still_underwater"] = float(values.hold < cost)
+    out["trim_still_underwater"] = float(values.trim < cost)
+    out["rebid_still_underwater"] = (
+        None if values.rebid is None else float(values.rebid < cost)
+    )
+    return out

--- a/research/underwater_spike_trim_study/spec.py
+++ b/research/underwater_spike_trim_study/spec.py
@@ -1,0 +1,53 @@
+"""The pre-registered specification, frozen before any result was computed.
+
+🔴 These constants are the pre-registration.  Changing one after seeing an
+output is a new study round and must be labelled as such in the report; it is
+not an edit to this file.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# --- event definition (identical across all three markets) -----------------
+SPIKE_RETURN_MIN: Final = 0.12  # close/prev_close - 1
+RSI_PERIOD: Final = 14
+RSI_MIN: Final = 75.0
+LEVEL_WINDOW: Final = 120  # trailing sessions used for the S/R proxy
+RESISTANCE_COUNT_MAX: Final = 0  # "no named resistance overhead"
+
+# How "명명 저항 0" is operationalised.  Both arms are fixed here before any
+# P&L was computed; the report carries both.
+#
+#   "any"   — literal: zero resistance clusters above the decision price.
+#   "named" — zero *corroborated* clusters above it, i.e. ignoring `weak`
+#             single-source ones.  On a bar that closes at a new window high
+#             the only "resistance" the production clustering reports is
+#             `fib_0`, which IS that same bar's own intraday high.  Counting a
+#             bar's own high as overhead resistance is a tautology, not a
+#             named level, so "named" is the headline arm.
+RESISTANCE_RULES: Final = ("any", "named")
+RESISTANCE_RULE_DEFAULT: Final = "named"
+NAMED_STRENGTHS: Final = ("moderate", "strong")
+
+# --- the three options -----------------------------------------------------
+TRIM_FRACTION: Final = 0.10
+REBUY_STRENGTH: Final = "strong"  # nearest strong support below the event price
+# Secondary arm: `strong` needs three independent sources inside one 2% band
+# and is rare, which would leave option (3) mostly "unavailable".  The
+# moderate-or-better fallback is reported alongside, never instead.
+REBUY_STRENGTH_FALLBACK: Final = ("moderate", "strong")
+HORIZONS: Final = (7, 30)  # sessions after the event bar
+
+# --- underwater cost-basis sensitivity grid --------------------------------
+# Synthetic: the average cost sits this far ABOVE the event price.
+COST_BASIS_GRID: Final = (0.10, 0.20, 0.30)
+
+# --- control group ---------------------------------------------------------
+CONTROLS_PER_EVENT: Final = 5
+RANDOM_SEED: Final = 20260821
+
+# --- execution bases (equities only; crypto trades continuously) -----------
+BASIS_EVENT_CLOSE: Final = "event_close"
+BASIS_NEXT_OPEN: Final = "next_open"
+BASES: Final = (BASIS_EVENT_CLOSE, BASIS_NEXT_OPEN)

--- a/research/underwater_spike_trim_study/tests/test_levels_match_repo.py
+++ b/research/underwater_spike_trim_study/tests/test_levels_match_repo.py
@@ -1,0 +1,139 @@
+"""The port in ``levels.py`` equals the production arithmetic, value for value.
+
+The study never imports ``app`` — doing so drags in the broker clients and
+therefore ``app.core.config.settings``, which needs live credentials.  This
+test does import them, under throw-away dummy settings, purely to prove the
+port is faithful.  It skips (rather than fails) where that import is not
+possible, because the study's own correctness does not depend on it.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from research.underwater_spike_trim_study import levels as port
+
+_DUMMY_ENV = {
+    "kis_app_key": "dummy",
+    "kis_app_secret": "dummy",
+    "opendart_api_key": "dummy",
+    "DATABASE_URL": "postgresql+asyncpg://u:p@localhost/db",
+    "upbit_access_key": "dummy",
+    "upbit_secret_key": "dummy",
+    "SECRET_KEY": "Abcdef0123456789Abcdef0123456789Abcdef01",
+}
+
+
+@pytest.fixture(scope="module")
+def repo():
+    for key, value in _DUMMY_ENV.items():
+        os.environ.setdefault(key, value)
+    try:
+        import app.mcp_server.tooling.market_data_indicators as module
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"production indicators not importable here: {exc}")
+    return module
+
+
+def _frame(seed: int, rows: int = 120) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    close = 1000 * np.exp(np.cumsum(rng.normal(0, 0.03, rows)))
+    spread = np.abs(rng.normal(0, 0.02, rows)) * close
+    high = close + spread
+    low = np.maximum(close - spread, close * 0.5)
+    return pd.DataFrame(
+        {
+            "high": high,
+            "low": low,
+            "close": close,
+            "open": close,
+            "volume": rng.integers(1, 10_000, rows).astype(float),
+        }
+    )
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3, 4, 5])
+def test_rsi_last_value_matches(repo, seed: int):
+    frame = _frame(seed)
+    expected = repo._calculate_rsi(frame["close"])[str(repo.DEFAULT_RSI_PERIOD)]
+    got = port.rsi_series(frame["close"]).iloc[-1]
+    assert round(float(got), 2) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3, 4, 5])
+def test_bollinger_matches(repo, seed: int):
+    frame = _frame(seed)
+    assert port.calculate_bollinger(frame["close"]) == repo._calculate_bollinger(
+        frame["close"]
+    )
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3, 4, 5])
+def test_fibonacci_levels_match_at_production_rounding(repo, seed: int):
+    frame = _frame(seed)
+    price = float(frame["close"].iloc[-1])
+    expected = repo._calculate_fibonacci(frame, price)
+    got = port.calculate_fibonacci(frame, price, price_decimals=2)
+    assert got["levels"] == expected["levels"]
+    assert got["trend"] == expected["trend"]
+    assert got["swing_high"]["price"] == expected["swing_high"]["price"]
+    assert got["swing_low"]["price"] == expected["swing_low"]["price"]
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3, 4, 5])
+def test_volume_profile_poc_and_value_area_match(repo, seed: int):
+    frame = _frame(seed)
+    expected = repo._calculate_volume_profile(frame, bins=20)
+    got = port.calculate_volume_profile(frame, bins=20)
+    assert got["poc"]["price"] == expected["poc"]["price"]
+    assert got["value_area"]["high"] == expected["value_area"]["high"]
+    assert got["value_area"]["low"] == expected["value_area"]["low"]
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3, 4, 5])
+def test_clustering_and_split_match_end_to_end(repo, seed: int):
+    """Rebuild the production handler's pure core and compare cluster for cluster."""
+    frame = _frame(seed)
+    price = round(float(frame["close"].iloc[-1]), 2)
+
+    fib = repo._calculate_fibonacci(frame, price)
+    volume_profile = repo._calculate_volume_profile(frame, bins=20)
+    bollinger = repo._calculate_bollinger(frame["close"])
+    expected_inputs: list[tuple[float, str]] = [
+        (float(value), repo._format_fibonacci_source(str(key)))
+        for key, value in fib["levels"].items()
+    ]
+    expected_inputs.append((float(volume_profile["poc"]["price"]), "volume_poc"))
+    expected_inputs.append(
+        (float(volume_profile["value_area"]["high"]), "volume_value_area_high")
+    )
+    expected_inputs.append(
+        (float(volume_profile["value_area"]["low"]), "volume_value_area_low")
+    )
+    for key, source in (
+        ("upper", "bb_upper"),
+        ("middle", "bb_middle"),
+        ("lower", "bb_lower"),
+    ):
+        expected_inputs.append((float(bollinger[key]), source))
+    expected_supports, expected_resistances = repo._split_support_resistance_levels(
+        repo._cluster_price_levels(expected_inputs, tolerance_pct=0.02), price
+    )
+
+    view = port.compute_levels(frame, current_price=price, price_decimals=2)
+    assert [level["price"] for level in view.supports] == [
+        level["price"] for level in expected_supports
+    ]
+    assert [level["strength"] for level in view.supports] == [
+        level["strength"] for level in expected_supports
+    ]
+    assert [level["price"] for level in view.resistances] == [
+        level["price"] for level in expected_resistances
+    ]
+    assert [level["sources"] for level in view.resistances] == [
+        level["sources"] for level in expected_resistances
+    ]

--- a/research/underwater_spike_trim_study/tests/test_market_rules.py
+++ b/research/underwater_spike_trim_study/tests/test_market_rules.py
@@ -1,0 +1,151 @@
+"""KR limit-lock and calendar-contiguity handling — the two honesty rules.
+
+Operator instruction (§129차 ②, KR/US extension):
+  ① a KR limit-up locked day is price-unreachable, so no fill may be assumed;
+  ② a gap (open != previous close) must also be reported on an open basis.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from research.underwater_spike_trim_study.corpora import (
+    SymbolBars,
+    _kr_limit_flags,
+    _mark_contiguity,
+)
+from research.underwater_spike_trim_study.events import scan_symbol
+from research.underwater_spike_trim_study.spec import BASIS_EVENT_CLOSE, BASIS_NEXT_OPEN
+
+
+def _kr_frame(
+    closes: list[float], zero_range_at: set[int] | None = None
+) -> pd.DataFrame:
+    zero_range_at = zero_range_at or set()
+    rows = []
+    for i, close in enumerate(closes):
+        if i in zero_range_at:
+            rows.append((close, close, close, close))
+        else:
+            rows.append((close * 0.99, close * 1.02, close * 0.97, close))
+    frame = pd.DataFrame(rows, columns=["open", "high", "low", "close"])
+    frame.insert(0, "session", pd.bdate_range("2020-01-02", periods=len(closes)))
+    frame["volume"] = 1000.0
+    return frame
+
+
+def test_limit_up_lock_needs_both_zero_range_and_the_statutory_cap():
+    frame = _kr_frame([100, 130, 130 * 1.3, 200], zero_range_at={2})
+    flags = _kr_limit_flags(frame)
+    assert flags.tolist() == [0, 0, 1, 0]
+
+
+def test_a_zero_range_bar_at_a_normal_move_is_not_a_lock():
+    """An illiquid no-trade day is not a ceiling lock and must not be labelled one."""
+    frame = _kr_frame([100, 101, 101, 102], zero_range_at={2})
+    assert _kr_limit_flags(frame).tolist() == [0, 0, 0, 0]
+
+
+def test_limit_down_lock_is_labelled_negative():
+    frame = _kr_frame([100, 100, 70, 71], zero_range_at={2})
+    assert _kr_limit_flags(frame).tolist() == [0, 0, -1, 0]
+
+
+def test_the_15_percent_cap_applies_before_2015_06_15():
+    frame = _kr_frame([100, 100, 115, 116], zero_range_at={2})
+    frame["session"] = pd.to_datetime(
+        ["2015-05-04", "2015-05-06", "2015-05-07", "2015-05-08"]
+    )
+    assert _kr_limit_flags(frame).tolist() == [0, 0, 1, 0]
+    frame["session"] = pd.to_datetime(
+        ["2020-05-04", "2020-05-06", "2020-05-07", "2020-05-08"]
+    )
+    assert _kr_limit_flags(frame).tolist() == [0, 0, 0, 0]
+
+
+def test_contiguity_flag_is_false_across_a_missing_session():
+    calendar = pd.DatetimeIndex(pd.bdate_range("2020-01-02", periods=10))
+    frame = pd.DataFrame({"session": calendar.delete(4)})
+    marked = _mark_contiguity(frame, calendar=calendar)
+    assert marked["contiguous_prev"].tolist() == [
+        False,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def _synthetic_kr_bars(lock_event_bar: bool) -> SymbolBars:
+    """One deterministic +12%/RSI>=75 spike with a controllable lock on it."""
+    rng = np.random.default_rng(7)
+    base = list(100 * np.exp(np.cumsum(rng.normal(0.0, 0.004, 200))))
+    # a clean run-up that pushes RSI over 75, then the spike bar
+    for step in range(30):
+        base.append(base[-1] * (1.03 + 0.0001 * step))
+    spike = base[-1] * 1.30 if lock_event_bar else base[-1] * 1.15
+    base.append(spike)
+    base.extend(base[-1] * (1 - 0.01 * k) for k in range(1, 45))
+
+    zero_range = {len(base) - 45} if lock_event_bar else set()
+    frame = _kr_frame(base, zero_range_at=zero_range)
+    frame = _mark_contiguity(frame, calendar=pd.DatetimeIndex(frame["session"]))
+    frame["limit_locked"] = _kr_limit_flags(frame)
+    return SymbolBars(
+        "kr", "000000", frame, 0, 0, group="code_suffix_0", segment="KOSPI"
+    )
+
+
+def test_a_ceiling_locked_event_bar_is_flagged_not_silently_traded():
+    bars = _synthetic_kr_bars(lock_event_bar=True)
+    events = [o for o in scan_symbol(bars).observations if o.kind == "event"]
+    assert events, "fixture must produce an event"
+    locked = [o for o in events if o.limit_locked == 1]
+    assert locked, "the ceiling-locked spike must be detected"
+    for observation in locked:
+        for horizon in (7, 30):
+            block = observation.forward[f"{BASIS_EVENT_CLOSE}:{horizon}"]
+            assert block["trim_executable"] is False
+
+
+def test_an_unlocked_event_bar_stays_executable():
+    bars = _synthetic_kr_bars(lock_event_bar=False)
+    events = [o for o in scan_symbol(bars).observations if o.kind == "event"]
+    assert events
+    for observation in events:
+        assert observation.limit_locked == 0
+        assert observation.forward[f"{BASIS_EVENT_CLOSE}:7"]["trim_executable"] is True
+
+
+def test_locked_bars_are_removed_from_the_rebid_fill_window():
+    bars = _synthetic_kr_bars(lock_event_bar=True)
+    for observation in scan_symbol(bars).observations:
+        for block in observation.forward.values():
+            low_all = block["window_low_including_locked"]
+            low_tradable = block["window_low"]
+            assert low_tradable is None or low_all <= low_tradable
+
+
+def test_both_execution_bases_are_recorded_for_every_observation():
+    bars = _synthetic_kr_bars(lock_event_bar=False)
+    for observation in scan_symbol(bars).observations:
+        for horizon in (7, 30):
+            assert f"{BASIS_EVENT_CLOSE}:{horizon}" in observation.forward
+            assert f"{BASIS_NEXT_OPEN}:{horizon}" in observation.forward
+        assert observation.gap_next_open is not None
+
+
+def test_next_open_basis_prices_from_the_bar_after_the_event():
+    bars = _synthetic_kr_bars(lock_event_bar=False)
+    frame = bars.frame
+    for observation in scan_symbol(bars).observations:
+        i = observation.index
+        block = observation.forward[f"{BASIS_NEXT_OPEN}:7"]
+        assert block["p0"] == pytest.approx(float(frame["open"].iloc[i + 1]))
+        assert block["exit_price"] == pytest.approx(float(frame["open"].iloc[i + 8]))

--- a/research/underwater_spike_trim_study/tests/test_no_lookahead.py
+++ b/research/underwater_spike_trim_study/tests/test_no_lookahead.py
@@ -1,0 +1,105 @@
+"""Proof that nothing in the event gate reads a bar after the decision bar.
+
+Method: take a real-shaped random frame, run the scan, then for every event
+truncate the frame *at* the event bar, pad it with bars that are deliberately
+absurd (a 10x crash, then a 10x melt-up) and re-derive the gate fields.  If a
+gate field changed, the gate read the future.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from research.underwater_spike_trim_study.corpora import SymbolBars
+from research.underwater_spike_trim_study.events import scan_symbol
+from research.underwater_spike_trim_study.levels import compute_levels, rsi_series
+from research.underwater_spike_trim_study.spec import LEVEL_WINDOW
+
+
+def _bars(seed: int, rows: int = 700) -> SymbolBars:
+    rng = np.random.default_rng(seed)
+    steps = rng.normal(0.001, 0.05, rows)
+    # inject spikes so the +12% / RSI>=75 gate actually fires
+    steps[rng.choice(rows, size=rows // 25, replace=False)] += 0.18
+    close = 1000 * np.exp(np.cumsum(steps))
+    spread = np.abs(rng.normal(0, 0.02, rows)) * close
+    frame = pd.DataFrame(
+        {
+            "session": pd.date_range("2018-01-01", periods=rows, freq="D"),
+            "open": close * (1 + rng.normal(0, 0.001, rows)),
+            "high": close + spread,
+            "low": np.maximum(close - spread, close * 0.5),
+            "close": close,
+            "volume": rng.integers(1, 10_000, rows).astype(float),
+        }
+    )
+    frame["contiguous_prev"] = True
+    frame.loc[0, "contiguous_prev"] = False
+    frame["limit_locked"] = 0
+    return SymbolBars("test", f"SYN-{seed}", frame, 0, 0, group="syn", segment="syn")
+
+
+def _poison(frame: pd.DataFrame, upto: int) -> pd.DataFrame:
+    """Bars 0..upto kept verbatim; everything after replaced by nonsense."""
+    head = frame.iloc[: upto + 1].copy()
+    tail = frame.iloc[upto + 1 :].copy()
+    if not tail.empty:
+        factor = np.where(np.arange(len(tail)) % 2 == 0, 0.1, 10.0)
+        for column in ("open", "high", "low", "close"):
+            tail[column] = tail[column].to_numpy() * factor
+        tail["volume"] = 1.0
+    return pd.concat([head, tail], ignore_index=True)
+
+
+@pytest.mark.parametrize("seed", [11, 12, 13])
+def test_gate_fields_are_invariant_to_the_future(seed: int):
+    bars = _bars(seed)
+    result = scan_symbol(bars)
+    events = [o for o in result.observations if o.kind == "event"]
+    assert events, "fixture must produce at least one event"
+
+    for observation in events:
+        i = observation.index
+        poisoned = _poison(bars.frame, i)
+        closes = poisoned["close"]
+        ret = float(closes.iloc[i] / closes.iloc[i - 1] - 1.0)
+        rsi = float(rsi_series(closes).iloc[i])
+        view = compute_levels(poisoned.iloc[i - LEVEL_WINDOW + 1 : i + 1])
+
+        assert ret == pytest.approx(observation.ret_24h)
+        assert rsi == pytest.approx(observation.rsi)
+        assert view.resistance_count == observation.resistance_count
+        assert view.named_resistance_count == observation.named_resistance_count
+        if observation.rebuy_price is None:
+            assert view.nearest_support("strong") is None
+        else:
+            assert view.nearest_support("strong") == pytest.approx(
+                observation.rebuy_price
+            )
+
+
+def test_control_sampling_is_reproducible():
+    first = scan_symbol(_bars(21))
+    second = scan_symbol(_bars(21))
+    assert [(o.kind, o.index) for o in first.observations] == [
+        (o.kind, o.index) for o in second.observations
+    ]
+
+
+def test_controls_are_never_events():
+    result = scan_symbol(_bars(22))
+    controls = [o for o in result.observations if o.kind == "control"]
+    assert controls
+    # a control fails the cheap gate outright, so it can never be an event
+    assert all(o.ret_24h < 0.12 or o.rsi < 75.0 for o in controls)
+
+
+def test_forward_window_never_reaches_past_the_frame():
+    bars = _bars(23)
+    result = scan_symbol(bars)
+    last = len(bars.frame) - 1
+    for observation in result.observations:
+        for block in observation.forward.values():
+            assert observation.index + block["horizon"] + 1 <= last

--- a/research/underwater_spike_trim_study/tests/test_offline_boundary.py
+++ b/research/underwater_spike_trim_study/tests/test_offline_boundary.py
@@ -1,0 +1,118 @@
+"""Static proof that the study cannot reach a broker, a database or a network.
+
+The pre-registration requires "브로커/DB/네트워크 호출 없이 코퍼스 파일로만".
+That is a property of the import graph, so it is checked as one: an AST scan
+of every module in the package, plus a transitive walk of the research
+packages the loaders reach into.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PACKAGE = Path(__file__).resolve().parent.parent
+
+FORBIDDEN_PREFIXES = (
+    "app",
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "redis",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib.request",
+    "socket",
+    "websockets",
+    "ccxt",
+    "yfinance",
+    "pykrx",
+)
+
+# The corpus packages the loaders import.  Their *collection* code legitimately
+# speaks HTTP; only the modules this study actually imports are walked.
+ALLOWED_RESEARCH_MODULES = {
+    "research.crypto_corpus.loader",
+    "research.crypto_corpus.policy",
+    "research.crypto_corpus.constants",
+    "research.kr_corpus.backtest.holdout_guard",
+    "research.us_corpus.holdout_gate",
+    "research.us_corpus.config",
+}
+
+
+def _module_files() -> list[Path]:
+    return sorted(p for p in PACKAGE.glob("*.py"))
+
+
+def _imported_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module)
+    return names
+
+
+@pytest.mark.parametrize("path", _module_files(), ids=lambda p: p.name)
+def test_no_forbidden_import(path: Path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for name in _imported_names(tree):
+        for prefix in FORBIDDEN_PREFIXES:
+            assert not (name == prefix or name.startswith(prefix + ".")), (
+                f"{path.name} imports {name!r}; the study must stay offline"
+            )
+
+
+def test_research_dependencies_are_the_declared_ones():
+    """The only cross-package imports are the corpus loaders and their guards."""
+    seen: set[str] = set()
+    for path in _module_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        seen.update(n for n in _imported_names(tree) if n.startswith("research."))
+    assert seen <= ALLOWED_RESEARCH_MODULES, seen - ALLOWED_RESEARCH_MODULES
+
+
+def test_transitively_imported_corpus_modules_are_also_offline():
+    repo_root = PACKAGE.parent.parent
+    for dotted in sorted(ALLOWED_RESEARCH_MODULES):
+        module_path = repo_root.joinpath(*dotted.split(".")).with_suffix(".py")
+        assert module_path.exists(), module_path
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        for name in _imported_names(tree):
+            for prefix in FORBIDDEN_PREFIXES:
+                assert not (name == prefix or name.startswith(prefix + ".")), (
+                    f"{dotted} imports {name!r}"
+                )
+
+
+def test_no_module_names_a_sealed_holdout_path():
+    """No module may build a path into a sealed holdout tree.
+
+    Checked over string literals for a path *segment*, so prose that merely
+    names the sealed tree cannot trip it while a real path into it would.
+    """
+    for path in _module_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                assert "/holdout" not in node.value.lower(), (
+                    f"{path.name} builds a holdout path literal: {node.value!r}"
+                )
+
+
+def test_us_reads_go_through_the_corpus_holdout_gate():
+    """Reading the US tree must call ``guard_read``, not open paths directly."""
+    source = (PACKAGE / "corpora.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "guard_read" in called
+    assert "assert_path_not_holdout" in called

--- a/research/underwater_spike_trim_study/tests/test_simulate.py
+++ b/research/underwater_spike_trim_study/tests/test_simulate.py
@@ -1,0 +1,98 @@
+"""Algebra of the three options, including the cost-basis invariance claim."""
+
+from __future__ import annotations
+
+import pytest
+
+from research.underwater_spike_trim_study.simulate import (
+    cost_basis_view,
+    deltas_vs_hold,
+    normalised,
+    option_values,
+)
+from research.underwater_spike_trim_study.spec import COST_BASIS_GRID, TRIM_FRACTION
+
+
+def test_hold_is_the_exit_price():
+    values = option_values(p0=100.0, pt=90.0, rebuy_price=None, window_low=80.0)
+    assert values.hold == 90.0
+    assert normalised(values, 100.0)["hold"] == pytest.approx(-0.10)
+
+
+def test_trim_keeps_the_trimmed_tenth_at_the_event_price():
+    values = option_values(p0=100.0, pt=90.0, rebuy_price=None, window_low=95.0)
+    assert values.trim == pytest.approx(0.9 * 90.0 + 0.1 * 100.0)
+    assert deltas_vs_hold(values, 100.0)["trim"] == pytest.approx(
+        TRIM_FRACTION * (100.0 - 90.0) / 100.0
+    )
+
+
+def test_trim_loses_to_hold_when_price_rises():
+    values = option_values(p0=100.0, pt=130.0, rebuy_price=None, window_low=99.0)
+    assert deltas_vs_hold(values, 100.0)["trim"] < 0
+
+
+def test_rebid_unavailable_is_recorded_as_none_not_as_trim():
+    values = option_values(p0=100.0, pt=90.0, rebuy_price=None, window_low=50.0)
+    assert values.rebid is None
+    assert deltas_vs_hold(values, 100.0)["rebid"] is None
+
+
+def test_rebid_unfilled_equals_trim():
+    values = option_values(p0=100.0, pt=90.0, rebuy_price=80.0, window_low=85.0)
+    assert values.rebuy_filled is False
+    assert values.rebid == pytest.approx(values.trim)
+
+
+def test_rebid_filled_beats_hold_by_the_discount_on_the_trimmed_tenth():
+    values = option_values(p0=100.0, pt=90.0, rebuy_price=80.0, window_low=79.0)
+    assert values.rebuy_filled is True
+    assert values.rebid == pytest.approx(90.0 + TRIM_FRACTION * (100.0 - 80.0))
+    assert deltas_vs_hold(values, 100.0)["rebid"] == pytest.approx(
+        TRIM_FRACTION * (100.0 - 80.0) / 100.0
+    )
+
+
+def test_rebid_above_the_decision_price_is_rejected():
+    with pytest.raises(ValueError):
+        option_values(p0=100.0, pt=90.0, rebuy_price=100.0, window_low=90.0)
+
+
+@pytest.mark.parametrize("pt", [55.0, 90.0, 100.0, 143.0])
+def test_cost_basis_does_not_change_ranking(pt: float):
+    """🔴 The +10/+20/+30% grid cannot reorder the options.
+
+    An underwater average cost enters every option's P&L as the same additive
+    constant, so it cancels in every pairwise difference.  The report states
+    this rather than presenting a sensitivity that does not exist.
+    """
+    values = option_values(p0=100.0, pt=pt, rebuy_price=85.0, window_low=80.0)
+    baseline = deltas_vs_hold(values, 100.0)
+    orderings = set()
+    for premium in COST_BASIS_GRID:
+        view = cost_basis_view(values, p0=100.0, cost_premium=premium)
+        ranked = tuple(
+            sorted(
+                ("hold", "trim", "rebid"),
+                key=lambda name: view[f"{name}_pnl_vs_cost"],
+                reverse=True,
+            )
+        )
+        orderings.add(ranked)
+        # differences in cost-basis space equal differences in p0 space
+        assert view["trim_pnl_vs_cost"] - view["hold_pnl_vs_cost"] == pytest.approx(
+            baseline["trim"] / (1 + premium)
+        )
+    assert len(orderings) == 1
+
+
+def test_realised_loss_on_trim_is_negative_and_grows_with_the_premium():
+    values = option_values(p0=100.0, pt=100.0, rebuy_price=None, window_low=100.0)
+    losses = [
+        cost_basis_view(values, p0=100.0, cost_premium=premium)[
+            "realised_loss_on_trim_pct_of_cost"
+        ]
+        for premium in COST_BASIS_GRID
+    ]
+    assert all(loss < 0 for loss in losses)
+    assert losses == sorted(losses, reverse=True)


### PR DESCRIPTION
사전등록 스펙 기반 오프라인 역사 백테스트. §129차 ② + KR/US 확장 지시 이행.

**질문**: 물린 포지션이 24h +12% 이상 · RSI(14) ≥ 75 · 저항 없음 조건으로 급등할 때 ①보유 ②10% 트림 ③트림+지지 재매수 중 무엇이 나았나.

**보고서**: `~/work/herdr-inbox/answer-uwtrim-backtest-20260821.md`
**데이터 산출물**: `~/work/herdr-artifacts/uwtrim-backtest-20260821/`

## 범위

- 🔴 `research/` 한정. **`app/` 변경 0**, 스케줄러 등록 0, 실행 표면 0, 마이그레이션 0.
- 네트워크 0 · DB 0 · 자격증명 0 · 브로커 어댑터 0. 코퍼스 Parquet 파일만 읽는다.
- 세 코퍼스의 sealed holdout(2025-01-01~)은 각 코퍼스 자체 가드로 거부시켰다. **어떤 결과도 2025년 이후를 포함하지 않는다.**

## 표본

| 시장 | 코퍼스 | 구간 | 심볼 | 이벤트 | 대조군 |
|---|---|---|---:|---:|---:|
| crypto | crypto-corpus-v1 (upbit_krw) | 2017-10-24 ~ 2024-12-31 | 139 | 1,206 | 6,030 |
| KR | kr-corpus-v1 run 20260803-1001 | 2015-01-02 ~ 2024-12-30 | 3,159 | 12,730 | 63,425 |
| US | us-corpus-v1 | 2016-01-04 ~ 2024-12-31 | 4,493 | 11,608 | 57,737 |

## 요약 (데이터 요약까지 — 정책 권고 없음)

- 트림은 **중앙값으로 이기고 평균값으로 진다.** 승률은 세 시장 모두 50% 초과(53~66%)지만 crypto D+30 기대값은 **−3.23%p**(보유 평균 +32.25%의 오른쪽 꼬리 때문).
- ③은 중앙값 기준 ②보다 낫거나 같지만, 우위 폭은 crypto D+30 +1.22%p 외에는 ±0.1%p 수준.
- **어떤 안도 "물림 탈출 확률"을 높이지 못한다** — 모든 시장·그리드에서 트림/재매수가 보유보다 0.5~1.6%p 더 물려 있다.
- **평단 그리드(+10/+20/+30%)는 세 안의 순위를 바꿀 수 없다** — 대수적으로 소거되며 테스트로 고정. 지시대로 민감도를 수행한 결과가 "민감도 부재"이므로 있는 척하지 않았다.

## 사전등록 스펙에서 재구성이 필요했던 지점 (P&L 보기 전 결정, 두 팔 모두 보고)

- **"명명 저항 0"**: 문자 그대로 적용하면 급등일 위에 남는 유일한 클러스터가 `fib_0` = 그 봉 자신의 고가라, crypto 급등 1,288건 중 11건(0.9%)만 통과한다. 그래서 `strict`(문자 그대로)와 `named`(2소스 이상 교차확인만 저항으로 인정) 두 팔을 고정했다. 🔴 `named` 게이트는 6.4%만 걸러내므로 **이 연구가 실제 측정한 것은 사실상 "+12% & RSI≥75"** 이며, 저항 조건이 정보를 거의 싣지 않는다는 것 자체가 결과다.
- **"strong 지지"**: crypto 에서 7.2%만 존재해 ③이 93% 결측이 된다. `moderate+` 폴백 팔을 병기했다.

## 시장별 정직 처리 (지시 ①②)

- **KR 상한가 잠김**: `high == low` **이고** 법정 일일제한(2015-06-15~ ±30%, 이전 ±15%)에 닿은 봉만 잠김. 이벤트봉 잠김 312건(2.5%)은 트림 불가로 제외. 잠김 봉을 ③ 체결 창에서 뺀 효과는 **0건** — 계량해서 보고했지 가정하지 않았다.
- **갭**: 모든 관측을 `event_close`/`next_open` 두 기준으로 계산. KR 만 방향이 유의하게 바뀐다(갭업 중앙 +0.67% → 다음날 시가 트림이 더 유리).

## 검증

```
uv run pytest research/underwater_spike_trim_study/tests/ -q   # 66 passed
```

🔴 `pyproject.toml` 의 `testpaths = ["tests"]` 때문에 **CI 는 이 테스트를 수집하지 않는다.** 위 명령으로 수동 실행해야 한다.

- **프로덕션 동일성**: `levels.py` 는 `app.mcp_server.tooling.market_data_indicators` 의 S/R 산술 포트다. 더미 설정으로 프로덕션 함수를 임포트해 RSI·볼린저·피보나치·볼륨프로파일·클러스터링·supports/resistances 분할을 **값 단위 대조**해 동일함을 증명(25건). 임포트가 아니라 포트인 이유는 프로덕션 모듈이 브로커 클라이언트를 타고 `settings` 를 요구해 실자격증명 없이는 임포트되지 않기 때문.
- **look-ahead 부재**: 이벤트 봉 이후를 교대로 ×0.1/×10 으로 오염시킨 프레임에서 게이트 필드를 재계산해 원값과 일치 확인.
- **오프라인 경계**: AST 임포트 스캔으로 `app`·`sqlalchemy`·`httpx`·`socket`·`pykrx` 등 부재 증명, holdout 경로 리터럴 부재 증명, US/KR 읽기가 코퍼스 가드를 거침을 증명.
- **산식 대칭성**: 3안 payoff 대수 고정 + 평단 불변성 파라미터 테스트.

## Draft 인 이유

결과 해석·정책 반영은 4주 forward 셰도우(§128차)와 합쳐 운영자가 결정한다. 이 PR 은 재현 가능한 코드와 산출물을 레포에 남기는 것이 목적이며, 리뷰 후 머지 여부를 운영자가 판단한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)