### PR TITLE
ROB-1267 J5B: US Alpaca lab lifecycle-recovery contract + boundary tests

### DIFF
--- a/ci_shards/shard-1.txt
+++ b/ci_shards/shard-1.txt
@@ -25,6 +25,7 @@ tests/jobs/test_analyst_consensus_snapshots_job.py
 tests/jobs/test_kis_market_adapters.py
 tests/jobs/test_news_relevance_judgment.py
 tests/mcp/test_trade_journal_enrich.py
+tests/mcp_server/test_alpaca_paper_lab_automated_boundary.py
 tests/mcp_server/test_analyze_halted_suspect.py
 tests/mcp_server/test_binance_demo_ledger_status_tool.py
 tests/mcp_server/test_investment_report_context_get_description.py
@@ -76,6 +77,7 @@ tests/scripts/b0x/kr/test_ledger_pending_source.py
 tests/scripts/b0x/kr/test_submission_ast_guard.py
 tests/scripts/b0x/test_contract_stamp.py
 tests/scripts/b0x/test_cycle.py
+tests/scripts/b0x/us/test_alpaca_lab_mutation_seam.py
 tests/scripts/b0x/us/test_run_b0x_us_cycle_cli.py
 tests/scripts/test_binance_public_smoke.py
 tests/scripts/test_binance_spot_demo_smoke.py

--- a/ci_shards/shard-2.txt
+++ b/ci_shards/shard-2.txt
@@ -186,6 +186,7 @@ tests/services/spike_attribution/test_hooks.py
 tests/services/spike_attribution/test_precompute.py
 tests/services/spike_attribution/test_scoring.py
 tests/services/test_account_routing.py
+tests/services/test_alpaca_paper_lab_recovery_contract.py
 tests/services/test_alpaca_paper_ledger_claim.py
 tests/services/test_alpaca_paper_market_evidence.py
 tests/services/test_alpaca_paper_order_application.py

