### PR TITLE
feat(D2): §134차 — register the r8 execution authority, narrow the dispatch tripwire (r8 seal only)

### DIFF
--- a/app/services/brokers/binance/spot_demo/d2_remediation_single.py
+++ b/app/services/brokers/binance/spot_demo/d2_remediation_single.py
@@ -24,15 +24,31 @@ script would have created an *unreviewed* execution surface.  A reviewed,
 narrower one is the correct answer, so this module exists and both CLIs name
 each other.
 
-**No sealed payload in this repository authorizes a dispatch.**
-:data:`D2_KNOWN_SEALED_PAYLOADS` is the complete set of digests
-:func:`load_sealed_authority` will parse; every entry carries
-``dispatch_authorized=False``, and :func:`_assert_closed_order_set` refuses to
-import if one does not.  So a caller entering through these functions — both env
-gates armed, live lease in hand — reaches ``--confirm`` and is refused, because
-there is nothing here to act under.  Granting dispatch takes the operator's
-re-sign (which produces different bytes, hence a different digest) plus a
-reviewed change that registers it.
+**Exactly one sealed object in this repository authorizes a dispatch, and it
+is the r8 execution authority.**  Operator decision §134차 (2026-08-21) reads:
+
+    「§132차가 바인딩한 r8 봉인 — pre_snapshot_hash 4816a1d9…66f830 ·
+      manifest fa7092a3…e8431 · 수량/가격 3건 §132차 원문 — 한정으로 dispatch 를
+      허용한다. 그 외 봉인은 계속 거부한다.」
+
+"그 외 봉인은 계속 거부한다" — *every other seal stays refused* — is the half
+this module has to enforce, so the permission is expressed as a closed set of
+one digest (:data:`D2_DISPATCH_AUTHORIZED_DIGESTS`) rather than as a flag a
+second entry could also carry.  :func:`_assert_closed_order_set` refuses to
+import unless the set of ``dispatch_authorized`` registry entries is *equal* to
+that closed set, so marking any other payload authorized is an import failure
+rather than a quiet dictionary edit.
+
+The r8 snapshot payload itself is **not** the authority and was not rewritten
+to become one: it is registered (digest ``00b975ff…``) with
+``dispatch_authorized=False``, exactly as it was sealed — unsigned, no expiry,
+``mutation_authorized=false`` on all three rows.  The authority is a separate,
+execution-only artifact that *names* the r8 seal by digest
+(``docs/contracts/d2-r8-execution-authority-20260821.json``), and
+:func:`_assert_execution_authority_shape` re-checks that naming from the file's
+own bytes at load time.  A dispatch-authorized payload that binds some other
+snapshot, manifest, or seal timestamp is refused even if its digest were
+somehow registered.
 
 That is a statement about this module's entry points, not about the process.
 See the threat model below.
@@ -154,16 +170,68 @@ D2_EXCEPTION_ID: Final[str] = "binance-demo-remediation-20260820"
 #: ``binding-payload-proposed.json: remediation_id``.
 D2_REMEDIATION_ID: Final[str] = "d2-binance-demo-both-remediation-v2.1-20260818"
 
-#: r7 attempt-2 — the only snapshot this writer will act under.  A payload
+#: r8 attempt-2 — the only snapshot this writer will act under.  A payload
 #: carrying any other hash is refused; there is no override argument.
+#: Transcribed verbatim from operator decision §132차, which re-signed the D2
+#: binding and supersedes §125차.  Not recomputed here.
 D2_PRE_SNAPSHOT_HASH: Final[str] = (
+    "sha256:4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830"
+)
+
+#: The r7 snapshot this writer used to be bound to.  Kept as a named constant
+#: rather than deleted, because :data:`D2_KNOWN_SEALED_PAYLOADS` still registers
+#: the r7 payload — parseable, and refused at :func:`bind_sealed_orders` because
+#: its ``pre_snapshot_hash`` is no longer the bound one.  A silent drop would
+#: turn "superseded" into "unknown digest", which reads like a different fault.
+D2_SUPERSEDED_R7_PRE_SNAPSHOT_HASH: Final[str] = (
     "sha256:5ba70a814654513c745e45c49206f11cf5f5d061478c668f86602af493e6b898"
 )
 
-#: ``r7-snapshot/attempt-2-authoritative.json`` selects attempt-2 and binds
-#: this seal digest to it.  Carried as evidence.
+#: ``r8-reseal-20260821/snapshot/attempt-2/snapshot-seal.json``.  Carried as
+#: evidence and re-checked against the execution authority's own binding block.
 D2_SNAPSHOT_SEAL_SHA256: Final[str] = (
-    "d4c9a13a148f6c6c0d4451264da275826084f0b27c7a69a7698fb8c2b7952ed9"
+    "7817e8df2da3f89b03df40caea5e313b3d113fd07328dc4aaad2c4559397d95f"
+)
+
+#: The r8 binding payload's exact bytes.  §134차 names it as one of the two
+#: values that bound the permission; it is registered below with
+#: ``dispatch_authorized=False`` because the payload itself is unsigned and was
+#: deliberately **not** rewritten to carry an authorization it never had.
+D2_R8_BINDING_PAYLOAD_SHA256: Final[str] = (
+    "00b975ff1a291917699588d91154a790765b0f3e7008b141a8f60f6925fbae61"
+)
+
+#: ``manifest_sha256`` from §132차 / §134차, verbatim.
+D2_R8_ARTIFACT_MANIFEST_SHA256: Final[str] = (
+    "fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431"
+)
+
+#: ``seal_timestamp_utc`` from §132차, verbatim.
+D2_R8_SEAL_TIMESTAMP_UTC: Final[str] = "2026-08-21T01:53:45.145298Z"
+
+#: The execution-only authority artifact introduced under §134차.  It does not
+#: restate the r8 snapshot; it names it by digest.  Repository-relative so a
+#: reviewer reads the same bytes the runtime hashes.
+D2_R8_EXECUTION_AUTHORITY_PATH: Final[str] = (
+    "docs/contracts/d2-r8-execution-authority-20260821.json"
+)
+
+D2_EXECUTION_AUTHORITY_SCHEMA_VERSION: Final[str] = "d2-execution-authority.v1"
+D2_EXECUTION_AUTHORITY_KIND: Final[str] = "D2_EXECUTION_AUTHORITY"
+D2_EXECUTION_AUTHORITY_SCOPE: Final[str] = "R8_SEAL_ONLY"
+
+#: The exact bytes of :data:`D2_R8_EXECUTION_AUTHORITY_PATH`.
+D2_R8_EXECUTION_AUTHORITY_SHA256: Final[str] = (
+    "ba6518e7cafa16160059aafb22cd304d13793e0f8ea7f035d8fbd8ddc967b00b"
+)
+
+#: 🔴 The complete set of digests §134차 permits to dispatch — one member.
+#: :func:`_assert_closed_order_set` compares the registry's authorized entries
+#: against this by ``==``, not by membership, so a *second* authorized digest
+#: fails the import just as an *unauthorized* one does.  That is the machine
+#: form of "그 외 봉인은 계속 거부한다".
+D2_DISPATCH_AUTHORIZED_DIGESTS: Final[frozenset[str]] = frozenset(
+    {D2_R8_EXECUTION_AUTHORITY_SHA256}
 )
 
 #: The credential fingerprint the signed J2A registry binds to the shared
@@ -364,12 +432,16 @@ class D2BoundOrder:
         return f"{D2_CLIENT_ORDER_ID_PREFIX}-{digest[:24]}"
 
 
-#: The three operations, in dispatch order.  Read from r7 attempt-2's
-#: ``binding-payload-proposed.json``:
+#: The three operations, in dispatch order.  🔴 Transcribed **verbatim** from
+#: operator decision §132차 — the values were copied, not recomputed and not
+#: re-rounded, and they are the same values r8 attempt-2's
+#: ``binding-payload-proposed.json`` carries:
 #:
-#:   BTCUSDT  SELL LIMIT 0.00015000 @ 69266.01000000
-#:   ETHUSDT  SELL LIMIT 0.00520000 @  2248.56000000
-#:   USDCUSDT SELL LIMIT 5000.00000000 @ 1.00072000
+#:   BTCUSDT  SELL LIMIT 0.00015000    @ 75421.27000000
+#:   ETHUSDT  SELL LIMIT 0.00520000    @  2368.46000000
+#:   USDCUSDT SELL LIMIT 5000.00000000 @     1.00030000
+#:
+#: (§125차's 69266.01 / 2248.56 / 1.00072 are superseded and must not reappear.)
 #:
 #: This tuple is the authority the runtime checks against.  The payload is
 #: re-read at runtime so a doctored file is caught, but the payload can only
