### PR TITLE
§138차 회고 채택분 — breadth 지표 분리·임계근방 태깅·A/B shadow 입력계약 (관측/기록 전용)

### DIFF
--- a/.smoke-out/rob179-feed-research-evidence.json
+++ b/.smoke-out/rob179-feed-research-evidence.json
@@ -1,7 +1,7 @@
 {
   "smoke": "rob-179-invest-research-api",
-  "captured_at": "2026-08-10T08:13:13.971815+00:00",
-  "source_used": "rob179-smoke-18adacff",
+  "captured_at": "2026-08-22T01:30:30.617878+00:00",
+  "source_used": "rob179-smoke-e7c2b8cd",
   "invariants_ok": true,
   "samples": {
     "top": {

--- a/app/mcp_server/tooling/buy_candidate_fanout.py
+++ b/app/mcp_server/tooling/buy_candidate_fanout.py
@@ -19,6 +19,15 @@ from app.services.analyst_normalizer import (
     consensus_has_stale_window_inputs,
     stale_window_input_count,
 )
+from app.services.threshold_proximity import (
+    PROXIMITY_BAND as THRESHOLD_PROXIMITY_BAND,
+)
+from app.services.threshold_proximity import (
+    build_forecast_tag as build_threshold_proximity_forecast_tag,
+)
+from app.services.threshold_proximity import (
+    near_miss as threshold_near_miss,
+)
 from app.services.trading_policy_service import (
     load_trading_policy,
     policy_version_stamp,
@@ -288,6 +297,32 @@ def _support_evidence(
     return min(usable, key=lambda level: float(level["distance_pct"])), "pass"
 
 
+def _nearest_support_distance_pct(
+    supports: object, *, current_price: float
+) -> float | None:
+    """Distance to the closest support below the current price, or ``None``.
+
+    ROB-1315 §7-3 read-only helper: ``_support_evidence`` reports *why* the
+    support stage failed but not *by how much*.  This recomputes the observed
+    distance so a "support was 8.05% away against an 8% ceiling" reject can be
+    told apart from a 30% one.  It re-derives, never relaxes.
+    """
+
+    if not isinstance(supports, list) or current_price <= 0:
+        return None
+    distances: list[float] = []
+    for level in supports:
+        if not isinstance(level, Mapping):
+            continue
+        price = _as_float(level.get("price"))
+        if price is None or price <= 0 or price >= current_price:
+            continue
+        distances.append((current_price - price) / current_price * 100)
+    if not distances:
+        return None
+    return min(distances)
+
+
 def _trading_restriction_reason(fresh: Mapping[str, Any]) -> str | None:
     """Use only fresh-analysis restriction evidence; unknown never becomes pass."""
 
@@ -359,18 +394,32 @@ def _funnel_result(
     regular_rsi_pass: bool = False,
     rsi_only_fail: bool = False,
     observation_gate_path_complete: bool = False,
+    proximity: Sequence[Mapping[str, Any]] = (),
+    symbol: str = "",
+    market: str = "",
 ) -> dict[str, Any]:
     """Keep unproven freshness from becoming a regular or RSI-only pass."""
 
     proven_fresh = freshness.get("status") == "proven_fresh"
-    return {
+    tags = [dict(tag) for tag in proximity]
+    result = {
         "funnel": funnel,
         "freshness": dict(freshness),
         "regular_evidence_eligible": proven_fresh and regular_rsi_pass,
         "rsi_only_fail_candidate": proven_fresh and rsi_only_fail,
         "observation_gate_path_complete": observation_gate_path_complete,
         "actionable": False,
+        # ROB-1315 §7-3 — recording only. A tag here means the candidate
+        # failed a numeric gate by <= the band; the failure itself stands.
+        "threshold_proximity": tags,
     }
+    hint = (
+        build_threshold_proximity_forecast_tag(tags, market=market, symbol=symbol)
+        if tags
+        else None
+    )
+    result["negative_class_forecast_hint"] = hint
+    return result
 
 
 def _minimum_snapshot_date(market: str) -> dt.date:
@@ -460,6 +509,12 @@ def _evaluate_funnel(
     diagnose the population, but it can never produce an eligibility pass.
     """
 
+    symbol = str(candidate.get("symbol") or "")
+    market = str(candidate.get("market") or "")
+    # ROB-1315 §7-3 — near-miss evidence collected alongside the verdicts.
+    # Appending to this list can never flip a stage: every append happens on
+    # the failing branch, after that branch has already been chosen.
+    proximity: list[dict[str, Any]] = []
     funnel: dict[str, dict[str, Any]] = {
         "source": {
             "status": "pass",
@@ -479,7 +534,7 @@ def _evaluate_funnel(
         }
         for stage in _FUNNEL_STAGE_NAMES[2:]:
             funnel[stage] = _not_evaluated("base_eligibility_failed")
-        return _funnel_result(funnel, unavailable)
+        return _funnel_result(funnel, unavailable, symbol=symbol, market=market)
 
     freshness = _freshness_contract(fresh)
     current_price = _first_float(fresh, "current_price", "price", "currentPrice")
@@ -493,7 +548,9 @@ def _evaluate_funnel(
         }
         for stage in _FUNNEL_STAGE_NAMES[2:]:
             funnel[stage] = _not_evaluated("base_eligibility_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
     if current_price is None or current_price <= 0:
         funnel["base_eligibility"] = {
             "status": "fail",
@@ -502,7 +559,9 @@ def _evaluate_funnel(
         }
         for stage in _FUNNEL_STAGE_NAMES[2:]:
             funnel[stage] = _not_evaluated("base_eligibility_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
     if restriction_reason is not None:
         funnel["base_eligibility"] = {
             "status": "fail",
@@ -511,7 +570,9 @@ def _evaluate_funnel(
         }
         for stage in _FUNNEL_STAGE_NAMES[2:]:
             funnel[stage] = _not_evaluated("base_eligibility_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
 
     observation_only_due_to_freshness = freshness["status"] == "undetermined"
 
@@ -548,10 +609,27 @@ def _evaluate_funnel(
         fresh.get("supports"), current_price=current_price, gates=gates
     )
     if support is None:
-        funnel["support_source_count"] = observed_stage("fail", reason=support_reason)
+        support_stage: dict[str, Any] = {"reason": support_reason}
+        if support_reason == "support_more_than_8pct_below_current":
+            tag = threshold_near_miss(
+                gate="buy.support_reserve_net.support_within_current_pct_max",
+                metric="support_distance_pct",
+                observed=_nearest_support_distance_pct(
+                    fresh.get("supports"), current_price=current_price
+                ),
+                threshold=gates.support_within_current_pct_max,
+                comparison="max",
+                unit="percent",
+            )
+            if tag is not None:
+                proximity.append(tag)
+                support_stage["threshold_proximity"] = tag
+        funnel["support_source_count"] = observed_stage("fail", **support_stage)
         for stage in _FUNNEL_STAGE_NAMES[3:]:
             funnel[stage] = _not_evaluated("support_source_count_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
     funnel["support_source_count"] = observed_stage("pass", **support)
 
     consensus = fresh.get("consensus")
@@ -569,7 +647,9 @@ def _evaluate_funnel(
         )
         for stage in _FUNNEL_STAGE_NAMES[4:]:
             funnel[stage] = _not_evaluated("upside_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
     target_price = _first_float(
         consensus_data, "avg_target_price", "avgTargetPrice", "target_price"
     )
@@ -577,19 +657,34 @@ def _evaluate_funnel(
         funnel["upside"] = observed_stage("fail", reason="fresh_consensus_missing")
         for stage in _FUNNEL_STAGE_NAMES[4:]:
             funnel[stage] = _not_evaluated("upside_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
     upside_pct = (target_price - current_price) / current_price * 100
     if upside_pct < gates.honest_upside_pct_min:
-        funnel["upside"] = observed_stage(
-            "fail",
-            reason="honest_upside_below_40pct",
-            current_price=current_price,
-            avg_target_price=target_price,
-            honest_upside_pct=round(upside_pct, 6),
+        upside_stage: dict[str, Any] = {
+            "reason": "honest_upside_below_40pct",
+            "current_price": current_price,
+            "avg_target_price": target_price,
+            "honest_upside_pct": round(upside_pct, 6),
+        }
+        tag = threshold_near_miss(
+            gate="buy.support_reserve_net.honest_upside_pct_min",
+            metric="honest_upside_pct",
+            observed=upside_pct,
+            threshold=gates.honest_upside_pct_min,
+            comparison="min",
+            unit="percent",
         )
+        if tag is not None:
+            proximity.append(tag)
+            upside_stage["threshold_proximity"] = tag
+        funnel["upside"] = observed_stage("fail", **upside_stage)
         for stage in _FUNNEL_STAGE_NAMES[4:]:
             funnel[stage] = _not_evaluated("upside_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
     funnel["upside"] = observed_stage(
         "pass",
         current_price=current_price,
@@ -608,12 +703,23 @@ def _evaluate_funnel(
     else:
         # This is a classification only.  It cannot create a proposal, an order,
         # or an actionable candidate from this read-only surface.
-        funnel["rsi"] = observed_stage(
-            "rsi_only_fail",
-            reason="rsi_missing_or_above_regular_max",
-            rsi_14=rsi,
-            max_rsi=gates.rsi_max,
+        rsi_stage: dict[str, Any] = {
+            "reason": "rsi_missing_or_above_regular_max",
+            "rsi_14": rsi,
+            "max_rsi": gates.rsi_max,
+        }
+        tag = threshold_near_miss(
+            gate="screen.rsi_max",
+            metric="rsi_14",
+            observed=rsi,
+            threshold=gates.rsi_max,
+            comparison="max",
+            unit="rsi_points",
         )
+        if tag is not None:
+            proximity.append(tag)
+            rsi_stage["threshold_proximity"] = tag
+        funnel["rsi"] = observed_stage("rsi_only_fail", **rsi_stage)
 
     anchor, anchor_reason = _anchor_band(
         support_price=float(support["price"]),
@@ -623,7 +729,9 @@ def _evaluate_funnel(
     if anchor is None:
         funnel["anchor_band"] = observed_stage("fail", reason=anchor_reason)
         funnel["budget"] = _not_evaluated("anchor_band_failed")
-        return _funnel_result(funnel, freshness)
+        return _funnel_result(
+            funnel, freshness, proximity=proximity, symbol=symbol, market=market
+        )
     funnel["anchor_band"] = observed_stage("pass", **anchor)
     # Account/broker evidence is deliberately unavailable in this task.  Keep
     # the cap literals visible but never infer a budget pass.
@@ -641,6 +749,9 @@ def _evaluate_funnel(
         regular_rsi_pass=regular_rsi_pass,
         rsi_only_fail=not regular_rsi_pass,
         observation_gate_path_complete=True,
+        proximity=proximity,
+        symbol=symbol,
+        market=market,
     )
 
 
@@ -1015,6 +1126,8 @@ async def discover_buy_candidates_fanout_impl(
 
     regular_evidence_eligible_count = 0
     rsi_only_fail_candidate_count = 0
+    threshold_proximity_candidates: list[dict[str, Any]] = []
+    threshold_proximity_gate_counts: dict[str, int] = {}
     freshness_undetermined_count = 0
     freshness_undetermined_reasons: dict[str, int] = {}
     funnel_stage_counts = _empty_funnel_stage_counts()
@@ -1060,6 +1173,23 @@ async def discover_buy_candidates_fanout_impl(
             regular_evidence_eligible_count += 1
         if candidate["rsi_only_fail_candidate"]:
             rsi_only_fail_candidate_count += 1
+        # ROB-1315 §7-3 — the near-miss cohort is reported, never filtered on.
+        # These candidates stay rejected; they are only made findable.
+        for tag in candidate.get("threshold_proximity") or []:
+            gate_name = str(tag["gate"])
+            threshold_proximity_gate_counts[gate_name] = (
+                threshold_proximity_gate_counts.get(gate_name, 0) + 1
+            )
+        if candidate.get("negative_class_forecast_hint"):
+            threshold_proximity_candidates.append(
+                {
+                    "symbol": symbol,
+                    "gates": [tag["gate"] for tag in candidate["threshold_proximity"]],
+                    "negative_class_forecast_hint": candidate[
+                        "negative_class_forecast_hint"
+                    ],
+                }
+            )
         failure_reason = _first_failed_reason(candidate["funnel"])
         for source in candidate["matched_sources"]:
             stats = source_stats[source]
@@ -1113,6 +1243,21 @@ async def discover_buy_candidates_fanout_impl(
             "freshness_undetermined_reasons": freshness_undetermined_reasons,
             "regular_evidence_eligible_count": regular_evidence_eligible_count,
             "rsi_only_fail_candidate_count": rsi_only_fail_candidate_count,
+            "threshold_proximity": {
+                "band": THRESHOLD_PROXIMITY_BAND,
+                "band_semantics": "absolute_units_of_the_gate_metric",
+                "gate_verdict_changed": False,
+                "recording_only": True,
+                "candidate_count": len(threshold_proximity_candidates),
+                "by_gate": threshold_proximity_gate_counts,
+                "candidates": threshold_proximity_candidates,
+                "how_to_record": (
+                    "merge negative_class_forecast_hint.threshold_proximity into "
+                    "forecast_save(forecast_target=...) with "
+                    "decision_bucket='deferred_no_action' (ROB-1283). This tool "
+                    "does not write."
+                ),
+            },
             "actionable_count": 0,
             "final_eligible_counts": {
                 "regular_evidence": regular_evidence_eligible_count,
@@ -1126,6 +1271,7 @@ async def discover_buy_candidates_fanout_impl(
 
 __all__ = [
     "MAX_SNAPSHOT_PRESETS_PER_CALL",
+    "THRESHOLD_PROXIMITY_BAND",
     "SNAPSHOT_MAX_STALE_SESSIONS",
     "TOP_N_PER_SOURCE",
     "TOP_N_REVALIDATION",

--- a/app/mcp_server/tooling/buy_candidate_fanout_registration.py
+++ b/app/mcp_server/tooling/buy_candidate_fanout_registration.py
@@ -30,7 +30,15 @@ def register_buy_candidate_fanout_tools(mcp: FastMCP) -> None:
             "is recorded as undetermined observation only, never as eligibility. "
             "Returns observation-only funnel evidence, never a proposal or order. It "
             "does not query broker or account state, so budget remains deferred. Do not "
-            "use this output for PnL scoring or immediate threshold tuning."
+            "use this output for PnL scoring or immediate threshold tuning. "
+            "ROB-1315 near-miss recording: a candidate rejected by a numeric gate by "
+            "no more than 1.0 unit of that gate's own metric (RSI point / percentage "
+            "point) carries a threshold_proximity tag naming the gate, threshold, "
+            "observed value, and miss, and a negative_class_forecast_hint ready to "
+            "merge into forecast_save(forecast_target=..., "
+            "decision_bucket='deferred_no_action'). The tag changes no verdict: a "
+            "tagged candidate is still rejected, and this tool still writes nothing. "
+            "digest_observation.threshold_proximity aggregates the same cohort."
         ),
     )
     async def discover_buy_candidates_fanout() -> dict[str, Any]:

--- a/app/mcp_server/tooling/buy_gate_ab_shadow.py
+++ b/app/mcp_server/tooling/buy_gate_ab_shadow.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from app.services.buy_gate_ab_shadow.evaluate import (
     EvaluationError,
+    candidate_input_contract,
     evaluate_candidates,
 )
 from app.services.buy_gate_ab_shadow.forecast_tag import build_shadow_buy_forecasts
@@ -50,6 +51,7 @@ def evaluate_buy_gate_ab_shadow_impl(
         return {
             "success": False,
             "error": "candidates must be a non-empty list",
+            "input_contract": candidate_input_contract(),
             "promote": False,
             "live_gate_impact": False,
         }
@@ -57,9 +59,14 @@ def evaluate_buy_gate_ab_shadow_impl(
         as_of = _parse_as_of(evaluation_as_of)
         rows = evaluate_candidates(candidates, evaluation_as_of=as_of)
     except EvaluationError as exc:
+        # ROB-1315 §5-1: a mis-keyed candidate set is refused loudly and the
+        # contract is echoed, so the caller fixes it in one round trip instead
+        # of collecting a day of all-reject rows that mean nothing.
         return {
             "success": False,
             "error": str(exc),
+            "input_contract": candidate_input_contract(),
+            "candidates_evaluated": 0,
             "promote": False,
             "live_gate_impact": False,
         }
@@ -79,6 +86,7 @@ def evaluate_buy_gate_ab_shadow_impl(
         "do_not_use_for_policy_change": True,
         "candidates": [row.as_dict() for row in rows],
         "shadow_buy_forecasts": shadow_forecasts,
+        "input_contract": candidate_input_contract(),
         "counts": {
             "n": len(rows),
             "a_and_b": sum(row.cohort == "a_and_b" for row in rows),

--- a/app/mcp_server/tooling/buy_gate_ab_shadow_registration.py
+++ b/app/mcp_server/tooling/buy_gate_ab_shadow_registration.py
@@ -24,7 +24,21 @@ _TOOL_DESCRIPTION = (
     "calibration_exclude. forecast_save appends the corresponding eligibility "
     "decision; do not call it unless you intend a pure "
     "record. Do not use this output for PnL scoring, threshold tuning, or "
-    "policy change before the pre-registered 4-week collection completes."
+    "policy change before the pre-registered 4-week collection completes. "
+    "INPUT CONTRACT (exact keys; an unknown key is rejected, never ignored): "
+    "required symbol, market ('kr'|'us'), current_price; optional "
+    "support_strength ('weak'|'moderate'|'strong'), support_distance_pct, "
+    "rsi, honest_upside_pct, other_gate_bits (booleans keyed liquid_midcap / "
+    "concentration / overhang). Note rsi, NOT rsi_14; support_strength, NOT "
+    "nearest_support_strength — those two typos silently voided a whole US "
+    "collection day on 2026-08-21 (ROB-1315 §5-1). A rejection echoes "
+    "input_contract naming the correct key. An omitted optional field is "
+    "still a rejection: a gate cannot pass on absent evidence. "
+    "US LIMITATION: the overhang bit has no US data source in this repo "
+    "(get_disclosures is DART/KR-only), so a US caller that sets "
+    "overhang=false is asserting an unverified gate and B-only stays at zero. "
+    "See docs/superpowers/specs/2026-08-22-us-overhang-gate-design.md — do not "
+    "invent a pass."
 )
 
 

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -573,12 +573,20 @@ def _register_fundamentals_tools_impl(
         name="get_upbit_altseason",
         description=(
             "Get an Upbit altseason snapshot: the UBAI/UBMI ratio (altcoin index "
-            "vs market index) and 24h breadth (fraction of KRW-quoted alts beating "
-            "BTC over 24h, derived from the official Upbit ticker). Higher ratio + "
-            "higher breadth lean altseason. Read-only public data. Note: breadth is "
-            "24h only (multi-period breadth is a separate follow-up). With constituents "
-            "enabled, breadth.constituents lists KRW alts beating BTC with 24h change, "
-            "vs-BTC relative strength, volume, and traded value."
+            "vs market index) plus TWO distinct 24h breadth metrics, reported "
+            "side by side and never interchangeable (ROB-1315): "
+            "breadth.alt_positive_24h_pct = ABSOLUTE breadth (share of KRW alts "
+            "whose 24h change is above zero); breadth.alts_beating_btc_pct = "
+            "BTC-RELATIVE breadth (share whose 24h change exceeds KRW-BTC's). "
+            "The trading_policy no_chasing breadth clause reads the BTC-relative "
+            "one, so in a BTC-led rally it can stay closed while absolute breadth "
+            "is high (2026-08-20: 78.09% absolute vs 17.38% relative, 60.71pp "
+            "apart). breadth.metric_semantics restates this in the payload. "
+            "Higher ratio + higher breadth lean altseason. Read-only public data. "
+            "Note: breadth is 24h only (multi-period breadth is a separate "
+            "follow-up). With constituents enabled, breadth.constituents lists "
+            "KRW alts beating BTC with 24h change, vs-BTC relative strength, "
+            "volume, and traded value."
         ),
     )
     async def get_upbit_altseason(

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -562,6 +562,13 @@ class PolicyRecoveryCondition(BaseModel):
     threshold: int | float | None
     unit: str
     semantics: str
+    # ROB-1315 §7-2 — optional metric disambiguation. When a data source
+    # exposes more than one number under one colloquial metric name, these
+    # name the exact field the gate reads and the field it must never read.
+    # Documentation only: no threshold, operator, or verdict depends on them.
+    input_field: str | None = None
+    input_basis: str | None = None
+    not_input_field: str | None = None
 
 
 class PolicyRecoveryGate(BaseModel):

--- a/app/services/buy_gate_ab_shadow/evaluate.py
+++ b/app/services/buy_gate_ab_shadow/evaluate.py
@@ -4,6 +4,26 @@ A and B consume one CandidateEvidence object and one evaluation_as_of.
 Shared gates are applied with the frozen pre-registration thresholds, not
 the live policy file. This module has no broker, proposal, watch, DB, or
 network import.
+
+Candidate input contract (ROB-1315 §5-1)
+----------------------------------------
+Every candidate mapping is validated against ``CANDIDATE_KEYS`` and an
+unknown key is a **hard error**, not a silent drop. On 2026-08-21 a US
+session sent ``rsi_14`` / ``nearest_support_strength``; both were ignored,
+both fields read as absent, and all seven candidates were rejected for
+gates they would have passed. Nothing in the response said so. A whole
+collection day was lost to a mis-typed key, so the surface now refuses the
+call and names the correct key.
+
+Required: ``symbol``, ``market`` (``kr`` | ``us``), ``current_price``.
+Optional: ``support_strength`` (``weak`` | ``moderate`` | ``strong``),
+``support_distance_pct``, ``rsi``, ``honest_upside_pct``,
+``other_gate_bits`` (booleans keyed by ``liquid_midcap`` /
+``concentration`` / ``overhang``).
+
+An omitted optional field is still a rejection — a gate cannot pass on
+absent evidence — but that is now the caller's explicit choice rather than
+a typo the evaluator swallowed.
 """
 
 from __future__ import annotations
@@ -34,6 +54,64 @@ ALLOWED_MARKETS: frozenset[str] = frozenset(PRE_REGISTRATION["markets"])
 
 class EvaluationError(ValueError):
     """Caller input cannot be evaluated fail-closed."""
+
+
+REQUIRED_CANDIDATE_KEYS: frozenset[str] = frozenset(
+    {"symbol", "market", "current_price"}
+)
+OPTIONAL_CANDIDATE_KEYS: frozenset[str] = frozenset(
+    {
+        "support_strength",
+        "support_distance_pct",
+        "rsi",
+        "honest_upside_pct",
+        "other_gate_bits",
+    }
+)
+CANDIDATE_KEYS: frozenset[str] = REQUIRED_CANDIDATE_KEYS | OPTIONAL_CANDIDATE_KEYS
+
+# Keys real sessions have sent instead of the contract key. Naming the
+# correction in the error is the difference between a one-round-trip fix and
+# a lost collection day (ROB-1315 §5-1).
+KEY_ALIASES: dict[str, str] = {
+    "rsi_14": "rsi",
+    "rsi14": "rsi",
+    "nearest_support_strength": "support_strength",
+    "support_strength_label": "support_strength",
+    "nearest_support_distance_pct": "support_distance_pct",
+    "support_distance": "support_distance_pct",
+    "upside_pct": "honest_upside_pct",
+    "honest_upside": "honest_upside_pct",
+    "price": "current_price",
+    "gate_bits": "other_gate_bits",
+}
+
+
+def candidate_input_contract() -> dict[str, Any]:
+    """Machine-readable input contract, echoed on rejection."""
+
+    return {
+        "required": sorted(REQUIRED_CANDIDATE_KEYS),
+        "optional": sorted(OPTIONAL_CANDIDATE_KEYS),
+        "other_gate_bit_keys": list(OTHER_GATE_KEYS),
+        "markets": sorted(ALLOWED_MARKETS),
+        "support_strength_values": ["weak", "moderate", "strong"],
+        "common_mistakes": dict(sorted(KEY_ALIASES.items())),
+        "unknown_keys_are_rejected": True,
+        "omitted_optional_field_is_a_rejection_not_a_pass": True,
+    }
+
+
+def _reject_unknown_keys(raw: Mapping[str, Any], *, where: str) -> None:
+    unknown = sorted(set(raw) - CANDIDATE_KEYS)
+    if not unknown:
+        return
+    hints = [f"{key} -> {KEY_ALIASES[key]}" for key in unknown if key in KEY_ALIASES]
+    message = f"{where}: unknown candidate key(s) {unknown}"
+    if hints:
+        message += f"; did you mean {hints}?"
+    message += f". Accepted keys: {sorted(CANDIDATE_KEYS)}"
+    raise EvaluationError(message)
 
 
 def _as_decimal(value: object, *, field: str) -> Decimal:
@@ -69,17 +147,36 @@ class CandidateEvidence:
     other_gate_bits: Mapping[str, bool]
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any]) -> CandidateEvidence:
+    def from_mapping(
+        cls, raw: Mapping[str, Any], *, index: int | None = None
+    ) -> CandidateEvidence:
+        where = "candidate" if index is None else f"candidates[{index}]"
+        if not isinstance(raw, Mapping):
+            raise EvaluationError(f"{where}: candidate must be an object")
+        _reject_unknown_keys(raw, where=where)
         symbol = str(raw.get("symbol") or "").strip().upper()
         if not symbol:
-            raise EvaluationError("symbol is required")
+            raise EvaluationError(f"{where}: symbol is required")
         market = str(raw.get("market") or "").strip().lower()
         if market not in ALLOWED_MARKETS:
-            raise EvaluationError("market must be kr or us")
+            raise EvaluationError(f"{where} ({symbol}): market must be kr or us")
         strength = str(raw.get("support_strength") or "").strip().lower()
+        if strength and strength not in _STRENGTH_RANK:
+            raise EvaluationError(
+                f"{where} ({symbol}): support_strength must be one of "
+                f"{sorted(_STRENGTH_RANK)}, got {strength!r}"
+            )
         bits_raw = raw.get("other_gate_bits") or {}
         if not isinstance(bits_raw, Mapping):
-            raise EvaluationError("other_gate_bits must be an object")
+            raise EvaluationError(
+                f"{where} ({symbol}): other_gate_bits must be an object"
+            )
+        unknown_bits = sorted(set(bits_raw) - set(OTHER_GATE_KEYS))
+        if unknown_bits:
+            raise EvaluationError(
+                f"{where} ({symbol}): unknown other_gate_bits key(s) {unknown_bits}. "
+                f"Accepted: {list(OTHER_GATE_KEYS)}"
+            )
         bits: dict[str, bool] = {}
         for key in OTHER_GATE_KEYS:
             if key not in bits_raw:
@@ -87,22 +184,28 @@ class CandidateEvidence:
                 continue
             value = bits_raw[key]
             if not isinstance(value, bool):
-                raise EvaluationError(f"other_gate_bits.{key} must be a boolean")
+                raise EvaluationError(
+                    f"{where} ({symbol}): other_gate_bits.{key} must be a boolean"
+                )
             bits[key] = value
-        price = _as_decimal(raw.get("current_price"), field="current_price")
+        price = _as_decimal(
+            raw.get("current_price"), field=f"{where} ({symbol}): current_price"
+        )
         if price <= 0:
-            raise EvaluationError("current_price must be positive")
+            raise EvaluationError(f"{where} ({symbol}): current_price must be positive")
         return cls(
             symbol=symbol,
             market=market,  # type: ignore[arg-type]
             current_price=price,
             support_strength=strength,
             support_distance_pct=_optional_decimal(
-                raw.get("support_distance_pct"), field="support_distance_pct"
+                raw.get("support_distance_pct"),
+                field=f"{where} ({symbol}): support_distance_pct",
             ),
-            rsi=_optional_decimal(raw.get("rsi"), field="rsi"),
+            rsi=_optional_decimal(raw.get("rsi"), field=f"{where} ({symbol}): rsi"),
             honest_upside_pct=_optional_decimal(
-                raw.get("honest_upside_pct"), field="honest_upside_pct"
+                raw.get("honest_upside_pct"),
+                field=f"{where} ({symbol}): honest_upside_pct",
             ),
             other_gate_bits=bits,
         )
@@ -278,8 +381,8 @@ def evaluate_candidates(
 ) -> list[CandidateEvaluation]:
     return [
         evaluate_candidate(
-            CandidateEvidence.from_mapping(row),
+            CandidateEvidence.from_mapping(row, index=index),
             evaluation_as_of=evaluation_as_of,
         )
-        for row in rows
+        for index, row in enumerate(rows)
     ]

--- a/app/services/external/upbit_index.py
+++ b/app/services/external/upbit_index.py
@@ -6,9 +6,15 @@ Read-only public market-data. Two data planes, deliberately split by robots poli
 - **Indices** come from ``datalab-static.upbit.com`` — an S3-hosted public data
   product with no robots restriction. We merge index/master (catalog) +
   index/recent (live value) + index/summary (yield/risk stats).
-- **24h breadth** (alts beating BTC) is derived from the **official** Open API
+- **24h breadth** is derived from the **official** Open API
   ``api.upbit.com/v1/ticker`` (``signed_change_rate`` is 24h only). We do NOT use
-  the robots-disallowed ``crix-api-cdn`` trends endpoints.
+  the robots-disallowed ``crix-api-cdn`` trends endpoints. Two breadth metrics
+  are reported side by side and must not be confused (ROB-1315 §7-2):
+  ``alt_positive_24h_pct`` (absolute: 24h change > 0) and
+  ``alts_beating_btc_pct`` (BTC-relative: 24h change > KRW-BTC's 24h change).
+  The ``no_chasing`` breadth clause in ``config/trading_policy.yaml`` reads the
+  **BTC-relative** one; the crypto policy table's ``market_context`` header
+  reports the **absolute** one. They diverged by 60.71pp on 2026-08-20.
 
 7/30/90d breadth is intentionally out of scope here (official ``/v1/ticker`` has no
 multi-period change rate); that is a separate follow-up over ``/v1/candles/days``.
@@ -276,13 +282,30 @@ async def _fetch_krw_breadth_24h(
         return None
 
     beating = sum(1 for rate in alt_rates if rate > btc_rate)
+    positive = sum(1 for rate in alt_rates if rate > 0)
     result: dict[str, Any] = {
         "window": "24h",
         "method": "open_api_ticker_24h_derived",
         "alts_total": len(alt_rates),
+        # ROB-1315 §7-2: the two breadth metrics are reported side by side
+        # because they can disagree by tens of points in a BTC-led rally
+        # (2026-08-20: 78.09% absolute vs 17.38% BTC-relative).  Neither
+        # replaces the other and neither changes a gate verdict here.
         "alts_beating_btc": beating,
         "alts_beating_btc_pct": round(beating / len(alt_rates), 4),
+        "alts_positive_24h": positive,
+        "alt_positive_24h_pct": round(positive / len(alt_rates), 4),
         "btc_change_24h": btc_rate,
+        "metric_semantics": {
+            "alt_positive_24h_pct": (
+                "absolute: share of KRW alts whose 24h change is above zero"
+            ),
+            "alts_beating_btc_pct": (
+                "BTC-relative: share of KRW alts whose 24h change exceeds "
+                "KRW-BTC's 24h change"
+            ),
+            "no_chasing_gate_input": "alts_beating_btc_pct",
+        },
     }
     if include_constituents:
         constituents = _build_altseason_constituents(

--- a/app/services/threshold_proximity.py
+++ b/app/services/threshold_proximity.py
@@ -1,0 +1,146 @@
+"""Near-miss tagging for discovery gate rejections (ROB-1315 §7-3).
+
+Recording only. Nothing in this module changes a gate verdict: a candidate
+that failed still failed, and the tag is attached *after* the comparison the
+gate already made. The point is that a reject at 45.03 against a 45 ceiling
+and a reject at 78 against the same ceiling are currently indistinguishable
+in the negative-class cohort, so the "we rejected correctly" claim cannot be
+tested at the margin.
+
+Two live cases motivated it (2026-08-21 US session):
+
+* CIEN — RSI 45.03 against ``screen.rsi_max`` 45 (subsequent MFE +19.39%)
+* RDDT — honest upside 39.93% against a 40% floor (subsequent MFE +20.09%)
+
+Band semantics
+--------------
+The retro says "within ±1% of the threshold". Both cited gates are measured
+in percent-like units (RSI points, percentage points of upside), so the band
+is applied as **±1.0 in the gate's own unit** — the reading that admits both
+cited cases. The relative distance is recorded alongside it
+(``miss_pct_of_threshold``) so a scorer can re-filter on the stricter
+relative reading without re-deriving anything.
+
+Pure: stdlib only. No DB, no network, no broker, no clock, no policy read.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+# ±1.0 in the gate's own unit. A constant, not a tunable: widening it would
+# change which rejects enter the cohort mid-collection.
+PROXIMITY_BAND = 1.0
+
+# ``max``   — the gate wanted observed <= threshold (e.g. RSI <= 45)
+# ``min``   — the gate wanted observed >= threshold (e.g. upside >= 40)
+Comparison = Literal["max", "min"]
+
+TAG = "threshold_proximity"
+
+
+def _miss(observed: float, threshold: float, comparison: Comparison) -> float:
+    """How far the observation fell on the failing side. Never negative here."""
+
+    if comparison == "max":
+        return observed - threshold
+    return threshold - observed
+
+
+def evaluate(
+    *,
+    gate: str,
+    metric: str,
+    observed: float | None,
+    threshold: float,
+    comparison: Comparison,
+    unit: str,
+) -> dict[str, Any] | None:
+    """Describe a failed numeric comparison, or ``None`` when it is untaggable.
+
+    ``None`` is returned when the observation is missing (a missing value is
+    not a near miss — it is an absent measurement) or when the observation did
+    not actually fail the comparison. Both cases are silence by construction:
+    this function never invents a value to tag.
+    """
+
+    if observed is None:
+        return None
+    try:
+        observed_value = float(observed)
+        threshold_value = float(threshold)
+    except (TypeError, ValueError):
+        return None
+    miss = _miss(observed_value, threshold_value, comparison)
+    if miss <= 0:
+        # It passed. A passing candidate has no rejection to tag.
+        return None
+    relative = (miss / abs(threshold_value) * 100) if threshold_value else None
+    return {
+        "gate": gate,
+        "metric": metric,
+        "comparison": comparison,
+        "threshold": threshold_value,
+        "observed": round(observed_value, 6),
+        "miss": round(miss, 6),
+        "miss_unit": unit,
+        "miss_pct_of_threshold": None if relative is None else round(relative, 6),
+        "band": PROXIMITY_BAND,
+        "band_unit": unit,
+        "band_semantics": "absolute_units_of_the_gate_metric",
+        "within_band": miss <= PROXIMITY_BAND,
+        "verdict_changed": False,
+    }
+
+
+def near_miss(**kwargs: Any) -> dict[str, Any] | None:
+    """``evaluate`` filtered to the ±band cohort. Returns ``None`` otherwise."""
+
+    tag = evaluate(**kwargs)
+    if tag is None or not tag["within_band"]:
+        return None
+    return tag
+
+
+def build_forecast_tag(
+    tags: list[dict[str, Any]],
+    *,
+    market: str,
+    symbol: str,
+) -> dict[str, Any] | None:
+    """Build the ``forecast_target`` fragment for a negative-class record.
+
+    The caller merges this into its own ``forecast_save(...)`` call with
+    ``decision_bucket='deferred_no_action'`` (ROB-1283). This module does not
+    write; returning ``None`` means there is nothing worth recording.
+    """
+
+    within = [tag for tag in tags if tag.get("within_band")]
+    if not within:
+        return None
+    closest = min(within, key=lambda tag: float(tag["miss"]))
+    return {
+        TAG: {
+            "experiment": "rob-1315-threshold-proximity",
+            "market": market,
+            "symbol": symbol,
+            "band": PROXIMITY_BAND,
+            "band_semantics": "absolute_units_of_the_gate_metric",
+            "closest_gate": closest["gate"],
+            "closest_miss": closest["miss"],
+            "gates": within,
+            "gate_verdict_changed": False,
+            "promote": False,
+            "live_gate_impact": False,
+        },
+        "decision_bucket_hint": "deferred_no_action",
+    }
+
+
+__all__ = [
+    "PROXIMITY_BAND",
+    "TAG",
+    "build_forecast_tag",
+    "evaluate",
+    "near_miss",
+]

--- a/ci_shards/shard-2.txt
+++ b/ci_shards/shard-2.txt
@@ -116,6 +116,7 @@ tests/services/brokers/toss/test_dto.py
 tests/services/brokers/toss/test_market_calendar.py
 tests/services/brokers/toss/test_transport.py
 tests/services/buy_gate_ab_shadow/test_forecast_tag.py
+tests/services/buy_gate_ab_shadow/test_input_contract.py
 tests/services/daily_candles/test_crypto_candles_1d_migration.py
 tests/services/execution_ledger/test_fill_event_sanitizer.py
 tests/services/execution_ledger/test_reconciler.py

--- a/ci_shards/shard-3.txt
+++ b/ci_shards/shard-3.txt
@@ -207,6 +207,7 @@ tests/services/test_paper_fills.py
 tests/services/test_portfolio_overview_currency.py
 tests/services/test_posture_shadow_service.py
 tests/services/test_research_run_service_safety.py
+tests/services/test_threshold_proximity.py
 tests/services/test_trade_journal_aggregates_scoreboard.py
 tests/services/test_trading_policy_service.py
 tests/services/test_tradingview_helpers.py

--- a/ci_shards/shard-4.txt
+++ b/ci_shards/shard-4.txt
@@ -75,6 +75,7 @@ tests/scripts/test_list_recent_watch_events_cli.py
 tests/scripts/test_mock_session_mcp.py
 tests/scripts/test_native_bluegreen_lib.py
 tests/scripts/test_native_run_wrappers.py
+tests/scripts/test_policy_table_alt_breadth_naming.py
 tests/scripts/test_policy_table_halt_suspect.py
 tests/scripts/test_run_haproxy_wrapper.py
 tests/scripts/test_spot_smoke_report.py

--- a/ci_shards/shard-4.txt
+++ b/ci_shards/shard-4.txt
@@ -122,6 +122,7 @@ tests/services/brokers/toss/test_config.py
 tests/services/brokers/toss/test_errors.py
 tests/services/brokers/toss/test_smoke_script.py
 tests/services/buy_gate_ab_shadow/test_evaluate.py
+tests/services/buy_gate_ab_shadow/test_preregistration_freeze.py
 tests/services/buy_gate_ab_shadow/test_spec_freeze.py
 tests/services/daily_candles/test_audit_no_other_consumer.py
 tests/services/daily_candles/test_crypto_venue_resolution.py

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -9,7 +9,10 @@
 # 저항 기반 매도 티어에 하나도 매칭되지 않아 익절 경로가 소멸한다. 그 공백만
 # 닫는 폴백 티어 sell.trim_preplace.breakeven_extension_ladder 를 신설한다.
 # 저항 티어의 대체가 아니며, exclusions.no_resistance_reference 는 유지된다.
-version: "2026-08-21.4"
+# §138차 (2026-08-22): alt breadth 지표 이름 분리 — 게이트 임계·판정은 불변이고
+# 어느 필드를 읽는지만 명시한다. 게이트 입력은 BTC 상대(alts_beating_btc_pct)이며
+# 절대 breadth(alt_positive_24h_pct)는 정책표 표기용이지 게이트 입력이 아니다.
+version: "2026-08-22.1"
 captured_as_of: "2026-08-12"
 source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change); §127차 concurrent-new-entry slots 1→2 and buy.winner_pullback_add pre-registered tier 2026-08-21 (operator decision in claude-mock session; breakout chase remains forbidden); §129차 buy.new_entry_overflow cash-conditioned overflow slots at 0.5x sizing 2026-08-21 (operator decision in claude-mock session; no gate relaxed); §133차 KR per-order auto-approve cap 2M 2026-08-21 (single-share high-priced KR exits structurally carded — SK하이닉스 1,776,000 measured case, §65차 US twin; daily cap unchanged); §136차 A(k) two add symbols per market + owned-symbol add exempt from new-entry symbol cap 2026-08-21 (operator directive to deploy idle Upbit KRW; measured blocker from 2026-08-21 20:20 session; k_used retained at 0.10 — k is the averaging-target parameter, and raising it flips A_limit non-positive, the opposite of expansion)"
 
@@ -747,8 +750,19 @@ market_rules:
       of: 2
       missing_or_null_threshold: do_not_infer_or_count_as_met
       conditions:
+        # ROB-1315 §7-2 — metric disambiguation, NOT a relaxation. The
+        # threshold, operator, and verdict are unchanged. get_upbit_altseason
+        # returns two breadth numbers; this gate reads the BTC-RELATIVE one
+        # (breadth.alts_beating_btc_pct), never the absolute one
+        # (breadth.alt_positive_24h_pct). On 2026-08-20 they were 17.38% vs
+        # 78.09% (60.71pp apart) — reading the wrong field silently inverts
+        # this gate. The crypto policy table header reports the absolute
+        # metric under the name alt_positive_24h; it is not this gate's input.
         - id: alt_breadth_24h
           metric: upbit_alt_breadth_24h
+          input_field: breadth.alts_beating_btc_pct
+          input_basis: btc_relative
+          not_input_field: breadth.alt_positive_24h_pct
           sources: [upbit_open_api_ticker_derived]
           operator: gt
           threshold: 50
@@ -796,7 +810,11 @@ market_rules:
       min_trade_value_24h_krw: null
       criteria:
         - exclude low-liquidity rotation-pump candidates
-        - new alt candidates are ineligible when 24h alt breadth is below 50 percent
+        # ROB-1315 §7-2 — "24h alt breadth" here means the BTC-RELATIVE metric
+        # (breadth.alts_beating_btc_pct from get_upbit_altseason), the same
+        # input as market_rules.crypto.recovery_gate.conditions[alt_breadth_24h].
+        # It is NOT breadth.alt_positive_24h_pct. Threshold unchanged at 50.
+        - new alt candidates are ineligible when 24h alt breadth (BTC-relative, breadth.alts_beating_btc_pct) is below 50 percent
         - exclude sharply rising candidates without support structure or decision history
       follow_up: reports contain no quantitative cutoff; operator fills values after live-operation evidence in a follow-up PR
 

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -465,6 +465,14 @@ B만 통과하는 후보는 `evaluate_buy_gate_ab_shadow`가 돌려준
 이 블록은 **lane sequence가 아니다.** `lanes.buy` / `lanes.discovery` 의
 집행 순서는 그대로다. mock 계좌도 쓰지 않는다 (1계좌=1전략).
 
+🔴 §139차 ② 로 **더 엄격한 사전등록 1건이 별도 등록**됐다 —
+[`docs/preregistrations/2026-08-22-support-strength-two-source-equivalence.md`](../preregistrations/2026-08-22-support-strength-two-source-equivalence.md)
+(회고 §7-1). variant B 가 `moderate AND source_count>=2 AND 독립 계열` 이고
+crypto `winner_pullback_add` 까지 포함하며 승격 조건이 수치로 사전 확정돼 있다.
+**위 ROB-1301 실험과 다른 실험이며 코호트를 섞지 않는다.** 수집 시작 조건이
+아직 하나도 충족되지 않아 **수집 미개시** 상태이고, 지금 집행되는 것은 위
+ROB-1301 문언 그대로다.
+
 ```yaml
 # playbook-machine-readable: ROB-1301 buy-gate A/B shadow (observation only)
 # NOT a lane sequence — live buy/discovery lanes are unchanged.

--- a/docs/preregistrations/2026-08-22-support-strength-two-source-equivalence.md
+++ b/docs/preregistrations/2026-08-22-support-strength-two-source-equivalence.md
@@ -1,0 +1,230 @@
+# Pre-registration — `support_strength_two_source_equivalence`
+
+- **Registered**: 2026-08-22
+- **Status**: 🔴 **REGISTERED, NOT COLLECTING.** The declaration below is frozen.
+  Collection has **not** started; the start conditions are in §7 and none of the
+  blocking ones are met as of registration.
+- **Origin**: buy-side multi-week retro 2026-08-22 §7-1 (ⓒ′)
+  (`~/work/herdr-inbox/retro-buyside-multiweek-20260822.md`)
+- **Confirmed as final by**: operator, relayed via claude-mock (상류 조정, wB:p4R),
+  §139차 ② — *"회고 §7-1 사전등록 문언을 운영자 동의 확정본으로 docs/에 등록"*.
+  🔴 This session did not receive operator sign-off directly; the confirmation
+  reaching it is the relay instruction quoted above. That provenance is recorded
+  rather than upgraded.
+- **Related experiment**: ROB-1301 (`app/services/buy_gate_ab_shadow/`) —
+  🔴 **this is not the same experiment as the one currently pinned in code.**
+  See §5.
+- **Execution impact**: 0. No order, proposal, watch, broker call, or scheduler.
+
+---
+
+## 1. The frozen declaration (verbatim, retro §7-1)
+
+Reproduced character-for-character (verified byte-identical to the retro
+source). `sha256` of the fenced body below — 12 lines, LF-terminated, fences
+excluded: `7d6e9251ef04890cb94a411f4548e6323f61217a1597db2b012dcddadddde479`
+
+```
+사전등록 (shadow only, promote=false, calibration_exclude=true)
+가설: regular discovery 및 winner_pullback_add의 support_strength_min을
+      "strong" → "moderate AND source_count>=2 AND sources가 서로 독립 계열"로 치환하면
+      게이트 통과율이 오르고, 통과 코호트의 D+5/D+20 수익률이 현행 코호트 대비 열등하지 않다.
+적용 lane: KR/US regular discovery, crypto winner_pullback_add
+수집 기간: 4주 (2026-08-22 ~ 2026-09-19), 목표 표본 n>=40 B-only
+기록: 후보별 (변형A reject reasons, 변형B reject reasons, 지지 레벨/강도/sources,
+      기각 시점가, D+1/D+5/D+20 종가, MFE, MAE)
+승격 조건 (사전 확정): B-only 코호트 D+20 중앙값 >= 0 AND 하위 4분위 평균 > -6%
+                       AND n >= 40. 하나라도 미달이면 기각한다.
+집행 영향: 0. 이 실험은 주문·워치·제안을 만들지 않는다.
+전제 조건: §5-1의 US overhang 구현 공백이 먼저 메워져야 US 표본이 수집된다.
+```
+
+## 2. Structured restatement (no content added)
+
+| Field | Value |
+| --- | --- |
+| Experiment id | `support_strength_two_source_equivalence` |
+| Mode | shadow only · `promote=false` · `calibration_exclude=true` |
+| Variant A (live, unchanged) | `support_strength_min = strong` |
+| Variant B (shadow) | `support_strength_min = moderate` **AND** `source_count >= 2` **AND** sources drawn from mutually independent families |
+| Only difference | the support-quality clause above. Every other gate identical. |
+| Lanes / markets | KR + US regular discovery; crypto `winner_pullback_add` |
+| Collection window | 2026-08-22 → 2026-09-19 (28 calendar days) |
+| Sample target | `n >= 40` B-only |
+| Recorded per candidate | variant A reject reasons · variant B reject reasons · support level/strength/sources · price at rejection · D+1, D+5, D+20 closes · MFE · MAE |
+| Promotion (pre-committed) | B-only cohort D+20 **median ≥ 0** AND **bottom-quartile mean > −6%** AND **n ≥ 40**. Any one short ⇒ **reject**. |
+| Execution impact | 0 |
+| Precondition | the §5-1 US overhang implementation gap must be closed before US samples can be collected |
+
+🔴 **The promotion rule is now pre-committed and may not be re-derived after
+seeing data.** "Bottom quartile" is the lowest 25% of the B-only cohort's D+20
+returns; its arithmetic mean must exceed −6%. Ties at the quartile boundary
+resolve by including the boundary observation in the bottom quartile (the
+conservative side). This tie-break is stated here, before collection, precisely
+so it cannot be chosen later to suit an outcome.
+
+## 3. What "independent families" means
+
+The declaration says *"sources가 서로 독립 계열"* without enumerating them. The
+repo already has exactly one such enumeration, and this pre-registration adopts
+it rather than inventing a second: `config/trading_policy.yaml`
+`buy.support_reserve_net.independent_support_source_families` =
+`[fib, bb_lower, volume_profile]`, with
+`independent_support_source_count_min: 2`.
+
+Consequence worth stating plainly: **variant B is not a new invention — it is
+the existing `buy.support_reserve_net` support contract lifted into the regular
+lane.** That tier already ships `support_strength_min: moderate` +
+`independent_support_source_count_min: 2` + those three families, and is today
+reachable only when the regular gate failed on RSI
+(`eligible_only_when_regular_gate_failure: RSI_ONLY`). The hypothesis is that
+the same support contract is adequate in the regular lane too.
+
+If a later reading of "independent families" differs from that list, it is a
+**different experiment** and needs its own pre-registration.
+
+## 4. Where the live "strong" requirement actually lives
+
+Recorded because it is not where a reader would guess: the regular-discovery
+strong-support requirement is **not** in `config/trading_policy.yaml`. It is in
+`docs/playbooks/trading-decision-playbook.md` screening step 3 —
+*"RSI < `screen.rsi_max` + **strong support** within `screen.support_within_pct`
+…"*. For the crypto arm it is
+`buy.winner_pullback_add.tiers[0].conditions.fresh_strong_support_above_avg_cost: true`.
+
+`_FanoutGates` in `app/mcp_server/tooling/buy_candidate_fanout.py` pins
+`support_strength_min == "moderate"` from `buy.support_reserve_net` — that is
+the reserve-net tier's literal, **not** the regular-lane strong requirement, and
+the two must not be conflated when implementing variant A.
+
+## 5. 🔴 Divergence from the ROB-1301 spec frozen in code
+
+`app/services/buy_gate_ab_shadow/spec.py::PRE_REGISTRATION`
+(`PINNED_SPEC_SHA256 = a2814c87…`) declares a **different** experiment. Both are
+called "the A/B shadow" in prose; they are not interchangeable.
+
+| Item | ROB-1301 (pinned in code, today) | §7-1 (this document) |
+| --- | --- | --- |
+| Variant B | `support_strength_min: "moderate"` — strength only | moderate **AND** `source_count>=2` **AND** independent families |
+| `only_difference` | `"support_strength_min"` | the composite support clause |
+| Markets | `["kr", "us"]`; crypto explicitly out of scope | KR/US regular discovery **+ crypto `winner_pullback_add`** |
+| Windows | `[5, 20]` trading days | D+1, **D+5**, **D+20** (adds D+1) |
+| Recorded metrics | `simple_return_to_close`, `max_drawdown_from_entry_close_peak` (+ window high/low as sensitivity) | + **MFE / MAE** named as recorded fields |
+| Sample target | none stated | **n ≥ 40** B-only |
+| Promotion rule | none; `winner_declaration: "forbidden"` | **numeric, pre-committed** (§2) |
+| Collection days | 28 | 28 (2026-08-22 → 2026-09-19) — agrees |
+
+**Nothing in the code was changed to match this document, deliberately.**
+ROB-1301's own rule is that an amendment must be approved and dated *before* the
+pin is moved, and that rows already collected keep the `spec_sha256` they were
+collected under. This file is that dated amendment text. Moving
+`PINNED_SPEC_SHA256` is a separate, later act — see §7.
+
+## 6. Forbidden (carried unchanged from ROB-1301)
+
+* shadow가 제안·주문·워치로 승격 금지(순수 기록)
+* 라이브 게이트 문언 무접촉
+* 채점 전 중간값으로 정책 변경 논거 삼지 않기(사전 등록 원칙)
+
+Additionally, for this registration:
+
+* No scheduler, cron, TaskIQ, or Prefect registration.
+* No mock account used as a consolation execution (1 account = 1 strategy).
+* Scoring runs **once**, after the window closes. No peeking, no extension
+  after a peek, no dropping names after seeing outcomes.
+
+## 7. 🔴 Collection start conditions
+
+Collection is **not** started by registering this document. It starts only when
+every blocking condition below is satisfied, and each is objectively checkable.
+
+### 7.1 Blocking — all markets
+
+| # | Condition | State at registration | Owner |
+| --- | --- | --- | --- |
+| B1 | ROB-1301 `PRE_REGISTRATION` amended to §2's variant-B definition, promotion rule, windows, and scope; `PINNED_SPEC_SHA256` re-pinned in the same change | ❌ not done — code still declares the §5 left column | operator approves amendment → implementation |
+| B2 | `CandidateEvidence` accepts support **source-count and family** evidence | ❌ not supported — `CANDIDATE_KEYS` is `{symbol, market, current_price, support_strength, support_distance_pct, rsi, honest_upside_pct, other_gate_bits}`; there is no source-count field | implementation |
+| B3 | Variant A implemented as the **regular-lane strong** requirement (§4), not the reserve-net moderate literal | ❌ not verified | implementation |
+| B4 | Rows carry `spec_sha256` of the **amended** spec, and pre-amendment rows are excluded from this cohort | ❌ blocked by B1 | implementation |
+
+🔴 **B2 fails loudly, not silently.** Since §138차 ③, `evaluate_buy_gate_ab_shadow`
+rejects unknown candidate keys. A session that starts sending
+`support_source_count` today gets an explicit `EvaluationError` naming the
+accepted keys — it will **not** quietly drop the field and record a
+meaningless cohort. That is the intended behaviour and it is why B2 cannot be
+skipped by "just sending it anyway".
+
+### 7.2 Blocking — US arm only
+
+| # | Condition | State at registration | Owner |
+| --- | --- | --- | --- |
+| U1 | The §5-1 US `overhang` gap is closed — an approved option from `docs/superpowers/specs/2026-08-22-us-overhang-gate-design.md` is implemented | ❌ awaiting operator decision | operator |
+
+This is the declaration's own `전제 조건`. Until U1 is met, **US contributes
+zero samples.** Measured precedent: on 2026-08-21 the valid US call returned
+`n=7 · a_and_b 0 · b_only 0 · neither 7`, with CRH and UPST failing on
+`overhang` alone. Setting `overhang=true` to unblock is forbidden (§6).
+
+### 7.3 Blocking — crypto arm only
+
+| # | Condition | State at registration | Owner |
+| --- | --- | --- | --- |
+| C1 | `winner_pullback_add` shadow evaluation exists for crypto | ❌ not implemented — ROB-1301's evaluator rejects any market other than `kr`/`us` (`ALLOWED_MARKETS`) | implementation |
+| C2 | Crypto entry/scoring semantics defined (24/7 sessions have no "trading day", so D+1/D+5/D+20 need an explicit definition) | ❌ undefined | operator + implementation |
+
+🔴 **C2 is a real gap in the declaration, not an implementation detail.**
+"D+5/D+20 trading days" is unambiguous for KR/US and undefined for a 24/7
+market. Whichever convention is chosen (UTC calendar days vs. exchange
+sessions) must be written down **before** the first crypto row, or the crypto
+arm is unscoreable. Recommend UTC calendar days for consistency with the
+existing crypto bar semantics, but this session does not get to decide it
+unilaterally — it changes what the numbers mean.
+
+### 7.4 Non-blocking but pre-recorded
+
+- **Feasibility risk on `n ≥ 40`.** The preceding window produced **1**
+  `shadow`-family row in `review.trade_forecasts` across all markets. Reaching
+  40 B-only rows in 28 days requires roughly an order-of-magnitude increase in
+  recorded shadow evaluations. If the window closes short of 40, the
+  pre-committed rule says **reject**, and extending the window after seeing
+  that count is forbidden (§6). Recording this now so that a short sample is
+  read as a real outcome rather than an excuse.
+- **Clock.** The window is stated as 2026-08-22 → 2026-09-19. If B1–B4 are not
+  cleared on 2026-08-22, the window start moves to the first day all blocking
+  conditions are met, and the end moves with it (28 calendar days). The
+  **duration** is frozen; the start date is not, because a window that runs
+  while collection is impossible is not a 4-week collection.
+
+### 7.5 Start checklist (all must be ✅ before the first row)
+
+```
+[ ] B1 spec amended + re-pinned, amendment dated
+[ ] B2 source-count / family evidence accepted by the evaluator
+[ ] B3 variant A = regular-lane strong requirement
+[ ] B4 rows stamped with the amended spec_sha256
+[ ] U1 US overhang option approved + implemented      (US arm only)
+[ ] C1 crypto winner_pullback_add shadow path          (crypto arm only)
+[ ] C2 crypto D+N convention written down              (crypto arm only)
+[ ] window start date recorded here once all of the above are ✅
+```
+
+Per-arm start is permitted: KR may begin on B1–B4 alone, with US and crypto
+joining when their own conditions clear. Each arm's start date is recorded
+separately, and arms are **not** pooled across different start dates without
+saying so in the scoring report.
+
+## 8. Scoring
+
+Formulas, single `scoring_as_of`, sensitivity separation, and the "do not use
+`forecast_resolve` Brier as the experiment score" rule are unchanged from
+`docs/runbooks/buy-gate-ab-shadow.md`. This document adds only the pre-committed
+promotion rule in §2, which the runbook's report shape does not currently carry.
+
+## 9. Amendment log
+
+| Date | Change | By |
+| --- | --- | --- |
+| 2026-08-22 | Initial registration (retro §7-1 verbatim; confirmed final via claude-mock relay §139차 ②) | claude (구현 세션) |
+
+Later changes require a **new dated file** that supersedes this one. See
+`docs/preregistrations/README.md`.

--- a/docs/preregistrations/README.md
+++ b/docs/preregistrations/README.md
@@ -1,0 +1,38 @@
+# Pre-registrations
+
+Frozen, dated experiment declarations. A file in this directory records what an
+experiment claimed **before** any of its outcomes were seen.
+
+## The one rule
+
+🔴 **A registered pre-registration is never edited in place.** Not to fix
+scope, not to widen a window, not to soften a promotion threshold, and
+especially not after seeing an intermediate result. To change one, add a new
+dated file that names the one it supersedes, and leave the original standing.
+
+That immutability is the entire value. A pre-registration you can edit is a
+post-registration, and a post-registration proves nothing.
+
+Typo fixes and added cross-references are the only permitted in-place edits,
+and they must not touch any of: hypothesis, variant definitions, lanes/markets,
+collection window, sample target, recorded fields, promotion conditions.
+
+## What belongs here vs elsewhere
+
+| Artifact | Home | Mutable? |
+| --- | --- | --- |
+| The frozen claim | `docs/preregistrations/` | **no** |
+| How to run/score it | `docs/runbooks/` | yes |
+| Code-side frozen constants | the experiment's `spec.py` + its pin test | only by an approved amendment |
+| Design options under debate | `docs/superpowers/specs/` | yes, until decided |
+
+A code pin (`PINNED_SPEC_SHA256`-style) and a file here must agree. If they
+disagree, **the file here wins as the statement of intent** and the code pin is
+the bug — but neither may be changed to match the other without a dated
+amendment recorded in this directory.
+
+## Index
+
+| Date | Experiment | Status |
+| --- | --- | --- |
+| 2026-08-22 | [`support_strength_two_source_equivalence`](2026-08-22-support-strength-two-source-equivalence.md) (§139차 ②, retro §7-1) | registered; **collection not started** — blockers in §7 of that file |

--- a/docs/runbooks/buy-candidate-fanout.md
+++ b/docs/runbooks/buy-candidate-fanout.md
@@ -71,6 +71,75 @@ caps. The upside stage is fail-closed on ROB-486 window metadata
 broker evidence, a reached `budget` stage is always `deferred` and
 `actionable_count` is always zero.
 
+## Threshold proximity (near-miss) tagging — ROB-1315 §7-3
+
+Recording only. **No verdict moves.** A candidate rejected by a numeric gate is
+still rejected; the tag exists so the negative-class cohort can distinguish a
+reject at 45.03 against a 45 ceiling from one at 78.
+
+Motivating cases (2026-08-21 US session): CIEN RSI 45.03 vs 45 (subsequent MFE
++19.39%) and RDDT honest upside 39.93% vs 40% (MFE +20.09%). Both were graded
+"correctly rejected" alongside rejects that missed by tens of points, so the
+margin claim could not be tested.
+
+### Band
+
+`app/services/threshold_proximity.PROXIMITY_BAND = 1.0`, applied as **±1.0 in
+the gate's own unit** — RSI points for `screen.rsi_max`, percentage points for
+the two percent gates. That is the reading which admits both cited cases. The
+relative distance is recorded too (`miss_pct_of_threshold`), so a scorer can
+re-filter on the stricter "1% of the threshold" reading without re-deriving
+anything. The band is a module constant, not a parameter: widening it
+mid-collection would change which rejects are in the cohort.
+
+### Tagged gates
+
+| Gate | Metric | Threshold | Comparison |
+| --- | --- | --- | --- |
+| `screen.rsi_max` | `rsi_14` | 45 | `max` |
+| `buy.support_reserve_net.honest_upside_pct_min` | `honest_upside_pct` | 40 | `min` |
+| `buy.support_reserve_net.support_within_current_pct_max` | `support_distance_pct` | 8 | `max` |
+
+Non-numeric failures (missing consensus, stale window inputs, freshness,
+trading restriction, family count, strength tier) are **not** tagged: a gate
+that failed for lack of data is an absent measurement, not a marginal
+rejection. A missing observation is never invented into a tag.
+
+### Where it appears
+
+- per stage: `funnel.<stage>.threshold_proximity` (only on the failing stage)
+- per candidate: `candidates[].threshold_proximity` (list) and
+  `candidates[].negative_class_forecast_hint`
+- aggregate: `digest_observation.threshold_proximity` — `band`, `by_gate`,
+  `candidate_count`, `candidates`, `recording_only: true`,
+  `gate_verdict_changed: false`
+
+Because the funnel short-circuits, a candidate carries at most one tag per run:
+the first numeric gate it failed. That is intentional — the later gates were
+never evaluated, so there is no observation to tag.
+
+### How to record it
+
+This tool writes nothing. Merge the hint into the negative-class record the
+session already makes (ROB-1283):
+
+```python
+hint = candidate["negative_class_forecast_hint"]
+forecast_save(
+    created_by="kr-open-trade",
+    symbol=candidate["symbol"],
+    instrument_type="equity_kr",
+    forecast_target={**your_resolvable_target, **hint},
+    probability=0.30,
+    review_date="2026-09-19",
+    decision_bucket="deferred_no_action",   # hint["decision_bucket_hint"]
+)
+```
+
+Score this cohort separately after four weeks. Do not use an intermediate read
+of it to move a threshold — that is the same pre-registration rule ROB-1301
+runs under.
+
 ## Consensus-window scope and limits
 
 This is a window-membership gate, not a maximum-age guarantee. It fails only

--- a/docs/runbooks/buy-gate-ab-shadow.md
+++ b/docs/runbooks/buy-gate-ab-shadow.md
@@ -45,6 +45,52 @@ Giving one arm later bars, a different entry, or a different other-gate
 bit is a contract violation; the evaluator/scorer drop bars after
 `scoring_as_of` and do not impute holes.
 
+## Candidate input contract (ROB-1315 §5-1)
+
+**An unknown key is rejected, not ignored.** On 2026-08-21 a US session sent
+`rsi_14` and `nearest_support_strength`; both were silently dropped, both
+fields read as absent, and all seven candidates were rejected for gates they
+would have passed. Nothing in the response said so. The evaluator now refuses
+the call and names the correct key.
+
+| Key | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `symbol` | yes | string | upper-cased |
+| `market` | yes | `kr` \| `us` | crypto is out of scope |
+| `current_price` | yes | number/decimal string | must be > 0; this is the frozen entry |
+| `support_strength` | no | `weak` \| `moderate` \| `strong` | the A/B fork; an unknown word is rejected |
+| `support_distance_pct` | no | number | percent below current price |
+| `rsi` | no | number | **`rsi`, not `rsi_14`** |
+| `honest_upside_pct` | no | number | percent |
+| `other_gate_bits` | no | object of booleans | keys exactly `liquid_midcap`, `concentration`, `overhang` |
+
+Rejection names the offending row (`candidates[1] (RDDT): ...`) and echoes
+`input_contract`, whose `common_mistakes` map spells out the correction. The
+same `input_contract` block rides on successful responses, so the contract is
+readable without triggering an error.
+
+An **omitted optional field is still a rejection** — a gate cannot pass on
+absent evidence — but that is now the caller's explicit choice rather than a
+typo the evaluator swallowed. Do not fill a field with a guess to make a
+candidate pass.
+
+## 🔴 US overhang: structurally uncollectable today
+
+`other_gate_bits.overhang` has **no US data source in this repo**.
+`get_disclosures` is DART/KR-only; there is no SEC EDGAR client, and the
+`market_events` `lockup_expiry` category is declared but has no ingester.
+
+Measured on 2026-08-21: the valid US call returned `n=7 · a_and_b 0 · b_only 0
+· neither 7`, with CRH and UPST failing on `overhang` alone under variant B.
+The session set `overhang=false` for all seven rather than inventing a pass —
+that was correct, and it is also why US B-only is pinned at zero.
+
+**Do not work around this by setting `overhang=true`.** Options (neutralize and
+flag / build an EDGAR ingester / drop US from scope) are laid out in
+`docs/superpowers/specs/2026-08-22-us-overhang-gate-design.md` and are
+**awaiting an operator decision**. Until one is approved, US shadow logic is
+unchanged and the US arm is not collecting. KR collection is unaffected.
+
 ## Session procedure
 
 1. Run the live screen as today (variant A). Winners still go through

--- a/docs/runbooks/buy-gate-ab-shadow.md
+++ b/docs/runbooks/buy-gate-ab-shadow.md
@@ -8,6 +8,15 @@ watch, a policy edit, or a scheduler.
 Controlling issue: [ROB-1301](https://linear.app/mgh3326/issue/ROB-1301).
 Code pin: `app/services/buy_gate_ab_shadow/spec.py` (`PINNED_SPEC_SHA256`).
 
+🔴 **A second, stricter pre-registration is registered but not collecting.**
+`docs/preregistrations/2026-08-22-support-strength-two-source-equivalence.md`
+(retro §7-1, confirmed §139차 ②) declares a variant B of *moderate AND
+source_count>=2 AND independent families*, adds crypto `winner_pullback_add`,
+and adds a pre-committed numeric promotion rule. **That is not the experiment
+this runbook and the code pin describe.** Do not mix the two cohorts. Its
+start conditions (§7 of that file) are unmet, so everything below still
+describes the live, pinned ROB-1301 experiment.
+
 ## Forbidden (issue canonical, not paraphrased)
 
 * shadow가 제안·주문·워치로 승격 금지(순수 기록)

--- a/docs/runbooks/negative-class-recording.md
+++ b/docs/runbooks/negative-class-recording.md
@@ -91,6 +91,29 @@ test_negative_class_forecast_is_gradeable_like_any_other`가 기계 증명)
 ROB-1301 A/B 채점기가 필요로 하는 (코호트, 결과, 귀속)은 전부 이 한 테이블에서 나온다:
 `decision_bucket` × `session_label`/`created_by` × `outcome`/`brier_score`.
 
+### 임계근방 태깅 (ROB-1315 §7-3)
+
+`discover_buy_candidates_fanout`은 임계를 **1.0 단위 이내로** 놓친 기각 후보에
+`threshold_proximity` 태그(게이트명·임계·실측·미달폭)를 붙이고, 그대로 병합할 수 있는
+`negative_class_forecast_hint`를 함께 돌려준다. **게이트 판정은 바뀌지 않는다** —
+태그 붙은 후보도 여전히 기각이고, 도구는 여전히 아무것도 쓰지 않는다.
+
+```python
+hint = candidate["negative_class_forecast_hint"]
+forecast_save(
+    ...,
+    forecast_target={**resolvable_target, **hint},   # threshold_proximity 블록 포함
+    decision_bucket="deferred_no_action",
+)
+```
+
+이렇게 기록해두면 "기각이 옳았나"를 **마진 구간에서만** 따로 채점할 수 있다. 45.03/45로
+탈락한 건과 78/45로 탈락한 건이 같은 코호트에 섞여 있으면 그 질문에 답할 수 없다.
+밴드·태깅 게이트 목록·기록 절차는 `docs/runbooks/buy-candidate-fanout.md`
+"Threshold proximity" 절.
+
+🔴 4주 수집이 끝나기 전에 중간값으로 임계를 움직이지 않는다(ROB-1301과 동일한 사전등록 규칙).
+
 ---
 
 ## 3. 링크 (AC3)

--- a/docs/superpowers/specs/2026-08-22-us-overhang-gate-design.md
+++ b/docs/superpowers/specs/2026-08-22-us-overhang-gate-design.md
@@ -1,0 +1,158 @@
+# US overhang gate — source options (design only, no implementation)
+
+- **Issue context**: ROB-1315 §5-1 (buy-side retro 2026-08-22), blocking ROB-1301
+- **Status**: 🔴 **DESIGN — awaiting operator decision. No US shadow logic changes
+  until one option is approved.** This document deliberately ships without code.
+- **Scope**: how the `overhang` gate bit should be produced for US symbols, or
+  what to do if it cannot be.
+
+## 1. The problem, stated exactly
+
+The discovery lane's `standard_tool_sequence` step 6 is *"rights-issue /
+overhang filter"* (`app/mcp_server/tooling/route_request_lanes.py`), and the
+ROB-1301 shadow experiment consumes it as one of three `other_gate_bits`.
+
+The only tool behind that step is `get_disclosures`, which is **DART-only** —
+`get_disclosures_impl` returns `"DART functionality not available"` when the
+DART client is absent and otherwise calls `list_filings`, a KR filings reader.
+There is **no US equivalent anywhere in this repo**: no SEC EDGAR client, no
+S-1/S-3/424B filing reader, no ATM-program tracker.
+
+Measured consequence (2026-08-21 US session, retro §5-1): after the input-key
+typo was corrected, the valid call returned `n=7 · a_and_b 0 · b_only 0 ·
+neither 7`. CRH and UPST failed **on `overhang` alone** under variant B. The
+session correctly refused to invent a pass and set `overhang=false` for all
+seven, which pinned B-only at zero. `review.trade_forecasts` holds **one**
+`shadow`-family row for the whole window. The 4-week collection that is
+supposed to decide §4-ⓐ and §4-ⓒ′ has effectively not started on the US side.
+
+**The gate is not wrong. The data is missing.** Those need different fixes, and
+conflating them is how a missing measurement turns into a fabricated pass.
+
+## 2. What "overhang" means here
+
+Borrowed from the KR lane: *known future supply of shares that is likely to cap
+the price* — a rights issue, a convertible/CB conversion window, a lock-up
+expiry, a registered secondary. It is a **forward-looking supply** signal, not a
+past-price signal. Any US substitute must preserve that: it has to name a
+future or freshly-announced supply event, not infer one from a chart.
+
+## 3. Candidate sources — what this repo can and cannot reach today
+
+| # | Source | In repo now? | Covers overhang? | Verdict |
+| --- | --- | --- | --- | --- |
+| A | SEC EDGAR full-text / submissions API (S-1, S-3, 424B5, 8-K Item 3.02) | **No** — no client, no key, no ingester | Directly: this is where US dilution is announced | New external dependency; highest fidelity, highest build cost |
+| B | Finnhub company profile `shareOutstanding` | Yes (`fundamentals_sources_finnhub._fetch_company_profile_finnhub`) | **Partly, and backwards** — point-in-time only, no history persisted, so it detects dilution *after* it happened | Not a forward signal. Insufficient alone |
+| C | Finnhub insider transactions (Form 4) | Yes (`_fetch_insider_transactions_finnhub`) | **No** — insider selling is a different phenomenon from issuance overhang | Reject as a substitute; useful separately |
+| D | `market_events` `lockup_expiry` category | **Category exists, ingester does not** — `taxonomy.CATEGORIES` and `catalyst/polarity.py` both list `lockup_expiry` (polarity `negative`), but `scripts/ingest_market_events.SUPPORTED` has only 5 combos and none produce it | Would cover one real overhang class (IPO lock-ups) | Cheapest real coverage; **partial** by construction |
+| E | yfinance | Yes | No dilution/filing surface | Reject |
+
+🔴 **Finding worth recording on its own**: `lockup_expiry` is a *declared but
+unfed* category. Anything that queries it today gets an empty result that reads
+like "no lock-up expiry" rather than "not ingested". That is the same failure
+shape as the one this document is about, one layer down.
+
+## 4. Options
+
+### Option 1 — SEC EDGAR ingester (full fidelity)
+
+Add a read-only EDGAR source under `app/services/market_events/` feeding
+`market_events` with US `disclosure` rows for dilution-relevant form types
+(S-1/S-3 and their /A amendments, 424B*, 8-K Item 3.02), then derive the
+`overhang` bit from "any qualifying filing within N days".
+
+- **Pro**: matches the KR semantics closely; reusable well beyond ROB-1301;
+  EDGAR is free, documented, and has no auth.
+- **Con**: a genuinely new external dependency with its own rate-limit and
+  User-Agent policy, form-type taxonomy work, and backfill. Not a
+  four-week-collection-unblocking change — this lands *after* the window it is
+  supposed to feed.
+- **Cost**: large. New ingester + normalizer + taxonomy entries + runbook + CLI
+  combo + tests.
+
+### Option 2 — Neutralize `overhang` for US and flag it in the record ✅ recommended
+
+Treat the bit as **not applicable** on US rows rather than false, and make the
+shadow record say so.
+
+- `other_gate_bits.overhang` becomes tri-state for US: `true` / `false` /
+  absent-meaning-unavailable, with the shared-gate evaluation skipping an
+  unavailable bit **for both variants symmetrically**.
+- Every affected evaluation carries `overhang_source: "unavailable_us"` and a
+  cohort flag (proposal: `gate_neutralized: ["overhang"]`) into
+  `forecast_target`, so the 4-week scorer can partition on it and **cannot**
+  silently mix neutralized rows with fully-gated ones.
+- **Pro**: unblocks US collection immediately; no new dependency; the weakening
+  is explicit, symmetric, per-row, and reversible.
+- **Con**: it *is* a weakened gate. The US B-only cohort is then "moderate
+  support AND unverified overhang", which is a strictly weaker claim than the
+  KR cohort. If the experiment later favors B, the US arm cannot by itself
+  justify promotion.
+- 🔴 **Non-negotiable conditions if this is chosen**:
+  1. The neutralization applies to **variant A and variant B identically**. An
+     asymmetric skip would manufacture B-only rows out of nothing and destroy
+     the experiment.
+  2. It applies **only to the shadow evaluator**, never to the live discovery
+     lane. The live US path keeps requiring the step-6 filter as it does today.
+  3. The flag is mandatory on the record. A neutralized row that does not say
+     it was neutralized is worse than no row.
+  4. Promotion on US-only evidence is forbidden; the pre-registration
+     amendment must say so before the first flagged row is written.
+
+### Option 3 — Manual operator-supplied bit
+
+The session supplies `overhang` from its own reading (news, filings it happened
+to see) and the tool records the provenance.
+
+- **Pro**: zero build.
+- **Con**: unreproducible, unauditable, and exactly the "session invents a
+  gate verdict" failure the 08-21 session correctly refused. **Reject.**
+
+### Option 4 — Drop US from ROB-1301
+
+Score the experiment on KR only and mark US out of scope.
+
+- **Pro**: honest, zero build, keeps the KR cohort clean.
+- **Con**: the pre-registration names both markets; amending scope after seeing
+  that US produced nothing is a peeking-adjacent move and must be recorded as a
+  formal amendment, not a quiet edit.
+
+## 5. Recommendation
+
+**Option 2 now, Option 1 as a separate follow-up issue**, with Option 1
+explicitly *not* blocking the current collection window.
+
+Rationale: the retro's binding constraint is that the experiment is not
+collecting at all. Option 2 restores collection this week at the cost of a
+clearly-labelled weaker US cohort; Option 1 restores fidelity but only for a
+future window. Option 4 stays available as the fallback if the operator judges
+a neutralized cohort to be worth less than no cohort — that is a judgment call
+about experiment quality, not an engineering one, which is why this document
+stops here.
+
+Recording `lockup_expiry` as unfed (§3, finding) should be filed as its own
+Linear issue regardless of which option wins.
+
+## 6. What is explicitly NOT decided here, and what must happen first
+
+1. Any change to `PRE_REGISTRATION` bumps `spec_sha256()` and fails the pin
+   test in `tests/services/buy_gate_ab_shadow/test_spec_freeze.py`. That is
+   the intended alarm. A **written amendment** — new hypothesis text, the
+   neutralization rule, the US-only-promotion prohibition — must be approved
+   and dated **before** the pin is re-pinned, and rows collected under the old
+   spec must keep their old `spec_sha256`.
+2. Already-collected rows are not retro-fitted. Mixing pre- and
+   post-amendment rows in one cohort without the flag is forbidden.
+3. No scheduler, no Prefect, no TaskIQ registration in any option.
+4. Nothing here authorizes a proposal, order, or watch. ROB-1301's three
+   forbidden acts stand unchanged.
+
+## 7. What was shipped alongside this document (ROB-1315 §5-1 ①)
+
+The **input-key half** of §5-1 is fixed and does not wait on this decision:
+`evaluate_buy_gate_ab_shadow` now rejects unknown candidate keys with the
+correct key named (`rsi_14 -> rsi`, `nearest_support_strength ->
+support_strength`) and echoes a machine-readable `input_contract` on both
+success and failure. That was a silent-drop bug; this document is about a
+missing data source. Fixing the first does not fix the second, and the US
+`b_only=0` result stands until an option above is approved.

--- a/scripts/build_policy_table.py
+++ b/scripts/build_policy_table.py
@@ -131,11 +131,15 @@ def _render_summary_md(payload: dict[str, Any]) -> str:
             + ", ".join(payload["universe"]["symbols_with_insufficient_history"])
         )
     lines.append("")
-    breadth = payload["market_context"]["alt_breadth"]
+    # ROB-1315 §7-2 — absolute breadth, printed under its own name so the
+    # summary can never be read as the BTC-relative gate metric.
+    breadth = payload["market_context"]["alt_positive_24h"]
     lines.append(
-        f"alt_breadth: {breadth['positive_24h_count']}/{breadth['swept_market_count']} "
+        f"alt_positive_24h: "
+        f"{breadth['positive_24h_count']}/{breadth['swept_market_count']} "
         f"positive 24h "
         f"({(breadth['positive_pct'] * 100) if breadth['positive_pct'] is not None else 'n/a'}%)"
+        " — absolute; not the no_chasing gate input (alts_beating_btc_pct)"
     )
     lines.append("")
 

--- a/scripts/policy_table/adapters/crypto.py
+++ b/scripts/policy_table/adapters/crypto.py
@@ -560,7 +560,17 @@ def compute_policy_table(
             "halted_suspect": halted_suspect,
         },
         "market_context": {
-            "alt_breadth": {
+            # ROB-1315 §7-2 — renamed from ``alt_breadth``. This block counts
+            # markets whose 24h change is ABSOLUTELY positive. It is NOT the
+            # input to the no_chasing / recovery_gate breadth clause, which
+            # reads the BTC-relative ``breadth.alts_beating_btc_pct`` from
+            # get_upbit_altseason. The two diverged by 60.71pp on 2026-08-20
+            # (78.09% here vs 17.38% at the gate), so the old shared name
+            # invited reading this table row as a gate verdict.
+            "alt_positive_24h": {
+                "basis": "absolute_24h_change_gt_zero",
+                "gate_input": False,
+                "gate_input_metric": "breadth.alts_beating_btc_pct",
                 "swept_market_count": swept_count,
                 "positive_24h_count": positive_count,
                 "negative_24h_count": negative_count,

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -217,7 +217,7 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
     }
     # advisory keys are echoed with the same version/content_hash stamp as
     # every other section of the response (ROB-932).
-    assert out["version"] == "2026-08-21.4"
+    assert out["version"] == "2026-08-22.1"
     assert out["content_hash"]
 
 

--- a/tests/mcp_server/tooling/test_buy_candidate_fanout.py
+++ b/tests/mcp_server/tooling/test_buy_candidate_fanout.py
@@ -838,3 +838,256 @@ def test_runbook_states_observation_only_and_no_tuning() -> None:
     assert "actionable_count` is always zero" in normalized
     assert "freshness_data_state_missing" in normalized
     assert "bounded_unknown" in normalized
+
+
+# ---------------------------------------------------------------------------
+# ROB-1315 §7-3 — threshold proximity tagging (recording only)
+# ---------------------------------------------------------------------------
+
+
+def _gates() -> Any:
+    return fanout._FanoutGates.from_policy(fanout.load_trading_policy())
+
+
+def _candidate() -> dict[str, Any]:
+    return {"matched_sources": ["rsi"], "symbol": "TEST", "market": "kr"}
+
+
+def test_near_miss_upside_is_tagged_but_still_rejected() -> None:
+    """RDDT-shaped: upside 39.9% against the 40% floor."""
+
+    # current_price 100, target 139.9 -> 39.9% upside, 0.1pp short
+    result = fanout._evaluate_funnel(_candidate(), _fresh_row(target=139.9), _gates())
+
+    upside = result["funnel"]["upside"]
+    assert upside["status"] == "fail"
+    assert upside["reason"] == "honest_upside_below_40pct"
+    assert result["regular_evidence_eligible"] is False
+    assert result["actionable"] is False
+
+    tag = upside["threshold_proximity"]
+    assert tag["gate"] == "buy.support_reserve_net.honest_upside_pct_min"
+    assert tag["threshold"] == 40
+    assert tag["observed"] == pytest.approx(39.9)
+    assert tag["miss"] == pytest.approx(0.1)
+    assert tag["within_band"] is True
+    assert tag["verdict_changed"] is False
+    assert result["threshold_proximity"] == [tag]
+
+
+def test_near_miss_rsi_is_tagged_but_still_rsi_only_fail() -> None:
+    """CIEN-shaped: RSI 45.03 against the 45 ceiling."""
+
+    result = fanout._evaluate_funnel(_candidate(), _fresh_row(rsi=45.03), _gates())
+
+    rsi_stage = result["funnel"]["rsi"]
+    assert rsi_stage["status"] == "rsi_only_fail"
+    assert rsi_stage["reason"] == "rsi_missing_or_above_regular_max"
+    assert result["regular_evidence_eligible"] is False
+
+    tag = rsi_stage["threshold_proximity"]
+    assert tag["gate"] == "screen.rsi_max"
+    assert tag["miss"] == pytest.approx(0.03)
+    assert tag["within_band"] is True
+
+
+def test_near_miss_support_distance_is_tagged_with_the_observed_distance() -> None:
+    # support at 91.5 -> 8.5% below current, 0.5pp past the 8% ceiling
+    result = fanout._evaluate_funnel(_candidate(), _fresh_row(support=91.5), _gates())
+
+    stage = result["funnel"]["support_source_count"]
+    assert stage["status"] == "fail"
+    assert stage["reason"] == "support_more_than_8pct_below_current"
+
+    tag = stage["threshold_proximity"]
+    assert tag["gate"] == "buy.support_reserve_net.support_within_current_pct_max"
+    assert tag["threshold"] == 8
+    assert tag["observed"] == pytest.approx(8.5)
+    assert tag["miss"] == pytest.approx(0.5)
+
+
+def test_wide_rejections_are_not_tagged() -> None:
+    """A candidate that missed by a mile carries no near-miss tag."""
+
+    wide_upside = fanout._evaluate_funnel(
+        _candidate(), _fresh_row(target=110), _gates()
+    )
+    assert wide_upside["funnel"]["upside"]["status"] == "fail"
+    assert "threshold_proximity" not in wide_upside["funnel"]["upside"]
+    assert wide_upside["threshold_proximity"] == []
+    assert wide_upside["negative_class_forecast_hint"] is None
+
+    wide_rsi = fanout._evaluate_funnel(_candidate(), _fresh_row(rsi=78), _gates())
+    assert "threshold_proximity" not in wide_rsi["funnel"]["rsi"]
+
+    wide_support = fanout._evaluate_funnel(
+        _candidate(), _fresh_row(support=70), _gates()
+    )
+    assert "threshold_proximity" not in wide_support["funnel"]["support_source_count"]
+
+
+def test_a_passing_candidate_carries_no_tag() -> None:
+    result = fanout._evaluate_funnel(_candidate(), _fresh_row(), _gates())
+
+    assert result["regular_evidence_eligible"] is True
+    assert result["threshold_proximity"] == []
+    assert result["negative_class_forecast_hint"] is None
+    assert "threshold_proximity" not in result["funnel"]["rsi"]
+    assert "threshold_proximity" not in result["funnel"]["upside"]
+
+
+@pytest.mark.parametrize(
+    "fresh_kwargs",
+    [
+        {},
+        {"rsi": 45.03},
+        {"rsi": 78},
+        {"target": 139.9},
+        {"target": 110},
+        {"support": 91.5},
+        {"support": 70},
+        {"rsi": 45.5, "target": 139.5},
+    ],
+    ids=[
+        "clean_pass",
+        "rsi_near_miss",
+        "rsi_wide_miss",
+        "upside_near_miss",
+        "upside_wide_miss",
+        "support_near_miss",
+        "support_wide_miss",
+        "two_near_misses",
+    ],
+)
+def test_tagging_changes_no_verdict_field(fresh_kwargs: dict[str, Any]) -> None:
+    """The AC: strip every ROB-1315 key and the funnel is byte-identical.
+
+    Recomputed against the pre-change contract — status/reason per stage plus
+    the three eligibility booleans — so a tag that silently promoted, demoted,
+    or reworded a verdict fails here.
+    """
+
+    result = fanout._evaluate_funnel(_candidate(), _fresh_row(**fresh_kwargs), _gates())
+
+    added_keys = {"threshold_proximity", "negative_class_forecast_hint"}
+    assert set(result) - added_keys == {
+        "funnel",
+        "freshness",
+        "regular_evidence_eligible",
+        "rsi_only_fail_candidate",
+        "observation_gate_path_complete",
+        "actionable",
+    }
+    for stage_name, stage in result["funnel"].items():
+        tag = stage.get("threshold_proximity")
+        if tag is None:
+            continue
+        # the tag is additive to the stage, and says so about itself
+        assert tag["verdict_changed"] is False
+        assert stage["status"] in {"fail", "rsi_only_fail"}, stage_name
+    assert result["actionable"] is False
+
+
+@pytest.mark.asyncio
+async def test_impl_aggregates_the_near_miss_cohort_without_filtering_it() -> None:
+    async def live_reader(source: Any, market: str, top_n: int) -> dict[str, Any]:
+        rows = [_source_row("NEAR.1")] if source.source == "rsi" else []
+        return {
+            "source": source.source,
+            "family": "live",
+            "kind": "live",
+            "rows": rows,
+            "metadata": {},
+        }
+
+    async def snapshot_reader(
+        family: str, presets: tuple[str, ...], market: str, top_n: int
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def fresh_revalidator(
+        symbols: list[str], market: str
+    ) -> dict[str, dict[str, Any]]:
+        return {symbol: _fresh_row(target=139.9) for symbol in symbols}
+
+    result = await discover_buy_candidates_fanout_impl(
+        _live_reader=live_reader,
+        _snapshot_reader=snapshot_reader,
+        _fresh_revalidator=fresh_revalidator,
+    )
+
+    proximity = result["digest_observation"]["threshold_proximity"]
+    assert proximity["recording_only"] is True
+    assert proximity["gate_verdict_changed"] is False
+    assert proximity["band"] == fanout.THRESHOLD_PROXIMITY_BAND
+    assert proximity["candidate_count"] == 1
+    assert proximity["by_gate"] == {"buy.support_reserve_net.honest_upside_pct_min": 1}
+    entry = proximity["candidates"][0]
+    assert entry["symbol"] == "NEAR.1"
+    hint = entry["negative_class_forecast_hint"]
+    assert hint["decision_bucket_hint"] == "deferred_no_action"
+    assert hint["threshold_proximity"]["symbol"] == "NEAR.1"
+    assert hint["threshold_proximity"]["promote"] is False
+
+    # the near-miss candidate is still rejected everywhere it counts
+    assert result["digest_observation"]["regular_evidence_eligible_count"] == 0
+    assert result["digest_observation"]["actionable_count"] == 0
+    assert all(candidate["actionable"] is False for candidate in result["candidates"])
+
+
+@pytest.mark.parametrize(
+    "fresh_kwargs",
+    [
+        {},
+        {"rsi": 45.03},
+        {"rsi": 78},
+        {"target": 139.9},
+        {"target": 110},
+        {"support": 91.5},
+        {"support": 70},
+        {"rsi": 45.5, "target": 139.5},
+    ],
+    ids=[
+        "clean_pass",
+        "rsi_near_miss",
+        "rsi_wide_miss",
+        "upside_near_miss",
+        "upside_wide_miss",
+        "support_near_miss",
+        "support_wide_miss",
+        "two_near_misses",
+    ],
+)
+def test_funnel_is_identical_with_tagging_disabled(
+    monkeypatch: pytest.MonkeyPatch, fresh_kwargs: dict[str, Any]
+) -> None:
+    """A/B invariance: the verdict tree does not depend on the tagger at all.
+
+    Run each case twice — once normally, once with the tagger stubbed to
+    return nothing — and require the funnel to match once the additive keys
+    are stripped. This is the AC for "게이트 판정 불변".
+    """
+
+    def _stripped(funnel: dict[str, Any]) -> dict[str, Any]:
+        return {
+            stage: {k: v for k, v in evidence.items() if k != "threshold_proximity"}
+            for stage, evidence in funnel.items()
+        }
+
+    tagged = fanout._evaluate_funnel(_candidate(), _fresh_row(**fresh_kwargs), _gates())
+
+    monkeypatch.setattr(fanout, "threshold_near_miss", lambda **_kwargs: None)
+    untagged = fanout._evaluate_funnel(
+        _candidate(), _fresh_row(**fresh_kwargs), _gates()
+    )
+
+    assert _stripped(tagged["funnel"]) == _stripped(untagged["funnel"])
+    for verdict_field in (
+        "regular_evidence_eligible",
+        "rsi_only_fail_candidate",
+        "observation_gate_path_complete",
+        "actionable",
+    ):
+        assert tagged[verdict_field] == untagged[verdict_field]
+    assert untagged["threshold_proximity"] == []
+    assert untagged["negative_class_forecast_hint"] is None

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -151,7 +151,7 @@ def _breakeven_reserve_trim_triggered(
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
-    assert doc.version == "2026-08-21.4"
+    assert doc.version == "2026-08-22.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -1067,9 +1067,47 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
             "tie_breaks"
         ][key]
 
+    # §138차 / ROB-1315 §7-2 (2026-08-22) — breadth metric disambiguation.
+    # Exactly two deltas, both naming-only: the three optional input_field
+    # markers on the alt_breadth_24h condition, and the no_chasing criterion
+    # string that now spells out which metric "24h alt breadth" means. The
+    # operator, threshold, and unit are asserted identical on both sides, so
+    # a relaxation smuggled in under this allowance fails here.
+    breadth_base = baseline_dump["market_rules"]["crypto"]["recovery_gate"][
+        "conditions"
+    ][0]
+    breadth_cur = normalized_current_dump["market_rules"]["crypto"]["recovery_gate"][
+        "conditions"
+    ][0]
+    assert breadth_base["id"] == breadth_cur["id"] == "alt_breadth_24h"
+    for frozen in ("operator", "threshold", "unit", "sources", "metric", "semantics"):
+        assert breadth_base[frozen] == breadth_cur[frozen]
+    assert (breadth_base["operator"], breadth_base["threshold"]) == ("gt", 50)
+    for marker in ("input_field", "input_basis", "not_input_field"):
+        assert breadth_base[marker] is None
+        assert breadth_cur[marker] is not None
+        breadth_cur[marker] = None
+
+    no_chasing_base = baseline_dump["market_rules"]["crypto"]["no_chasing"]
+    no_chasing_cur = normalized_current_dump["market_rules"]["crypto"]["no_chasing"]
+    (base_breadth_criterion,) = [
+        c for c in no_chasing_base["criteria"] if "breadth" in c
+    ]
+    (cur_breadth_criterion,) = [c for c in no_chasing_cur["criteria"] if "breadth" in c]
+    assert "alts_beating_btc_pct" not in base_breadth_criterion
+    assert "alts_beating_btc_pct" in cur_breadth_criterion
+    # same threshold, same direction — only the metric name is added
+    for fragment in ("new alt candidates are ineligible", "below 50 percent"):
+        assert fragment in base_breadth_criterion
+        assert fragment in cur_breadth_criterion
+    no_chasing_cur["criteria"] = [
+        base_breadth_criterion if "breadth" in c else c
+        for c in no_chasing_cur["criteria"]
+    ]
+
     # Only the six explicitly enumerated cap deltas and the enumerated
-    # §115차 additions are accepted; every other pre-existing key/value,
-    # including the retained exclusions list, must still
+    # §115차 / §138차 additions are accepted; every other pre-existing
+    # key/value, including the retained exclusions list, must still
     # match the ROB-1289 baseline exactly.
     assert normalized_current_dump == baseline_dump
 
@@ -1578,3 +1616,43 @@ def test_rob_1298_leaves_loss_guard_d7_and_auto_approve_gates_untouched():
     current_trim = current["decision_rules"]["sell.trim_preplace"]
     assert current_trim["tiers"][0] == baseline_trim["tiers"][0]
     assert current_trim["tiers"][1] == baseline_trim["tiers"][1]
+
+
+def test_alt_breadth_gate_names_its_input_field_without_changing_the_verdict():
+    """ROB-1315 §7-2 — disambiguation only. Threshold and operator are frozen."""
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    gate = doc.market_rules["crypto"].recovery_gate
+    breadth = gate.conditions[0]
+
+    assert breadth.id == "alt_breadth_24h"
+    # unchanged verdict inputs
+    assert (breadth.operator, breadth.threshold, breadth.unit) == ("gt", 50, "percent")
+    assert breadth.sources == ["upbit_open_api_ticker_derived"]
+    # newly explicit: which of the two get_upbit_altseason numbers feeds it
+    assert breadth.input_field == "breadth.alts_beating_btc_pct"
+    assert breadth.input_basis == "btc_relative"
+    assert breadth.not_input_field == "breadth.alt_positive_24h_pct"
+
+
+def test_no_chasing_breadth_criterion_names_the_btc_relative_metric():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    criteria = doc.market_rules["crypto"].no_chasing.criteria
+    breadth_criteria = [c for c in criteria if "breadth" in c]
+
+    assert len(breadth_criteria) == 1
+    text = breadth_criteria[0]
+    assert "alts_beating_btc_pct" in text
+    assert "50 percent" in text
+    # the absolute metric must not be named as this criterion's input
+    assert "alt_positive_24h_pct" not in text
+
+
+def test_recovery_condition_disambiguation_fields_are_optional():
+    """Conditions without a multi-metric ambiguity stay untouched."""
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    gate = doc.market_rules["crypto"].recovery_gate
+
+    assert gate.conditions[1].input_field is None
+    assert all(context.input_field is None for context in gate.advisory_context)

--- a/tests/scripts/test_policy_table_alt_breadth_naming.py
+++ b/tests/scripts/test_policy_table_alt_breadth_naming.py
@@ -1,0 +1,105 @@
+"""ROB-1315 §7-2 — the crypto policy table's breadth header is renamed.
+
+``market_context.alt_breadth`` counted markets whose 24h change was
+*absolutely* positive, but the ``no_chasing`` / ``recovery_gate`` breadth
+clause reads the *BTC-relative* ``breadth.alts_beating_btc_pct``. Sharing the
+colloquial name "alt breadth" let a table row be read as a gate verdict; on
+2026-08-20 the two were 78.09% and 17.38%. The block is now
+``market_context.alt_positive_24h`` and says so in its own payload.
+
+Pure compute — no DB, no network, no broker.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from scripts.build_policy_table import _render_summary_md
+from scripts.policy_table.adapters import crypto as crypto_adapter
+
+pytestmark = pytest.mark.unit
+
+
+def _bars(n: int = 150, *, start: Decimal, step: Decimal) -> list[list[str]]:
+    bars: list[list[str]] = []
+    price = start
+    for i in range(n):
+        price = price + (step if i % 5 else -step * 2 // 3)
+        bars.append(
+            [str(price), str(price + step * 4), str(price - step * 3), "120000"]
+        )
+    return bars
+
+
+def _raw(change_rates: dict[str, str]) -> crypto_adapter.RawInputs:
+    candles = {
+        symbol: _bars(start=Decimal("1000000"), step=Decimal("1000"))
+        for symbol in change_rates
+    }
+    return crypto_adapter.RawInputs(
+        as_of="2026-08-20T02:20:00+00:00",
+        holdings=[],
+        watch_alerts=[],
+        top_traded=[
+            {
+                "market": symbol,
+                "trade_price": candles[symbol][-1][0],
+                "acc_trade_price_24h": "1000000000",
+                "signed_change_rate": rate,
+            }
+            for symbol, rate in change_rates.items()
+        ],
+        orderable_krw="1000000",
+        candles=candles,
+    )
+
+
+def test_market_context_block_is_named_alt_positive_24h():
+    payload = crypto_adapter.compute_policy_table(
+        _raw({"KRW-BTC": "0.03", "KRW-ETH": "0.02", "KRW-XRP": "-0.01"})
+    )
+
+    context = payload["market_context"]
+    assert "alt_breadth" not in context
+    block = context["alt_positive_24h"]
+    assert block["basis"] == "absolute_24h_change_gt_zero"
+    assert block["positive_24h_count"] == 2
+    assert block["negative_24h_count"] == 1
+    assert block["swept_market_count"] == 3
+
+
+def test_block_declares_it_is_not_the_gate_input():
+    payload = crypto_adapter.compute_policy_table(_raw({"KRW-BTC": "0.03"}))
+
+    block = payload["market_context"]["alt_positive_24h"]
+    assert block["gate_input"] is False
+    assert block["gate_input_metric"] == "breadth.alts_beating_btc_pct"
+
+
+def test_counts_are_unchanged_by_the_rename():
+    """Only the key moved; the arithmetic behind it is identical."""
+
+    payload = crypto_adapter.compute_policy_table(
+        _raw({"KRW-A": "0.05", "KRW-B": "0.00", "KRW-C": "-0.02", "KRW-D": "0.01"})
+    )
+
+    block = payload["market_context"]["alt_positive_24h"]
+    # a zero rate is neither positive nor negative, as before
+    assert (block["positive_24h_count"], block["negative_24h_count"]) == (2, 1)
+    assert block["swept_market_count"] == 4
+    assert block["positive_pct"] == Decimal(2) / Decimal(4)
+
+
+def test_rendered_summary_uses_the_new_name_and_disclaims_the_gate():
+    payload = crypto_adapter.compute_policy_table(
+        _raw({"KRW-BTC": "0.03", "KRW-ETH": "0.02"})
+    )
+    summary = _render_summary_md(
+        {**payload, "stamps": {"policy_table_hash": "x", "auto_trader_head": "y"}}
+    )
+
+    assert "alt_positive_24h:" in summary
+    assert "not the no_chasing gate input" in summary
+    assert "alts_beating_btc_pct" in summary

--- a/tests/services/buy_gate_ab_shadow/test_input_contract.py
+++ b/tests/services/buy_gate_ab_shadow/test_input_contract.py
@@ -1,0 +1,164 @@
+"""ROB-1315 §5-1 — a mis-keyed candidate is refused, never silently ignored.
+
+On 2026-08-21 a US session sent ``rsi_14`` and ``nearest_support_strength``.
+Both keys were dropped, both fields read as absent, all seven candidates were
+rejected for gates they would have passed, and the response said nothing. A
+collection day produced rows that meant nothing. These tests pin the opposite
+behaviour.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.mcp_server.tooling.buy_gate_ab_shadow import (
+    evaluate_buy_gate_ab_shadow_impl,
+)
+from app.services.buy_gate_ab_shadow.evaluate import (
+    CANDIDATE_KEYS,
+    CandidateEvidence,
+    EvaluationError,
+    candidate_input_contract,
+    evaluate_candidates,
+)
+
+pytestmark = pytest.mark.unit
+
+_AS_OF = datetime(2026, 8, 21, 0, 0, tzinfo=UTC)
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "symbol": "CIEN",
+        "market": "us",
+        "current_price": "95",
+        "support_strength": "moderate",
+        "support_distance_pct": "4",
+        "rsi": "40",
+        "honest_upside_pct": "45",
+        "other_gate_bits": {
+            "liquid_midcap": True,
+            "concentration": True,
+            "overhang": True,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_the_2026_08_21_typos_are_rejected_and_named() -> None:
+    bad = _row()
+    bad["rsi_14"] = bad.pop("rsi")
+    bad["nearest_support_strength"] = bad.pop("support_strength")
+
+    with pytest.raises(EvaluationError) as exc:
+        CandidateEvidence.from_mapping(bad)
+
+    message = str(exc.value)
+    assert "rsi_14" in message
+    assert "nearest_support_strength" in message
+    # the correction, not just the complaint
+    assert "rsi_14 -> rsi" in message
+    assert "nearest_support_strength -> support_strength" in message
+
+
+def test_an_unrecognised_key_without_a_known_alias_is_still_rejected() -> None:
+    with pytest.raises(EvaluationError) as exc:
+        CandidateEvidence.from_mapping(_row(sector="tech"))
+
+    assert "sector" in str(exc.value)
+
+
+def test_the_failing_row_is_identified_by_index_and_symbol() -> None:
+    rows = [_row(), _row(symbol="RDDT", rsi_14="39")]
+    rows[1].pop("rsi")
+
+    with pytest.raises(EvaluationError) as exc:
+        evaluate_candidates(rows, evaluation_as_of=_AS_OF)
+
+    assert "candidates[1]" in str(exc.value)
+
+
+def test_unknown_other_gate_bits_key_is_rejected() -> None:
+    with pytest.raises(EvaluationError) as exc:
+        CandidateEvidence.from_mapping(
+            _row(other_gate_bits={"liquid_midcap": True, "overhang_risk": False})
+        )
+
+    assert "overhang_risk" in str(exc.value)
+    assert "liquid_midcap" in str(exc.value)
+
+
+def test_an_invalid_support_strength_word_is_rejected() -> None:
+    with pytest.raises(EvaluationError) as exc:
+        CandidateEvidence.from_mapping(_row(support_strength="firm"))
+
+    assert "firm" in str(exc.value)
+
+
+def test_omitting_an_optional_field_is_allowed_and_still_rejects_the_gate() -> None:
+    """Absent evidence is a rejection — but a deliberate one, not a typo."""
+
+    row = _row()
+    del row["rsi"]
+
+    evidence = CandidateEvidence.from_mapping(row)
+    result = evaluate_candidates([row], evaluation_as_of=_AS_OF)[0]
+
+    assert evidence.rsi is None
+    assert "rsi_not_below_max" in result.variant_b.reject_reasons
+    assert result.cohort == "neither"
+
+
+def test_every_contract_key_is_accepted() -> None:
+    evidence = CandidateEvidence.from_mapping(_row())
+
+    assert set(_row()) == CANDIDATE_KEYS
+    assert evidence.symbol == "CIEN"
+
+
+def test_impl_echoes_the_contract_on_a_mis_keyed_call() -> None:
+    bad = _row()
+    bad["rsi_14"] = bad.pop("rsi")
+
+    result = evaluate_buy_gate_ab_shadow_impl(
+        [bad],
+        evaluation_as_of=_AS_OF.isoformat(),
+        created_by="us-open",
+    )
+
+    assert result["success"] is False
+    assert result["candidates_evaluated"] == 0
+    contract = result["input_contract"]
+    assert "rsi" in contract["optional"]
+    assert contract["common_mistakes"]["rsi_14"] == "rsi"
+    assert contract["unknown_keys_are_rejected"] is True
+    # a refused call produces no shadow rows at all
+    assert "shadow_buy_forecasts" not in result
+    assert result["promote"] is False
+
+
+def test_impl_echoes_the_contract_on_success_too() -> None:
+    result = evaluate_buy_gate_ab_shadow_impl(
+        [_row()],
+        evaluation_as_of=_AS_OF.isoformat(),
+        created_by="us-open",
+    )
+
+    assert result["success"] is True
+    assert result["input_contract"] == candidate_input_contract()
+    assert result["counts"]["n"] == 1
+
+
+def test_contract_lists_exactly_the_accepted_keys() -> None:
+    contract = candidate_input_contract()
+
+    assert set(contract["required"]) | set(contract["optional"]) == CANDIDATE_KEYS
+    assert contract["other_gate_bit_keys"] == [
+        "liquid_midcap",
+        "concentration",
+        "overhang",
+    ]
+    assert contract["omitted_optional_field_is_a_rejection_not_a_pass"] is True

--- a/tests/services/buy_gate_ab_shadow/test_preregistration_freeze.py
+++ b/tests/services/buy_gate_ab_shadow/test_preregistration_freeze.py
@@ -1,0 +1,153 @@
+"""§139차 ② — the §7-1 pre-registration is frozen and its blockers are honest.
+
+A pre-registration nobody can verify is a post-registration. Two guards:
+
+1. The verbatim declaration is hash-pinned, so an in-place edit to the
+   hypothesis / window / sample target / promotion rule fails here.
+2. The blocking start conditions in §7 are asserted against the code they
+   describe. When the real work lands, these flip and the failure message
+   says to update §7 and §9 — a reverse tripwire, on purpose: the document
+   must not keep claiming "not collecting" after collection becomes possible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import re
+
+import pytest
+
+from app.services.buy_gate_ab_shadow.evaluate import ALLOWED_MARKETS, CANDIDATE_KEYS
+from app.services.buy_gate_ab_shadow.spec import PRE_REGISTRATION
+
+pytestmark = pytest.mark.unit
+
+_DOC = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "docs"
+    / "preregistrations"
+    / "2026-08-22-support-strength-two-source-equivalence.md"
+)
+
+
+def _text() -> str:
+    return _DOC.read_text(encoding="utf-8")
+
+
+def _verbatim_block() -> str:
+    match = re.search(r"```\n(.*?)\n```", _text(), re.S)
+    assert match is not None, "the verbatim declaration block is missing"
+    return match.group(1) + "\n"
+
+
+def test_the_registered_declaration_is_hash_frozen() -> None:
+    text = _text()
+    claimed = re.search(r"`([0-9a-f]{64})`", text)
+    assert claimed is not None, "the declaration's sha256 pin is missing"
+
+    computed = hashlib.sha256(_verbatim_block().encode("utf-8")).hexdigest()
+
+    assert computed == claimed.group(1), (
+        "the frozen declaration changed. A pre-registration is never edited in "
+        "place — add a new dated file that supersedes this one "
+        "(docs/preregistrations/README.md)."
+    )
+
+
+def test_the_declaration_still_carries_its_load_bearing_terms() -> None:
+    """Guards against a 'reformatting' that quietly drops a commitment."""
+
+    block = _verbatim_block()
+
+    assert "promote=false" in block
+    assert "calibration_exclude=true" in block
+    assert "source_count>=2" in block
+    assert "2026-08-22 ~ 2026-09-19" in block
+    assert "n>=40" in block
+    # the promotion rule, all three clauses
+    assert "D+20 중앙값 >= 0" in block
+    assert "하위 4분위 평균 > -6%" in block
+    assert "하나라도 미달이면 기각한다" in block
+    # execution impact and the US precondition
+    assert "집행 영향: 0" in block
+    assert "US overhang" in block
+
+
+def test_registered_status_says_collection_has_not_started() -> None:
+    text = _text()
+
+    assert "REGISTERED, NOT COLLECTING" in text
+    assert "Collection is **not** started by registering this document" in text
+
+
+# ---------------------------------------------------------------------------
+# Blocking start conditions — asserted against the code they describe.
+# ---------------------------------------------------------------------------
+
+
+def test_b1_code_spec_is_not_yet_amended_to_this_declaration() -> None:
+    """B1: the pinned ROB-1301 spec still declares the *other* experiment.
+
+    When B1 is done, this test fails. That is the signal to update §7.1 and
+    the §9 amendment log — not to delete the assertion.
+    """
+
+    assert PRE_REGISTRATION["variant_b"]["support_strength_min"] == "moderate"
+    assert PRE_REGISTRATION["only_difference"] == "support_strength_min"
+    assert PRE_REGISTRATION["markets"] == ["kr", "us"]
+    assert PRE_REGISTRATION["windows_trading_days"] == [5, 20]
+    assert "promotion_rule" not in PRE_REGISTRATION["scoring"]
+
+
+def test_b2_evaluator_cannot_yet_accept_source_count_evidence() -> None:
+    """B2: variant B needs source-count/family evidence the contract lacks.
+
+    Critically, this fails *loudly* rather than silently: since §138차 ③ an
+    unknown key is rejected, so a session cannot start sending
+    support_source_count and quietly collect a meaningless cohort.
+    """
+
+    assert "support_source_count" not in CANDIDATE_KEYS
+    assert not any("famil" in key for key in CANDIDATE_KEYS)
+
+    from app.services.buy_gate_ab_shadow.evaluate import (
+        CandidateEvidence,
+        EvaluationError,
+    )
+
+    with pytest.raises(EvaluationError) as exc:
+        CandidateEvidence.from_mapping(
+            {
+                "symbol": "005930",
+                "market": "kr",
+                "current_price": "70000",
+                "support_strength": "moderate",
+                "support_source_count": 2,
+            }
+        )
+    assert "support_source_count" in str(exc.value)
+
+
+def test_c1_crypto_arm_is_not_reachable_yet() -> None:
+    """C1: the declaration covers crypto winner_pullback_add; the code does not."""
+
+    assert "crypto" not in ALLOWED_MARKETS
+    assert set(ALLOWED_MARKETS) == {"kr", "us"}
+
+
+def test_doc_records_every_blocker_it_relies_on() -> None:
+    text = _text()
+
+    for blocker in ("B1", "B2", "B3", "B4", "U1", "C1", "C2"):
+        assert f"| {blocker} |" in text, f"blocker {blocker} vanished from §7"
+    # the start checklist must list them too
+    for blocker in ("B1", "B2", "B3", "B4", "U1", "C1", "C2"):
+        assert f"[ ] {blocker}" in text
+
+
+def test_readme_declares_the_no_inplace_edit_rule() -> None:
+    readme = (_DOC.parent / "README.md").read_text(encoding="utf-8")
+
+    assert "never edited in place" in readme
+    assert "2026-08-22-support-strength-two-source-equivalence.md" in readme

--- a/tests/services/test_threshold_proximity.py
+++ b/tests/services/test_threshold_proximity.py
@@ -1,0 +1,201 @@
+"""ROB-1315 §7-3 — near-miss tagging arithmetic. Pure, no I/O."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import threshold_proximity as tp
+
+pytestmark = pytest.mark.unit
+
+
+def test_ciena_rsi_case_is_a_near_miss():
+    """CIEN: RSI 45.03 against a 45 ceiling (retro §7-3 cited case)."""
+
+    tag = tp.evaluate(
+        gate="screen.rsi_max",
+        metric="rsi_14",
+        observed=45.03,
+        threshold=45,
+        comparison="max",
+        unit="rsi_points",
+    )
+
+    assert tag is not None
+    assert tag["within_band"] is True
+    assert tag["miss"] == pytest.approx(0.03)
+    assert tag["threshold"] == 45
+    assert tag["observed"] == pytest.approx(45.03)
+    assert tag["comparison"] == "max"
+    assert tag["verdict_changed"] is False
+
+
+def test_rddt_upside_case_is_a_near_miss():
+    """RDDT: honest upside 39.93% against a 40% floor (retro §7-3)."""
+
+    tag = tp.evaluate(
+        gate="buy.support_reserve_net.honest_upside_pct_min",
+        metric="honest_upside_pct",
+        observed=39.93,
+        threshold=40,
+        comparison="min",
+        unit="percent",
+    )
+
+    assert tag is not None
+    assert tag["within_band"] is True
+    assert tag["miss"] == pytest.approx(0.07)
+    assert tag["miss_pct_of_threshold"] == pytest.approx(0.175)
+
+
+def test_a_wide_miss_is_recorded_but_outside_the_band():
+    tag = tp.evaluate(
+        gate="screen.rsi_max",
+        metric="rsi_14",
+        observed=78.0,
+        threshold=45,
+        comparison="max",
+        unit="rsi_points",
+    )
+
+    assert tag is not None
+    assert tag["within_band"] is False
+    assert tag["miss"] == pytest.approx(33.0)
+    # the band-filtered helper drops it
+    assert (
+        tp.near_miss(
+            gate="screen.rsi_max",
+            metric="rsi_14",
+            observed=78.0,
+            threshold=45,
+            comparison="max",
+            unit="rsi_points",
+        )
+        is None
+    )
+
+
+def test_a_passing_observation_has_nothing_to_tag():
+    assert (
+        tp.evaluate(
+            gate="screen.rsi_max",
+            metric="rsi_14",
+            observed=44.0,
+            threshold=45,
+            comparison="max",
+            unit="rsi_points",
+        )
+        is None
+    )
+    # exactly at the threshold passes a `max` gate, so it is not a rejection
+    assert (
+        tp.evaluate(
+            gate="screen.rsi_max",
+            metric="rsi_14",
+            observed=45.0,
+            threshold=45,
+            comparison="max",
+            unit="rsi_points",
+        )
+        is None
+    )
+
+
+def test_a_missing_observation_is_not_a_near_miss():
+    """A gate that failed for lack of data is not a marginal rejection."""
+
+    assert (
+        tp.evaluate(
+            gate="screen.rsi_max",
+            metric="rsi_14",
+            observed=None,
+            threshold=45,
+            comparison="max",
+            unit="rsi_points",
+        )
+        is None
+    )
+
+
+def test_band_edge_is_inclusive_and_just_outside_is_not():
+    inside = tp.near_miss(
+        gate="g",
+        metric="m",
+        observed=46.0,
+        threshold=45,
+        comparison="max",
+        unit="rsi_points",
+    )
+    outside = tp.near_miss(
+        gate="g",
+        metric="m",
+        observed=46.001,
+        threshold=45,
+        comparison="max",
+        unit="rsi_points",
+    )
+
+    assert inside is not None and inside["miss"] == pytest.approx(tp.PROXIMITY_BAND)
+    assert outside is None
+
+
+def test_forecast_tag_picks_the_closest_gate_and_stays_non_promoting():
+    tags = [
+        tp.evaluate(
+            gate="screen.rsi_max",
+            metric="rsi_14",
+            observed=45.5,
+            threshold=45,
+            comparison="max",
+            unit="rsi_points",
+        ),
+        tp.evaluate(
+            gate="buy.support_reserve_net.honest_upside_pct_min",
+            metric="honest_upside_pct",
+            observed=39.93,
+            threshold=40,
+            comparison="min",
+            unit="percent",
+        ),
+    ]
+
+    fragment = tp.build_forecast_tag(tags, market="us", symbol="RDDT")
+
+    assert fragment is not None
+    block = fragment[tp.TAG]
+    assert block["closest_gate"] == "buy.support_reserve_net.honest_upside_pct_min"
+    assert block["closest_miss"] == pytest.approx(0.07)
+    assert len(block["gates"]) == 2
+    assert block["gate_verdict_changed"] is False
+    assert block["promote"] is False
+    assert block["live_gate_impact"] is False
+    assert fragment["decision_bucket_hint"] == "deferred_no_action"
+
+
+def test_forecast_tag_is_none_when_nothing_is_within_band():
+    wide = tp.evaluate(
+        gate="screen.rsi_max",
+        metric="rsi_14",
+        observed=70,
+        threshold=45,
+        comparison="max",
+        unit="rsi_points",
+    )
+
+    assert tp.build_forecast_tag([wide], market="kr", symbol="005930") is None
+    assert tp.build_forecast_tag([], market="kr", symbol="005930") is None
+
+
+def test_module_has_no_io_imports():
+    """The tag must never reach a DB, broker, network, or clock."""
+
+    source = __import__("pathlib").Path(tp.__file__).read_text(encoding="utf-8")
+    for forbidden in (
+        "import httpx",
+        "sqlalchemy",
+        "app.core.db",
+        "app.services.brokers",
+        "datetime",
+        "requests",
+    ):
+        assert forbidden not in source

--- a/tests/test_upbit_index_service.py
+++ b/tests/test_upbit_index_service.py
@@ -315,3 +315,85 @@ async def test_handle_get_upbit_altseason_passes_constituent_options(monkeypatch
         "include_constituents": True,
         "constituents_limit": 200,
     }
+
+
+# ---------------------------------------------------------------------------
+# ROB-1315 §7-2 — breadth metric disambiguation (reporting only, no gate change)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_altseason_reports_absolute_and_btc_relative_breadth(monkeypatch):
+    """A BTC-led rally: many alts up, few beating BTC. Both numbers surface."""
+
+    upbit_index._clear_caches()
+    mapping = {
+        **_datalab_mapping(),
+        "/market/all": _MARKET_ALL,
+        "/ticker": [
+            {"market": "KRW-BTC", "signed_change_rate": 0.0312},
+            # up in absolute terms, but behind BTC
+            {"market": "KRW-ETH", "signed_change_rate": 0.0200},
+            # up and ahead of BTC
+            {"market": "KRW-XRP", "signed_change_rate": 0.0500},
+        ],
+    }
+    monkeypatch.setattr(httpx.AsyncClient, "get", _route(mapping))
+
+    payload = await upbit_index.fetch_upbit_altseason()
+
+    breadth = payload["breadth"]
+    assert breadth["alts_total"] == 2
+    # absolute: both alts are above zero
+    assert breadth["alts_positive_24h"] == 2
+    assert breadth["alt_positive_24h_pct"] == pytest.approx(1.0)
+    # BTC-relative: only XRP beats BTC
+    assert breadth["alts_beating_btc"] == 1
+    assert breadth["alts_beating_btc_pct"] == pytest.approx(0.5)
+    # the two metrics disagree, which is exactly why both are reported
+    assert breadth["alt_positive_24h_pct"] != breadth["alts_beating_btc_pct"]
+
+
+@pytest.mark.asyncio
+async def test_altseason_names_the_gate_input_metric(monkeypatch):
+    upbit_index._clear_caches()
+    mapping = {
+        **_datalab_mapping(),
+        "/market/all": _MARKET_ALL,
+        "/ticker": _TICKER,
+    }
+    monkeypatch.setattr(httpx.AsyncClient, "get", _route(mapping))
+
+    payload = await upbit_index.fetch_upbit_altseason()
+
+    semantics = payload["breadth"]["metric_semantics"]
+    assert semantics["no_chasing_gate_input"] == "alts_beating_btc_pct"
+    assert "absolute" in semantics["alt_positive_24h_pct"]
+    assert "BTC-relative" in semantics["alts_beating_btc_pct"]
+
+
+@pytest.mark.asyncio
+async def test_btc_relative_breadth_value_is_unchanged_by_the_split(monkeypatch):
+    """Regression: adding the absolute metric must not move the gate metric."""
+
+    upbit_index._clear_caches()
+    mapping = {
+        **_datalab_mapping(),
+        "/market/all": _MARKET_ALL,
+        # all three alts negative but two still above BTC
+        "/ticker": [
+            {"market": "KRW-BTC", "signed_change_rate": -0.05},
+            {"market": "KRW-ETH", "signed_change_rate": -0.01},
+            {"market": "KRW-XRP", "signed_change_rate": -0.02},
+        ],
+    }
+    monkeypatch.setattr(httpx.AsyncClient, "get", _route(mapping))
+
+    payload = await upbit_index.fetch_upbit_altseason()
+
+    breadth = payload["breadth"]
+    assert breadth["alts_beating_btc"] == 2
+    assert breadth["alts_beating_btc_pct"] == pytest.approx(1.0)
+    # absolute breadth is zero in the same snapshot — a bear tape stays closed
+    assert breadth["alts_positive_24h"] == 0
+    assert breadth["alt_positive_24h_pct"] == pytest.approx(0.0)


### PR DESCRIPTION
회고 §7-2 · §7-3 · §5-1 채택분 구현. 근거 원문 = `~/work/herdr-inbox/retro-buyside-multiweek-20260822.md`.

🔴 **T1 — 관측·기록 표면 한정. 게이트 판정 로직 불변이 AC이며, 그 불변을 테스트로 증명한다.**
브로커·주문·워치·제안 mutation 0. DB 스키마 변경 0. 스케줄러 등록 0.

## 커밋 3개 (각각 독립)

### ① `899999d7` breadth 지표 분리·병기 (§7-2) — 완화 아님

2026-08-20 실측에서 정책표 `alt_breadth`(78.09%)와 게이트 입력 `alts_beating_btc_pct`(17.38%)가
**60.71%p** 어긋났고, 둘이 같은 구어체 이름을 쓰던 탓에 표의 한 줄이 게이트 판정처럼 읽혔다.

- `get_upbit_altseason` breadth 에 `alt_positive_24h_pct`(절대) 병기. 기존 BTC상대 값·계산 불변.
  `metric_semantics.no_chasing_gate_input = "alts_beating_btc_pct"` 를 페이로드에 박제.
- `trading_policy.yaml`: `recovery_gate.conditions[alt_breadth_24h]` 에
  `input_field` / `input_basis` / `not_input_field` 추가(스키마 optional). `no_chasing` 문언에도 metric 명시.
  **`operator=gt` / `threshold=50` / `unit=percent` 전부 불변.** version `2026-08-22.1`.
- 정책표 `market_context.alt_breadth` → `alt_positive_24h` 개명 + `gate_input: false` 표기.
  소비자 대조: 유일 소비자(`build_policy_table` 요약 렌더러) 동반 수정.

### ② `268ae110` 임계근방 태깅 (§7-3) — 기록만

CIEN RSI 45.03/45(MFE +19.39%)·RDDT upside 39.93/40(MFE +20.09%)이 78/45로 탈락한 건과
같은 코호트에 섞여 있어 "기각이 옳았나"를 마진 구간에서 검증할 수 없었다.

- `app/services/threshold_proximity.py` (신규, 순수·stdlib): 실패한 수치 비교를
  (게이트명·임계·실측·미달폭·상대폭)으로 기술. 밴드 = 게이트 자체 단위 ±1.0.
  상대 1% 재필터용 `miss_pct_of_threshold` 도 함께 기록. **관측 부재는 태그하지 않는다.**
- `discover_buy_candidates_fanout`: rsi(45)·honest_upside(40)·support 거리(8) 세 지점의
  **실패 분기에서만** append. 후보별 `negative_class_forecast_hint`
  (`decision_bucket_hint="deferred_no_action"`) + `digest_observation.threshold_proximity` 집계.

### ③ `573eded0` A/B shadow 입력계약 + US overhang 설계안 (§5-1)

08-21 US 세션이 `rsi_14`/`nearest_support_strength` 로 보낸 1차 호출이 전건 무효였다.
도구가 미지의 키를 조용히 버리고 7종 전부를 통과했을 게이트에서 기각했으며 응답 어디에도 그 사실이 없었다.

- **① 입력키 계약**: 미지의 최상위 키·`other_gate_bits` 키·`support_strength` 값을 전부 거부.
  오탈자는 교정까지 제시(`"rsi_14 -> rsi"`), 실패 행은 `candidates[i] (SYMBOL)` 로 특정.
  성공/실패 양쪽 응답에 `input_contract` echo.
- **② US overhang**: 지시대로 **코드가 아니라 설계 문서**로 제출 —
  `docs/superpowers/specs/2026-08-22-us-overhang-gate-design.md`.
  옵션 4개 비교 후 권고 = 옵션 2(중화 + 플래그) + 옵션 1(EDGAR) 별건 후속.
  🔴 **설계 승인 전 US 셰도우 로직 변경 0** — `spec_sha256` 핀 그대로.


### ④ `5fb1e8aa` (CI) 신규 테스트 3종 file-shard 매니페스트 등록

1차 푸시에서 `taskiq-smoke` 의 exact-cover 가드가 잡았다. 🔴 **신규 테스트 파일은 샤드 매니페스트에
등록 전까지 CI 에서 한 번도 실행되지 않는다** — 이번 런이 정확히 그 상태였고(4샤드 전부 초록인데
신규 40건 미실행), 그 red 를 무관한 실패로 넘겼으면 false-green 이었다.
각 파일을 LC_ALL=C 정렬 위치에 1개 샤드씩만 추가. `weights.json` 은 감사용이라 무변경.

## 검증

- 로컬 전체 스위트: `22340 passed, 21 skipped` (exit 0)
- CI exact-head `5fb1e8aa7`: `lint` · `test (3.13, 1..4)` · `taskiq-smoke` · `ci-required` ·
  `security` 외 전 체크 **green** (`WIP` pending 은 draft 표식)


### ⑤ `674fbcad` §139차 ② — §7-1 사전등록 확정본 등록 (docs)

회고 §7-1 `support_strength_two_source_equivalence` 를 운영자 동의 확정본으로 등록.
🔴 **등록 = 수집 시작이 아니다.** 차단 조건 7개 중 등록 시점 충족 **0개**.

- `docs/preregistrations/README.md` — 제자리 수정 금지 규칙(고칠 수 있는 사전등록은 사후등록이다)
- `docs/preregistrations/2026-08-22-support-strength-two-source-equivalence.md`
  회고 원문 축자 재현(byte-identical 검증) + sha256 핀, 하위 4분위 경계 동률 처리를 수집 전 확정,
  수집 시작 조건(전 시장 B1~B4 / US U1 / crypto C1~C2)

**발견 3건 (보고서 §3-3 상세)**

1. 🔴 §7-1 은 코드에 핀된 ROB-1301 과 **다른 실험**이다 — variant B 정의·시장 범위·창·승격 규칙
   4개 항목이 전부 다름. 코드 스펙은 **의도적 무변경**(ROB-1301 규칙상 개정문 승인이 재핀에 선행,
   이 파일이 그 개정문). 런북·플레이북에 "코호트 섞지 말 것" 경고 교차링크.
2. variant B 는 신규 발명이 아니라 **기존 `buy.support_reserve_net` 지지 계약을 regular lane 으로
   올린 것**. "독립 계열"은 기존 열거(`[fib, bb_lower, volume_profile]`)를 채택.
3. 라이브 `strong` 요건은 정책 YAML 이 아니라 **플레이북 screening step 3** 에 있다.
   `_FanoutGates` 의 moderate 는 reserve-net 티어 리터럴이며 혼동 시 실험이 무의미해진다.

**§138차 ③ 의 배당금**: 차단 B2(source-count 증거 미수용)는 미지의 키 거부 덕분에
`EvaluationError` 로 **시끄럽게** 실패한다. 예전 동작이었다면 필드가 무시된 채 4주간
무의미한 코호트를 모았을 것이다. 가드 테스트로 박음.

가드: `test_preregistration_freeze.py` 8건 — 축자 블록 해시 대조 + 차단 조건 코드 대조
(역트립와이어: 실제로 뚫리면 red 가 뜨고 §7·§9 갱신을 지시).

## 판정 불변 증거 (AC)

1. `test_funnel_is_identical_with_tagging_disabled` — 태거를 스텁으로 무력화한 런과
   정상 런을 **8개 케이스**에서 대조, 추가 키 제거 후 funnel·판정 불리언 완전 일치 요구.
2. 기존 fanout 계약 테스트 **28건 무수정 통과**.
3. ROB-1289 무드리프트 baseline 에 §138차 델타를 **naming-only 2건으로 열거**하고,
   양쪽 `operator`/`threshold`/`unit` 동일을 assert — 허용 블록 안에서 임계를 바꾸면 red.

## 부수효과 / 주의

- 🔴 policy version `2026-08-21.4` → `2026-08-22.1`. 판정 기록의 `{version, content_hash}`
  인용값이 머지 후 바뀐다. **이전 인용은 이전 문서를 가리키므로 소급 재해석 금지.**
- 🔴 부수 발견: `market_events` 의 `lockup_expiry` 는 카테고리·polarity만 선언돼 있고
  **인제스터가 없다**. 지금 조회하면 "락업 없음"처럼 읽히는 빈 결과가 나온다 (별건 이슈감).
- 잔여 오칭: `D_context.alt_breadth_rank` 는 실은 거래대금 순위. 이번 범위 밖으로 남김.

## 정지점

draft. 머지 지시 대기. US overhang 옵션 선택은 운영자 결정 사항.

🤖 Generated with [Claude Code](https://claude.com/claude-code)