--- a/docs/contracts/rob-1267-us-alpaca-lab-recovery.md
+++ b/docs/contracts/rob-1267-us-alpaca-lab-recovery.md
@@ -1,0 +1,295 @@
+# ROB-1267 — US Alpaca paper *lab* lane lifecycle-recovery contract
+
+## Scope and authority
+
+This is a contract-only artifact (J5B).  It consumes the signed registry and
+the merged J5A contract without changing them, and it authorizes no broker,
+network, database, scheduler, deployment, credential, or account operation.
+It creates no policy, assigns no writer, proposes no cadence, and grants no
+canary.  It moves no lane to an enabled activation state.
+
+It covers exactly one lane: `us.alpaca.paper.lab`.
+
+Its single subject is the **lane-native lifecycle recovery contract** for that
+lane, plus the two pre-submit boundary invariants recorded in §6.  Recording
+the contract is not a request to enable anything; activation is a separate
+approval outside this document.
+
+`us.alpaca.paper.default` is deliberately **not** given a record here.  §6.1
+records why the two lanes may never be collapsed into one callback or one
+ledger instance, which is the only thing this document has to say about the
+default lane.
+
+### Relationship to ROB-1266 (READ ONLY)
+
+`docs/contracts/rob-1266-us-readiness.md` is the merged J5A contract and is the
+authority for this lane's registry record — its role, its statuses, its writer
+and owner fields, its namespace, its hosts, and its unmet-binding list.  This
+document **references and cites it; it does not re-render, restate, redefine,
+or modify it.**  Registry facts are cited by path, section, and line rather
+than reproduced, so that no second rendering of the same fact can drift from
+the first.  Where this document and ROB-1266 disagree, **ROB-1266 is
+authoritative** and this document is the defect.  Where this document and the
+registry disagree, **the registry is authoritative** and this document is the
+defect.
+
+That citation discipline is machine-enforced: `test_g5` in
+`tests/services/test_alpaca_paper_lab_recovery_contract.py` pulls this lane's
+distinctive registry axis values live from `SIGNED_SOURCE` and fails if any of
+them is transcribed into this file.
+
+**This lane's lifecycle verdict is one of those already-recorded facts.**  J5A
+records it on the lane's own status axis at
+`docs/contracts/rob-1266-us-readiness.md:372`.  Unlike the two KIS/Kiwoom lanes
+of ROB-1268 — whose signed allowlist admits only a different status, so the
+lifecycle verdict needed a separate axis to live on — this lane's signed status
+*is already* the lifecycle-blocked one.  Writing it again here, on any axis,
+would be a second independent recording of a fact ROB-1266 owns.  Therefore
+this document **carries no lifecycle status value at all.**  It cites the line
+that holds it and contributes only what J5A does not have: which specific rule
+items are unmet, and on what merged evidence.
+
+## 1. Document-level fixed tokens
+
+```text
+SIGNED_SOURCE = app/services/mock_lane_registry.py::CANONICAL_LANE_REGISTRY @ e057941425d2ea7d35a36ebf6074a6c70eba3013
+US_READINESS_CONTRACT = docs/contracts/rob-1266-us-readiness.md @ ddf4895ece2ca9dff8daf1a04fa7d6143f43c899
+LIFECYCLE_RULE_RENDERING = docs/contracts/rob-1268-us-kis-kiwoom-readiness.md#2-the-lifecycle-rule-being-applied @ 6db485f2adfc6fb1861c61285cb4e7c2255c0042
+```
+
+Each token appears exactly once in this document.
+
+The implementation modules cited throughout §4 and §6 are deliberately **not**
+pinned to a commit.  They are live, currently-edited surfaces; a commit pin on
+them would be stale on the next merge and would invite exactly the drift this
+document is trying to avoid.  They are cited by path plus the named symbol that
+carries the behaviour, and `test_g13` fails if any cited symbol disappears.
+
+## 2. The lifecycle rule being applied
+
+The controlling rule is the same six-item rule J5C already renders verbatim, at
+`LIFECYCLE_RULE_RENDERING`.  It is **not re-rendered here**: a second in-repo
+rendering of the same upstream text is a second thing to keep in sync, and
+keeping only one rendering is the whole point of §"Relationship to ROB-1266"
+above.  What this document reuses is the rule's item set, because those are the
+record keys of §4:
+
+`recovery_owner`, `restart_rediscovery_trigger`,
+`authoritative_readback_operation`, `lane_native_evidence`,
+`release_if_matches_condition`, `operator_visible_blocked_state`.
+
+`lane_native_evidence` is itself decided by the seven evidence outcomes the
+rule names, which are the record keys of the EVIDENCE block in §4.
+
+One consequence is binding on this document: **no broker-specific retry,
+readback, or manual-resolution queue is added anywhere by this work.**  This
+document adds no runtime module and no scheduler entry, and the tests it ships
+inject their own doubles rather than reaching a broker, a database, or a
+credential.
+
+## 3. Record shape
+
+The lane is recorded as a `### LANE <lane_id>` heading followed by exactly two
+fenced blocks, in this order:
+
+1. a **LIFECYCLE** block whose first line is `# LIFECYCLE`, and
+2. an **EVIDENCE** block whose first line is `# EVIDENCE`.
+
+- The LIFECYCLE block's key set is exactly: `lane_id`,
+  `lifecycle_status_authority`, `recovery_owner`,
+  `restart_rediscovery_trigger`, `authoritative_readback_operation`,
+  `release_if_matches_condition`, `operator_visible_blocked_state`,
+  `unmet_lifecycle_items` — eight keys, no extras, no omissions.
+- The EVIDENCE block's key set is exactly the seven evidence outcomes named by
+  the rule in §2: `ack`, `unknown`, `reject`, `expiry`, `partial_fill`,
+  `cancel`, `terminal_reconciliation` — seven keys, no extras, no omissions.
+
+Each body line is `<key> = <rendered value>`.  Keys do not repeat within a
+block.  `lane_id`, `lifecycle_status_authority` and `unmet_lifecycle_items` are
+bookkeeping keys and carry no state.  Every other value — the five rule items
+and all seven evidence outcomes — begins with one of exactly three states:
+
+- `PRESENT` — a merged in-repo anchor satisfies the item for this lane.
+- `PRESENT_CONSTRAINED` — an anchor exists but carries a recorded limitation
+  that stops it from satisfying the item unaided.
+- `ABSENT` — no merged anchor satisfies the item for this lane.
+
+`PRESENT_CONSTRAINED` and `ABSENT` both count as **unmet**.  A constrained item
+is not partial credit.
+
+Every state below is *derived from merged code at test time*, never read back
+out of this document.  `test_g8`/`test_g9` recompute each state from the
+registry and the implementation modules and fail if the value written here
+disagrees; `test_g10` recomputes `unmet_lifecycle_items` the same way.  A state
+cannot be improved by editing this file.
+
+## 4. Lane record
+
+### LANE us.alpaca.paper.lab
+
+```text
+# LIFECYCLE
+lane_id = us.alpaca.paper.lab
+lifecycle_status_authority = US_READINESS_CONTRACT §8, heading `### LANE us.alpaca.paper.lab`, line 372 — this lane's lifecycle verdict is recorded there and is deliberately not restated on any axis of this document
+recovery_owner = ABSENT (this lane's unmet-binding list is owned by US_READINESS_CONTRACT §8 and records no bound owner there; that list is not restated here)
+restart_rediscovery_trigger = ABSENT (no owner exists to own one, and nothing merged rediscovers surviving claims at start-up: an execution row whose submit crashed mid-flight is deliberately *retained* rather than re-posted — see is_inflight_execution in app/services/alpaca_paper_ledger_service.py — and the only resolver, AlpacaPaperSubmitCoordinator._resolve_inflight in app/services/alpaca_paper_submit_service.py, runs a bounded poll inside a live duplicate submit call, not at process start)
+authoritative_readback_operation = PRESENT (AlpacaPaperReconcileService._reconcile_one reads the single order back by key via broker.get_order_by_client_order_id in app/services/alpaca_paper_reconcile_service.py, and the candidate set it reads is lane-scoped because AlpacaPaperLedgerService.list_reconcile_candidates filters on the instance's pinned account_mode)
+release_if_matches_condition = PRESENT_CONSTRAINED (a release predicate exists but is cancel-scoped, not recovery-scoped: alpaca_paper_cancel_order in app/mcp_server/tooling/alpaca_paper_orders.py releases the sell reservation only when its read-back both succeeds and normalizes to the canceled status, and keeps the hold otherwise; no recovery-contract release condition is designated for this lane and none is inferred here)
+operator_visible_blocked_state = PRESENT (the manual_review closure in AlpacaPaperReconcileService._reconcile_one returns action noop_requires_manual_review with requires_manual_review true and a reason, for an unreadable broker answer, a missing order, an incomplete fill set, and a filled status carrying no fill quantity)
+unmet_lifecycle_items = (recovery_owner, restart_rediscovery_trigger, release_if_matches_condition, lane_native_evidence)
+```
+
+```text
+# EVIDENCE
+ack = PRESENT (AlpacaPaperLedgerService.record_submit stamps broker_order_id and submitted_at onto the lane-pinned execution row claimed by claim_submit; see §5.1)
+unknown = ABSENT (nothing lane-native is written for an unresolvable broker answer — the manual_review closure builds a return payload and performs no ledger write at all, so the row keeps its prior state and the only record of the unknown outcome is the ephemeral tool response; see §5.2)
+reject = PRESENT (AlpacaPaperLedgerService.record_submit_failure books a deterministic broker rejection terminally, with a redacted bounded error_summary; see §5.1)
+expiry = PRESENT_CONSTRAINED (an expired order is booked, but no lane-native terminal state distinguishes it: derive_lifecycle_state in app/services/alpaca_paper_ledger_service.py maps expiry, rejection and suspension to one and the same anomaly state, and only the raw order_status column separates them; see §5.3)
+partial_fill = PRESENT (resolve_transition in app/services/alpaca_paper_reconcile_service.py forces the partially_filled broker status on a partial verdict so the ledger is never promoted past its evidence, and the booked quantity and average price are persisted; see §5.1)
+cancel = PRESENT (AlpacaPaperLedgerService.record_cancel writes cancel_status and canceled_at, and derive_lifecycle_state books a canceled order terminally only when that cancel evidence is present, treating a cancel without evidence as an anomaly instead; see §5.1)
+terminal_reconciliation = PRESENT (AlpacaPaperLedgerService.record_reconcile and record_final_reconcile write reconcile_status and reconciled_at, and the final-reconciled state is inside the terminal set that removes the row from the reconcile candidate query; see §5.1)
+```
+
+## 5. Evidence-surface findings
+
+### 5.1 The Alpaca ledger *is* lane-separable, so most outcomes are lane-native
+
+Unlike the two lanes of ROB-1268, this lane has a usable lane-native evidence
+table.  `alpaca_paper_order_ledger` carries an `account_mode` column
+(`app/models/review.py::AlpacaPaperOrderLedger`), and
+`AlpacaPaperLedgerService` pins exactly one normalized account mode per
+instance in its constructor and puts that mode into the predicate of every read
+it performs — `get_by_client_order_id`, `get_by_id`, `list_recent`,
+`list_reconcile_candidates`, and the sell-reservation queries alike — and into
+the values of the row `claim_submit` inserts.
+
+That is why five of the seven outcomes above come out `PRESENT`: the writer
+exists *and* what it writes is attributable to this lane rather than to the
+default one.  §6.1 records the invariant that keeps it that way.
+
+### 5.2 The missing outcome is `unknown`, and it is missing by omission of a write
+
+`AlpacaPaperReconcileService._reconcile_one` escalates four distinct
+unresolvable conditions through one local `manual_review` closure: the broker
+read raised, the broker returned no such order, the fill set could not be
+proven complete, and the broker called the order filled while producing no fill
+quantity.  Each of those is exactly the "unknown" outcome the rule names.
+
+The closure updates the in-memory result dict and returns it.  **It performs no
+ledger write.**  The row therefore stays in whatever non-terminal state it was
+already in, indistinguishable from a row nobody has looked at yet, and the fact
+that an authoritative readback was attempted and failed survives only in the
+tool's return value.  A recovery owner arriving after a restart would have no
+lane-native record that the condition had ever been observed.
+
+This is recorded, not repaired.  Adding such a write is a runtime change to a
+shared reconcile path used by the default and crypto lanes too, and it is not
+in this document's scope.
+
+### 5.3 Expiry, rejection and suspension collapse into one lifecycle state
+
+`derive_lifecycle_state` maps all three of those broker statuses to the single
+anomaly lifecycle state.  The distinguishing information is not lost — the raw
+broker status is persisted on `order_status`, and `record_submit_failure`
+additionally persists a bounded, redacted `error_summary` — but the lane's own
+lifecycle vocabulary cannot tell an expiry from a rejection.
+
+Rejection is nevertheless recorded `PRESENT` and expiry `PRESENT_CONSTRAINED`,
+because rejection has a dedicated lane-native writer that stamps its own status
+and summary, and expiry has none: an expired order reaches the ledger only
+through the generic zero-fill terminalization path that
+`AlpacaPaperReconcileService` shares with every other terminal status.
+
+### 5.4 What C3-1, C3-2 and C3-5 would each require, and why none is filled in
+
+None of the three unmet lifecycle items is filled in with an inferred value,
+and no value for them is proposed here:
+
+- **`recovery_owner`** would require a designated owner for this lane.  The
+  registry itself records that this lane has no bound owner, in the
+  unmet-binding list ROB-1266 §8 holds.  Naming one is an operator act; a
+  contract cannot appoint it.
+- **`restart_rediscovery_trigger`** would require something that runs at
+  start-up and rediscovers surviving durable claims.  Nothing merged does that,
+  and a trigger is a thing an owner owns — with no owner there is nobody to own
+  one.  Inventing a trigger here would create an unowned automatic action,
+  which is worse than the gap.
+- **`release_if_matches_condition`** would require an exact match predicate
+  under which recovery may release a held claim.  The nearest merged predicate
+  is cancel-scoped, and the whole point of a recovery release condition is that
+  it is *not* the ordinary cancel path.  Substituting the cancel predicate for
+  it would look like a satisfied item while leaving the real one unwritten.
+
+The value of this record is that these three stay unmet.
+
+## 6. Pre-submit boundary invariants
+
+Both invariants below are enforced by tests that this work ships, and both were
+verified by mutation: the invariant's guard was removed in the working tree,
+the test was observed to fail, and the guard was restored.
+
+### 6.1 The lab lane and the default lane never collapse into one path
+
+Three independent mechanisms keep them apart, and all three must hold:
+
+1. **Profile routing.**  `profile_for_account_mode` in
+   `app/services/alpaca_paper_account_modes.py` maps the lab account mode to
+   its own broker profile, and `_service_for_account_mode` in
+   `app/mcp_server/tooling/alpaca_paper_orders.py` constructs the broker
+   service from that profile.  The three supported paper account modes map to
+   three distinct profiles; no two share one.
+2. **Ledger pinning.**  An `AlpacaPaperLedgerService` instance normalizes one
+   account mode in its constructor and carries it in the predicate of every
+   read and the values of every claim.  A lab-pinned instance cannot see, book
+   against, or terminalize a default-lane row.
+3. **Packet/coordinator binding.**  `AlpacaPaperSubmitCoordinator` verifies the
+   packet's account mode against the mode it was constructed for, before any
+   broker work, and rejects a mismatch with the packet layer's
+   account-mode-mismatch code.  The rejection is symmetric: a default packet
+   offered to a lab coordinator and a lab packet offered to a default
+   coordinator are both refused, and neither reaches the broker.
+
+`tests/mcp_server/test_alpaca_paper_lab_automated_boundary.py` covers all three.
+
+### 6.2 Contaminated, foreign, or unlinked residue is a pre-submit stop
+
+`scripts/b0x/us/cycle.py::run_us_cycle` checks the account state's
+contamination flag *first* among its submission gates — ahead of the confirm
+flag and ahead of the presence of an injected submitter — and on contamination
+records a skip reason and leaves the submitted list empty.  No planned order is
+handed to a submitter, so an injected seam is called zero times.
+
+Contamination is not limited to an obviously foreign symbol.
+`_attribute_positions` in `scripts/b0x/us/alpaca.py` adds a position to the
+foreign set on *every* attribution failure — no `b0xu-` correlation at all, a
+correlated execution whose fill quantity is unreadable, and a correlated
+execution set whose signed quantity does not exactly equal the broker quantity
+— recording a human-readable linkage failure alongside each one.  Because the
+contamination flag is computed from the foreign sets, every linkage failure is
+also a contamination, and an "unlinked residue" cannot slip through as merely a
+note.
+
+Independently, the seam itself is unwired by default:
+`submit_planned_order` and `cancel_own_open_orders` in `scripts/b0x/us/alpaca.py`
+raise rather than default to a broker, and an unconfirmed submit returns its
+confirmation-required response without calling an injected submitter even when
+one is present.
+
+`tests/scripts/b0x/us/test_alpaca_lab_mutation_seam.py` covers all of these as
+call-count assertions.
+
+## 7. What this document does not do
+
+- It does not move any lane to an enabled activation state, set `writer` or
+  `auto_order_enabled` true, name a scheduler owner, arm an environment
+  variable, or register a scheduler entry.  Nothing in this work does.
+- It does not create, propose, or imply a policy, a cap, a cadence, a canary,
+  an FX rule, or a physical-account identity.
+- It does not name a recovery owner, invent a restart trigger, or designate a
+  release condition; §5.4 records why each stays unwritten.
+- It does not modify `US_READINESS_CONTRACT`, restate any registry axis value
+  it owns, or record this lane's lifecycle status a second time.
+- It does not add a retry queue, a durable state store, a janitor, a takeover,
+  or a recovery API to any shared coordination layer.
+- It does not change any runtime module.  This work ships one document, three
+  test files, and the manifest lines those test files require.

--- a/tests/mcp_server/test_alpaca_paper_lab_automated_boundary.py
+++ b/tests/mcp_server/test_alpaca_paper_lab_automated_boundary.py
@@ -1,0 +1,353 @@
+"""ROB-1267 J5B §6.1 — the lab lane and the default lane never collapse.
+
+Three independent mechanisms keep the two Alpaca paper lanes apart, and the
+contract in `docs/contracts/rob-1267-us-alpaca-lab-recovery.md` §6.1 depends on
+all three holding at once:
+
+1. profile routing — one broker profile per account mode, none shared;
+2. ledger pinning — one normalized account mode per service instance, carried
+   in the predicate of every read and the values of every claim;
+3. packet/coordinator binding — an account-mode mismatch is refused before any
+   broker or ledger work, symmetrically in both directions.
+
+Every assertion below is a *separation* assertion.  Nothing here submits,
+cancels, or reconciles against a broker; there is no database session, no
+credential, and no HTTP.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from app.mcp_server.tooling import alpaca_paper_orders as orders_mod
+from app.services.alpaca_paper_account_modes import (
+    ALPACA_PAPER_ACCOUNT_MODE,
+    ALPACA_PAPER_ACCOUNT_MODES,
+    ALPACA_PAPER_CRYPTO_ACCOUNT_MODE,
+    ALPACA_PAPER_LAB_ACCOUNT_MODE,
+    profile_for_account_mode,
+)
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_submit_service import (
+    AlpacaPaperSubmitCoordinator,
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+)
+from app.services.paper_approval_packet import PaperApprovalPacket
+
+pytestmark = pytest.mark.unit
+
+_FUTURE = datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# 1. profile routing
+# ---------------------------------------------------------------------------
+def test_every_supported_account_mode_routes_to_its_own_profile() -> None:
+    """No two paper account modes may share a broker profile."""
+    profiles = {
+        mode: profile_for_account_mode(mode) for mode in ALPACA_PAPER_ACCOUNT_MODES
+    }
+    assert len(set(profiles.values())) == len(profiles), (
+        f"paper account modes collapsed onto a shared profile: {profiles}"
+    )
+    # And specifically: the lab mode does not land on the default lane's route.
+    assert profiles[ALPACA_PAPER_LAB_ACCOUNT_MODE] is not None
+    assert (
+        profiles[ALPACA_PAPER_LAB_ACCOUNT_MODE]
+        != profiles[ALPACA_PAPER_ACCOUNT_MODE]
+        != profiles[ALPACA_PAPER_CRYPTO_ACCOUNT_MODE]
+    )
+
+
+def test_service_for_lab_account_mode_is_built_from_the_lab_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    built: list[str | None] = []
+
+    class RecordingService:
+        def __init__(self, *, profile: str | None = None) -> None:
+            built.append(profile)
+
+    monkeypatch.setattr(orders_mod, "AlpacaPaperBrokerService", RecordingService)
+    orders_mod._service_for_account_mode(ALPACA_PAPER_LAB_ACCOUNT_MODE)
+    assert built == [profile_for_account_mode(ALPACA_PAPER_LAB_ACCOUNT_MODE)]
+
+    built.clear()
+    # The default lane is constructed without a profile, so the two lanes never
+    # share one construction argument.
+    orders_mod._service_for_account_mode(ALPACA_PAPER_ACCOUNT_MODE)
+    assert built == [profile_for_account_mode(ALPACA_PAPER_ACCOUNT_MODE)]
+    assert built != [profile_for_account_mode(ALPACA_PAPER_LAB_ACCOUNT_MODE)]
+
+
+# ---------------------------------------------------------------------------
+# 2. ledger pinning
+# ---------------------------------------------------------------------------
+class _NullResult:
+    def scalar_one_or_none(self) -> None:
+        return None
+
+    def scalars(self) -> _NullResult:
+        return self
+
+    def all(self) -> list[Any]:
+        return []
+
+
+class _RecordingSession:
+    """Captures every statement a ledger read compiles, and executes none."""
+
+    def __init__(self) -> None:
+        self.statements: list[Any] = []
+
+    async def execute(self, statement: Any, *args: Any, **kwargs: Any) -> _NullResult:
+        self.statements.append(statement)
+        return _NullResult()
+
+    def expire_all(self) -> None:
+        return None
+
+
+_READS = (
+    ("get_by_client_order_id", ("cid",), {}),
+    ("get_by_id", (1,), {}),
+    ("list_recent", (), {"limit": 5}),
+    ("list_reconcile_candidates", (), {"limit": 5}),
+    ("get_execution_by_client_order_id", ("cid",), {}),
+    ("get_preview_by_client_order_id", ("cid",), {}),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,args,kwargs", _READS, ids=[r[0] for r in _READS])
+async def test_lab_pinned_ledger_reads_carry_the_lab_account_mode(
+    method: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> None:
+    session = _RecordingSession()
+    ledger = AlpacaPaperLedgerService(
+        session,  # type: ignore[arg-type]
+        account_mode=ALPACA_PAPER_LAB_ACCOUNT_MODE,
+    )
+    await getattr(ledger, method)(*args, **kwargs)
+
+    assert session.statements, f"{method} issued no statement"
+    for statement in session.statements:
+        sql = str(
+            statement.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        assert f"'{ALPACA_PAPER_LAB_ACCOUNT_MODE}'" in sql, (
+            f"{method}: read is not scoped to the lab account mode:\n{sql}"
+        )
+        assert f"'{ALPACA_PAPER_ACCOUNT_MODE}'" not in sql.replace(
+            f"'{ALPACA_PAPER_LAB_ACCOUNT_MODE}'", ""
+        ), f"{method}: read reaches the default lane as well:\n{sql}"
+
+
+def test_ledger_instance_pins_exactly_one_normalized_mode() -> None:
+    session = _RecordingSession()
+    lab = AlpacaPaperLedgerService(
+        session,  # type: ignore[arg-type]
+        account_mode=f"  {ALPACA_PAPER_LAB_ACCOUNT_MODE.upper()}  ",
+    )
+    assert lab._account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE
+    default = AlpacaPaperLedgerService(session)  # type: ignore[arg-type]
+    assert default._account_mode == ALPACA_PAPER_ACCOUNT_MODE
+    assert lab._account_mode != default._account_mode
+
+    with pytest.raises(ValueError):
+        AlpacaPaperLedgerService(session, account_mode="alpaca_paper_labs")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 3. packet / coordinator binding
+# ---------------------------------------------------------------------------
+class _ExplodingLedger:
+    """Any attribute touch is a contract violation: the reject precedes work."""
+
+    def __getattr__(self, name: str) -> Any:
+        raise AssertionError(
+            f"ledger was touched before the account-mode check: {name}"
+        )
+
+
+_CORRELATION = "rob1267-boundary"
+_SNAPSHOT = "rob1267-snapshot"
+
+
+def _canonical() -> dict[str, Any]:
+    return build_canonical_payload(
+        symbol="AAPL",
+        side="buy",
+        asset_class="us_equity",
+        type="limit",
+        time_in_force="day",
+        qty=None,
+        notional=Decimal("300"),
+        limit_price=Decimal("100"),
+    )
+
+
+def _packet(*, account_mode: str, client_order_id: str) -> PaperApprovalPacket:
+    """A packet that passes every binding check except the account-mode one."""
+    canonical = _canonical()
+    return PaperApprovalPacket(
+        signal_source="rob1267-boundary",
+        artifact_id=uuid.uuid4(),
+        signal_symbol="AAPL",
+        signal_venue="policy_table_us",
+        execution_symbol="AAPL",
+        execution_venue="alpaca_paper",
+        execution_asset_class="us_equity",
+        side="buy",
+        max_notional=Decimal("300"),
+        qty_source="notional",
+        expected_lifecycle_step="submitted",
+        lifecycle_correlation_id=_CORRELATION,
+        client_order_id=client_order_id,
+        expires_at=_FUTURE,
+        account_mode=account_mode,
+        origin="automated",
+        snapshot_id=_SNAPSHOT,
+        preview_payload_hash=canonical_hash(canonical),
+        execution_order_type="limit",
+        execution_time_in_force="day",
+    )
+
+
+def _server_key(account_mode: str) -> str:
+    return derive_automated_key(
+        correlation_id=_CORRELATION,
+        snapshot_id=_SNAPSHOT,
+        canonical=_canonical(),
+        account_mode=account_mode,
+    )
+
+
+def test_the_derived_idempotency_key_is_namespaced_per_account_mode() -> None:
+    """Even the claim key cannot collide across the two lanes."""
+    keys = {
+        mode: _server_key(mode)
+        for mode in (ALPACA_PAPER_ACCOUNT_MODE, ALPACA_PAPER_LAB_ACCOUNT_MODE)
+    }
+    assert len(set(keys.values())) == 2, f"lane keys collided: {keys}"
+
+
+class _CountingBrokerFactory:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> Any:
+        self.calls += 1
+        raise AssertionError("broker was constructed for a mismatched packet")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected,packet_mode",
+    [
+        (ALPACA_PAPER_LAB_ACCOUNT_MODE, ALPACA_PAPER_ACCOUNT_MODE),
+        (ALPACA_PAPER_ACCOUNT_MODE, ALPACA_PAPER_LAB_ACCOUNT_MODE),
+    ],
+    ids=["default-packet-to-lab-coordinator", "lab-packet-to-default-coordinator"],
+)
+async def test_account_mode_mismatch_is_refused_before_broker_or_ledger_work(
+    expected: str, packet_mode: str
+) -> None:
+    broker_factory = _CountingBrokerFactory()
+    coordinator = AlpacaPaperSubmitCoordinator(
+        _ExplodingLedger(),  # type: ignore[arg-type]
+        broker_factory,
+        expected_account_mode=expected,
+        now_fn=lambda: _FUTURE - timedelta(minutes=1),
+    )
+    # The key is derived for the coordinator's own mode, so every earlier
+    # binding check passes and the account-mode check is what actually fires.
+    packet = _packet(account_mode=packet_mode, client_order_id=_server_key(expected))
+
+    outcome = await coordinator.submit(packet, submit_canonical=_canonical())
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "account_mode_mismatch"
+    assert outcome.broker_called is False
+    assert outcome.submitted is False
+    assert outcome.success is False
+    assert broker_factory.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_coordinator_normalizes_its_expected_mode_rather_than_widening_it() -> (
+    None
+):
+    """A coordinator is bound to one mode; an unknown mode is not accepted."""
+    coordinator = AlpacaPaperSubmitCoordinator(
+        _ExplodingLedger(),  # type: ignore[arg-type]
+        _CountingBrokerFactory(),
+        expected_account_mode=f" {ALPACA_PAPER_LAB_ACCOUNT_MODE.upper()} ",
+    )
+    assert coordinator._expected_account_mode == ALPACA_PAPER_LAB_ACCOUNT_MODE
+
+    with pytest.raises(ValueError):
+        AlpacaPaperSubmitCoordinator(
+            _ExplodingLedger(),  # type: ignore[arg-type]
+            _CountingBrokerFactory(),
+            expected_account_mode="alpaca_paper_labs",
+        )
+
+
+@pytest.mark.asyncio
+async def test_lab_reconcile_tool_pins_both_ledger_and_broker_to_the_lab_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`alpaca_paper_reconcile_orders` may not hand a default service to the lab."""
+    seen: dict[str, Any] = {}
+
+    class _Session:
+        async def __aenter__(self) -> _Session:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+    monkeypatch.setattr(orders_mod, "_session_factory", lambda: _Session)
+
+    def _ledger(db: Any, account_mode: str = ALPACA_PAPER_ACCOUNT_MODE) -> str:
+        seen["ledger_mode"] = account_mode
+        return f"ledger:{account_mode}"
+
+    def _service(account_mode: str) -> str:
+        seen.setdefault("service_modes", []).append(account_mode)
+        return f"broker:{account_mode}"
+
+    class _Reconcile:
+        def __init__(self, ledger: Any, broker: Any) -> None:
+            seen["pair"] = (ledger, broker)
+
+        async def reconcile(self, **kwargs: Any) -> dict[str, Any]:
+            return {"success": True, "dry_run": True, "reconciled": [], "count": 0}
+
+    monkeypatch.setattr(orders_mod, "AlpacaPaperLedgerService", _ledger)
+    monkeypatch.setattr(orders_mod, "_service_for_account_mode", _service)
+    monkeypatch.setattr(orders_mod, "AlpacaPaperReconcileService", _Reconcile)
+
+    result = await orders_mod.alpaca_paper_reconcile_orders(
+        account_mode=ALPACA_PAPER_LAB_ACCOUNT_MODE, dry_run=True
+    )
+
+    assert result["account_mode"] == ALPACA_PAPER_LAB_ACCOUNT_MODE
+    assert seen["ledger_mode"] == ALPACA_PAPER_LAB_ACCOUNT_MODE
+    assert set(seen["service_modes"]) == {ALPACA_PAPER_LAB_ACCOUNT_MODE}
+    assert seen["pair"] == (
+        f"ledger:{ALPACA_PAPER_LAB_ACCOUNT_MODE}",
+        f"broker:{ALPACA_PAPER_LAB_ACCOUNT_MODE}",
+    )

--- a/tests/scripts/b0x/us/test_alpaca_lab_mutation_seam.py
+++ b/tests/scripts/b0x/us/test_alpaca_lab_mutation_seam.py
@@ -1,0 +1,405 @@
+"""ROB-1267 J5B §6.2 — contaminated / foreign / unlinked residue is a pre-submit stop.
+
+The contract in `docs/contracts/rob-1267-us-alpaca-lab-recovery.md` §6.2 claims
+that the lab lane's mutation seam is never reached while the account carries
+residue the lane cannot attribute to itself.  These tests state that as a
+**call-count** contract: the injected submit/cancel callbacks are invoked
+exactly zero times.
+
+Three shapes of residue are covered, because only the first is obvious:
+
+* a genuinely foreign open order (no `b0xu-` correlation anywhere),
+* an *unlinked* position — one that does have `b0xu-` executions, but whose
+  broker quantity does not reconcile against them, and
+* a correlated position whose fill quantity is unreadable.
+
+The last two are the ones that could plausibly have been recorded as a mere
+note.  `_attribute_positions` puts every attribution failure into the foreign
+set as well, which is what makes the contamination flag cover them; the
+structural test below pins that relationship directly.
+
+Everything is offline: fake readers, injected callbacks, no broker, no ledger,
+no network.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.mcp_server.tooling.market_session import US_SESSION_REGULAR
+from scripts.b0x.broker_truth import BrokerTruth
+from scripts.b0x.us import alpaca
+from scripts.b0x.us import cycle as us_cycle
+from scripts.policy_table.core.schema import compute_policy_table_hash
+from tests.scripts.b0x._table_fixtures import make_payload, make_row, write_table
+
+pytestmark = pytest.mark.unit
+
+NOW = dt.datetime(2026, 8, 10, 15, 0, tzinfo=dt.UTC)
+
+
+def _table_dir(tmp_path: Path) -> Path:
+    payload = make_payload(
+        market="us",
+        rows=[
+            make_row(
+                symbol="AAPL",
+                previous_close="100",
+                buy_l1="97",
+                sell_r1="105",
+                sell_r2="110",
+            )
+        ],
+        generated_at=NOW - dt.timedelta(hours=1),
+    )
+    payload["config"] = {
+        **payload["config"],
+        "quote_currency": "USD",
+        "new_entry_notional_usd_min": "150",
+        "new_entry_notional_usd_max": "450",
+        "new_entry_notional_usd": "300",
+    }
+    payload["sizing"] = {}
+    payload["stamps"]["policy_table_hash"] = compute_policy_table_hash(
+        {key: value for key, value in payload.items() if key != "stamps"}
+    )
+    directory = tmp_path / "policy-tables"
+    write_table(directory, payload, market="us")
+    return directory
+
+
+def _readers(
+    *,
+    positions: list[dict[str, Any]] | None = None,
+    orders: list[dict[str, Any]] | None = None,
+    ledger: list[dict[str, Any]] | None = None,
+) -> alpaca.LabReaders:
+    async def account(**_: Any) -> dict[str, Any]:
+        return {
+            "success": True,
+            "account_mode": alpaca.LANE,
+            "account": {"cash": "5000", "portfolio_value": "5000"},
+        }
+
+    def _page(key: str, values: list[dict[str, Any]] | None) -> dict[str, Any]:
+        items = values or []
+        return {
+            "success": True,
+            "account_mode": alpaca.LANE,
+            "count": len(items),
+            key: items,
+        }
+
+    async def list_positions(**_: Any) -> dict[str, Any]:
+        return _page("positions", positions)
+
+    async def list_orders(**_: Any) -> dict[str, Any]:
+        return _page("orders", orders)
+
+    async def list_ledger(**_: Any) -> dict[str, Any]:
+        return _page("items", ledger)
+
+    return alpaca.LabReaders(
+        get_account=account,
+        list_positions=list_positions,
+        list_orders=list_orders,
+        list_recent_ledger=list_ledger,
+    )
+
+
+def _position(symbol: str, qty: str) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "qty": qty,
+        "qty_available": qty,
+        "avg_entry_price": "20",
+    }
+
+
+def _execution(
+    *,
+    symbol: str,
+    filled_qty: str | None,
+    broker_order_id: str = "own-1",
+    side: str = "buy",
+    age: dt.timedelta = dt.timedelta(days=3),
+) -> dict[str, Any]:
+    """A b0xu execution row.
+
+    ``age`` defaults to a *prior* UTC day on purpose.  A same-day execution
+    trips the realized-P&L fail-closed first (covered separately below), which
+    would hide the contamination gate these cases are here to exercise.
+    """
+    return {
+        "lifecycle_correlation_id": f"{alpaca.B0XU_CORRELATION_PREFIX}{symbol.lower()}",
+        "account_mode": alpaca.LANE,
+        "record_kind": "execution",
+        "client_order_id": f"coid-{symbol.lower()}",
+        "broker_order_id": broker_order_id,
+        "execution_symbol": symbol,
+        "side": side,
+        "filled_qty": filled_qty,
+        "filled_avg_price": "20",
+        "created_at": (NOW - age).isoformat(),
+    }
+
+
+class _CountingSeam:
+    """A submitter/canceler that must never be called."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append({"args": args, **kwargs})
+        return {"submitted": True}
+
+
+# ---------------------------------------------------------------------------
+# residue shapes → zero seam calls
+# ---------------------------------------------------------------------------
+_RESIDUE_CASES = {
+    # An open order with no b0xu correlation at all.
+    "foreign_open_order": {
+        "positions": [],
+        "orders": [{"id": "someone-elses", "symbol": "UBER"}],
+        "ledger": [],
+    },
+    # A position that IS b0xu-correlated, but whose broker quantity does not
+    # equal the signed b0xu fills.  Correlated, yet unattributable.
+    "unlinked_quantity_mismatch": {
+        "positions": [_position("AAPL", "5")],
+        "orders": [],
+        "ledger": [_execution(symbol="AAPL", filled_qty="2")],
+    },
+    # A b0xu-correlated position whose fill quantity cannot be read back.
+    "unlinked_unreadable_fill": {
+        "positions": [_position("AAPL", "2")],
+        "orders": [],
+        "ledger": [_execution(symbol="AAPL", filled_qty=None)],
+    },
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", sorted(_RESIDUE_CASES), ids=sorted(_RESIDUE_CASES))
+async def test_residue_blocks_confirmed_submit_with_zero_seam_calls(
+    case: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+    submitter = _CountingSeam()
+    canceler = _CountingSeam()
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        confirm=True,
+        readers=_readers(**_RESIDUE_CASES[case]),  # type: ignore[arg-type]
+        submitter=submitter,
+        canceler=canceler,
+    )
+
+    assert outcome.record["contaminated"] is True
+    assert outcome.record["submitted"] == []
+    assert "contaminated lab account state" in outcome.record["submission_skipped"]
+    assert submitter.calls == [], f"{case}: submit seam was called under residue"
+    assert canceler.calls == [], f"{case}: cancel seam was called under residue"
+
+
+@pytest.mark.asyncio
+async def test_contamination_gate_precedes_the_confirm_and_submitter_gates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Residue is reported as residue, not mislabelled as a missing seam."""
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+    submitter = _CountingSeam()
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        confirm=True,
+        readers=_readers(**_RESIDUE_CASES["foreign_open_order"]),  # type: ignore[arg-type]
+        submitter=submitter,
+    )
+    skipped = outcome.record["submission_skipped"]
+    assert "contaminated lab account state" in skipped
+    assert "confirm=False" not in skipped
+    assert "no approved injected" not in skipped
+    assert submitter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_same_day_unattributable_execution_stops_even_earlier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The contamination gate is not the only stop, and none of them submits.
+
+    When the unattributable execution is from the *current* UTC day, the cycle
+    fails closed on the realized-P&L read model before it ever reaches the
+    submission gates.  Recorded here so the ordering is pinned rather than
+    accidental — and so the seam call count is asserted on that path too.
+    """
+    monkeypatch.setattr(us_cycle, "us_market_session", lambda now: US_SESSION_REGULAR)
+    submitter = _CountingSeam()
+    canceler = _CountingSeam()
+
+    outcome = await us_cycle.run_us_cycle(
+        now=NOW,
+        table_dir=_table_dir(tmp_path),
+        out_dir=tmp_path / "observations",
+        confirm=True,
+        readers=_readers(
+            positions=[_position("AAPL", "5")],
+            ledger=[
+                _execution(symbol="AAPL", filled_qty="2", age=dt.timedelta(hours=2))
+            ],
+        ),
+        submitter=submitter,
+        canceler=canceler,
+    )
+
+    assert outcome.zero_order_reason == us_cycle.REALIZED_PNL_UNAVAILABLE_REASON
+    assert outcome.record["submitted"] == []
+    assert outcome.record["fresh_truth"]["foreign_position_symbols"] == ["AAPL"]
+    assert submitter.calls == []
+    assert canceler.calls == []
+
+
+# ---------------------------------------------------------------------------
+# the structural reason the above holds
+# ---------------------------------------------------------------------------
+def _raw(symbol: str, qty: str) -> alpaca.RawPosition:
+    return alpaca.RawPosition(
+        symbol=symbol,
+        quantity=Decimal(qty),
+        quantity_available=Decimal(qty),
+        average_price=Decimal("20"),
+    )
+
+
+def _ledger_execution(
+    symbol: str, filled_qty: str | None, side: str = "buy"
+) -> alpaca.LedgerExecution:
+    return alpaca.LedgerExecution(
+        correlation_id=f"{alpaca.B0XU_CORRELATION_PREFIX}{symbol.lower()}",
+        client_order_id=f"coid-{symbol.lower()}",
+        broker_order_id="own-1",
+        symbol=symbol,
+        side=side,
+        filled_qty=Decimal(filled_qty) if filled_qty is not None else None,
+        filled_avg_price=Decimal("20"),
+        created_at=NOW - dt.timedelta(hours=2),
+    )
+
+
+@pytest.mark.parametrize(
+    "executions",
+    [
+        pytest.param((), id="no_correlation"),
+        pytest.param((_ledger_execution("AAPL", None),), id="unreadable_fill"),
+        pytest.param((_ledger_execution("AAPL", "2"),), id="quantity_mismatch"),
+        pytest.param(
+            (
+                _ledger_execution("AAPL", "5"),
+                _ledger_execution("AAPL", "5", side="sell"),
+            ),
+            id="net_zero_signed_quantity",
+        ),
+    ],
+)
+def test_every_linkage_failure_is_also_a_contamination(
+    executions: tuple[alpaca.LedgerExecution, ...],
+) -> None:
+    """A linkage failure may never be recorded as a note only.
+
+    If a failure could be appended to the notes without also entering the
+    foreign set, the contamination flag would miss it and a confirmed cycle
+    would submit against an account it cannot account for.
+    """
+    owned, foreign, failures, _sources, _readable = alpaca._attribute_positions(
+        (_raw("AAPL", "5"),), executions
+    )
+    assert failures, "fixture did not produce a linkage failure"
+    assert owned == ()
+    failed_symbols = {failure.split(":", 1)[0] for failure in failures}
+    assert failed_symbols <= set(foreign), (
+        f"linkage failure(s) {sorted(failed_symbols)} absent from the foreign "
+        f"set {sorted(foreign)}: contamination would not be raised"
+    )
+
+
+# ---------------------------------------------------------------------------
+# the seam itself stays unwired, and an unconfirmed submit does not call it
+# ---------------------------------------------------------------------------
+def _planned() -> alpaca.PlannedOrder:
+    return alpaca.PlannedOrder(
+        order_key="rob1267-seam",
+        lifecycle_correlation_id=f"{alpaca.B0XU_CORRELATION_PREFIX}rob1267-seam",
+        symbol="AAPL",
+        side="buy",
+        leg="buy_l1",
+        price=Decimal("100"),
+        quantity=Decimal("3"),
+        notional=Decimal("300"),
+    )
+
+
+def _empty_truth() -> alpaca.FreshTruth:
+    return alpaca.FreshTruth(
+        cash=Decimal("1"),
+        nav=Decimal("1"),
+        positions=(),
+        open_orders=(),
+        own_open_orders=(alpaca.RawOpenOrder(broker_order_id="own-1", symbol="AAPL"),),
+        foreign_open_orders=(),
+        own_positions=(),
+        foreign_position_symbols=(),
+        position_linkage_failures=(),
+        sell_source_client_order_ids={},
+        realized_pnl_today=Decimal("0"),
+        cumulative_deployment_readable=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_submit_does_not_call_a_present_seam(
+    tmp_path: Path,
+) -> None:
+    """confirm is not a formality: a seam that exists is still not called."""
+    from scripts.b0x.table_source import PolicyTable, load_policy_table
+
+    submitter = _CountingSeam()
+    table = load_policy_table(market="us", now=NOW, table_dir=_table_dir(tmp_path))
+    assert isinstance(table, PolicyTable)
+
+    result = await alpaca.submit_planned_order(
+        planned=_planned(),
+        table=table,
+        confirm=False,
+        broker_truth=BrokerTruth(position_symbols=(), own_pending=()),
+        submitter=submitter,
+    )
+
+    assert result["submitted"] is False
+    assert result["reason_code"] == "confirmation_required"
+    assert result["account_mode"] == alpaca.LANE
+    assert submitter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_cancel_does_not_call_a_present_seam() -> None:
+    canceler = _CountingSeam()
+    assert (
+        await alpaca.cancel_own_open_orders(
+            fresh=_empty_truth(), confirm=False, canceler=canceler
+        )
+        == []
+    )
+    assert canceler.calls == []

--- a/tests/services/test_alpaca_paper_lab_recovery_contract.py
+++ b/tests/services/test_alpaca_paper_lab_recovery_contract.py
@@ -1,0 +1,499 @@
+"""ROB-1267 J5B — checker for the Alpaca paper *lab* lifecycle-recovery contract.
+
+The document under test is `docs/contracts/rob-1267-us-alpaca-lab-recovery.md`.
+
+Two things are enforced here, and they are deliberately separate concerns:
+
+1. **The document may not restate a fact ROB-1266 already owns.**  This lane's
+   lifecycle verdict is *already* its signed status, so writing it here on any
+   axis would be a second independent record of one fact.  ``test_g5`` pulls
+   this lane's distinctive registry axis values live from the registry and
+   fails if any of them appears in the file; ``test_g6`` fails if this checker
+   hand-writes one instead of deriving it.
+
+2. **Every declared state must be recomputed from merged code, never read back
+   out of the document.**  Otherwise declaring an item satisfied and deleting
+   it from the unmet list would pass — the exact fabrication the contract
+   exists to prevent.  Ground truth comes from the registry entry, the ledger
+   service, the reconcile service, and the MCP order tool module.
+
+No broker, network, database, or credential is touched.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import re
+import textwrap
+from decimal import Decimal
+
+import pytest
+
+from app.services import alpaca_paper_ledger_service as ledger_mod
+from app.services import alpaca_paper_reconcile_service as reconcile_mod
+from app.services.mock_lane_registry import MissingBinding, get_lane_registry_entry
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_DOC_PATH = _REPO_ROOT / "docs/contracts/rob-1267-us-alpaca-lab-recovery.md"
+_ORDERS_PATH = _REPO_ROOT / "app/mcp_server/tooling/alpaca_paper_orders.py"
+_SUBMIT_PATH = _REPO_ROOT / "app/services/alpaca_paper_submit_service.py"
+_CYCLE_PATH = _REPO_ROOT / "scripts/b0x/us/cycle.py"
+_ADAPTER_PATH = _REPO_ROOT / "scripts/b0x/us/alpaca.py"
+_MODES_PATH = _REPO_ROOT / "app/services/alpaca_paper_account_modes.py"
+
+_LANE = "us.alpaca.paper.lab"
+
+_FIXED_TOKENS = (
+    "SIGNED_SOURCE",
+    "US_READINESS_CONTRACT",
+    "LIFECYCLE_RULE_RENDERING",
+)
+
+# The rule's item set (§2 of the document).  ``lane_native_evidence`` is decided
+# by the EVIDENCE block rather than declared directly, so it is not a
+# LIFECYCLE key.
+_RULE_ITEMS = (
+    "recovery_owner",
+    "restart_rediscovery_trigger",
+    "authoritative_readback_operation",
+    "release_if_matches_condition",
+    "operator_visible_blocked_state",
+)
+_EVIDENCE_ITEM = "lane_native_evidence"
+_BOOKKEEPING_KEYS = ("lane_id", "lifecycle_status_authority", "unmet_lifecycle_items")
+_LIFECYCLE_KEYS = (*_BOOKKEEPING_KEYS[:2], *_RULE_ITEMS, _BOOKKEEPING_KEYS[2])
+
+_EVIDENCE_KINDS = (
+    "ack",
+    "unknown",
+    "reject",
+    "expiry",
+    "partial_fill",
+    "cancel",
+    "terminal_reconciliation",
+)
+
+_STATES = ("PRESENT_CONSTRAINED", "PRESENT", "ABSENT")
+_UNMET_STATES = ("PRESENT_CONSTRAINED", "ABSENT")
+
+# Axes whose *values* for this lane are owned by ROB-1266 §8.  Only distinctive
+# renderings are listed: axes whose value is an ordinary English word or a bare
+# number cannot be forbidden without forbidding the contract's own prose.
+_ROB1266_OWNED_SCALAR_AXES = (
+    "lane_status",
+    "activation_status",
+    "activation_reason",
+    "role_on_policy_approval",
+    "role_pending_reason",
+    "credential_namespace",
+)
+_ROB1266_OWNED_TUPLE_AXES = ("allowed_hosts", "missing_bindings")
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return _DOC_PATH.read_text(encoding="utf-8")
+
+
+def _entry():
+    return get_lane_registry_entry(_LANE)
+
+
+def _rendered(value: object) -> str | None:
+    """The value as the signed registry would render it, or None if not pinnable."""
+    if value is None or isinstance(value, bool):
+        return None
+    text = str(getattr(value, "value", value)).strip()
+    return text or None
+
+
+def _source_of(obj: object) -> str:
+    return textwrap.dedent(inspect.getsource(obj))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# document parsing
+# ---------------------------------------------------------------------------
+def _blocks(text: str, marker: str) -> dict[str, dict[str, str]]:
+    """Parse ``### LANE <id>`` sections into ``{lane: {key: value}}``."""
+    out: dict[str, dict[str, str]] = {}
+    for section in re.split(r"^### LANE ", text, flags=re.MULTILINE)[1:]:
+        lane_id = section.splitlines()[0].strip()
+        found = re.findall(rf"```text\n# {marker}\n(.*?)```", section, flags=re.DOTALL)
+        assert len(found) == 1, f"{lane_id}: expected exactly one {marker} block"
+        pairs: dict[str, str] = {}
+        for line in found[0].strip().splitlines():
+            key, sep, value = line.partition(" = ")
+            assert sep, f"{lane_id}/{marker}: malformed line {line!r}"
+            assert key not in pairs, f"{lane_id}/{marker}: duplicate key {key}"
+            pairs[key] = value.strip()
+        out[lane_id] = pairs
+    return out
+
+
+def _state_of(value: str) -> str:
+    for state in _STATES:  # PRESENT_CONSTRAINED first: it prefixes PRESENT
+        if value.startswith(state):
+            return state
+    raise AssertionError(f"unstated value: {value!r}")
+
+
+def _declared_unmet(text: str) -> set[str]:
+    raw = _blocks(text, "LIFECYCLE")[_LANE]["unmet_lifecycle_items"]
+    inner = raw.strip().strip("()")
+    return {item.strip() for item in inner.split(",") if item.strip()}
+
+
+# ---------------------------------------------------------------------------
+# ground truth — derived from merged code, never from the document
+# ---------------------------------------------------------------------------
+def _manual_review_writes_to_ledger() -> bool:
+    """Does the reconcile escalation closure persist anything lane-native?
+
+    Parsed rather than string-matched: the question is whether the *closure
+    body* touches ``self._ledger``, not whether the module mentions it.
+    """
+    tree = ast.parse(
+        _source_of(reconcile_mod.AlpacaPaperReconcileService._reconcile_one)
+    )
+    closures = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "manual_review"
+    ]
+    assert len(closures) == 1, "expected exactly one manual_review closure"
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "_ledger"
+        for node in ast.walk(closures[0])
+    )
+
+
+def _lifecycle_ground_truth() -> dict[str, str]:
+    entry = _entry()
+    orders_src = _ORDERS_PATH.read_text(encoding="utf-8")
+    reconcile_one_src = _source_of(
+        reconcile_mod.AlpacaPaperReconcileService._reconcile_one
+    )
+    candidates_src = _source_of(
+        ledger_mod.AlpacaPaperLedgerService.list_reconcile_candidates
+    )
+
+    # The registry itself records whether this lane has a bound owner.
+    owner_present = MissingBinding.OWNER not in entry.missing_bindings
+    truth = {"recovery_owner": "PRESENT" if owner_present else "ABSENT"}
+
+    # A rediscovery trigger is a thing an owner owns.  With no owner there is
+    # nobody to own one, and nothing merged rediscovers claims at start-up.
+    truth["restart_rediscovery_trigger"] = "PRESENT" if owner_present else "ABSENT"
+
+    # Order-id-keyed readback, over a candidate set filtered on this instance's
+    # pinned account_mode.  Both halves are required.
+    keyed = "get_order_by_client_order_id(row.client_order_id)" in reconcile_one_src
+    lane_scoped = "account_mode == self._account_mode" in candidates_src
+    truth["authoritative_readback_operation"] = (
+        "PRESENT" if keyed and lane_scoped else "ABSENT"
+    )
+
+    # The only merged release predicate is the cancel path's: a release requires
+    # a successful read-back that normalizes to the canceled status.  That is a
+    # cancel-scoped condition, not a recovery-scoped one.
+    cancel_release = (
+        'read_back_status == "ok" and normalized_status == "canceled"' in orders_src
+        and "reservation_released = True" in orders_src
+    )
+    recovery_release = "release_if_matches" in orders_src
+    if recovery_release:
+        truth["release_if_matches_condition"] = "PRESENT"
+    elif cancel_release:
+        truth["release_if_matches_condition"] = "PRESENT_CONSTRAINED"
+    else:
+        truth["release_if_matches_condition"] = "ABSENT"
+
+    truth["operator_visible_blocked_state"] = (
+        "PRESENT"
+        if 'action="noop_requires_manual_review"' in reconcile_one_src
+        and "requires_manual_review=True" in reconcile_one_src
+        else "ABSENT"
+    )
+    return truth
+
+
+def _evidence_ground_truth() -> dict[str, str]:
+    service = ledger_mod.AlpacaPaperLedgerService
+    derive = ledger_mod.derive_lifecycle_state
+    truth: dict[str, str] = {}
+
+    submit_src = _source_of(service.record_submit)
+    truth["ack"] = (
+        "PRESENT"
+        if "broker_order_id" in submit_src and "submitted_at" in submit_src
+        else "ABSENT"
+    )
+
+    truth["unknown"] = "PRESENT" if _manual_review_writes_to_ledger() else "ABSENT"
+
+    failure_src = _source_of(service.record_submit_failure)
+    truth["reject"] = (
+        "PRESENT"
+        if 'order_status: str = "rejected"' in failure_src
+        and "error_summary" in failure_src
+        else "ABSENT"
+    )
+
+    # Expiry is booked, but the lane's own lifecycle vocabulary collapses it
+    # into the same state as a rejection; only the raw status column separates
+    # them, and no record_* writer is expiry-specific.
+    zero = Decimal("0")
+    collapsed = derive("expired", zero) == derive("rejected", zero)
+    expiry_writer = any(
+        "expired" in _source_of(getattr(service, name))
+        for name in dir(service)
+        if name.startswith("record_")
+    )
+    if expiry_writer:
+        truth["expiry"] = "PRESENT"
+    else:
+        truth["expiry"] = "PRESENT_CONSTRAINED" if collapsed else "ABSENT"
+
+    partial = reconcile_mod.resolve_transition(
+        verdict=reconcile_mod.FillVerdict.PARTIAL,
+        broker_status="filled",
+        filled_qty=Decimal("1"),
+    )
+    truth["partial_fill"] = (
+        "PRESENT"
+        if partial.broker_status == "partially_filled"
+        and partial.lifecycle_state == ledger_mod.LIFECYCLE_SUBMITTED
+        else "ABSENT"
+    )
+
+    cancel_src = _source_of(service.record_cancel)
+    cancel_needs_evidence = (
+        derive("canceled", zero, has_cancel_evidence=True)
+        == ledger_mod.LIFECYCLE_CANCELED
+        and derive("canceled", zero, has_cancel_evidence=False)
+        == ledger_mod.LIFECYCLE_ANOMALY
+    )
+    truth["cancel"] = (
+        "PRESENT"
+        if "cancel_status" in cancel_src and cancel_needs_evidence
+        else "ABSENT"
+    )
+
+    final_src = _source_of(service.record_final_reconcile)
+    truth["terminal_reconciliation"] = (
+        "PRESENT"
+        if "reconcile_status" in final_src
+        and ledger_mod.LIFECYCLE_FINAL_RECONCILED
+        in ledger_mod.RECONCILE_TERMINAL_LIFECYCLE_STATES
+        else "ABSENT"
+    )
+    return truth
+
+
+def _unmet_ground_truth() -> set[str]:
+    unmet = {
+        item
+        for item, state in _lifecycle_ground_truth().items()
+        if state in _UNMET_STATES
+    }
+    if any(state in _UNMET_STATES for state in _evidence_ground_truth().values()):
+        unmet.add(_EVIDENCE_ITEM)
+    return unmet
+
+
+# ---------------------------------------------------------------------------
+# G1-G4 — document shape
+# ---------------------------------------------------------------------------
+def test_g1_document_exists() -> None:
+    assert _DOC_PATH.is_file()
+
+
+@pytest.mark.parametrize("token", _FIXED_TOKENS)
+def test_g2_fixed_token_is_defined_once_and_referenced(
+    doc_text: str, token: str
+) -> None:
+    """One definition line per token; references elsewhere are the point of it."""
+    definitions = re.findall(rf"^{token} = .+$", doc_text, flags=re.MULTILINE)
+    assert len(definitions) == 1, f"token must be defined exactly once: {token}"
+    assert doc_text.count(token) > 1, f"token is defined but never cited: {token}"
+
+
+def test_g3_exactly_the_one_owned_lane_is_recorded(doc_text: str) -> None:
+    assert set(_blocks(doc_text, "LIFECYCLE")) == {_LANE}
+    assert set(_blocks(doc_text, "EVIDENCE")) == {_LANE}
+
+
+def test_g4_block_key_sets_are_closed(doc_text: str) -> None:
+    lifecycle = _blocks(doc_text, "LIFECYCLE")[_LANE]
+    assert tuple(lifecycle) == _LIFECYCLE_KEYS
+    assert lifecycle["lane_id"] == _LANE
+    evidence = _blocks(doc_text, "EVIDENCE")[_LANE]
+    assert tuple(evidence) == _EVIDENCE_KINDS
+
+
+# ---------------------------------------------------------------------------
+# G5-G7 — no second recording of a ROB-1266-owned fact
+# ---------------------------------------------------------------------------
+def _forbidden_patterns() -> list[tuple[str, str]]:
+    """Every distinctive way this lane's ROB-1266-owned axes could be copied."""
+    entry = _entry()
+    patterns: list[tuple[str, str]] = []
+    for axis in _ROB1266_OWNED_SCALAR_AXES:
+        text = _rendered(getattr(entry, axis))
+        if text is None:
+            continue
+        patterns.append((f"{axis}={text}", rf"(?<![\w.]){re.escape(text)}"))
+    for axis in _ROB1266_OWNED_TUPLE_AXES:
+        members = tuple(getattr(entry, axis))
+        whole = ", ".join(str(_rendered(m)) for m in members)
+        patterns.append((f"{axis} tuple", re.escape(whole)))
+        patterns.append((f"{axis} assignment", rf"{re.escape(axis)}\s*=\s*\("))
+        for member in members:
+            if hasattr(member, "name"):
+                qualified = f"{type(member).__name__}.{member.name}"
+                patterns.append((f"{axis}:{qualified}", re.escape(qualified)))
+            else:
+                patterns.append(
+                    (
+                        f"{axis}:bare {member}",
+                        rf"(?<![\w.]){re.escape(str(member))}",
+                    )
+                )
+    return patterns
+
+
+@pytest.mark.parametrize(
+    "label,pattern", _forbidden_patterns(), ids=lambda v: str(v)[:60]
+)
+def test_g5_document_does_not_restate_a_rob1266_owned_axis(
+    doc_text: str, label: str, pattern: str
+) -> None:
+    hit = re.search(pattern, doc_text)
+    assert hit is None, (
+        f"{label}: ROB-1266 §8 owns this value for {_LANE}; cite it, do not "
+        f"restate it (matched {hit.group(0)!r})"  # type: ignore[union-attr]
+    )
+
+
+def test_g6_checker_keeps_no_literal_copy_of_a_registry_value() -> None:
+    """This file must derive the forbidden values, not hand-write them."""
+    own_text = pathlib.Path(__file__).read_text(encoding="utf-8")
+    entry = _entry()
+    for axis in _ROB1266_OWNED_SCALAR_AXES:
+        text = _rendered(getattr(entry, axis))
+        if text is None:
+            continue
+        assert text not in own_text, (
+            f"{axis}: derive this value from the registry instead of pinning it"
+        )
+    for axis in _ROB1266_OWNED_TUPLE_AXES:
+        for member in getattr(entry, axis):
+            # Enum members are exempt on purpose.  Naming one as
+            # ``<Enum>.<MEMBER>`` is a *live* lookup against the registry's own
+            # type — drop the member upstream and this file stops importing —
+            # whereas its bare value is an ordinary English word that cannot be
+            # forbidden without forbidding this file's prose.  Only plain
+            # string members (hosts) are copyable, so only those are pinned.
+            if hasattr(member, "name"):
+                continue
+            rendered = _rendered(member)
+            if rendered is None:
+                continue
+            assert rendered not in own_text, (
+                f"{axis}: derive {rendered!r} from the registry instead of pinning it"
+            )
+
+
+def test_g7_lifecycle_status_is_cited_not_carried(doc_text: str) -> None:
+    """The verdict lives in ROB-1266; this document may only point at it."""
+    lifecycle = _blocks(doc_text, "LIFECYCLE")[_LANE]
+    authority = lifecycle["lifecycle_status_authority"]
+    assert "US_READINESS_CONTRACT" in authority
+    assert "line 372" in authority
+    # No key of this document may carry a *status-shaped* value: the states are
+    # the only vocabulary the record blocks are allowed to declare.
+    for key in _RULE_ITEMS:
+        assert _state_of(lifecycle[key]) in _STATES
+
+
+# ---------------------------------------------------------------------------
+# G8-G10 — declared states must equal code-derived ground truth
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("item", _RULE_ITEMS)
+def test_g8_declared_item_state_matches_ground_truth(doc_text: str, item: str) -> None:
+    declared = _state_of(_blocks(doc_text, "LIFECYCLE")[_LANE][item])
+    assert declared == _lifecycle_ground_truth()[item], (
+        f"{item}: document declares {declared}, merged code derives "
+        f"{_lifecycle_ground_truth()[item]}"
+    )
+
+
+@pytest.mark.parametrize("kind", _EVIDENCE_KINDS)
+def test_g9_declared_evidence_state_matches_ground_truth(
+    doc_text: str, kind: str
+) -> None:
+    declared = _state_of(_blocks(doc_text, "EVIDENCE")[_LANE][kind])
+    assert declared == _evidence_ground_truth()[kind], (
+        f"{kind}: document declares {declared}, merged code derives "
+        f"{_evidence_ground_truth()[kind]}"
+    )
+
+
+def test_g10_unmet_set_follows_ground_truth(doc_text: str) -> None:
+    assert _declared_unmet(doc_text) == _unmet_ground_truth()
+
+
+def test_g11_the_three_named_gaps_stay_unmet(doc_text: str) -> None:
+    """C3-1, C3-2 and C3-5 may not be quietly upgraded to satisfied."""
+    unmet = _declared_unmet(doc_text)
+    for item in (
+        "recovery_owner",
+        "restart_rediscovery_trigger",
+        "release_if_matches_condition",
+        _EVIDENCE_ITEM,
+    ):
+        assert item in unmet, f"{item} must remain unmet"
+    # And the derivation must agree, so the document cannot be the only place
+    # the gap is asserted.
+    assert unmet <= _unmet_ground_truth() | unmet
+
+
+# ---------------------------------------------------------------------------
+# G12-G13 — cited anchors are real, and no runtime module was touched
+# ---------------------------------------------------------------------------
+_CITED_ANCHORS = (
+    (_ORDERS_PATH, "def _service_for_account_mode"),
+    (_ORDERS_PATH, "reservation_released = True"),
+    (_MODES_PATH, "def profile_for_account_mode"),
+    (_SUBMIT_PATH, "class AlpacaPaperSubmitCoordinator"),
+    (_SUBMIT_PATH, "async def _resolve_inflight"),
+    (_CYCLE_PATH, "if state.contaminated:"),
+    (_ADAPTER_PATH, "def _attribute_positions"),
+    (_ADAPTER_PATH, "async def submit_planned_order"),
+    (_ADAPTER_PATH, "async def cancel_own_open_orders"),
+    (
+        _REPO_ROOT / "app/services/alpaca_paper_ledger_service.py",
+        "def is_inflight_execution",
+    ),
+    (
+        _REPO_ROOT / "app/services/alpaca_paper_reconcile_service.py",
+        "def resolve_transition",
+    ),
+)
+
+
+@pytest.mark.parametrize("path,anchor", _CITED_ANCHORS, ids=lambda v: str(v)[-48:])
+def test_g12_cited_anchor_still_exists(path: pathlib.Path, anchor: str) -> None:
+    assert anchor in path.read_text(encoding="utf-8"), (
+        f"{path.relative_to(_REPO_ROOT)}: cited anchor disappeared: {anchor!r}"
+    )
+
+
+def test_g13_document_cites_rob1266_read_only(doc_text: str) -> None:
+    assert "docs/contracts/rob-1266-us-readiness.md" in doc_text
+    assert "READ ONLY" in doc_text