@@ -381,7 +453,7 @@ D2_BOUND_ORDERS: Final[tuple[D2BoundOrder, ...]] = (
         side=D2_SIDE,
         order_type=D2_ORDER_TYPE,
         quantity=Decimal("0.00015000"),
-        price=Decimal("69266.01000000"),
+        price=Decimal("75421.27000000"),
         time_in_force=D2_TIME_IN_FORCE,
         sealed_free_quantity=Decimal("0.00015957"),
         sealed_locked_quantity=Decimal("0"),
@@ -392,7 +464,7 @@ D2_BOUND_ORDERS: Final[tuple[D2BoundOrder, ...]] = (
         side=D2_SIDE,
         order_type=D2_ORDER_TYPE,
         quantity=Decimal("0.00520000"),
-        price=Decimal("2248.56000000"),
+        price=Decimal("2368.46000000"),
         time_in_force=D2_TIME_IN_FORCE,
         sealed_free_quantity=Decimal("0.00529470"),
         sealed_locked_quantity=Decimal("0"),
@@ -403,7 +475,7 @@ D2_BOUND_ORDERS: Final[tuple[D2BoundOrder, ...]] = (
         side=D2_SIDE,
         order_type=D2_ORDER_TYPE,
         quantity=Decimal("5000.00000000"),
-        price=Decimal("1.00072000"),
+        price=Decimal("1.00030000"),
         time_in_force=D2_TIME_IN_FORCE,
         sealed_free_quantity=Decimal("5000.00000000"),
         sealed_locked_quantity=Decimal("0"),
@@ -438,24 +510,49 @@ class SealedPayloadRecord:
 
 #: The complete set of sealed payloads this writer will parse.
 #:
-#: 🔴 Every entry today is ``dispatch_authorized=False``.  That is what makes
-#: "this module creates no execution authority" a structural fact rather than a
-#: claim: with both env gates armed and a lease held, ``--confirm`` still has
-#: no digest to act under.  When the operator re-signs, the re-signed file has
-#: *different bytes* and therefore a different digest, and teaching this map
-#: about it is a reviewed change with its own diff.
+#: 🔴 Exactly one entry is ``dispatch_authorized=True``: the r8 execution
+#: authority, under §134차.  The other two parse and then refuse — the r7
+#: payload because its ``pre_snapshot_hash`` is superseded, the r8 binding
+#: payload because it is unsigned.  Registration is *permission to parse*;
+#: ``dispatch_authorized`` is the separate half, and it is checked against the
+#: closed set :data:`D2_DISPATCH_AUTHORIZED_DIGESTS` at import.
 D2_KNOWN_SEALED_PAYLOADS: Final[Mapping[str, SealedPayloadRecord]] = {
     "e1c2d250d73ae3bdb631289a7293c35c217b9e5c6e2694d3f8ea572d1835a3aa": (
         SealedPayloadRecord(
             sha256=("e1c2d250d73ae3bdb631289a7293c35c217b9e5c6e2694d3f8ea572d1835a3aa"),
-            pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+            pre_snapshot_hash=D2_SUPERSEDED_R7_PRE_SNAPSHOT_HASH,
             dispatch_authorized=False,
             note=(
-                "r7 attempt-2 binding payload, unsigned: operator_authorization "
-                "is null and every row is mutation_authorized=false. Rehearsal "
-                "only; a re-signed payload will hash differently."
+                "r7 attempt-2 binding payload, unsigned and superseded by "
+                "§132차. Parseable so the refusal names 'superseded snapshot' "
+                "rather than 'unknown digest'; it can never bind, because its "
+                "pre_snapshot_hash is not D2_PRE_SNAPSHOT_HASH."
             ),
         )
+    ),
+    D2_R8_BINDING_PAYLOAD_SHA256: SealedPayloadRecord(
+        sha256=D2_R8_BINDING_PAYLOAD_SHA256,
+        pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+        dispatch_authorized=False,
+        note=(
+            "r8 attempt-2 binding payload, exactly as sealed: "
+            "operator_authorization is null, expiry is null, and all three "
+            "rows are mutation_authorized=false. It binds the three §132차 "
+            "orders and authorizes none of them. It was deliberately not "
+            "rewritten to carry an authorization it never had; the authority "
+            "is the separate execution artifact below."
+        ),
+    ),
+    D2_R8_EXECUTION_AUTHORITY_SHA256: SealedPayloadRecord(
+        sha256=D2_R8_EXECUTION_AUTHORITY_SHA256,
+        pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+        dispatch_authorized=True,
+        note=(
+            "r8 execution authority under operator decision §134차 "
+            "(docs/contracts/d2-r8-execution-authority-20260821.json). "
+            "Execution-only: it names the r8 seal by digest rather than "
+            "restating it, and its scope is that seal alone."
+        ),
     ),
 }
 
@@ -512,15 +609,47 @@ def _assert_closed_order_set() -> None:
                 D2ReasonCode.UNAUTHORIZED_OPERATION,
                 f"allowed_operation {operation_id!r} does not name {order.symbol}",
             )
-    if any(record.dispatch_authorized for record in D2_KNOWN_SEALED_PAYLOADS.values()):
-        # Not a prohibition on ever authorizing dispatch — a tripwire, so that
-        # flipping the flag is a deliberate, visible act rather than a quiet
-        # dictionary edit that no reviewer's eye catches.
+    # 🔴 The §134차 tripwire, replacing the pre-cutover "nothing may dispatch"
+    # form.  It is not weaker for being narrower: the comparison is closed
+    # equality against a one-member set, so *adding* a second authorized digest
+    # fails the import exactly as marking an unauthorized one does.  Widening
+    # the permission therefore still costs a visible, reviewed diff in two
+    # places — the registry and this constant.
+    if D2_DISPATCH_AUTHORIZED_DIGESTS != frozenset({D2_R8_EXECUTION_AUTHORITY_SHA256}):
         raise D2UnauthorizedOperation(
             D2ReasonCode.UNAUTHORIZED_OPERATION,
-            "a sealed payload is marked dispatch_authorized; adding one is a "
-            "reviewed operator cutover and must also update this tripwire",
+            "§134차 authorizes exactly one digest — the r8 execution "
+            f"authority — but D2_DISPATCH_AUTHORIZED_DIGESTS is "
+            f"{sorted(D2_DISPATCH_AUTHORIZED_DIGESTS)}",
         )
+    authorized = frozenset(
+        digest
+        for digest, record in D2_KNOWN_SEALED_PAYLOADS.items()
+        if record.dispatch_authorized
+    )
+    if authorized != D2_DISPATCH_AUTHORIZED_DIGESTS:
+        raise D2UnauthorizedOperation(
+            D2ReasonCode.UNAUTHORIZED_OPERATION,
+            "the set of dispatch_authorized sealed payloads must equal the "
+            "§134차 permission exactly; §134차 reads 'that seal only, every "
+            "other seal stays refused'. Registered as authorized: "
+            f"{sorted(authorized)}; permitted: "
+            f"{sorted(D2_DISPATCH_AUTHORIZED_DIGESTS)}",
+        )
+    for digest in sorted(authorized):
+        record = D2_KNOWN_SEALED_PAYLOADS[digest]
+        if record.sha256 != digest:
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                f"authorized record {digest} carries sha256={record.sha256!r}",
+            )
+        if record.pre_snapshot_hash != D2_PRE_SNAPSHOT_HASH:
+            raise D2UnauthorizedOperation(
+                D2ReasonCode.UNAUTHORIZED_OPERATION,
+                f"authorized record {digest} binds "
+                f"{record.pre_snapshot_hash!r}, not the §132차 snapshot "
+                f"{D2_PRE_SNAPSHOT_HASH!r}",
+            )
 
 
 _assert_closed_order_set()
@@ -867,13 +996,21 @@ class SealedAuthority:
             reasons.append(
                 f"authority expired at {self.expiry.isoformat()} (now {now.isoformat()})"
             )
-        missing = sorted(
-            order.symbol
-            for order in self.orders
-            if order.symbol not in self.mutation_authorized_symbols
-        )
+        bound = {order.symbol for order in self.orders}
+        missing = sorted(bound - self.mutation_authorized_symbols)
         if missing:
             reasons.append(f"mutation_authorized is not true for {missing}")
+        # The other direction, which used to go unchecked: a payload that
+        # authorizes the three bound symbols *and a fourth* satisfied every
+        # test above. The bound set can never grow, so the fourth could not
+        # become an order — but a seal that claims more than it is allowed to
+        # claim is not a seal this writer should act under at all.
+        extra = sorted(self.mutation_authorized_symbols - bound)
+        if extra:
+            reasons.append(
+                "mutation_authorized is true for symbols outside the bound "
+                f"set: {extra}"
+            )
         return tuple(reasons)
 
     @property
@@ -891,6 +1028,77 @@ class SealedAuthority:
             "mutation_authorized_symbols": sorted(self.mutation_authorized_symbols),
             "credential_fingerprint": self.credential_fingerprint,
         }
+
+
+def _assert_execution_authority_shape(
+    payload: Mapping[str, Any], *, source: Path
+) -> None:
+    """Re-check a dispatch-authorized payload's *contents*, not just its bytes.
+
+    Only runs for a registry entry with ``dispatch_authorized=True``. For the
+    shipped artifact this is redundant with the digest — the bytes cannot
+    differ — and that redundancy is the point: if the registry is ever edited
+    to authorize some other digest, these checks are what still refuse it. They
+    are the content-level form of §134차's "그 외 봉인은 계속 거부한다".
+
+    Nothing here reads the r8 snapshot payload. It re-reads the digests the
+    authority *claims* to be bound to and compares them against the frozen
+    §132차 / §134차 values, so an authority that names a different snapshot,
+    manifest, or seal instant is refused.
+    """
+
+    def _require(field: str, actual: Any, expected: Any) -> None:
+        if actual != expected:
+            raise D2SealBindingMismatch(
+                D2ReasonCode.SEAL_IDENTITY_MISMATCH,
+                f"{source}: dispatch-authorized artifact has {field}="
+                f"{actual!r}, expected {expected!r}",
+            )
+
+    _require(
+        "schema_version",
+        payload.get("schema_version"),
+        D2_EXECUTION_AUTHORITY_SCHEMA_VERSION,
+    )
+    _require("artifact_kind", payload.get("artifact_kind"), D2_EXECUTION_AUTHORITY_KIND)
+    _require(
+        "authority_scope", payload.get("authority_scope"), D2_EXECUTION_AUTHORITY_SCOPE
+    )
+
+    binding = payload.get("sealed_snapshot_binding")
+    if not isinstance(binding, Mapping):
+        raise D2SealBindingMismatch(
+            D2ReasonCode.SEAL_IDENTITY_MISMATCH,
+            f"{source}: dispatch-authorized artifact carries no "
+            "sealed_snapshot_binding, so it names no seal",
+        )
+    # ① of §134차: the r8 snapshot payload keeps its own bytes. An authority
+    # that admits to having rewritten it is refused rather than trusted.
+    _require(
+        "sealed_snapshot_binding.snapshot_payload_rewritten",
+        binding.get("snapshot_payload_rewritten"),
+        False,
+    )
+    _require(
+        "sealed_snapshot_binding.binding_payload_sha256",
+        binding.get("binding_payload_sha256"),
+        D2_R8_BINDING_PAYLOAD_SHA256,
+    )
+    _require(
+        "sealed_snapshot_binding.artifact_manifest_sha256",
+        binding.get("artifact_manifest_sha256"),
+        D2_R8_ARTIFACT_MANIFEST_SHA256,
+    )
+    _require(
+        "sealed_snapshot_binding.snapshot_seal_sha256",
+        binding.get("snapshot_seal_sha256"),
+        D2_SNAPSHOT_SEAL_SHA256,
+    )
+    _require(
+        "sealed_snapshot_binding.seal_timestamp_utc",
+        binding.get("seal_timestamp_utc"),
+        D2_R8_SEAL_TIMESTAMP_UTC,
+    )
 
 
 def load_sealed_authority(path: str | Path) -> SealedAuthority:
@@ -935,6 +1143,9 @@ def load_sealed_authority(path: str | Path) -> SealedAuthority:
             D2ReasonCode.SEAL_HASH_MISMATCH,
             "registered digest and payload disagree on pre_snapshot_hash",
         )
+
+    if record.dispatch_authorized:
+        _assert_execution_authority_shape(payload, source=source)
 
     assert_registry_credential_fingerprint()
     fingerprint = _sealed_credential_fingerprint(payload)
@@ -1940,17 +2151,27 @@ __all__ = [
     "D2_BOUND_ORDERS",
     "D2_CLIENT_ORDER_ID_PREFIX",
     "D2_CREDENTIAL_FINGERPRINT",
+    "D2_DISPATCH_AUTHORIZED_DIGESTS",
     "D2_EXCEPTION_ID",
+    "D2_EXECUTION_AUTHORITY_KIND",
+    "D2_EXECUTION_AUTHORITY_SCHEMA_VERSION",
+    "D2_EXECUTION_AUTHORITY_SCOPE",
     "D2_KNOWN_SEALED_PAYLOADS",
     "D2_LANE_ID",
     "D2_ORDER_TYPE",
     "D2_PRE_SNAPSHOT_HASH",
     "D2_PRODUCT",
     "D2_QUOTE_ASSET",
+    "D2_R8_ARTIFACT_MANIFEST_SHA256",
+    "D2_R8_BINDING_PAYLOAD_SHA256",
+    "D2_R8_EXECUTION_AUTHORITY_PATH",
+    "D2_R8_EXECUTION_AUTHORITY_SHA256",
+    "D2_R8_SEAL_TIMESTAMP_UTC",
     "D2_REMEDIATION_ENABLED_ENV",
     "D2_REMEDIATION_ID",
     "D2_SIDE",
     "D2_SNAPSHOT_SEAL_SHA256",
+    "D2_SUPERSEDED_R7_PRE_SNAPSHOT_HASH",
     "D2_TIME_IN_FORCE",
     "D2_VENUE",
     "D2_VENUE_HOST",

--- a/ci_shards/shard-1.txt
+++ b/ci_shards/shard-1.txt
@@ -121,6 +121,7 @@ tests/services/brokers/binance/futures_demo/test_signing.py
 tests/services/brokers/binance/paper/test_binance_adapter.py
 tests/services/brokers/binance/spot_demo/test_audit_no_live_host.py
 tests/services/brokers/binance/spot_demo/test_config_env.py
+tests/services/brokers/binance/spot_demo/test_d2_r8_authority_registration.py
 tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
 tests/services/brokers/binance/spot_demo/test_execution_client_fail_closed.py
 tests/services/brokers/binance/spot_demo/test_execution_client_submit_cancel.py

--- a/docs/contracts/d2-r8-execution-authority-20260821.json
+++ b/docs/contracts/d2-r8-execution-authority-20260821.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": "d2-execution-authority.v1",
+  "artifact_kind": "D2_EXECUTION_AUTHORITY",
+  "authority_scope": "R8_SEAL_ONLY",
+  "authority_note": "Execution-only companion to the r8 seal. It does not restate, replace, or re-seal the r8 snapshot: the r8 binding payload keeps its own bytes and its own digest, and this file names that digest rather than carrying its contents. Loading this file authorizes dispatch under the r8 seal and under no other seal.",
+  "remediation_id": "d2-binance-demo-both-remediation-v2.1-20260818",
+  "product_domain": "both",
+  "pre_snapshot_hash": "sha256:4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830",
+  "sealed_snapshot_binding": {
+    "seal": "r8-reseal-20260821/snapshot/attempt-2",
+    "snapshot_payload_rewritten": false,
+    "binding_payload_path": "jobs/d2-r2-snapshot-20260819-1315/events/r8-reseal-20260821/snapshot/attempt-2/binding-payload-proposed.json",
+    "binding_payload_sha256": "00b975ff1a291917699588d91154a790765b0f3e7008b141a8f60f6925fbae61",
+    "artifact_manifest_sha256": "fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431",
+    "snapshot_seal_sha256": "7817e8df2da3f89b03df40caea5e313b3d113fd07328dc4aaad2c4559397d95f",
+    "pre_snapshot_observation_sha256": "4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830",
+    "snapshot_core_sha256": "7c2ae51b0f6d3183022352bed633c797108cd4a6180f777e711d029ac8348374",
+    "seal_timestamp_utc": "2026-08-21T01:53:45.145298Z"
+  },
+  "operator_authorization": {
+    "kind": "OPERATOR_DECISION_LEDGER_REFERENCE",
+    "section": "§134차",
+    "decided_at_kst": "2026-08-21 12:3x",
+    "decision_file_path": "/Users/mgh3326/work/herdr-inbox/operator-decisions-20260805-0830.md",
+    "decision_file_digest_binding": "NOT_BOUND_APPEND_ONLY_LEDGER",
+    "decision_file_sha256_at_authoring": "01f5ee221b6d2ef4f2b196660ad2ce3b5dfea35c1e43d24b381c5eae66d9edb8",
+    "signing_sections": ["§108차", "§132차", "§134차"],
+    "supersedes": ["§125차"],
+    "verbatim_ko": "§132차가 바인딩한 r8 봉인 — pre_snapshot_hash sha256:4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830 · manifest_sha256 fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431 · 수량/가격 3건 §132차 원문 — 한정으로 dispatch를 허용한다. 그 외 봉인은 계속 거부한다.",
+    "scope_note": "The permission is bounded by the r8 pre_snapshot_hash, the r8 artifact manifest digest, and the three §132차 quantity/price pairs. Any other seal, any other digest, any other quantity or price is outside it and stays refused.",
+    "signature_kind_note": "This is a reference to a recorded operator decision, not a cryptographic signature. The cutover it authorizes is the reviewed registration of this file's digest in d2_remediation_single."
+  },
+  "expiry": "2026-08-22T14:59:59Z",
+  "expiry_note": "2026-08-22 23:59:59 KST. Chosen to cover the operator's stated §134차 target (execution on the night of 2026-08-21 KST) with one working margin day and no more. Enforced against the real clock; a backdated now_fn cannot revive it.",
+  "physical_account_identity": {
+    "credential_fingerprint": "sha256:e33925948f2cb6e03842cca9967b70f11f9242bc5c8f99c69ce0ca5cbc4d73df",
+    "identity_status": "KNOWN_SHARED_SPOT_FUTURES_J2A",
+    "spot_host": "demo-api.binance.com"
+  },
+  "authorized_symbols": {
+    "spot": {
+      "BTCUSDT": {
+        "symbol": "BTCUSDT",
+        "asset": "BTC",
+        "product": "spot",
+        "disposition": "REVIEWED_SCOPE_LIMIT_CANDIDATE",
+        "mutation_authorized": true,
+        "operator_authorization_section": "§134차",
+        "value_source": {
+          "section": "§132차",
+          "r8_field": "authorized_symbols.spot.BTCUSDT.proposed_one_step",
+          "transcribed_not_recomputed": true
+        },
+        "proposed_one_step": {
+          "side": "SELL",
+          "order_type": "LIMIT",
+          "time_in_force": null,
+          "proposed_quantity_floor": "0.00015000",
+          "proposed_limit_price_floor": "75421.27000000",
+          "raw_free_quantity": "0.00015957",
+          "raw_locked_quantity": "0E-8",
+          "rounding_direction": "floor_only_no_uplift"
+        }
+      },
+      "ETHUSDT": {
+        "symbol": "ETHUSDT",
+        "asset": "ETH",
+        "product": "spot",
+        "disposition": "REVIEWED_SCOPE_LIMIT_CANDIDATE",
+        "mutation_authorized": true,
+        "operator_authorization_section": "§134차",
+        "value_source": {
+          "section": "§132차",
+          "r8_field": "authorized_symbols.spot.ETHUSDT.proposed_one_step",
+          "transcribed_not_recomputed": true
+        },
+        "proposed_one_step": {
+          "side": "SELL",
+          "order_type": "LIMIT",
+          "time_in_force": null,
+          "proposed_quantity_floor": "0.00520000",
+          "proposed_limit_price_floor": "2368.46000000",
+          "raw_free_quantity": "0.00529470",
+          "raw_locked_quantity": "0E-8",
+          "rounding_direction": "floor_only_no_uplift"
+        }
+      },
+      "USDCUSDT": {
+        "symbol": "USDCUSDT",
+        "asset": "USDC",
+        "product": "spot",
+        "disposition": "REVIEWED_SCOPE_LIMIT_CANDIDATE",
+        "mutation_authorized": true,
+        "operator_authorization_section": "§134차",
+        "value_source": {
+          "section": "§132차",
+          "r8_field": "authorized_symbols.spot.USDCUSDT.proposed_one_step",
+          "transcribed_not_recomputed": true
+        },
+        "proposed_one_step": {
+          "side": "SELL",
+          "order_type": "LIMIT",
+          "time_in_force": null,
+          "proposed_quantity_floor": "5000.00000000",
+          "proposed_limit_price_floor": "1.00030000",
+          "raw_free_quantity": "5000.00000000",
+          "raw_locked_quantity": "0E-8",
+          "rounding_direction": "floor_only_no_uplift"
+        }
+      },
+      "SOLUSDT": {
+        "symbol": "SOLUSDT",
+        "asset": "SOL",
+        "product": "spot",
+        "disposition": "DUST_ATTESTATION_REVIEW_CANDIDATE",
+        "mutation_authorized": false,
+        "planned_quantity": "0",
+        "exact_free_quantity": "0.00094600",
+        "rule_id": "LOT_SIZE_FLOOR_ZERO_V1_2",
+        "operator_reference": {"section": "§108차 ②", "disposition": "dust proof only; no order"}
+      },
+      "XRPUSDT": {
+        "symbol": "XRPUSDT",
+        "asset": "XRP",
+        "product": "spot",
+        "disposition": "DUST_ATTESTATION_REVIEW_CANDIDATE",
+        "mutation_authorized": false,
+        "planned_quantity": "0",
+        "exact_free_quantity": "0.09660000",
+        "rule_id": "LOT_SIZE_FLOOR_ZERO_V1_2",
+        "operator_reference": {"section": "§108차 ③", "disposition": "dust proof only; no order"}
+      },
+      "DOGEUSDT": {
+        "symbol": "DOGEUSDT",
+        "asset": "DOGE",
+        "product": "spot",
+        "disposition": "DUST_ATTESTATION_REVIEW_CANDIDATE",
+        "mutation_authorized": false,
+        "planned_quantity": "0",
+        "exact_free_quantity": "0.56100000",
+        "rule_id": "LOT_SIZE_FLOOR_ZERO_V1_2",
+        "operator_reference": {"section": "§108차 ③", "disposition": "dust proof only; no order"}
+      },
+      "USDT": {
+        "asset": "USDT",
+        "product": "spot",
+        "disposition": "QUOTE_CASH_ATTESTATION_ONLY",
+        "mutation_authorized": false,
+        "observed_free": "4978.04451557",
+        "observed_locked": "0E-8",
+        "operator_reference": {"section": "§108차", "disposition": "USDT is retained, not converted"}
+      }
+    }
+  },
+  "execution_exclusions": {
+    "BSBUSDT_260611": {
+      "product": "futures",
+      "reason": "EXACT_SYMBOL_REJECTED_BY_BROKER",
+      "operator_reference": {"section": "§121차", "contract_section": "v2.2 §7.5"},
+      "mutation_authorized": false
+    },
+    "futures_domain": {
+      "reason": "This authority covers spot only. The named writer has no futures path.",
+      "mutation_authorized": false
+    }
+  },
+  "contract": {
+    "path": "/Users/mgh3326/work/herdr-inbox/contract-d2-binance-remediation-v2.2-20260820.md",
+    "version": "v2.2",
+    "unchanged_by_this_artifact": true,
+    "dual_attestation_required": true,
+    "writer": "d2_remediation_single"
+  }
+}

--- a/docs/runbooks/binance-spot-demo-d2-remediation.md
+++ b/docs/runbooks/binance-spot-demo-d2-remediation.md
@@ -4,9 +4,10 @@
 `binance-demo-remediation-20260820` exception. This runbook covers the code that
 answers to that name.
 
-**Scope of this document.** It describes the writer and how to rehearse it. It
-does **not** authorize execution. Execution requires a separate operator
-re-sign, and the runbook cannot supply one.
+**Scope of this document.** It describes the writer, how to rehearse it, and —
+since operator decision §134차 (2026-08-21) — what it is now permitted to
+dispatch. The runbook does not itself authorize anything; the authority is
+§134차, and it is bounded to one seal.
 
 ## 1. What it is
 
@@ -15,17 +16,21 @@ re-sign, and the runbook cannot supply one.
 | Writer | `app/services/brokers/binance/spot_demo/d2_remediation_single.py` |
 | CLI | `scripts/binance_spot_demo_d2_remediation.py` |
 | Contract | `~/work/herdr-inbox/contract-d2-binance-remediation-v2.2-20260820.md` |
-| Seal | r7 attempt-2, `pre_snapshot_hash=sha256:5ba70a81…3e6b898` |
+| Seal | r8 attempt-2, `pre_snapshot_hash=sha256:4816a1d9…66f830` (§132차, supersedes §125차) |
+| Dispatch authority | `docs/contracts/d2-r8-execution-authority-20260821.json`, sha256 `ba6518e7…67b00b` (§134차) |
 | Surface | `binance_spot_demo_remediation_only` |
 | Canary/strategy use | forbidden |
 
 It can express exactly three orders:
 
 ```text
-BTCUSDT  SELL LIMIT 0.00015000    @ 69266.01000000
-ETHUSDT  SELL LIMIT 0.00520000    @  2248.56000000
-USDCUSDT SELL LIMIT 5000.00000000 @     1.00072000
+BTCUSDT  SELL LIMIT 0.00015000    @ 75421.27000000
+ETHUSDT  SELL LIMIT 0.00520000    @  2368.46000000
+USDCUSDT SELL LIMIT 5000.00000000 @     1.00030000
 ```
+
+Transcribed verbatim from §132차; §125차's `69266.01` / `2248.56` / `1.00072`
+are superseded and must not reappear.
 
 There is no fourth, no BUY, no MARKET, and no flag that selects a symbol,
 quantity, or price. The set lives in `D2_BOUND_ORDERS`; the sealed payload is
@@ -70,7 +75,7 @@ touches nothing.
 ```bash
 uv run python -m scripts.binance_spot_demo_d2_remediation \
   --plan-only \
-  --sealed-payload <path>/r7-snapshot/attempt-2/binding-payload-proposed.json
+  --sealed-payload docs/contracts/d2-r8-execution-authority-20260821.json
 ```
 
 `--dry-run` walks the whole path — both env gates, host re-assertion,