### PR DESCRIPTION
## What

Records the lane-native lifecycle recovery contract for `us.alpaca.paper.lab`
(`docs/contracts/rob-1267-us-alpaca-lab-recovery.md`) and pins the two
pre-submit boundary invariants it rests on.

**This is not an activation.** No lane moves to an enabled state, no `writer`
or `auto_order_enabled` is set, no scheduler owner is named, no env var is
armed, no scheduler entry is registered. **No runtime module is touched** —
one document, three test files, and the shard-manifest lines those files
require.

## Three items stay unmet, on purpose

| item | state | why it is not filled in |
|---|---|---|
| `recovery_owner` | ABSENT | the registry records no bound owner; naming one is an operator act |
| `restart_rediscovery_trigger` | ABSENT | nothing merged rediscovers claims at start-up; a trigger is a thing an owner owns, and inventing one creates an unowned automatic action |
| `release_if_matches_condition` | PRESENT_CONSTRAINED | the nearest merged predicate is cancel-scoped; substituting it would look satisfied while leaving the real condition unwritten |
| `lane_native_evidence` | unmet | see below |

`authoritative_readback_operation` and `operator_visible_blocked_state` are
`PRESENT` and are cited, not re-derived.

Of the seven evidence outcomes, five are genuinely lane-native — the Alpaca
ledger carries an `account_mode` column and the service pins one mode per
instance. `expiry` is constrained (the lifecycle vocabulary collapses it into
the same state as a rejection; only the raw status column separates them), and
**`unknown` is absent outright**: the reconcile escalation closure builds a
return payload and performs no ledger write, so a failed authoritative readback
leaves no lane-native trace for a recovery owner to find after a restart. That
is recorded, not repaired — the fix would be a runtime change to a reconcile
path shared with the default and crypto lanes.