@@ -83,7 +88,13 @@ reachable database.
 ```bash
 BINANCE_SPOT_DEMO_ENABLED=true D2_REMEDIATION_SINGLE_ENABLED=true \
 uv run python -m scripts.binance_spot_demo_d2_remediation \
-  --dry-run --sealed-payload <path>/binding-payload-proposed.json
+  --dry-run --sealed-payload docs/contracts/d2-r8-execution-authority-20260821.json
+```
+
+Any registered payload may be rehearsed. Rehearsing the r8 *snapshot* payload
+(`<r8>/snapshot/attempt-2/binding-payload-proposed.json`) is the useful control:
+it binds the same three orders and prints four dispatch blockers, which is what
+"the snapshot was not rewritten into an authority" looks like from the outside.
 ```
 
 There is no flag to skip the order-shape check. It was optional in the first
@@ -91,19 +102,30 @@ revision, which meant the mode that sends real orders could also be the mode
 that skipped the only broker-side proof that the sealed filters still describe
 the market.
 
-## 5. Execution — refused, at runtime, on every registered payload
+## 5. Execution — permitted under one seal, refused under every other
 
 `--confirm` is the only mode that reaches `submit_order(..., confirm=True)`.
-For a caller entering through this module's functions, it is refused — not by
-convention but by checks that run, each named with where it lives:
+Operator decision §134차 (2026-08-21) reads, verbatim:
+
+> 「§132차가 바인딩한 r8 봉인 — pre_snapshot_hash
+> `sha256:4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830` ·
+> manifest_sha256
+> `fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431` ·
+> 수량/가격 3건 §132차 원문 — **한정으로 dispatch를 허용한다. 그 외 봉인은 계속
+> 거부한다.**」
+
+The second sentence — *every other seal stays refused* — is the operative one
+for this code, so the permission is expressed as a closed one-member set rather
+than as a flag another entry could also carry.
 
 | Gate | Enforced at | Current state |
 |---|---|---|
-| Payload bytes hashed before parsing; unknown digest refused | `load_sealed_authority` | one registered digest |
-| Every registered digest is `dispatch_authorized=false`, and import fails if not | `_assert_closed_order_set` | holds |
-| `operator_authorization` non-null | `SealedAuthority.dispatch_block_reasons` | `null` |
-| `expiry` present and not past, read from the real clock | `SealedAuthority.dispatch_block_reasons`, `D2RemediationSingleWriter.dispatch_block_reasons` | absent |
-| `mutation_authorized` on all three rows | `SealedAuthority.dispatch_block_reasons` | `false` on all three |
+| Payload bytes hashed before parsing; unknown digest refused | `load_sealed_authority` | three registered digests |
+| The set of `dispatch_authorized` entries **equals** `D2_DISPATCH_AUTHORIZED_DIGESTS`, or the import fails | `_assert_closed_order_set` | one member, the r8 execution authority |
+| A dispatch-authorized artifact must name the r8 seal, manifest, and seal instant, and declare the snapshot un-rewritten | `_assert_execution_authority_shape` | enforced |
+| `operator_authorization` non-null | `SealedAuthority.dispatch_block_reasons` | §134차 reference on the authority; `null` on the r8 snapshot payload |
+| `expiry` present and not past, read from the real clock | `SealedAuthority.dispatch_block_reasons`, `D2RemediationSingleWriter.dispatch_block_reasons` | `2026-08-22T14:59:59Z` |
+| `mutation_authorized` true on the three bound rows **and on nothing else** | `SealedAuthority.dispatch_block_reasons` | exactly BTCUSDT/ETHUSDT/USDCUSDT |
 | Sealed credential fingerprint = signed J2A registry | `load_sealed_authority`, `assert_registry_credential_fingerprint` | matches |
 | Live client credential fingerprint = sealed | `D2RemediationSingleWriter._assert_client_account` | checked per run |
 | Account-wide writer freeze | `assert_writer_freeze` | in force |
@@ -116,18 +138,37 @@ that goes stale on the next edit without anyone noticing, and
 `test_the_runbook_gate_table_names_symbols_that_exist` checks every name in the
 "Enforced at" column against the live modules.
 
-`--dry-run` prints the whole blocker list; `--confirm` refuses on it *before*
-opening a client, a lease, or a database session. Both env gates being armed
-changes none of this.
+### 5.1 What the authority artifact is, and what it is not
 
-Authorizing dispatch takes two separate things, in this order:
+`docs/contracts/d2-r8-execution-authority-20260821.json` (sha256
+`ba6518e7cafa16160059aafb22cd304d13793e0f8ea7f035d8fbd8ddc967b00b`) is an
+**execution-only** artifact. It does not restate or replace the r8 snapshot: it
+names the r8 binding payload (`00b975ff…`), artifact manifest (`fa7092a3…`),
+snapshot seal (`7817e8df…`), and seal instant by digest, and carries
+`snapshot_payload_rewritten: false`, which
+`_assert_execution_authority_shape` re-checks from the file's own bytes.
 
-1. the operator's fresh re-sign bound to the exact r7 `pre_snapshot_hash`,
-   which produces a **different file with a different digest**; and
-2. a reviewed change that registers that digest with
-   `dispatch_authorized=True` — which also has to update the import-time
-   tripwire in `_assert_closed_order_set` that currently asserts no such entry
-   exists.
+Its `operator_authorization` is a **reference to a recorded operator decision**
+(§134차 in `operator-decisions-20260805-0830.md`), quoted verbatim inside the
+file — not a cryptographic signature, and the file says so. The cutover it
+authorizes is the reviewed registration of its digest in the writer.
+
+The r8 snapshot payload stays registered with `dispatch_authorized=false` and
+still prints four blockers, which is the observable form of "it was not
+rewritten". The superseded r7 payload also stays registered, and refuses at
+`bind_sealed_orders` because its `pre_snapshot_hash` is no longer the bound one
+— a named refusal rather than "unknown digest".
+
+### 5.2 Widening the permission is still a two-place diff
+
+Authorizing a *different* seal takes, in this order:
+
+1. an operator decision naming it (§134차 authorizes r8 and explicitly nothing
+   else), and a new artifact bound to it — **different bytes, different
+   digest**; and
+2. a reviewed change that registers that digest **and** adds it to
+   `D2_DISPATCH_AUTHORIZED_DIGESTS`. Registering it alone fails the import,
+   because `_assert_closed_order_set` compares the two by equality.
 
 Neither step is something this repository can do to itself.
 

--- a/scripts/binance_spot_demo_d2_remediation.py
+++ b/scripts/binance_spot_demo_d2_remediation.py
@@ -1,24 +1,32 @@
 """D2 one-shot remediation CLI — the operator entry point for the writer.
 
-Default-disabled, dry-run by default, and bound to the sealed r7 attempt-2
-snapshot.  It can express exactly three orders and no fourth:
+Default-disabled, dry-run by default, and bound to the sealed r8 attempt-2
+snapshot (operator decision §132차).  It can express exactly three orders and
+no fourth:
 
-    BTCUSDT  SELL LIMIT 0.00015000    @ 69266.01000000
-    ETHUSDT  SELL LIMIT 0.00520000    @  2248.56000000
-    USDCUSDT SELL LIMIT 5000.00000000 @     1.00072000
+    BTCUSDT  SELL LIMIT 0.00015000    @ 75421.27000000
+    ETHUSDT  SELL LIMIT 0.00520000    @  2368.46000000
+    USDCUSDT SELL LIMIT 5000.00000000 @     1.00030000
 
 There is no ``--symbol``, ``--side``, ``--quantity``, or ``--price`` flag,
 because there is nothing for them to select.  The orders come from the sealed
 payload file, whose **bytes are hashed and checked against a registered
 digest** before the JSON is even parsed.
 
-**``--confirm`` cannot dispatch today, and that is by construction.** Every
-registered sealed payload carries ``dispatch_authorized=false``, the current r7
-object has ``operator_authorization=null``, no expiry, and
-``mutation_authorized=false`` on all three rows. ``--dry-run`` prints that list;
-``--confirm`` refuses on it. Authorizing dispatch takes the operator's re-sign
-(which produces different bytes, and therefore a different digest) plus a
-reviewed change that registers it.
+**What ``--confirm`` can dispatch, and what it still cannot.** Operator
+decision §134차 permits dispatch under the r8 seal *and no other seal*:
+
+    「§132차가 바인딩한 r8 봉인 — pre_snapshot_hash 4816a1d9…66f830 ·
+      manifest fa7092a3…e8431 · 수량/가격 3건 §132차 원문 — 한정으로 dispatch 를
+      허용한다. 그 외 봉인은 계속 거부한다.」
+
+So exactly one file clears the gate: the execution authority artifact
+``docs/contracts/d2-r8-execution-authority-20260821.json``. The r8 *snapshot*
+payload is registered too and still refuses — it is unsigned, has no expiry,
+and carries ``mutation_authorized=false`` on all three rows, and it was not
+rewritten to say otherwise. Passing the superseded r7 payload, an unregistered
+file, or a one-byte edit of either is refused before the JSON is parsed.
+``--dry-run`` prints the whole blocker list; ``--confirm`` refuses on it.
 
 **Relationship to ``scripts/binance_spot_demo_smoke.py``.**  That CLI is the
 ROB-298 BUY round-trip smoke path and remains exactly what it is; it does not
@@ -122,7 +130,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--sealed-payload",
         type=Path,
-        help="path to the sealed r7 attempt-2 binding payload JSON",
+        help="path to a registered sealed payload JSON. Dispatch requires the "
+        "r8 execution authority "
+        "(docs/contracts/d2-r8-execution-authority-20260821.json); every other "
+        "registered payload rehearses and refuses",
     )
     return parser
 

--- a/tests/scripts/test_binance_spot_demo_d2_remediation_cli.py
+++ b/tests/scripts/test_binance_spot_demo_d2_remediation_cli.py
@@ -147,18 +147,23 @@ def test_confirm_with_both_gates_armed_still_refuses_the_unsigned_seal(
     assert "dispatch_authorized=false" in reasons
 
 
-def test_the_shipped_registry_leaves_confirm_unreachable(
+def test_the_shipped_registry_reaches_confirm_only_through_the_r8_authority(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No registered payload authorizes dispatch, so there is nothing to run.
+    """Exactly one registered payload authorizes dispatch, and it is r8's.
 
-    This is the structural version of "creates no execution authority": it
-    reads the shipped constant rather than a fixture.
+    The structural version of §134차's "그 외 봉인은 계속 거부한다": read from the
+    shipped constant rather than a fixture, so a registry edit that widens the
+    permission fails here as well as at import.
     """
 
-    assert not any(
-        record.dispatch_authorized for record in d2.D2_KNOWN_SEALED_PAYLOADS.values()
-    )
+    authorized = {
+        digest
+        for digest, record in d2.D2_KNOWN_SEALED_PAYLOADS.items()
+        if record.dispatch_authorized
+    }
+    assert authorized == {d2.D2_R8_EXECUTION_AUTHORITY_SHA256}
+    assert d2.D2_DISPATCH_AUTHORIZED_DIGESTS == authorized
 
 
 @pytest.mark.parametrize(

--- a/tests/services/brokers/binance/spot_demo/test_d2_r8_authority_registration.py
+++ b/tests/services/brokers/binance/spot_demo/test_d2_r8_authority_registration.py
@@ -1,0 +1,848 @@
+"""§134차 — the r8 execution authority, and the eight things it still refuses.
+
+Operator decision §134차 (2026-08-21) reads, verbatim:
+
+    「§132차가 바인딩한 r8 봉인 — pre_snapshot_hash
+      sha256:4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830 ·
+      manifest_sha256
+      fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431 ·
+      수량/가격 3건 §132차 원문 — 한정으로 dispatch를 허용한다.
+      그 외 봉인은 계속 거부한다.」
+
+The first clause is one test: the committed artifact clears every gate. The
+second clause — *every other seal stays refused* — is the rest of this file,
+and it is the part worth testing, because a cutover that quietly widened the
+permission would pass the first test just as well.
+
+Each case takes the **committed artifact's own bytes**, makes one change, and
+proves the refusal. Where the change would be caught by the digest alone, the
+mutant is *also* registered as ``dispatch_authorized`` so the content check is
+exercised rather than shadowed: the question is not "does the digest gate
+work" but "if someone got past it, what else refuses".
+
+    M1  a different seal (the superseded r7 digest)          -> refused
+    M2  an unregistered digest                                -> refused
+    M3  the artifact with one byte changed                    -> refused
+    M4  ``operator_authorization`` null                       -> refused
+    M5  an expired authority                                  -> refused
+    M6  any one row with ``mutation_authorized=false``        -> refused
+    M7  a quantity or price that is not the §132차 value       -> refused
+    M8  a fourth symbol, a BUY, a MARKET                      -> refused
+
+Every comparison is closed equality against a frozen constant. Nothing here
+matches on a name or a substring.
+"""
+
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import hashlib
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.services.brokers.binance.spot_demo import d2_remediation_single as d2
+from app.services.brokers.binance.spot_demo.d2_remediation_single import (
+    D2_ALLOWED_OPERATION_IDS,
+    D2_BOUND_ORDERS,
+    D2_DISPATCH_AUTHORIZED_DIGESTS,
+    D2_PRE_SNAPSHOT_HASH,
+    D2_R8_ARTIFACT_MANIFEST_SHA256,
+    D2_R8_BINDING_PAYLOAD_SHA256,
+    D2_R8_EXECUTION_AUTHORITY_PATH,
+    D2_R8_EXECUTION_AUTHORITY_SHA256,
+    D2_R8_SEAL_TIMESTAMP_UTC,
+    D2_REMEDIATION_ENABLED_ENV,
+    D2_SNAPSHOT_SEAL_SHA256,
+    D2_SUPERSEDED_R7_PRE_SNAPSHOT_HASH,
+    D2DispatchNotAuthorized,
+    D2ReasonCode,
+    D2SealBindingMismatch,
+    SealedPayloadRecord,
+    load_sealed_authority,
+)
+
+# The fakes are the ones the round-1/round-2 suite already uses; reusing them
+# means a mutant is proved against the same transport-counting client rather
+# than a second, more forgiving one.
+from tests.services.brokers.binance.spot_demo.test_d2_remediation_single import (
+    FakeExecutionClient,
+    FakeLedger,
+    make_lease,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# §132차, transcribed. Not recomputed, not re-rounded.
+# --------------------------------------------------------------------------
+
+SECTION_132_ORDERS: tuple[tuple[str, str, str], ...] = (
+    ("BTCUSDT", "0.00015000", "75421.27000000"),
+    ("ETHUSDT", "0.00520000", "2368.46000000"),
+    ("USDCUSDT", "5000.00000000", "1.00030000"),
+)
+SECTION_132_PRE_SNAPSHOT_HASH = (
+    "sha256:4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830"
+)
+SECTION_132_MANIFEST_SHA256 = (
+    "fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431"
+)
+
+#: Well before the artifact's expiry, so the "it clears" cases assert an
+#: authority state rather than a wall-clock accident.
+BEFORE_EXPIRY = dt.datetime(2026, 8, 21, 13, 0, tzinfo=dt.UTC)
+AFTER_EXPIRY = dt.datetime(2026, 8, 23, 0, 0, tzinfo=dt.UTC)
+
+ARTIFACT = Path(D2_R8_EXECUTION_AUTHORITY_PATH)
+
+
+def artifact_bytes() -> bytes:
+    return ARTIFACT.read_bytes()
+
+
+def artifact_payload() -> dict[str, Any]:
+    return json.loads(artifact_bytes().decode("utf-8"))
+
+
+def write_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, Any],
+    *,
+    register: bool = True,
+    dispatch_authorized: bool = True,
+    pre_snapshot_hash: str = D2_PRE_SNAPSHOT_HASH,
+) -> Path:
+    """Write a mutant and optionally register its exact-byte digest.
+
+    Registration is monkeypatched module state. Nothing in ``app/`` or
+    ``scripts/`` can add an entry at runtime; the shipped map is a
+    ``Final[Mapping]`` with three entries, one of them authorized.
+    """
+
+    path = tmp_path / "mutant-authority.json"
+    raw = json.dumps(payload).encode("utf-8")
+    path.write_bytes(raw)
+    registry = dict(d2.D2_KNOWN_SEALED_PAYLOADS)
+    if register:
+        registry[hashlib.sha256(raw).hexdigest()] = SealedPayloadRecord(
+            sha256=hashlib.sha256(raw).hexdigest(),
+            pre_snapshot_hash=pre_snapshot_hash,
+            dispatch_authorized=dispatch_authorized,
+            note="mutant fixture",
+        )
+    monkeypatch.setattr(d2, "D2_KNOWN_SEALED_PAYLOADS", registry)
+    return path
+
+
+def blockers(path: Path, *, now: dt.datetime = BEFORE_EXPIRY) -> tuple[str, ...]:
+    return load_sealed_authority(path).dispatch_block_reasons(now=now)
+
+
+# --------------------------------------------------------------------------
+# The permission itself
+# --------------------------------------------------------------------------
+
+
+def test_the_registered_digest_is_the_committed_artifact_bytes() -> None:
+    """The echo the operator's ledger records.
+
+    If this fails, the file in the diff is not the file the writer authorizes,
+    and no other test in this module means anything.
+    """
+
+    assert ARTIFACT.is_file(), D2_R8_EXECUTION_AUTHORITY_PATH
+    assert hashlib.sha256(artifact_bytes()).hexdigest() == (
+        "ba6518e7cafa16160059aafb22cd304d13793e0f8ea7f035d8fbd8ddc967b00b"
+    )
+    assert D2_R8_EXECUTION_AUTHORITY_SHA256 == (
+        "ba6518e7cafa16160059aafb22cd304d13793e0f8ea7f035d8fbd8ddc967b00b"
+    )
+    assert D2_DISPATCH_AUTHORIZED_DIGESTS == {D2_R8_EXECUTION_AUTHORITY_SHA256}
+
+
+def test_the_committed_authority_clears_every_dispatch_gate() -> None:
+    """The gate discriminates; it is not a blanket permission either.
+
+    Without this, the eight refusals below would be satisfied by an artifact
+    that never authorizes anything, which would prove nothing.
+    """
+
+    authority = load_sealed_authority(ARTIFACT)
+    assert authority.payload_sha256 == D2_R8_EXECUTION_AUTHORITY_SHA256
+    assert authority.record.dispatch_authorized is True
+    assert authority.dispatch_block_reasons(now=BEFORE_EXPIRY) == ()
+    assert authority.mutation_authorized_symbols == {
+        "BTCUSDT",
+        "ETHUSDT",
+        "USDCUSDT",
+    }
+
+
+def test_the_frozen_constants_are_the_132_values_verbatim() -> None:
+    """Requirement ③, checked against the decision text rather than itself."""
+
+    assert D2_PRE_SNAPSHOT_HASH == SECTION_132_PRE_SNAPSHOT_HASH
+    assert D2_R8_ARTIFACT_MANIFEST_SHA256 == SECTION_132_MANIFEST_SHA256
+    assert (
+        tuple(
+            (o.symbol, format(o.quantity, "f"), format(o.price, "f"))
+            for o in D2_BOUND_ORDERS
+        )
+        == SECTION_132_ORDERS
+    )
+    # And §125차's superseded prices are gone from the bound set entirely.
+    superseded = {"69266.01000000", "2248.56000000", "1.00072000"}
+    assert not superseded & {format(o.price, "f") for o in D2_BOUND_ORDERS}
+
+
+def test_the_authority_binds_the_r8_seal_without_restating_it() -> None:
+    """Requirement ①: the r8 snapshot payload keeps its own bytes.
+
+    The artifact names the snapshot by digest and declares it un-rewritten;
+    the snapshot payload stays registered as a *separate*, unauthorized entry.
+    """
+
+    binding = artifact_payload()["sealed_snapshot_binding"]
+    assert binding["snapshot_payload_rewritten"] is False
+    assert binding["binding_payload_sha256"] == D2_R8_BINDING_PAYLOAD_SHA256
+    assert binding["artifact_manifest_sha256"] == D2_R8_ARTIFACT_MANIFEST_SHA256
+    assert binding["snapshot_seal_sha256"] == D2_SNAPSHOT_SEAL_SHA256
+    assert binding["seal_timestamp_utc"] == D2_R8_SEAL_TIMESTAMP_UTC
+
+    assert D2_R8_BINDING_PAYLOAD_SHA256 != D2_R8_EXECUTION_AUTHORITY_SHA256
+    snapshot_record = d2.D2_KNOWN_SEALED_PAYLOADS[D2_R8_BINDING_PAYLOAD_SHA256]
+    assert snapshot_record.dispatch_authorized is False
+    assert snapshot_record.pre_snapshot_hash == D2_PRE_SNAPSHOT_HASH
+
+
+def test_the_operator_authorization_is_a_decision_reference_not_a_signature() -> None:
+    """Requirement ⑤'s honesty half.
+
+    ``operator_authorization`` being non-null is a gate the writer enforces.
+    What it contains is a pointer to a recorded decision, and the artifact says
+    so rather than presenting itself as cryptographically signed.
+    """
+
+    auth = artifact_payload()["operator_authorization"]
+    assert auth is not None
+    assert auth["kind"] == "OPERATOR_DECISION_LEDGER_REFERENCE"
+    assert auth["section"] == "§134차"
+    assert "그 외 봉인은 계속 거부한다" in auth["verbatim_ko"]
+    assert SECTION_132_PRE_SNAPSHOT_HASH.split(":", 1)[1] in auth["verbatim_ko"]
+    assert SECTION_132_MANIFEST_SHA256 in auth["verbatim_ko"]
+    assert "not a cryptographic signature" in auth["signature_kind_note"]
+
+
+# --------------------------------------------------------------------------
+# M1 — a different seal
+# --------------------------------------------------------------------------
+
+
+def test_m1_marking_another_registered_seal_authorized_fails_the_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tripwire §134차 replaced, in its narrowed form.
+
+    The old tripwire refused *any* authorized entry. This one refuses any set
+    of authorized entries that is not equal to the one-member permission — so
+    it still catches exactly this, which is the failure mode the replacement
+    was most likely to introduce.
+    """
+
+    r7_digest = "e1c2d250d73ae3bdb631289a7293c35c217b9e5c6e2694d3f8ea572d1835a3aa"
+    widened = dict(d2.D2_KNOWN_SEALED_PAYLOADS)
+    widened[r7_digest] = SealedPayloadRecord(
+        sha256=r7_digest,
+        pre_snapshot_hash=D2_SUPERSEDED_R7_PRE_SNAPSHOT_HASH,
+        dispatch_authorized=True,
+        note="r7, wrongly authorized",
+    )
+    monkeypatch.setattr(d2, "D2_KNOWN_SEALED_PAYLOADS", widened)
+    with pytest.raises(d2.D2UnauthorizedOperation) as exc:
+        d2._assert_closed_order_set()
+    assert exc.value.reason_code is D2ReasonCode.UNAUTHORIZED_OPERATION
+    assert r7_digest in str(exc.value)
+
+
+def test_m1_dropping_the_r8_authority_also_fails_the_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closed equality cuts both ways.
+
+    A registry that authorizes *nothing* is no longer silently fine either: it
+    disagrees with the recorded permission, and disagreement is the signal.
+    """
+
+    narrowed = dict(d2.D2_KNOWN_SEALED_PAYLOADS)
+    narrowed[D2_R8_EXECUTION_AUTHORITY_SHA256] = SealedPayloadRecord(
+        sha256=D2_R8_EXECUTION_AUTHORITY_SHA256,
+        pre_snapshot_hash=D2_PRE_SNAPSHOT_HASH,
+        dispatch_authorized=False,
+        note="authority de-registered",
+    )
+    monkeypatch.setattr(d2, "D2_KNOWN_SEALED_PAYLOADS", narrowed)
+    with pytest.raises(d2.D2UnauthorizedOperation):
+        d2._assert_closed_order_set()
+
+
+def test_m1_an_authority_naming_the_superseded_r7_snapshot_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Content-level M1: registered *and* authorized, and still refused.
+
+    This is the case the digest gate would normally shadow. It is exercised on
+    purpose, because the digest gate is exactly what an operator error in the
+    registry removes.
+    """
+
+    payload = artifact_payload()
+    payload["pre_snapshot_hash"] = D2_SUPERSEDED_R7_PRE_SNAPSHOT_HASH
+    path = write_authority(
+        tmp_path,
+        monkeypatch,
+        payload,
+        pre_snapshot_hash=D2_SUPERSEDED_R7_PRE_SNAPSHOT_HASH,
+    )
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_HASH_MISMATCH
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "binding_payload_sha256",
+        "artifact_manifest_sha256",
+        "snapshot_seal_sha256",
+        "seal_timestamp_utc",
+    ],
+)
+def test_m1_an_authority_naming_a_different_seal_component_is_refused(
+    field: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = artifact_payload()
+    payload["sealed_snapshot_binding"][field] = "0" * 64
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_IDENTITY_MISMATCH
+    assert field in str(exc.value)
+
+
+def test_m1_an_authority_admitting_it_rewrote_the_snapshot_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Requirement ① as a runtime check, not only as a promise in a docstring."""
+
+    payload = artifact_payload()
+    payload["sealed_snapshot_binding"]["snapshot_payload_rewritten"] = True
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_IDENTITY_MISMATCH
+
+
+@pytest.mark.parametrize(
+    "field", ["schema_version", "artifact_kind", "authority_scope"]
+)
+def test_m1_an_authorized_payload_that_is_not_an_execution_authority_is_refused(
+    field: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = artifact_payload()
+    payload[field] = "something-else"
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_IDENTITY_MISMATCH
+
+
+def test_m1_the_r8_snapshot_payload_shape_cannot_be_promoted_to_an_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stripping the execution-authority block leaves a payload that binds and
+    refuses — a snapshot re-registered as authorized does not become one."""
+
+    payload = artifact_payload()
+    del payload["sealed_snapshot_binding"]
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert "names no seal" in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# M2 / M3 — the digest gate
+# --------------------------------------------------------------------------
+
+
+def test_m2_an_unregistered_digest_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = write_authority(tmp_path, monkeypatch, artifact_payload(), register=False)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_UNKNOWN_DIGEST
+
+
+def test_m2_arbitrary_bytes_are_refused_before_the_json_is_parsed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "not-an-authority.json"
+    path.write_bytes(b"{ this is not json")
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    # Unknown digest, not a JSON error: the bytes never reach the parser.
+    assert exc.value.reason_code is D2ReasonCode.SEAL_UNKNOWN_DIGEST
+
+
+def test_m3_one_changed_byte_in_the_committed_artifact_is_refused(
+    tmp_path: Path,
+) -> None:
+    """No registry monkeypatching: the shipped map is what refuses this."""
+
+    raw = bytearray(artifact_bytes())
+    index = raw.index(b"75421.27000000") + 4
+    assert raw[index : index + 1] == b"1"
+    raw[index : index + 1] = b"2"
+    path = tmp_path / "one-byte-off.json"
+    path.write_bytes(bytes(raw))
+    assert hashlib.sha256(bytes(raw)).hexdigest() != D2_R8_EXECUTION_AUTHORITY_SHA256
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_UNKNOWN_DIGEST
+
+
+def test_m3_even_a_whitespace_only_reserialisation_is_refused(
+    tmp_path: Path,
+) -> None:
+    """Same JSON, different bytes. The digest is over bytes, not over meaning."""
+
+    path = tmp_path / "reserialised.json"
+    path.write_bytes(json.dumps(artifact_payload(), indent=4).encode("utf-8"))
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_UNKNOWN_DIGEST
+
+
+# --------------------------------------------------------------------------
+# M4 / M5 / M6 — the authorization fields, verified from the new artifact
+# --------------------------------------------------------------------------
+
+
+def test_m4_a_null_operator_authorization_blocks_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = artifact_payload()
+    payload["operator_authorization"] = None
+    path = write_authority(tmp_path, monkeypatch, payload)
+    reasons = blockers(path)
+    assert any("operator_authorization is null" in r for r in reasons)
+
+
+@pytest.mark.parametrize(
+    ("expiry", "now", "fragment"),
+    [
+        (None, BEFORE_EXPIRY, "expiry is absent"),
+        ("2026-08-22T14:59:59Z", AFTER_EXPIRY, "authority expired at"),
+        ("2020-01-01T00:00:00Z", BEFORE_EXPIRY, "authority expired at"),
+    ],
+)
+def test_m5_an_absent_or_expired_authority_blocks_dispatch(
+    expiry: str | None,
+    now: dt.datetime,
+    fragment: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = artifact_payload()
+    payload["expiry"] = expiry
+    path = write_authority(tmp_path, monkeypatch, payload)
+    reasons = blockers(path, now=now)
+    assert any(fragment in r for r in reasons), reasons
+
+
+def test_m5_the_committed_authority_does_expire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shipped artifact is a one-shot, not a standing permission."""
+
+    authority = load_sealed_authority(ARTIFACT)
+    assert authority.expiry == dt.datetime(2026, 8, 22, 14, 59, 59, tzinfo=dt.UTC)
+    assert authority.dispatch_block_reasons(now=AFTER_EXPIRY) != ()
+
+
+@pytest.mark.parametrize("symbol", ["BTCUSDT", "ETHUSDT", "USDCUSDT"])
+def test_m6_any_single_row_losing_mutation_authorized_blocks_dispatch(
+    symbol: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = artifact_payload()
+    payload["authorized_symbols"]["spot"][symbol]["mutation_authorized"] = False
+    path = write_authority(tmp_path, monkeypatch, payload)
+    reasons = blockers(path)
+    assert any(
+        f"mutation_authorized is not true for ['{symbol}']" in r for r in reasons
+    )
+
+
+def test_m6_the_dust_and_quote_rows_stay_unauthorized_in_the_artifact() -> None:
+    """§108차's dust attestations and USDT retention are not orders and are not
+    authorized to become any."""
+
+    spot = artifact_payload()["authorized_symbols"]["spot"]
+    for symbol in ("SOLUSDT", "XRPUSDT", "DOGEUSDT", "USDT"):
+        assert spot[symbol]["mutation_authorized"] is False
+    authority = load_sealed_authority(ARTIFACT)
+    assert authority.mutation_authorized_symbols.isdisjoint(
+        {"SOLUSDT", "XRPUSDT", "DOGEUSDT", "USDT"}
+    )
+
+
+# --------------------------------------------------------------------------
+# M7 — the quantities and prices
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("symbol", "field", "value"),
+    [
+        ("BTCUSDT", "proposed_limit_price_floor", "75421.28000000"),
+        ("BTCUSDT", "proposed_limit_price_floor", "69266.01000000"),
+        ("BTCUSDT", "proposed_quantity_floor", "0.00016000"),
+        ("ETHUSDT", "proposed_limit_price_floor", "2248.56000000"),
+        ("ETHUSDT", "proposed_quantity_floor", "0.00530000"),
+        ("USDCUSDT", "proposed_limit_price_floor", "1.00072000"),
+        ("USDCUSDT", "proposed_quantity_floor", "5001.00000000"),
+    ],
+)
+def test_m7_a_quantity_or_price_that_is_not_the_132_value_is_refused(
+    symbol: str,
+    field: str,
+    value: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Includes the §125차 values explicitly: the superseded numbers must be
+    refused like any other foreign value, not accepted as a familiar default."""
+
+    payload = artifact_payload()
+    payload["authorized_symbols"]["spot"][symbol]["proposed_one_step"][field] = value
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+def test_m7_a_trailing_zero_is_not_a_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Decimal comparison is by value, so ``0.00015`` and ``0.00015000`` are the
+    same order. The refusals above are about the number, not its spelling."""
+
+    payload = artifact_payload()
+    step = payload["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
+    step["proposed_quantity_floor"] = "0.00015"
+    step["proposed_limit_price_floor"] = "75421.2700"
+    path = write_authority(tmp_path, monkeypatch, payload)
+    assert load_sealed_authority(path).dispatch_block_reasons(now=BEFORE_EXPIRY) == ()
+
+
+def test_m7_a_drifted_sealed_balance_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The observed balances are part of the bound identity, not decoration."""
+
+    payload = artifact_payload()
+    payload["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"][
+        "raw_free_quantity"
+    ] = "0.00015958"
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# M8 — the shape of the order set
+# --------------------------------------------------------------------------
+
+
+def test_m8_a_fourth_actionable_symbol_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = artifact_payload()
+    spot = payload["authorized_symbols"]["spot"]
+    spot["SOLUSDT"] = copy.deepcopy(spot["BTCUSDT"])
+    spot["SOLUSDT"].update({"symbol": "SOLUSDT", "asset": "SOL"})
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+def test_m8_promoting_a_dust_row_to_actionable_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The realistic shape of a fourth order: reuse a row that is already in
+    the artifact and change only its disposition."""
+
+    payload = artifact_payload()
+    spot = payload["authorized_symbols"]["spot"]
+    spot["SOLUSDT"]["disposition"] = "REVIEWED_SCOPE_LIMIT_CANDIDATE"
+    spot["SOLUSDT"]["mutation_authorized"] = True
+    spot["SOLUSDT"]["proposed_one_step"] = {
+        "side": "SELL",
+        "order_type": "LIMIT",
+        "time_in_force": None,
+        "proposed_quantity_floor": "0.00090000",
+        "proposed_limit_price_floor": "100.00000000",
+        "raw_free_quantity": "0.00094600",
+        "raw_locked_quantity": "0E-8",
+    }
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+def test_m8_a_symbol_authorized_for_mutation_outside_the_bound_set_blocks_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The half that used to go unchecked.
+
+    Flipping ``mutation_authorized`` on a non-actionable row cannot create an
+    order — the bound set is a constant — but it is a seal claiming more than
+    §134차 granted, and that is now a refusal rather than a shrug.
+    """
+
+    payload = artifact_payload()
+    payload["authorized_symbols"]["spot"]["SOLUSDT"]["mutation_authorized"] = True
+    path = write_authority(tmp_path, monkeypatch, payload)
+    reasons = blockers(path)
+    assert any("outside the bound set: ['SOLUSDT']" in r for r in reasons), reasons
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("side", "BUY"), ("order_type", "MARKET"), ("time_in_force", "IOC")],
+)
+def test_m8_a_buy_a_market_or_a_foreign_time_in_force_is_refused(
+    field: str, value: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = artifact_payload()
+    payload["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"][field] = value
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+def test_m8_a_missing_third_order_is_refused_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = artifact_payload()
+    del payload["authorized_symbols"]["spot"]["USDCUSDT"]
+    path = write_authority(tmp_path, monkeypatch, payload)
+    with pytest.raises(D2SealBindingMismatch) as exc:
+        load_sealed_authority(path)
+    assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# The dry run, bound to the committed artifact
+# --------------------------------------------------------------------------
+
+
+def _writer(
+    monkeypatch: pytest.MonkeyPatch, client: FakeExecutionClient
+) -> d2.D2RemediationSingleWriter:
+    monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
+    lease, grant = make_lease()
+    return d2.D2RemediationSingleWriter(
+        execution_client=client,  # type: ignore[arg-type]
+        authority=load_sealed_authority(ARTIFACT),
+        lease=lease,
+        lease_grant=grant,
+        ledger=FakeLedger(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_dry_run_is_still_the_default_under_the_r8_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """🔴 Authorizing dispatch did not make dispatch the default.
+
+    ``execute()`` with no argument mutates nothing, even now that the authority
+    is complete — which is the property most at risk from this cutover.
+    """
+
+    client = FakeExecutionClient()
+    report = await _writer(monkeypatch, client).execute()
+    assert isinstance(report, d2.D2DryRunReport)
+    assert client.submit_calls == []
+    assert report.broker_mutation_count == 0
+    assert report.dispatch_block_reasons == ()
+
+
+@pytest.mark.asyncio
+async def test_the_dry_run_request_payload_equals_the_132_values_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What the operator reads out of the rehearsal before arming --confirm."""
+
+    client = FakeExecutionClient()
+    report = await _writer(monkeypatch, client).execute()
+    assert isinstance(report, d2.D2DryRunReport)
+
+    emitted = [op.request_params for op in report.operations]
+    assert emitted == [
+        {
+            "symbol": symbol,
+            "side": "SELL",
+            "type": "LIMIT",
+            "quantity": quantity,
+            "price": price,
+            "timeInForce": "GTC",
+        }
+        for symbol, quantity, price in SECTION_132_ORDERS
+    ]
+    # The order-shape check crossed the transport with the same values, and
+    # nothing else did.
+    assert [
+        (c["symbol"], format(c["qty"], "f"), format(c["price"], "f"))
+        for c in client.order_test_calls
+    ] == list(SECTION_132_ORDERS)
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_dry_run_operations_are_the_three_contract_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeExecutionClient()
+    report = await _writer(monkeypatch, client).execute()
+    assert isinstance(report, d2.D2DryRunReport)
+    assert (
+        tuple(op.operation_id for op in report.operations) == D2_ALLOWED_OPERATION_IDS
+    )
+    evidence = report.as_evidence()
+    assert evidence["dispatch_authorized"] is True
+    assert evidence["broker_mutation_count"] == 0
+    assert evidence["authority"]["payload_sha256"] == D2_R8_EXECUTION_AUTHORITY_SHA256
+    assert evidence["pre_snapshot_hash"] == SECTION_132_PRE_SNAPSHOT_HASH
+
+
+@pytest.mark.asyncio
+async def test_confirm_still_refuses_when_the_authority_is_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The writer-level counterpart of M4/M5/M6: an incomplete authority raises
+    before anything lease-protected runs, and nothing is submitted."""
+
+    payload = artifact_payload()
+    payload["operator_authorization"] = None
+    path = write_authority(tmp_path, monkeypatch, payload)
+    monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
+    client = FakeExecutionClient()
+    lease, grant = make_lease()
+    writer = d2.D2RemediationSingleWriter(
+        execution_client=client,  # type: ignore[arg-type]
+        authority=load_sealed_authority(path),
+        lease=lease,
+        lease_grant=grant,
+        ledger=FakeLedger(),
+    )
+    with pytest.raises(D2DispatchNotAuthorized):
+        await writer.execute(confirm=True)
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_backdated_clock_cannot_revive_the_expired_r8_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``now_fn`` is an evidence-timestamp seam, not an expiry seam."""
+
+    client = FakeExecutionClient()
+    monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
+    lease, grant = make_lease()
+    writer = d2.D2RemediationSingleWriter(
+        execution_client=client,  # type: ignore[arg-type]
+        authority=load_sealed_authority(ARTIFACT),
+        lease=lease,
+        lease_grant=grant,
+        ledger=FakeLedger(),
+        now_fn=lambda: dt.datetime(2020, 1, 1, tzinfo=dt.UTC),
+    )
+    # The expiry comparison uses the real clock, so this test says the same
+    # thing before and after 2026-08-22: the seam is not wired to the gate.
+    real_now = dt.datetime.now(dt.UTC)
+    expected = load_sealed_authority(ARTIFACT).dispatch_block_reasons(now=real_now)
+    assert writer.dispatch_block_reasons() == expected
+
+
+# --------------------------------------------------------------------------
+# Documentation stays true
+# --------------------------------------------------------------------------
+
+
+def test_the_runbook_quotes_the_authorization_verbatim() -> None:
+    runbook = Path("docs/runbooks/binance-spot-demo-d2-remediation.md").read_text(
+        encoding="utf-8"
+    )
+    # The runbook wraps the quote across lines, so this checks the two clauses
+    # rather than one exact line: the permission and its explicit limit.
+    assert "한정으로 dispatch를 허용한다." in runbook
+    assert "그 외 봉인은 계속" in runbook and "거부한다" in runbook
+    assert SECTION_132_PRE_SNAPSHOT_HASH in runbook
+    assert SECTION_132_MANIFEST_SHA256 in runbook
+    assert D2_R8_EXECUTION_AUTHORITY_SHA256 in runbook
+    for _symbol, quantity, price in SECTION_132_ORDERS:
+        assert quantity in runbook and price in runbook
+
+
+def test_no_superseded_price_survives_anywhere_in_the_d2_surface() -> None:
+    """§125차's prices are gone from code, CLI, artifact, and runbook alike.
+
+    A stale price left in a docstring is the failure this whole round exists to
+    avoid: it reads as the bound value to anyone who does not open the seal.
+    """
+
+    superseded = ("69266.01", "2248.56", "1.00072")
+
+    # Zero tolerance where a reader could mistake one for a live value.
+    for path in (Path("scripts/binance_spot_demo_d2_remediation.py"), ARTIFACT):
+        text = path.read_text(encoding="utf-8")
+        for price in superseded:
+            assert price not in text, f"{path}: superseded price {price}"
+
+    # The writer and the runbook may each name them exactly once, and only in
+    # the sentence that says they are superseded — naming them there is what
+    # stops a future edit from reintroducing them as if they were current.
+    for path in (
+        Path("app/services/brokers/binance/spot_demo/d2_remediation_single.py"),
+        Path("docs/runbooks/binance-spot-demo-d2-remediation.md"),
+    ):
+        text = path.read_text(encoding="utf-8")
+        for price in superseded:
+            assert text.count(price) <= 1, f"{path}: superseded price {price}"
+        assert "superseded and must not reappear" in text
+
+
+def test_the_artifact_is_valid_json_and_declares_its_schema() -> None:
+    payload = artifact_payload()
+    assert payload["schema_version"] == d2.D2_EXECUTION_AUTHORITY_SCHEMA_VERSION
+    assert payload["artifact_kind"] == d2.D2_EXECUTION_AUTHORITY_KIND
+    assert payload["authority_scope"] == d2.D2_EXECUTION_AUTHORITY_SCOPE
+    assert Decimal(
+        payload["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"][
+            "proposed_limit_price_floor"
+        ]
+    ) == Decimal("75421.27")

--- a/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
+++ b/tests/services/brokers/binance/spot_demo/test_d2_remediation_single.py
@@ -160,7 +160,7 @@ def sealed_payload(*, authorized: bool = False) -> dict[str, Any]:
                     "BTCUSDT",
                     "BTC",
                     "0.00015000",
-                    "69266.01000000",
+                    "75421.27000000",
                     "0.00015957",
                     mutation_authorized=authorized,
                 ),
@@ -168,7 +168,7 @@ def sealed_payload(*, authorized: bool = False) -> dict[str, Any]:
                     "ETHUSDT",
                     "ETH",
                     "0.00520000",
-                    "2248.56000000",
+                    "2368.46000000",
                     "0.00529470",
                     mutation_authorized=authorized,
                 ),
@@ -176,7 +176,7 @@ def sealed_payload(*, authorized: bool = False) -> dict[str, Any]:
                     "USDCUSDT",
                     "USDC",
                     "5000.00000000",
-                    "1.00072000",
+                    "1.00030000",
                     "5000.00000000",
                     mutation_authorized=authorized,
                 ),
@@ -191,9 +191,23 @@ def sealed_payload(*, authorized: bool = False) -> dict[str, Any]:
         },
     }
     if authorized:
+        # A dispatch-authorized payload must also *look* like an execution
+        # authority: since §134차 the writer re-checks which seal a
+        # dispatch-authorized artifact names, so the fixture carries the same
+        # binding block the shipped artifact does.
+        payload["schema_version"] = d2.D2_EXECUTION_AUTHORITY_SCHEMA_VERSION
+        payload["artifact_kind"] = d2.D2_EXECUTION_AUTHORITY_KIND
+        payload["authority_scope"] = d2.D2_EXECUTION_AUTHORITY_SCOPE
+        payload["sealed_snapshot_binding"] = {
+            "snapshot_payload_rewritten": False,
+            "binding_payload_sha256": d2.D2_R8_BINDING_PAYLOAD_SHA256,
+            "artifact_manifest_sha256": d2.D2_R8_ARTIFACT_MANIFEST_SHA256,
+            "snapshot_seal_sha256": d2.D2_SNAPSHOT_SEAL_SHA256,
+            "seal_timestamp_utc": d2.D2_R8_SEAL_TIMESTAMP_UTC,
+        }
         payload["operator_authorization"] = {
-            "section": "§125차",
-            "signature": "operator-resign-fixture",
+            "section": "§134차",
+            "signature": "operator-decision-reference-fixture",
         }
         payload["expiry"] = "2099-01-01T00:00:00Z"
     return payload
@@ -630,7 +644,7 @@ def test_request_params_equal_the_sealed_values_exactly(
             "side": "SELL",
             "type": "LIMIT",
             "quantity": "0.00015000",
-            "price": "69266.01000000",
+            "price": "75421.27000000",
             "timeInForce": "GTC",
         },
         {
@@ -638,7 +652,7 @@ def test_request_params_equal_the_sealed_values_exactly(
             "side": "SELL",
             "type": "LIMIT",
             "quantity": "0.00520000",
-            "price": "2248.56000000",
+            "price": "2368.46000000",
             "timeInForce": "GTC",
         },
         {
@@ -646,7 +660,7 @@ def test_request_params_equal_the_sealed_values_exactly(
             "side": "SELL",
             "type": "LIMIT",
             "quantity": "5000.00000000",
-            "price": "1.00072000",
+            "price": "1.00030000",
             "timeInForce": "GTC",
         },
     ]
@@ -702,8 +716,8 @@ def test_m3_trailing_zero_difference_is_not_a_mutation() -> None:
 def test_m4_price_one_tick_changed_is_refused() -> None:
     mutant = copy.deepcopy(sealed_payload())
     step = mutant["authorized_symbols"]["spot"]["BTCUSDT"]["proposed_one_step"]
-    assert step["proposed_limit_price_floor"] == "69266.01000000"
-    step["proposed_limit_price_floor"] = "69266.02000000"  # tickSize is 0.01
+    assert step["proposed_limit_price_floor"] == "75421.27000000"
+    step["proposed_limit_price_floor"] = "75421.28000000"  # tickSize is 0.01
     with pytest.raises(D2SealBindingMismatch) as exc:
         bind_sealed_orders(mutant)
     assert exc.value.reason_code is D2ReasonCode.SEAL_ORDER_SET_MISMATCH
@@ -894,17 +908,28 @@ async def test_b1_registered_dispatch_authorized_false_blocks_confirm(
         await writer.execute(confirm=True)
 
 
-def test_b1_every_shipped_sealed_payload_is_dispatch_blocked() -> None:
-    """The structural claim: this repository grants no dispatch authority.
+def test_b1_the_shipped_dispatch_permission_is_exactly_one_seal() -> None:
+    """The structural claim, in its §134차 form.
 
-    Not "we checked once" — the shipped map is asserted empty of authorized
-    entries here and again by an import-time tripwire in the module.
+    Before the cutover this asserted the shipped map was *empty* of authorized
+    entries. §134차 authorized one seal and explicitly kept every other one
+    refused, so the assertion becomes closed equality against a one-member set
+    rather than a blanket "none" — and the import-time tripwire checks the same
+    equality, so a second authorized entry cannot be added quietly.
     """
 
     assert d2.D2_KNOWN_SEALED_PAYLOADS
-    assert not any(
-        record.dispatch_authorized for record in d2.D2_KNOWN_SEALED_PAYLOADS.values()
-    )
+    authorized = {
+        digest
+        for digest, record in d2.D2_KNOWN_SEALED_PAYLOADS.items()
+        if record.dispatch_authorized
+    }
+    assert authorized == {d2.D2_R8_EXECUTION_AUTHORITY_SHA256}
+    assert d2.D2_DISPATCH_AUTHORIZED_DIGESTS == authorized
+    # And the two seals that are registered but not authorized stay that way.
+    assert not d2.D2_KNOWN_SEALED_PAYLOADS[
+        d2.D2_R8_BINDING_PAYLOAD_SHA256
+    ].dispatch_authorized
 
 
 @pytest.mark.asyncio
@@ -1247,7 +1272,7 @@ async def test_b4_account_truth_is_read_before_the_first_submit(
 @pytest.mark.parametrize(
     ("override", "needle"),
     [
-        ({"price": "69266.02000000"}, "price"),
+        ({"price": "75421.28000000"}, "price"),
         ({"timeInForce": "IOC"}, "timeInForce"),
         ({"price": None}, "carries no price"),
         ({"timeInForce": None}, "carries no timeInForce"),


### PR DESCRIPTION
## Operator authorization (§134차, quoted verbatim as required)

> 「§132차가 바인딩한 r8 봉인 — pre_snapshot_hash
> `sha256:4816a1d93da8a6e754d46b98d01e70aab9a82c7720bd86e0d5720583cc66f830` ·
> manifest_sha256
> `fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431` ·
> 수량/가격 3건 §132차 원문 — **한정으로 dispatch를 허용한다. 그 외 봉인은 계속 거부한다.**」

🔴 **"그 외 봉인은 계속 거부한다" is the contract of this PR.** The permission is therefore
implemented as a **closed one-member set** compared by `==`, not as a boolean flag a second
registry entry could also carry. Half of the new tests exist to prove the narrowing did not
leak.

## 🔴 Digest echo (for the operator ledger)

```text
docs/contracts/d2-r8-execution-authority-20260821.json
bytes  8227
sha256 ba6518e7cafa16160059aafb22cd304d13793e0f8ea7f035d8fbd8ddc967b00b
```

Supporting digests, all measured in this branch, none recalled from memory:

| Object | sha256 |
|---|---|
| r8 binding payload (**unchanged**) | `00b975ff1a291917699588d91154a790765b0f3e7008b141a8f60f6925fbae61` |
| r8 artifact manifest | `fa7092a32e09689927228c400dbc97312af4eb1cd9f76d34a208d1fe7f1e8431` (= §134차 verbatim) |
| r8 snapshot seal | `7817e8df2da3f89b03df40caea5e313b3d113fd07328dc4aaad2c4559397d95f` |
| seal_timestamp_utc | `2026-08-21T01:53:45.145298Z` (= §132차 verbatim) |

## §132차 values — transcribed, not recomputed and not re-rounded

| Symbol | Side/type | Quantity | Limit price |
|---|---|---:|---:|
| BTCUSDT | SELL LIMIT | `0.00015000` | `75421.27000000` |
| ETHUSDT | SELL LIMIT | `0.00520000` | `2368.46000000` |
| USDCUSDT | SELL LIMIT | `5000.00000000` | `1.00030000` |

Independently cross-read from r8 `binding-payload-proposed.json` and from
`postseal-integrity.json: proposed_values`; all three sources agree character for character.
§125차's `69266.01` / `2248.56` / `1.00072` are superseded, appear nowhere in the CLI or the
artifact, and appear exactly once each in the writer and runbook — in the sentence saying so.

## The five required items

| # | Requirement | Where |
|---|---|---|
| ① | r8 snapshot payload **not** rewritten; execution-only §132-bound artifact introduced | `docs/contracts/d2-r8-execution-authority-20260821.json` (new). The r8 payload is untouched and registered separately with `dispatch_authorized=False`. The artifact carries `snapshot_payload_rewritten: false`, re-checked at load. |
| ② | exact bytes/digest registered in the named writer | `D2_R8_EXECUTION_AUTHORITY_SHA256` + registry entry in `d2_remediation_single.py`; digest echoed above |
| ③ | frozen `pre_snapshot_hash` + 3 quantity/price constants → §132 values | `D2_PRE_SNAPSHOT_HASH`, `D2_BOUND_ORDERS` |
| ④ | import-time no-dispatch tripwire replaced under §134차 | `_assert_closed_order_set` |
| ⑤ | non-null operator authorization · expiry · 3× `mutation_authorized`, verified **from the new artifact** | `SealedAuthority.dispatch_block_reasons` (now closed on both sides) + `_assert_execution_authority_shape` |

### On ④ — the tripwire is narrower, not weaker

The old form refused *any* `dispatch_authorized` entry. The new form requires the set of
authorized entries to **equal** `D2_DISPATCH_AUTHORIZED_DIGESTS`, so:

- marking a **second** digest authorized fails the import (M1), and
- **de-registering** the r8 authority also fails the import (M1').

Widening the permission still costs a visible diff in **two** places — the registry and the
constant — and either one alone is red.

## Mutants — 8 classes, all refused, all pinned by tests

New file `tests/services/brokers/binance/spot_demo/test_d2_r8_authority_registration.py`
(54 tests). Every check is closed equality against a frozen constant; no name or substring
matching anywhere.

| Mutant | Result | Refused by |
|---|---|---|
| **M1** another seal (r7 `e1c2d250…`) marked authorized | refused at import | `_assert_closed_order_set` |
| **M1'** r8 authority de-registered | refused at import | same equality, other direction |
| **M1''** authority naming the r7 `pre_snapshot_hash` | `SEAL_HASH_MISMATCH` | `bind_sealed_orders` |
| **M1'''** authority naming a different binding-payload / manifest / seal / seal-instant (4 cases) | `SEAL_IDENTITY_MISMATCH` | `_assert_execution_authority_shape` |
| **M1''''** `snapshot_payload_rewritten: true`, missing binding block, foreign `schema_version`/`artifact_kind`/`authority_scope` (5 cases) | `SEAL_IDENTITY_MISMATCH` | same |
| **M2** unregistered digest / arbitrary bytes | `SEAL_UNKNOWN_DIGEST` **before the JSON is parsed** | `load_sealed_authority` |
| **M3** one byte changed; whitespace-only re-serialisation | `SEAL_UNKNOWN_DIGEST`, against the **shipped** registry (no monkeypatch) | `load_sealed_authority` |
| **M4** `operator_authorization = null` | dispatch blocked; `--confirm` raises with 0 submits | `dispatch_block_reasons` |
| **M5** expiry absent / past / real expiry + later clock | dispatch blocked; backdated `now_fn` proven not to revive it | `dispatch_block_reasons` |
| **M6** any one of the three rows `mutation_authorized=false` | dispatch blocked | `dispatch_block_reasons` |
| **M7** quantity or price ≠ §132 (7 cases, **including §125차's own values**) | `SEAL_ORDER_SET_MISMATCH` | `bind_sealed_orders` |
| **M8** 4th symbol; dust row promoted; BUY; MARKET; foreign TIF; missing 3rd order | `SEAL_ORDER_SET_MISMATCH` | `bind_sealed_orders` |
| **M8'** symbol authorized for mutation outside the bound set | dispatch blocked — **new check** | `dispatch_block_reasons` |

Positive control so the refusals are not satisfied by a writer that never runs:
`test_the_committed_authority_clears_every_dispatch_gate` — the shipped artifact yields
`dispatch_block_reasons() == ()`.

## Dry-run proof — `--confirm` never used, 0 broker calls in this PR

`--plan-only` on the committed authority (pure: no HTTP, no DB, no lease):

```json
"authority": {"payload_sha256": "ba6518e7…67b00b", "registered_dispatch_authorized": true,
              "operator_authorization_present": true, "expiry": "2026-08-22T14:59:59+00:00",
              "mutation_authorized_symbols": ["BTCUSDT","ETHUSDT","USDCUSDT"]},