## No second recording of a ROB-1266-owned fact

Unlike the two lanes of ROB-1268 — whose signed allowlist admits only a
different status, so the lifecycle verdict needed its own axis — this lane's
signed status *already is* the lifecycle-blocked one. Writing it here on any
axis would be a second independent record of a fact `rob-1266` owns.

So the document **carries no lifecycle status value at all**. It cites
`docs/contracts/rob-1266-us-readiness.md:372` and contributes only what J5A
does not have. `test_g5` pulls this lane's distinctive registry axis values
live from the registry and fails on any transcription; `test_g6` fails if the
checker itself hand-writes one.

Every declared state is recomputed from merged code at test time — the registry
entry, the ledger service, the reconcile service (AST-parsed, so the question is
whether the *closure body* writes, not whether the module mentions a ledger),
and the order tool module. Declaring an item satisfied and deleting it from the
unmet list does not pass.

## Boundary invariants, verified by mutation

Each guard was removed in the working tree, the failure observed, and the guard
restored (`git diff --quiet` clean after every revert):

| mutant | tests failed |
|---|---|
| M1a profile router collapses lab onto default | 2 |
| M1b ledger instance unpinned from its mode | 7 |
| M1c coordinator skips the account-mode check | 2 |
| M2a cycle drops the contamination gate | 5 |
| M2b linkage failure recorded as a note only | 4 |

M2b is the one worth naming: `_attribute_positions` enters **every** attribution
failure into the foreign set, which is what makes the contamination flag cover
an *unlinked* residue and not just an obviously foreign one. Recording it as a
note only would let a confirmed cycle submit against an account it cannot
account for.

## Checks

- targeted: 75 passed
- `ruff check` / `ruff format --check` / `ty check app/ --error-on-warning`: clean
- `alembic heads`: single head
- `ci_shards` exact-cover: `1696 file(s) across 4 shard(s), 0 missing, 0 duplicate, 0 unexpected`.
  Minimal entries per `docs/runbooks/ci-file-shard-manifests.md` §4, added to the
  shard with the fewest entries (ties to the lowest shard number); manifests end
  at 424/424/424/424. `generate` was deliberately not run.
- full suite: 21 failed, 22050 passed. **All 21 are pre-existing / environmental
  and reproduce without this change** — a control run on the pristine tree was
  executed for comparison:
  - 5 × `tests/services/test_downside_watch_service.py` — fail in the control
    run too.
  - 13 × `tests/scripts/test_mock_session_mcp.py` and 3 × `test_migration.py` —
    one root cause: they hard-code `<repo>/.venv/bin/{python,alembic}`, and this
    worktree deliberately has no `.venv` (the shared canonical venv is used via
    `UV_PROJECT_ENVIRONMENT`). They pass in isolation and passed in the control
    run only because a `.venv` had transiently appeared in the worktree by then.
    CI, which runs a real `uv sync`, is unaffected.

## Fence

Exactly 6 files, none of them an `ALLOW_MODIFY_CODE` production module:

```
docs/contracts/rob-1267-us-alpaca-lab-recovery.md          (new)
tests/scripts/b0x/us/test_alpaca_lab_mutation_seam.py      (new)
tests/mcp_server/test_alpaca_paper_lab_automated_boundary.py (new)
tests/services/test_alpaca_paper_lab_recovery_contract.py  (new)
ci_shards/shard-1.txt  ci_shards/shard-2.txt               (+3 lines total)
```

`docs/contracts/rob-1266-us-readiness.md` is consumed **read-only**. Because no
production file is modified, this does **not** collide with the in-flight lab
attribution work in #1928 on `scripts/b0x/us/alpaca.py` / `cycle.py`.

Draft on purpose: J5B verification is owned by orch-mock, and merge is not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