"dispatch_block_reasons": [], "broker_mutation_count": 0,
"operations": [
 {"symbol":"BTCUSDT", "side":"SELL","type":"LIMIT","quantity":"0.00015000",   "price":"75421.27000000","timeInForce":"GTC"},
 {"symbol":"ETHUSDT", "side":"SELL","type":"LIMIT","quantity":"0.00520000",   "price":"2368.46000000", "timeInForce":"GTC"},
 {"symbol":"USDCUSDT","side":"SELL","type":"LIMIT","quantity":"5000.00000000","price":"1.00030000",    "timeInForce":"GTC"}]
```

🔴 Field-for-field identical to the §132차 table above.

The **control**, `--plan-only` on the r8 *snapshot* payload — what "the snapshot was not
rewritten into an authority" looks like from outside:

```text
"registered_dispatch_authorized": false, "broker_mutation_count": 0,
"dispatch_block_reasons": [
  "payload digest 00b975ff… is registered as dispatch_authorized=false (…)",
  "operator_authorization is null — no re-sign is present",
  "expiry is absent — a one-shot authority must expire",
  "mutation_authorized is not true for ['BTCUSDT', 'ETHUSDT', 'USDCUSDT']"]
```

Superseded r7 payload → `d2_seal_hash_mismatch`. One byte changed → `d2_seal_unknown_digest`.
`--confirm` with gates off → `default-disabled: … nothing was read, locked, or dispatched`.

Full-path `--dry-run` against the existing test fakes (no sockets):
`submit_order calls: 0`, `order_test calls: 3`, `broker_mutation_count: 0`, and
`execute()` with **no argument** still returns a `D2DryRunReport` — authorizing dispatch did
not make dispatch the default, which was the property most at risk here.

## Checks

```text
make lint     ruff check: passed · ruff format --check: 4050 files formatted · ty: passed
alembic heads 20260820_rob1290_reconcile (head)   — single head, 0 migrations added
full suite    17 failed, 22123 passed, 13 skipped, 8 deselected  (19:28)
ci_shards     +1 line in shard-1.txt; LC_ALL=C order verified; no cross-shard duplicates
```

🔴 **The 17 failures are pre-existing and that is measured, not assumed.** The same 17 node
ids were re-run at base `402967581` in a throwaway detached worktree with none of this change
present → `17 failed, 29 passed`, the identical ids. Groups:
`test_mock_session_mcp.py` (13, MCP stdio wrapper/signals), three real-PostgreSQL
`test_migration.py` round trips (3), `test_mcp_call_template.py` (1, SSE subprocess timeout).
None touches the D2 surface; this change adds no migration.

## Judgment calls, stated rather than buried

1. **`D2_SNAPSHOT_SEAL_SHA256` was also updated** (`d4c9a13a…` → `7817e8df…`). Not one of the
   three quantity/price constants item ③ enumerates, but it is a frozen constant identifying
   the seal, and the writer stamps it into every ledger row as provenance. Leaving r7's value
   would have mislabelled r8 executions. Widens nothing.
2. **Expiry = `2026-08-22T14:59:59Z`** (= 2026-08-22 23:59:59 KST). §134차 named none and the
   gate requires a real, unexpired instant. Chosen to cover the stated target (execution
   tonight, 2026-08-21 KST) with one margin day and no more. Enforced against the real clock.
3. **`operator_authorization` is a decision *reference*, not a signature.** The artifact says
   so in `signature_kind_note` and a test asserts that wording. Claiming a cryptographic
   signature would have been a fabrication.
4. **The r8 binding payload was newly registered** with `dispatch_authorized=False`. Not
   requested; it makes the control above possible and makes "unsigned snapshot ≠ authority"
   checkable rather than merely asserted. It grants nothing.

## What this PR does not do

* No execution. No `--confirm`. **No broker call, no signing, no order, no cancel.**
* No env-gate change: `BINANCE_SPOT_DEMO_ENABLED` and `D2_REMEDIATION_SINGLE_ENABLED` remain
  untouched and default-off. Arming them is the operator's act.
* No migration, no scheduler registration, no `operator_contract.yaml` edit (out of repo).
* No widening beyond the r8 seal — r7, the r8 snapshot payload itself, and any unregistered
  bytes all still refuse.

🔴 Draft on purpose. No self-merge, no ready-for-review, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
