### PR TITLE
feat(policy): §139차 — US one_share 상한 철폐·지수 ETF 동등 편입·crypto 보유 메이저 지지 그물

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -332,6 +332,34 @@ class PolicyDecisionRule(BaseModel):
                 "filled-cohort D+20 lower-quartile floor of -8"
             )
 
+        # ENFORCEMENT SURFACE (B1) — the tier is advisory like every other
+        # tier here. Saying so is the honest description, so it is pinned:
+        # a later edit claiming this tier is code-enforced, or claiming a
+        # machine "major" allowlist exists, fails the build instead of
+        # shipping a promise the repo cannot keep.
+        if conditions.get("enforcement_surface") != "advisory_session_contract":
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must declare "
+                "enforcement_surface: advisory_session_contract"
+            )
+        if (
+            conditions.get("code_enforced_boundary")
+            != "crypto_per_order_auto_approve_cap_then_card"
+        ):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must name the only "
+                "code-enforced boundary: crypto_per_order_auto_approve_cap_then_card"
+            )
+        if (
+            conditions.get("major_classification")
+            != "session_judgment_no_machine_allowlist"
+        ):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must declare "
+                "major_classification: session_judgment_no_machine_allowlist — "
+                "the tier carries no coin allowlist or classifier"
+            )
+
         # CRASH REGIME — explicitly NOT the preplanned ladder's "keep".
         if conditions.get("crash_day_new_batch_suspended") is not True:
             raise ValueError(

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -82,6 +82,13 @@ INDEX_ETF_CANDIDATE_TIER_ID = "index_etf_candidate"
 HELD_MAJORS_SUPPORT_NET_TIER_ID = "held_majors_support_net"
 _NOT_APPLICABLE_GATE = "not_applicable_structurally_absent"
 _INDEX_ETF_REQUIRED_EXCLUSIONS = ("leveraged_etf", "inverse_etf")
+# §139차 B2 — the per-tier validators below key off the TIER id, so renaming a
+# tier silently skips every pin on it. Bind each §139차 rule KEY to the tier id
+# it must declare, checked at document level where the key is known.
+_S139_REQUIRED_TIER_IDS = {
+    "buy.index_etf_candidate": INDEX_ETF_CANDIDATE_TIER_ID,
+    "buy.held_majors_support_net": HELD_MAJORS_SUPPORT_NET_TIER_ID,
+}
 _HELD_MAJORS_REQUIRED_EXCLUSIONS = (
     "new_coin_entry",
     "unheld_symbol",
@@ -1153,3 +1160,24 @@ class TradingPolicyDocument(BaseModel):
     market_overrides: dict[Market, dict[str, ThresholdValue]]
     crash_day: CrashDayPolicy
     user_stances: list[UserStance]
+
+    @model_validator(mode="after")
+    def validate_s139_rule_keys_bind_their_tier_ids(self) -> TradingPolicyDocument:
+        """A §139차 rule key must carry the tier id its validators key off.
+
+        Removing the rule entirely is a sanctioned retirement (§139차 ⓒ is
+        scored and retired on 2026-09-19); renaming its tier while keeping the
+        key is not — that keeps the policy surface and drops every guard.
+        """
+
+        for key, tier_id in _S139_REQUIRED_TIER_IDS.items():
+            rule = self.decision_rules.get(key)
+            if rule is None:
+                continue
+            tier_ids = [tier.id for tier in getattr(rule, "tiers", [])]
+            if not isinstance(rule, PolicyDecisionRule) or tier_id not in tier_ids:
+                raise ValueError(
+                    f"{key} must declare tier id {tier_id!r} so its §139차 "
+                    f"validators run; got {tier_ids}"
+                )
+        return self

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -73,6 +73,23 @@ BREAKEVEN_EXTENSION_LADDER_TIER_ID = "breakeven_extension_ladder"
 NO_RESISTANCE_REFERENCE_EXCLUSION = "no_resistance_reference"
 _RESISTANCE_CONDITION_MARKER = "resistance_near_pct"
 
+# §139차 (2026-08-22) — the two tiers added by §139차 are the first decision
+# rules that are not meaningful in every market: the index-ETF admission is a
+# KR/US equity-universe rule, and held_majors_support_net is a crypto-only
+# LIVE tier. ``markets`` is the structural scope declaration that keeps a
+# crypto live tier from being quoted back to a KR or US buy session.
+INDEX_ETF_CANDIDATE_TIER_ID = "index_etf_candidate"
+HELD_MAJORS_SUPPORT_NET_TIER_ID = "held_majors_support_net"
+_NOT_APPLICABLE_GATE = "not_applicable_structurally_absent"
+_INDEX_ETF_REQUIRED_EXCLUSIONS = ("leveraged_etf", "inverse_etf")
+_HELD_MAJORS_REQUIRED_EXCLUSIONS = (
+    "new_coin_entry",
+    "unheld_symbol",
+    "losing_position_averaging_down",
+    "market_order",
+    "crash_day_new_batch",
+)
+
 
 class PolicyDecisionRule(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -82,6 +99,279 @@ class PolicyDecisionRule(BaseModel):
     tiers: list[PolicyDecisionRuleTier]
     tie_breaks: dict[str, str] = Field(default_factory=dict)
     exclusions: list[str] = Field(default_factory=list)
+    # None means "every market", which is what every pre-§139차 rule declares
+    # by omission; the field is additive and back-compatible.
+    markets: list[Market] | None = None
+
+    @model_validator(mode="after")
+    def validate_markets_scope_is_non_empty(self) -> PolicyDecisionRule:
+        """An empty ``markets`` list would silently hide the rule everywhere.
+
+        Omitting the key is the sanctioned way to say "all markets"; declaring
+        ``markets: []`` is almost certainly a truncation accident, so it fails
+        the build instead of quietly disabling a live tier.
+        """
+
+        if self.markets is not None and not self.markets:
+            raise ValueError(
+                "markets must be omitted (all markets) or list at least one market"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_index_etf_candidate_stays_an_equal_candidate(
+        self,
+    ) -> PolicyDecisionRule:
+        """§139차 ③ — the ETF is admitted as a competitor, not as a fallback.
+
+        The retrospective rejected the *allocation* form of this idea ("if N
+        rounds produce no candidate, park idle cash in an index ETF") on
+        measured grounds: KR 069500 +9.62% vs US VOO -0.51% in the same
+        window, i.e. the sign flips by market and picking the market after
+        the fact is hindsight. What the operator approved is the narrower
+        thing — universe admission on equal terms. Every way the narrow form
+        could drift back into the rejected one is asserted here.
+        """
+
+        tier = self._tier_by_id(INDEX_ETF_CANDIDATE_TIER_ID)
+        if tier is None:
+            return self
+        conditions = tier.conditions
+
+        # NOT A FALLBACK — none of the three allocation-shaped behaviours may
+        # be switched on.
+        for key in (
+            "slot_reserved_for_etf",
+            "promoted_when_candidate_set_empty",
+            "idle_cash_allocation_rule",
+            "etf_specific_sizing_multiplier",
+        ):
+            if conditions.get(key) is not False:
+                raise ValueError(
+                    f"{INDEX_ETF_CANDIDATE_TIER_ID} must declare {key}: false"
+                )
+        if conditions.get("ranked_against_equities_in_same_pool") is not True:
+            raise ValueError(
+                f"{INDEX_ETF_CANDIDATE_TIER_ID} must declare "
+                "ranked_against_equities_in_same_pool: true"
+            )
+
+        # NOT A WAIVER — the gates an ETF *can* satisfy stay on; the ones it
+        # structurally cannot are marked not-applicable, never "waived", so no
+        # equity can ever inherit the relaxation.
+        for key in (
+            "rsi_gate_applies",
+            "support_strength_gate_applies",
+            "support_distance_gate_applies",
+        ):
+            if conditions.get(key) is not True:
+                raise ValueError(f"{INDEX_ETF_CANDIDATE_TIER_ID} must keep {key}: true")
+        for key in ("honest_upside_gate", "analyst_gate"):
+            if conditions.get(key) != _NOT_APPLICABLE_GATE:
+                raise ValueError(
+                    f"{INDEX_ETF_CANDIDATE_TIER_ID} must declare {key}: "
+                    f"{_NOT_APPLICABLE_GATE}"
+                )
+
+        missing = [
+            name
+            for name in _INDEX_ETF_REQUIRED_EXCLUSIONS
+            if name not in self.exclusions
+        ]
+        if missing:
+            raise ValueError(
+                f"{INDEX_ETF_CANDIDATE_TIER_ID} must retain exclusions {missing}"
+            )
+        # Equity-universe rule; crypto has no index ETF to admit.
+        if self.markets != ["kr", "us"]:
+            raise ValueError(
+                f"{INDEX_ETF_CANDIDATE_TIER_ID} is scoped to markets [kr, us]"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_held_majors_support_net_stays_bounded_and_time_boxed(
+        self,
+    ) -> PolicyDecisionRule:
+        """§139차 ⑤ — the only LIVE tier here, so its bounds are machine-pinned.
+
+        This is a pre-registered hypothesis ("상승장이라면 지지선에 매수 걸면
+        돈 벌 거잖아") running against measured counter-evidence: ROB-1031's
+        60% post-touch breakdown rate with a negative D+20 median, and the
+        XRP -8.36% one-hour flush on 2026-08-22. A pre-registration is only
+        worth the name if its scope, its size, and its retirement condition
+        cannot be edited after the fact, so each is asserted here rather than
+        left to prose.
+        """
+
+        tier = self._tier_by_id(HELD_MAJORS_SUPPORT_NET_TIER_ID)
+        if tier is None:
+            return self
+        conditions = tier.conditions
+
+        # SCOPE — held, profitable, crypto. The new-coin discovery gate is
+        # explicitly untouched, which is only true while this cannot admit an
+        # unheld or losing symbol.
+        if conditions.get("holding_required") is not True:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must require holding_required: true"
+            )
+        if conditions.get("unrealized_pnl_pct_min_exclusive") != 0:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must require "
+                "unrealized_pnl_pct_min_exclusive: 0 (profitable holdings only)"
+            )
+        if conditions.get("new_coin_discovery_gate_unchanged") is not True:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must declare "
+                "new_coin_discovery_gate_unchanged: true"
+            )
+        if self.markets != ["crypto"]:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} is scoped to markets [crypto]"
+            )
+
+        # ANCHOR — moderate strength is the relaxation the operator approved;
+        # the >= 2 independent sources are what pays for it. Neither may drift.
+        if conditions.get("support_strength_min") != "moderate":
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} anchor strength must be moderate"
+            )
+        source_min = conditions.get("independent_support_source_count_min")
+        if not isinstance(source_min, int) or isinstance(source_min, bool):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} requires a numeric "
+                "independent_support_source_count_min"
+            )
+        if source_min < 2:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} requires at least 2 "
+                "independent support sources"
+            )
+        band = conditions.get("support_distance_from_current_pct_range")
+        if (
+            not isinstance(band, list)
+            or len(band) != 2
+            or any(
+                not isinstance(edge, int | float) or isinstance(edge, bool)
+                for edge in band
+            )
+        ):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} requires a two-number "
+                "support_distance_from_current_pct_range"
+            )
+        if band != [-12, -3]:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} band must be [-12, -3]"
+            )
+
+        # EXECUTION — resting limit only. A market order here would buy the
+        # flush instead of resting under it.
+        if conditions.get("order_type") != "limit":
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must be order_type: limit"
+            )
+        if conditions.get("resting_only") is not True:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must be resting_only: true"
+            )
+        if conditions.get("per_order_cap_raised") is not False:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must declare "
+                "per_order_cap_raised: false — it rides the existing cap"
+            )
+
+        # SIZE — per-coin and tier caps, and the per-(coin, level) once rule.
+        per_coin = conditions.get("max_notional_krw_per_coin")
+        per_tier = conditions.get("max_notional_krw_per_tier")
+        if per_coin != 300000:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} per-coin cap must be 300000 KRW"
+            )
+        if per_tier != 900000:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} tier cap must be 900000 KRW"
+            )
+        if (
+            conditions.get(
+                "max_placements_per_coin_per_support_level_per_policy_version"
+            )
+            != 1
+        ):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} allows one placement per "
+                "coin per support level per policy version"
+            )
+
+        # SCORING — a pre-registration with no scoring obligation is just an
+        # authorization, and the retirement bar must predate the batches.
+        if conditions.get("forecast_save_required") is not True:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must require forecast_save"
+            )
+        review_date = conditions.get("review_date")
+        if not isinstance(review_date, str):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} requires a review_date"
+            )
+        date.fromisoformat(review_date)
+        if conditions.get("retire_unless_filled_cohort_d20_median_pct_min") != 0:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} retirement bar requires a "
+                "filled-cohort D+20 median floor of 0"
+            )
+        if (
+            conditions.get(
+                "retire_unless_filled_cohort_d20_lower_quartile_pct_min_exclusive"
+            )
+            != -8
+        ):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} retirement bar requires a "
+                "filled-cohort D+20 lower-quartile floor of -8"
+            )
+
+        # CRASH REGIME — explicitly NOT the preplanned ladder's "keep".
+        if conditions.get("crash_day_new_batch_suspended") is not True:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must suspend new batches on "
+                "a crash day"
+            )
+        drawdown = conditions.get("crypto_crash_24h_drawdown_pct_max")
+        if not isinstance(drawdown, int | float) or isinstance(drawdown, bool):
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} requires a numeric "
+                "crypto_crash_24h_drawdown_pct_max"
+            )
+        # Pinned, not bounded: a MORE negative threshold is the loosening that
+        # matters (it keeps batching through a deeper crash), and a less
+        # negative one silently redefines "crash" for this tier only. §139차
+        # fixed the number at -10%, so drift in either direction fails.
+        if drawdown != -10:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} crash suspension triggers at a "
+                "-10% 24h drawdown"
+            )
+
+        missing = [
+            name
+            for name in _HELD_MAJORS_REQUIRED_EXCLUSIONS
+            if name not in self.exclusions
+        ]
+        if missing:
+            raise ValueError(
+                f"{HELD_MAJORS_SUPPORT_NET_TIER_ID} must retain exclusions {missing}"
+            )
+        return self
+
+    def _tier_by_id(self, tier_id: str) -> PolicyDecisionRuleTier | None:
+        matches = [tier for tier in self.tiers if tier.id == tier_id]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise ValueError(f"{tier_id} must be declared exactly once")
+        return matches[0]
 
     @model_validator(mode="after")
     def validate_breakeven_extension_ladder_stays_a_fallback(

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 import yaml
 
 from app.schemas.trading_policy import (
+    PolicyDecisionRule,
     SingleShareExitDecisionRule,
     TradingPolicyDocument,
 )
@@ -177,7 +178,18 @@ def get_policy_for(market: str, lane: str) -> dict[str, Any]:
             and market not in spec.scope.markets
         ):
             continue
-        decision_rules[key] = spec.model_dump(exclude={"lanes"})
+        # §139차 — a rule may declare the markets it is meaningful in. Omitting
+        # the key keeps the pre-§139차 behaviour (every market), so this only
+        # narrows the two rules that opt in: the crypto-only held-majors LIVE
+        # tier must never be quoted back to a KR or US buy session, and the
+        # index-ETF admission must never surface in a crypto one.
+        if (
+            isinstance(spec, PolicyDecisionRule)
+            and spec.markets is not None
+            and market not in spec.markets
+        ):
+            continue
+        decision_rules[key] = spec.model_dump(exclude={"lanes", "markets"})
     market_rules: dict[str, Any] = {}
     rules = doc.market_rules.get("crypto") if market == "crypto" else None
     if rules is not None:

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -9,9 +9,13 @@
 # 저항 기반 매도 티어에 하나도 매칭되지 않아 익절 경로가 소멸한다. 그 공백만
 # 닫는 폴백 티어 sell.trim_preplace.breakeven_extension_ladder 를 신설한다.
 # 저항 티어의 대체가 아니며, exclusions.no_resistance_reference 는 유지된다.
-version: "2026-08-21.4"
+# §139차 (2026-08-22): 매수 회고 운영자 결정 3건이 정책 표면에 내려온다 — US
+# one_share 절대상한 철폐, 지수 ETF 유니버스 동등 편입, crypto 보유
+# 메이저 지지선 사전 그물(한시·4주 채점). 세 개 모두 게이트를 낮추지
+# 않고, 세 번째는 배치 전에 폐지 조건을 문서에 고정해 둔다.
+version: "2026-08-22.1"
 captured_as_of: "2026-08-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change); §127차 concurrent-new-entry slots 1→2 and buy.winner_pullback_add pre-registered tier 2026-08-21 (operator decision in claude-mock session; breakout chase remains forbidden); §129차 buy.new_entry_overflow cash-conditioned overflow slots at 0.5x sizing 2026-08-21 (operator decision in claude-mock session; no gate relaxed); §133차 KR per-order auto-approve cap 2M 2026-08-21 (single-share high-priced KR exits structurally carded — SK하이닉스 1,776,000 measured case, §65차 US twin; daily cap unchanged); §136차 A(k) two add symbols per market + owned-symbol add exempt from new-entry symbol cap 2026-08-21 (operator directive to deploy idle Upbit KRW; measured blocker from 2026-08-21 20:20 session; k_used retained at 0.10 — k is the averaging-target parameter, and raising it flips A_limit non-positive, the opposite of expansion)"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change); §127차 concurrent-new-entry slots 1→2 and buy.winner_pullback_add pre-registered tier 2026-08-21 (operator decision in claude-mock session; breakout chase remains forbidden); §129차 buy.new_entry_overflow cash-conditioned overflow slots at 0.5x sizing 2026-08-21 (operator decision in claude-mock session; no gate relaxed); §133차 KR per-order auto-approve cap 2M 2026-08-21 (single-share high-priced KR exits structurally carded — SK하이닉스 1,776,000 measured case, §65차 US twin; daily cap unchanged); §136차 A(k) two add symbols per market + owned-symbol add exempt from new-entry symbol cap 2026-08-21 (operator directive to deploy idle Upbit KRW; measured blocker from 2026-08-21 20:20 session; k_used retained at 0.10 — k is the averaging-target parameter, and raising it flips A_limit non-positive, the opposite of expansion); §139차 buy-side retrospective decisions 2026-08-22 (operator decisions in claude-mock session, sourced from retro-buyside-multiweek-20260822.md): US one_share_exception absolute_ceiling_usd 700 -> 10000 (operator: deposited cash is the ceiling; the real boundary is cash plus the USD 1,500 per-order auto-approve cap, and the AVGO -11.58% counter-evidence is retained), buy.index_etf_candidate equal-candidate universe admission for broad index ETFs with structurally-absent gates declared not-applicable rather than waived, and buy.held_majors_support_net time-boxed pre-registered LIVE crypto tier for profitable held coins (<=300k KRW per coin, <=900k KRW tier, scored 2026-09-19 and retired unless the filled cohort D+20 median >= 0 and lower quartile > -8%; ROB-1031 60% post-touch breakdown and the XRP -8.36% one-hour flush recorded as counter-evidence). No gate relaxed for new-coin discovery; no approval cap raised."
 
 authority:
   scope: judgment_policy_only
@@ -165,9 +169,20 @@ thresholds:
     lanes: [buy, discovery]
     value: [150, 450]  # 신규 진입 1차 트란치 밴드
     unit: usd
+    # §139차 (2026-08-22): 700 -> 10000. 운영자 문언 그대로 — "입금해둔 게
+    # 상한, 덜 거래하려면 출금하겠다". 즉 이 숫자는 더 이상 리스크 상한을
+    # 표현하지 않는다. 실질 경계는 두 가지로만 남는다: ① 계좌에 입금된 현금
+    # ② per-order 자동승인 캡 USD 1,500(order_proposals.auto_approve
+    # .per_order_cap.us) — 이를 넘는 1주는 카드(수동 승인)로 나간다. 10000은
+    # BRK.A/NVR급 초고가 오타를 막는 fat-finger 상한으로만 남는다.
+    # 반대 증거는 지우지 않고 기록한다(회고 §4-ⓕ-1): 상한 상향은 SNDK
+    # (1주 $1,237.92 -> +25.67%, MFE +43.82%)를 통과시켰겠지만 동시에
+    # AVGO(1주 $416.05 -> -11.58%)도 통과시켰을 것이다. n=2, 평균 +7.04% —
+    # 표본은 승격 근거가 되지 못하며, 이 변경은 실측이 아니라 운영자의
+    # 자산배분 권한 행사다.
     one_share_exception:
       enabled: true
-      absolute_ceiling_usd: 700
+      absolute_ceiling_usd: 10000
       max_deep_rungs: 1
     semantics: per-symbol first-tranche sizing for US new entries; advisory (ROB-646 원칙 — 코드 강제 아님)
   sell.loss_guard_min_multiple:
@@ -450,6 +465,118 @@ decision_rules:
         sizing: "0.5x standard tranche; gate-fitness rank order; label overflow in report"
     exclusions:
       - budget_consumption_entry
+
+  # §139차 (2026-08-22) — 지수 ETF는 발굴 유니버스의 "동등 후보"다.
+  # 회고 §4-ⓔ가 기각한 것은 "N회차 연속 후보 0이면 유휴 현금 X%를 지수
+  # ETF에"라는 자산배분 규칙이지 후보 자격이 아니다. 그 규칙을 기각한 근거는
+  # 그대로 유효하다 — 같은 창에서 KR 069500 +9.62% / US VOO -0.51%로 부호가
+  # 반대였고, 시장을 사후에 골라 적용하면 hindsight이며, KR 계좌는 이미 KR
+  # 베타에 과다 노출(45 lot 중 22 lot이 -15% 미만)이라 지수 ETF 추가는 베타
+  # 위의 베타다. 그래서 이 티어는 배분을 만들지 않고 "같은 게이트로 경쟁"만
+  # 시킨다. ETF에 구조적으로 부재한 게이트는 면제가 아니라 부적용이다.
+  buy.index_etf_candidate:
+    lanes: [buy, discovery]
+    markets: [kr, us]
+    semantics: >-
+      Advisory (§139차). A broad-market index ETF (KR 069500-class, US
+      VOO/IVV-class) enters the discovery universe as an EQUAL candidate. It
+      is never a special allocation rule, never an idle-cash fallback, and is
+      never promoted because the candidate set came back empty — zero passing
+      candidates still means zero orders. Gates that are structurally absent
+      for an index ETF (honest_upside, analyst consensus/count) are declared
+      NOT APPLICABLE for this instrument class; they are not waived for
+      equities and no equity inherits that non-applicability. Every gate an
+      ETF can satisfy — RSI, support strength, support distance — applies
+      unchanged, at the same thresholds. Sizing is the standard per-market
+      new-entry tranche with no ETF-specific multiplier, and the entry
+      consumes a normal new-entry slot rather than a reserved one. If another
+      candidate ranks higher, the other candidate wins: this tier adds an
+      entrant to the ranking, it does not reserve a place in it.
+    tiers:
+      - id: index_etf_candidate
+        conditions:
+          instrument_class: broad_market_index_etf
+          ranked_against_equities_in_same_pool: true
+          slot_reserved_for_etf: false
+          promoted_when_candidate_set_empty: false
+          idle_cash_allocation_rule: false
+          etf_specific_sizing_multiplier: false
+          rsi_gate_applies: true
+          support_strength_gate_applies: true
+          support_distance_gate_applies: true
+          honest_upside_gate: not_applicable_structurally_absent
+          analyst_gate: not_applicable_structurally_absent
+        action: rank_as_equal_new_entry_candidate
+        sizing: "standard per-market new-entry tranche (buy.per_symbol_notional_krw_range / buy.per_symbol_notional_usd_range); no ETF-specific multiplier"
+    exclusions:
+      - leveraged_etf
+      - inverse_etf
+
+  # §139차 (2026-08-22) — crypto 보유 메이저 지지선 사전 그물. 사전등록
+  # 라이브 티어이며 한시적이다: 2026-09-19 채점으로 존속/폐지가 갈리고,
+  # 폐지 조건은 배치 전에 여기 고정돼 있다. 운영자 문언 — "상승장이라면
+  # 지지선에 매수 걸면 돈 벌 거잖아". 그것이 가설이기 때문에 채점 게이트가
+  # 붙는다. 반대 증거는 지우지 않고 병기한다: ROB-1031 실측 지지 터치 후
+  # 붕괴율 60%·D+20 중앙값 음수, 그리고 XRP가 2026-08-22 02:00봉 고가
+  # 1,842에서 03:00봉 저가 1,688까지 1시간에 -8.36% 플러시를 냈다 —
+  # moderate 지지가 그 속도를 버틴다는 증거는 없다.
+  # 신규 코인 발굴 게이트는 이 티어와 무관하며 하나도 완화되지 않는다.
+  buy.held_majors_support_net:
+    lanes: [buy]
+    markets: [crypto]
+    semantics: >-
+      Pre-registered LIVE tier, time-boxed (§139차; armed 2026-08-22, scored
+      2026-09-19). Eligibility is crypto HOLDINGS ONLY and only while the
+      holding's unrealized P&L is positive at decision time — this tier can
+      never admit an unheld coin and never averages down a losing lot, so the
+      new-coin discovery gate is untouched by it. A resting LIMIT may be
+      pre-placed at a support of at least `moderate` strength that is
+      confirmed by at least 2 independent source families and sits between
+      -12% and -3% of the current price. Sizing is capped at 300,000 KRW per
+      coin and 900,000 KRW across the whole tier, at most one placement per
+      (coin, support level) per policy version. Orders route through the
+      EXISTING auto-approve path — each is far below the 1,000,000 KRW crypto
+      per-order cap, so no new approval surface is created and no cap is
+      raised. Crypto orders rest GTC by Upbit convention; DAY is not used
+      here. Every placement records a forecast (touch / fill / D+20 outcome).
+      On 2026-09-19 the tier is RETIRED unless the FILLED cohort's D+20
+      median is >= 0 AND its lower quartile is > -8%; those two numbers are
+      fixed in advance and may not be reinterpreted at scoring time. During a
+      crypto crash regime (24h drawdown worse than -10%) no new batch is
+      placed — this tier does not carry the preplanned-ladder "keep"
+      behaviour.
+    tiers:
+      - id: held_majors_support_net
+        conditions:
+          holding_required: true
+          unrealized_pnl_pct_min_exclusive: 0
+          new_coin_discovery_gate_unchanged: true
+          support_strength_min: moderate
+          independent_support_source_count_min: 2
+          support_distance_from_current_pct_range: [-12, -3]
+          order_type: limit
+          resting_only: true
+          tif: GTC
+          auto_approve_path: existing_per_order_cap
+          per_order_cap_raised: false
+          max_notional_krw_per_coin: 300000
+          max_notional_krw_per_tier: 900000
+          max_placements_per_coin_per_support_level_per_policy_version: 1
+          forecast_save_required: true
+          forecast_scored_fields: "touch, fill, d20_outcome"
+          crash_day_new_batch_suspended: true
+          crypto_crash_24h_drawdown_pct_max: -10
+          review_date: "2026-09-19"
+          retire_unless_filled_cohort_d20_median_pct_min: 0
+          retire_unless_filled_cohort_d20_lower_quartile_pct_min_exclusive: -8
+        action: pre_place_resting_limit_at_support
+        sizing: "<= 300000 KRW per coin; <= 900000 KRW tier total; one placement per (coin, support level) per policy version; forecast_save required per placement"
+    exclusions:
+      - new_coin_entry
+      - unheld_symbol
+      - losing_position_averaging_down
+      - market_order
+      - crash_day_new_batch
 
   sell.trim_preplace:
     lanes: [sell]

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -521,12 +521,41 @@ decision_rules:
   # 1,842에서 03:00봉 저가 1,688까지 1시간에 -8.36% 플러시를 냈다 —
   # moderate 지지가 그 속도를 버틴다는 증거는 없다.
   # 신규 코인 발굴 게이트는 이 티어와 무관하며 하나도 완화되지 않는다.
+  #
+  # 🔴 집행 표면(B1 수리, 2026-08-22): "LIVE" 는 실자금이라는 뜻이지 이 레포에
+  # 집행기가 있다는 뜻이 아니다. 이 파일의 모든 티어와 동일하게 advisory 다
+  # (authority.scope: judgment_policy_only — §115차/§127차/§129차와 같은 구조).
+  # 아래 조건을 읽어 주문을 만들거나 막는 코드는 레포에 없다. 세션이 판단으로
+  # 적용하고, 결과 주문에 걸리는 유일한 코드 경계는 서버측 자동승인 게이트다:
+  # crypto per-order 100만 KRW 초과는 자동승인 불가 → 카드(수동 승인)로 내려간다.
+  # 그 아래의 30만/90만·(코인,지지레벨)당 1회·급락 중지·forecast 의무는 전부
+  # 세션 계약이며 기계 가드가 아니다 — 무시하는 세션을 레포가 멈추지 못한다.
+  # 그래서 대응 절이 운영자 레포(auto_trader-operator live/CLAUDE.md)에 있다.
+  # "메이저" 역시 기계 판정 대상이 아니다 — 코인 allowlist/classifier 조건은
+  # 없고, 기계로 표현된 것은 보유 여부와 이익권뿐이다.
   buy.held_majors_support_net:
     lanes: [buy]
     markets: [crypto]
     semantics: >-
-      Pre-registered LIVE tier, time-boxed (§139차; armed 2026-08-22, scored
-      2026-09-19). Eligibility is crypto HOLDINGS ONLY and only while the
+      Pre-registered tier for LIVE funds, time-boxed (§139차; armed
+      2026-08-22, scored 2026-09-19). ENFORCEMENT SURFACE — advisory, exactly
+      like every other tier in this file (authority.scope:
+      judgment_policy_only; same structure as §115차/§127차/§129차): no code
+      in this repo reads these conditions to place, size, aggregate, or block
+      an order. "LIVE" describes the funds, not an armed executor. The
+      session applies the conditions as judgment, and the only code-enforced
+      boundary on a resulting order is the server-side auto-approve gate — a
+      crypto order above the 1,000,000 KRW per-order cap cannot auto-approve
+      and falls back to a manual card. Everything below that line — the
+      300,000 KRW per-coin cap, the 900,000 KRW tier total, the
+      one-placement-per-(coin, support level) rule, the crash-day suspension,
+      and the forecast obligation — is a SESSION CONTRACT, not a machine
+      guard; the repo will not stop a session that ignores it, which is why
+      the matching clause lives in the operator prompt
+      (auto_trader-operator live/CLAUDE.md). "Major" is likewise session
+      judgment: this tier carries no coin allowlist or classifier, so held
+      and profitable are the only machine-expressed eligibility conditions.
+      Eligibility is crypto HOLDINGS ONLY and only while the
       holding's unrealized P&L is positive at decision time — this tier can
       never admit an unheld coin and never averages down a losing lot, so the
       new-coin discovery gate is untouched by it. A resting LIMIT may be
@@ -564,6 +593,10 @@ decision_rules:
           max_placements_per_coin_per_support_level_per_policy_version: 1
           forecast_save_required: true
           forecast_scored_fields: "touch, fill, d20_outcome"
+          # B1 수리 — 이 세 키가 "무엇이 기계로 강제되는가"의 정본이다.
+          enforcement_surface: advisory_session_contract
+          code_enforced_boundary: crypto_per_order_auto_approve_cap_then_card
+          major_classification: session_judgment_no_machine_allowlist
           crash_day_new_batch_suspended: true
           crypto_crash_24h_drawdown_pct_max: -10
           review_date: "2026-09-19"

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -21,6 +21,8 @@ async def test_get_trading_policy_returns_thresholds_and_version():
         "buy.preplanned_support_ladder",
         "buy.winner_pullback_add",
         "buy.new_entry_overflow",
+        # §139차 — the index-ETF admission is a KR/US equity-universe rule.
+        "buy.index_etf_candidate",
     }
     reserve = out["decision_rules"]["buy.support_reserve_net"]
     assert reserve["eligible_only_when_regular_gate_failure"] == "RSI_ONLY"
@@ -217,7 +219,7 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
     }
     # advisory keys are echoed with the same version/content_hash stamp as
     # every other section of the response (ROB-932).
-    assert out["version"] == "2026-08-21.4"
+    assert out["version"] == "2026-08-22.1"
     assert out["content_hash"]
 
 
@@ -240,7 +242,9 @@ async def test_get_trading_policy_returns_us_notional_usd_range_with_one_share_e
     assert out["success"] is True
     us_range = out["thresholds"]["buy.per_symbol_notional_usd_range"]
     assert us_range["value"] == [150, 450]
-    assert us_range["one_share_exception"]["absolute_ceiling_usd"] == 700
+    # §139차 — 700 -> 10000; the effective boundary is cash plus the USD 1,500
+    # per-order auto-approve cap, not this number.
+    assert us_range["one_share_exception"]["absolute_ceiling_usd"] == 10000
     assert us_range["one_share_exception"]["max_deep_rungs"] == 1
 
 

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -1775,6 +1775,13 @@ def test_s139_held_majors_support_net_parses_as_a_bounded_time_boxed_tier():
         conditions["retire_unless_filled_cohort_d20_lower_quartile_pct_min_exclusive"]
         == -8
     )
+    # Enforcement surface (B1): advisory, with the one real boundary named.
+    assert conditions["enforcement_surface"] == "advisory_session_contract"
+    assert (
+        conditions["code_enforced_boundary"]
+        == "crypto_per_order_auto_approve_cap_then_card"
+    )
+    assert conditions["major_classification"] == "session_judgment_no_machine_allowlist"
     # Crash regime: explicitly NOT the preplanned ladder's "keep".
     assert conditions["crash_day_new_batch_suspended"] is True
     assert conditions["crypto_crash_24h_drawdown_pct_max"] == -10
@@ -1806,6 +1813,34 @@ def test_s139_held_majors_semantics_records_the_counter_evidence():
 
     assert "2026-09-19" in semantics
     assert "RETIRED" in semantics
+
+
+def test_s139_held_majors_semantics_does_not_overclaim_enforcement():
+    """B1 — "LIVE" must not read as "this repo enforces it".
+
+    Every tier in this file is advisory (``authority.scope:
+    judgment_policy_only``). The caps, the once-per-level rule, the crash
+    suspension, and the forecast obligation are a session contract carried by
+    the operator prompt; the only boundary code actually enforces on a
+    resulting order is the crypto per-order auto-approve cap.
+    """
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    semantics = doc.decision_rules[_HELD_MAJORS_RULE_KEY].semantics
+
+    assert "ENFORCEMENT SURFACE" in semantics
+    assert "advisory" in semantics
+    assert "judgment_policy_only" in doc.authority.scope
+    assert "SESSION CONTRACT" in semantics
+    assert "not a machine" in semantics
+    assert '"LIVE" describes the funds, not an armed executor' in semantics
+    # The operator-side counterpart is named, so the contract has an owner.
+    assert "auto_trader-operator live/CLAUDE.md" in semantics
+    # "Major" is not claimed to be machine-checked, because it is not.
+    assert "no coin allowlist or classifier" in semantics
+    # And the named boundary is the one that is really enforced in code.
+    assert "1,000,000 KRW per-order cap" in semantics
+    assert doc.order_proposals.auto_approve.per_order_cap["crypto"] == 1000000
 
 
 def test_s139_held_majors_is_scoped_out_of_the_equity_lanes():
@@ -1998,6 +2033,23 @@ def _mutate_net_leaks_into_equity_lanes(rule) -> None:
     rule["markets"] = ["kr", "us", "crypto"]
 
 
+def _mutate_net_claims_code_enforcement(rule) -> None:
+    rule["tiers"][0]["conditions"]["enforcement_surface"] = "code_enforced"
+
+
+def _mutate_net_drops_the_enforcement_surface(rule) -> None:
+    del rule["tiers"][0]["conditions"]["enforcement_surface"]
+
+
+def _mutate_net_claims_a_major_allowlist(rule) -> None:
+    conditions = rule["tiers"][0]["conditions"]
+    conditions["major_classification"] = "machine_allowlist_btc_eth_link"
+
+
+def _mutate_net_renames_the_real_boundary(rule) -> None:
+    rule["tiers"][0]["conditions"]["code_enforced_boundary"] = "tier_total_900000_krw"
+
+
 @pytest.mark.parametrize(
     "mutate",
     [
@@ -2020,6 +2072,10 @@ def _mutate_net_leaks_into_equity_lanes(rule) -> None:
         _mutate_net_raises_the_per_order_cap,
         _mutate_net_drops_new_coin_exclusion,
         _mutate_net_leaks_into_equity_lanes,
+        _mutate_net_claims_code_enforcement,
+        _mutate_net_drops_the_enforcement_surface,
+        _mutate_net_claims_a_major_allowlist,
+        _mutate_net_renames_the_real_boundary,
     ],
     ids=[
         "admits_an_unheld_coin",
@@ -2041,6 +2097,10 @@ def _mutate_net_leaks_into_equity_lanes(rule) -> None:
         "raises_the_per_order_cap",
         "drops_the_new_coin_exclusion",
         "leaks_into_the_equity_lanes",
+        "claims_code_enforcement",
+        "drops_the_enforcement_surface",
+        "claims_a_machine_major_allowlist",
+        "renames_the_real_code_boundary",
     ],
 )
 def test_s139_held_majors_support_net_mutants_are_rejected(mutate):

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -46,6 +46,25 @@ _ROB1292_ALLOWED_POLICY_DELTAS = (
     ("order_proposals.auto_approve.daily_cap.crypto", 300000, 5000000),
 )
 
+# §139차 (2026-08-22) — value deltas outside the auto-approve block. Kept in a
+# separate tuple because _ROB1292_ALLOWED_POLICY_DELTAS is also consumed by a
+# test that strips the "order_proposals.auto_approve." prefix from every entry.
+# Key tuples, not dotted strings: policy threshold keys contain dots
+# ("buy.per_symbol_notional_usd_range"), so the dotted-path helpers used for
+# the auto-approve block cannot address them.
+_S139_ALLOWED_POLICY_DELTAS = (
+    (
+        (
+            "thresholds",
+            "buy.per_symbol_notional_usd_range",
+            "one_share_exception",
+            "absolute_ceiling_usd",
+        ),
+        700,
+        10000,
+    ),
+)
+
 
 def _raw() -> dict:
     return yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
@@ -56,6 +75,20 @@ def _policy_path_get(payload: dict, path: str):
     for key in path.split("."):
         value = value[key]
     return value
+
+
+def _policy_keys_get(payload: dict, keys: tuple[str, ...]):
+    value = payload
+    for key in keys:
+        value = value[key]
+    return value
+
+
+def _policy_keys_set(payload: dict, keys: tuple[str, ...], value) -> None:
+    target = payload
+    for key in keys[:-1]:
+        target = target[key]
+    target[keys[-1]] = value
 
 
 def _policy_path_set(payload: dict, path: str, value) -> None:
@@ -151,7 +184,7 @@ def _breakeven_reserve_trim_triggered(
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
-    assert doc.version == "2026-08-21.4"
+    assert doc.version == "2026-08-22.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -1037,7 +1070,37 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
     ]
     del current_dump["decision_rules"]["buy.new_entry_overflow"]
 
+    # §139차 (2026-08-22) — two additive decision rules and exactly one value
+    # delta outside them. Pin the load-bearing fields of both new rules here so
+    # a later silent rewrite (a waived gate, a raised cap, a dropped
+    # retirement bar) fails this closed-equivalence test rather than shipping.
+    assert "buy.index_etf_candidate" not in baseline_dump["decision_rules"]
+    etf = current_dump["decision_rules"]["buy.index_etf_candidate"]
+    assert etf["exclusions"] == ["leveraged_etf", "inverse_etf"]
+    assert etf["tiers"][0]["conditions"]["idle_cash_allocation_rule"] is False
+    assert etf["tiers"][0]["conditions"]["promoted_when_candidate_set_empty"] is False
+    del current_dump["decision_rules"]["buy.index_etf_candidate"]
+
+    assert "buy.held_majors_support_net" not in baseline_dump["decision_rules"]
+    net = current_dump["decision_rules"]["buy.held_majors_support_net"]
+    assert net["exclusions"] == [
+        "new_coin_entry",
+        "unheld_symbol",
+        "losing_position_averaging_down",
+        "market_order",
+        "crash_day_new_batch",
+    ]
+    net_conditions = net["tiers"][0]["conditions"]
+    assert net_conditions["max_notional_krw_per_coin"] == 300000
+    assert net_conditions["max_notional_krw_per_tier"] == 900000
+    assert net_conditions["review_date"] == "2026-09-19"
+    del current_dump["decision_rules"]["buy.held_majors_support_net"]
+
     normalized_current_dump = deepcopy(current_dump)
+    for keys, baseline_value, current_value in _S139_ALLOWED_POLICY_DELTAS:
+        assert _policy_keys_get(baseline_dump, keys) == baseline_value
+        assert _policy_keys_get(current_dump, keys) == current_value
+        _policy_keys_set(normalized_current_dump, keys, baseline_value)
     for path, baseline_value, current_value in _ROB1292_ALLOWED_POLICY_DELTAS:
         assert _policy_path_get(baseline_dump, path) == baseline_value
         assert _policy_path_get(current_dump, path) == current_value
@@ -1143,7 +1206,9 @@ def test_us_notional_usd_range_parses_with_one_share_exception():
     exception = us_range.one_share_exception
     assert exception is not None
     assert exception.enabled is True
-    assert exception.absolute_ceiling_usd == 700
+    # §139차 — the absolute ceiling is now a fat-finger guard only (BRK.A /
+    # NVR class), not a risk cap; cash and the per-order auto-approve cap are.
+    assert exception.absolute_ceiling_usd == 10000
     assert exception.max_deep_rungs == 1
 
 
@@ -1578,3 +1643,446 @@ def test_rob_1298_leaves_loss_guard_d7_and_auto_approve_gates_untouched():
     current_trim = current["decision_rules"]["sell.trim_preplace"]
     assert current_trim["tiers"][0] == baseline_trim["tiers"][0]
     assert current_trim["tiers"][1] == baseline_trim["tiers"][1]
+
+
+# ---------------------------------------------------------------------------
+# §139차 (2026-08-22) — buy-side retrospective decisions ⓐ/ⓑ/ⓒ
+# ---------------------------------------------------------------------------
+
+_ETF_TIER_ID = "index_etf_candidate"
+_HELD_MAJORS_TIER_ID = "held_majors_support_net"
+_ETF_RULE_KEY = "buy.index_etf_candidate"
+_HELD_MAJORS_RULE_KEY = "buy.held_majors_support_net"
+
+
+def _rule_mutant(rule_key: str, mutate) -> dict:
+    raw = _raw()
+    mutate(raw["decision_rules"][rule_key])
+    return raw
+
+
+def test_s139_one_share_ceiling_is_raised_but_the_gate_is_still_armed():
+    """ⓐ — the ceiling moves; the exception itself does not become unbounded.
+
+    The operator's boundary is cash plus the per-order auto-approve cap, so
+    the two keys that express that boundary must be unchanged by this edit.
+    """
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    exception = doc.thresholds["buy.per_symbol_notional_usd_range"].one_share_exception
+
+    assert exception is not None
+    assert exception.enabled is True
+    assert exception.absolute_ceiling_usd == 10000
+    # Averaging-down exposure on an exception entry is NOT widened alongside it.
+    assert exception.max_deep_rungs == 1
+    # The real boundary: the USD per-order auto-approve cap is untouched, so a
+    # single share above it still routes to manual approval rather than auto.
+    assert doc.order_proposals.auto_approve.per_order_cap["us"] == 1500
+    # And the standard tranche band is unchanged — this is an exception path,
+    # not a new default size.
+    assert doc.thresholds["buy.per_symbol_notional_usd_range"].value == [150, 450]
+
+
+def test_s139_index_etf_candidate_parses_as_an_equal_candidate():
+    """ⓑ — admission to the universe, not an allocation rule."""
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    rule = doc.decision_rules[_ETF_RULE_KEY]
+
+    assert isinstance(rule, policy_schema.PolicyDecisionRule)
+    assert rule.lanes == ["buy", "discovery"]
+    assert rule.markets == ["kr", "us"]
+    assert [tier.id for tier in rule.tiers] == [_ETF_TIER_ID]
+    assert rule.exclusions == ["leveraged_etf", "inverse_etf"]
+
+    conditions = rule.tiers[0].conditions
+    # The rejected allocation form stays rejected.
+    assert conditions["idle_cash_allocation_rule"] is False
+    assert conditions["slot_reserved_for_etf"] is False
+    assert conditions["promoted_when_candidate_set_empty"] is False
+    assert conditions["etf_specific_sizing_multiplier"] is False
+    assert conditions["ranked_against_equities_in_same_pool"] is True
+    # Gates an ETF can satisfy stay on at the same thresholds.
+    assert conditions["rsi_gate_applies"] is True
+    assert conditions["support_strength_gate_applies"] is True
+    assert conditions["support_distance_gate_applies"] is True
+    # Gates it structurally cannot are not-applicable, never "waived".
+    assert conditions["honest_upside_gate"] == "not_applicable_structurally_absent"
+    assert conditions["analyst_gate"] == "not_applicable_structurally_absent"
+    assert "EQUAL candidate" in rule.semantics
+    assert "never an idle-cash fallback" in rule.semantics
+
+
+def test_s139_index_etf_is_scoped_out_of_the_crypto_lane():
+    from app.services.trading_policy_service import get_policy_for
+
+    assert _ETF_RULE_KEY in get_policy_for("kr", "buy")["decision_rules"]
+    assert _ETF_RULE_KEY in get_policy_for("us", "buy")["decision_rules"]
+    assert _ETF_RULE_KEY in get_policy_for("kr", "discovery")["decision_rules"]
+    assert _ETF_RULE_KEY not in get_policy_for("crypto", "buy")["decision_rules"]
+
+
+def test_s139_held_majors_support_net_parses_as_a_bounded_time_boxed_tier():
+    """ⓒ — the only LIVE tier here; every bound is asserted, not assumed."""
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    rule = doc.decision_rules[_HELD_MAJORS_RULE_KEY]
+
+    assert isinstance(rule, policy_schema.PolicyDecisionRule)
+    assert rule.lanes == ["buy"]
+    assert rule.markets == ["crypto"]
+    assert [tier.id for tier in rule.tiers] == [_HELD_MAJORS_TIER_ID]
+    assert rule.exclusions == [
+        "new_coin_entry",
+        "unheld_symbol",
+        "losing_position_averaging_down",
+        "market_order",
+        "crash_day_new_batch",
+    ]
+
+    conditions = rule.tiers[0].conditions
+    # Scope: held + profitable only, so new-coin discovery is untouched.
+    assert conditions["holding_required"] is True
+    assert conditions["unrealized_pnl_pct_min_exclusive"] == 0
+    assert conditions["new_coin_discovery_gate_unchanged"] is True
+    # Anchor: moderate is the relaxation, >= 2 independent sources pay for it.
+    assert conditions["support_strength_min"] == "moderate"
+    assert conditions["independent_support_source_count_min"] == 2
+    assert conditions["support_distance_from_current_pct_range"] == [-12, -3]
+    # Execution: resting limit through the existing cap, GTC per Upbit.
+    assert conditions["order_type"] == "limit"
+    assert conditions["resting_only"] is True
+    assert conditions["tif"] == "GTC"
+    assert conditions["auto_approve_path"] == "existing_per_order_cap"
+    assert conditions["per_order_cap_raised"] is False
+    # Size: per-coin cap fits three placements inside the tier cap, and every
+    # single order is far below the crypto per-order auto-approve cap.
+    assert conditions["max_notional_krw_per_coin"] == 300000
+    assert conditions["max_notional_krw_per_tier"] == 900000
+    assert (
+        conditions["max_placements_per_coin_per_support_level_per_policy_version"] == 1
+    )
+    assert (
+        conditions["max_notional_krw_per_coin"]
+        <= doc.order_proposals.auto_approve.per_order_cap["crypto"]
+    )
+    # Scoring: pre-registered, with the retirement bar fixed before the batches.
+    assert conditions["forecast_save_required"] is True
+    assert conditions["review_date"] == "2026-09-19"
+    assert conditions["retire_unless_filled_cohort_d20_median_pct_min"] == 0
+    assert (
+        conditions["retire_unless_filled_cohort_d20_lower_quartile_pct_min_exclusive"]
+        == -8
+    )
+    # Crash regime: explicitly NOT the preplanned ladder's "keep".
+    assert conditions["crash_day_new_batch_suspended"] is True
+    assert conditions["crypto_crash_24h_drawdown_pct_max"] == -10
+    ladder = doc.decision_rules["buy.preplanned_support_ladder"]
+    assert isinstance(ladder, PreplannedSupportLadderPolicy)
+    assert ladder.crash_day_behavior == "keep"
+
+
+def test_s139_held_majors_semantics_records_the_counter_evidence():
+    """A pre-registration that argues its counter-evidence away is not one."""
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    semantics = doc.decision_rules[_HELD_MAJORS_RULE_KEY].semantics
+
+    yaml_text = _CONFIG.read_text(encoding="utf-8")
+    start = yaml_text.index("# §139차 (2026-08-22) — crypto 보유 메이저")
+    end = yaml_text.index("  sell.trim_preplace:", start)
+    rule_block = yaml_text[start:end]
+
+    # The measured evidence that argues AGAINST this tier is carried with it.
+    assert "ROB-1031" in rule_block
+    assert "60%" in rule_block
+    assert "-8.36%" in rule_block
+    assert "XRP" in rule_block
+    # And the operator's own words, so the hypothesis is attributable.
+    # (the quote wraps across two comment lines in the YAML)
+    assert "상승장이라면" in rule_block
+    assert "지지선에 매수 걸면 돈 벌 거잖아" in rule_block
+
+    assert "2026-09-19" in semantics
+    assert "RETIRED" in semantics
+
+
+def test_s139_held_majors_is_scoped_out_of_the_equity_lanes():
+    from app.services.trading_policy_service import get_policy_for
+
+    assert _HELD_MAJORS_RULE_KEY in get_policy_for("crypto", "buy")["decision_rules"]
+    assert _HELD_MAJORS_RULE_KEY not in get_policy_for("kr", "buy")["decision_rules"]
+    assert _HELD_MAJORS_RULE_KEY not in get_policy_for("us", "buy")["decision_rules"]
+
+
+def test_s139_markets_scope_is_stripped_from_the_consumer_view():
+    """``markets`` is scoping metadata, echoed no more than ``lanes`` is."""
+
+    from app.services.trading_policy_service import get_policy_for
+
+    for market, lane in (("kr", "buy"), ("us", "buy"), ("crypto", "buy")):
+        for rule in get_policy_for(market, lane)["decision_rules"].values():
+            assert "markets" not in rule
+            assert "lanes" not in rule
+
+
+def test_s139_pre_existing_rules_keep_the_all_markets_default():
+    doc = TradingPolicyDocument.model_validate(_raw())
+
+    for key in (
+        "buy.support_reserve_net",
+        "buy.preplanned_support_ladder",
+        "buy.winner_pullback_add",
+        "buy.new_entry_overflow",
+        "sell.trim_preplace",
+    ):
+        rule = doc.decision_rules[key]
+        assert getattr(rule, "markets", None) is None
+
+
+def test_s139_empty_markets_list_is_rejected():
+    """``markets: []`` would silently disable a live tier in every market."""
+
+    raw = _raw()
+    raw["decision_rules"][_HELD_MAJORS_RULE_KEY]["markets"] = []
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def _mutate_etf_becomes_idle_cash_allocation(rule) -> None:
+    rule["tiers"][0]["conditions"]["idle_cash_allocation_rule"] = True
+
+
+def _mutate_etf_reserves_a_slot(rule) -> None:
+    rule["tiers"][0]["conditions"]["slot_reserved_for_etf"] = True
+
+
+def _mutate_etf_promoted_when_empty(rule) -> None:
+    rule["tiers"][0]["conditions"]["promoted_when_candidate_set_empty"] = True
+
+
+def _mutate_etf_waives_rsi(rule) -> None:
+    rule["tiers"][0]["conditions"]["rsi_gate_applies"] = False
+
+
+def _mutate_etf_waives_support_strength(rule) -> None:
+    rule["tiers"][0]["conditions"]["support_strength_gate_applies"] = False
+
+
+def _mutate_etf_upside_gate_waived_not_inapplicable(rule) -> None:
+    rule["tiers"][0]["conditions"]["honest_upside_gate"] = "waived"
+
+
+def _mutate_etf_drops_leverage_exclusion(rule) -> None:
+    rule["exclusions"] = ["inverse_etf"]
+
+
+def _mutate_etf_special_sizing(rule) -> None:
+    rule["tiers"][0]["conditions"]["etf_specific_sizing_multiplier"] = True
+
+
+def _mutate_etf_leaks_into_crypto(rule) -> None:
+    rule["markets"] = ["kr", "us", "crypto"]
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _mutate_etf_becomes_idle_cash_allocation,
+        _mutate_etf_reserves_a_slot,
+        _mutate_etf_promoted_when_empty,
+        _mutate_etf_waives_rsi,
+        _mutate_etf_waives_support_strength,
+        _mutate_etf_upside_gate_waived_not_inapplicable,
+        _mutate_etf_drops_leverage_exclusion,
+        _mutate_etf_special_sizing,
+        _mutate_etf_leaks_into_crypto,
+    ],
+    ids=[
+        "becomes_idle_cash_allocation",
+        "reserves_a_slot",
+        "promoted_when_candidate_set_empty",
+        "waives_rsi_gate",
+        "waives_support_strength_gate",
+        "upside_gate_waived_instead_of_inapplicable",
+        "drops_leveraged_etf_exclusion",
+        "invents_etf_specific_sizing",
+        "leaks_into_the_crypto_lane",
+    ],
+)
+def test_s139_index_etf_candidate_mutants_are_rejected(mutate):
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(_rule_mutant(_ETF_RULE_KEY, mutate))
+
+
+def _mutate_net_admits_unheld(rule) -> None:
+    rule["tiers"][0]["conditions"]["holding_required"] = False
+
+
+def _mutate_net_admits_losing_lot(rule) -> None:
+    rule["tiers"][0]["conditions"]["unrealized_pnl_pct_min_exclusive"] = -5
+
+
+def _mutate_net_touches_new_coin_gate(rule) -> None:
+    rule["tiers"][0]["conditions"]["new_coin_discovery_gate_unchanged"] = False
+
+
+def _mutate_net_drops_support_strength_to_weak(rule) -> None:
+    rule["tiers"][0]["conditions"]["support_strength_min"] = "weak"
+
+
+def _mutate_net_drops_to_single_source(rule) -> None:
+    rule["tiers"][0]["conditions"]["independent_support_source_count_min"] = 1
+
+
+def _mutate_net_widens_band(rule) -> None:
+    rule["tiers"][0]["conditions"]["support_distance_from_current_pct_range"] = [-20, 0]
+
+
+def _mutate_net_allows_market_order(rule) -> None:
+    rule["tiers"][0]["conditions"]["order_type"] = "market"
+
+
+def _mutate_net_raises_per_coin_cap(rule) -> None:
+    rule["tiers"][0]["conditions"]["max_notional_krw_per_coin"] = 1000000
+
+
+def _mutate_net_raises_tier_cap(rule) -> None:
+    rule["tiers"][0]["conditions"]["max_notional_krw_per_tier"] = 3000000
+
+
+def _mutate_net_allows_repeat_placements(rule) -> None:
+    conditions = rule["tiers"][0]["conditions"]
+    conditions["max_placements_per_coin_per_support_level_per_policy_version"] = 5
+
+
+def _mutate_net_drops_forecast_obligation(rule) -> None:
+    rule["tiers"][0]["conditions"]["forecast_save_required"] = False
+
+
+def _mutate_net_softens_retirement_median(rule) -> None:
+    rule["tiers"][0]["conditions"][
+        "retire_unless_filled_cohort_d20_median_pct_min"
+    ] = -5
+
+
+def _mutate_net_softens_retirement_quartile(rule) -> None:
+    conditions = rule["tiers"][0]["conditions"]
+    conditions["retire_unless_filled_cohort_d20_lower_quartile_pct_min_exclusive"] = -30
+
+
+def _mutate_net_drops_review_date(rule) -> None:
+    del rule["tiers"][0]["conditions"]["review_date"]
+
+
+def _mutate_net_keeps_batching_through_a_crash(rule) -> None:
+    rule["tiers"][0]["conditions"]["crash_day_new_batch_suspended"] = False
+
+
+def _mutate_net_loosens_crash_trigger(rule) -> None:
+    rule["tiers"][0]["conditions"]["crypto_crash_24h_drawdown_pct_max"] = -30
+
+
+def _mutate_net_raises_the_per_order_cap(rule) -> None:
+    rule["tiers"][0]["conditions"]["per_order_cap_raised"] = True
+
+
+def _mutate_net_drops_new_coin_exclusion(rule) -> None:
+    rule["exclusions"] = [
+        name for name in rule["exclusions"] if name != "new_coin_entry"
+    ]
+
+
+def _mutate_net_leaks_into_equity_lanes(rule) -> None:
+    rule["markets"] = ["kr", "us", "crypto"]
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _mutate_net_admits_unheld,
+        _mutate_net_admits_losing_lot,
+        _mutate_net_touches_new_coin_gate,
+        _mutate_net_drops_support_strength_to_weak,
+        _mutate_net_drops_to_single_source,
+        _mutate_net_widens_band,
+        _mutate_net_allows_market_order,
+        _mutate_net_raises_per_coin_cap,
+        _mutate_net_raises_tier_cap,
+        _mutate_net_allows_repeat_placements,
+        _mutate_net_drops_forecast_obligation,
+        _mutate_net_softens_retirement_median,
+        _mutate_net_softens_retirement_quartile,
+        _mutate_net_drops_review_date,
+        _mutate_net_keeps_batching_through_a_crash,
+        _mutate_net_loosens_crash_trigger,
+        _mutate_net_raises_the_per_order_cap,
+        _mutate_net_drops_new_coin_exclusion,
+        _mutate_net_leaks_into_equity_lanes,
+    ],
+    ids=[
+        "admits_an_unheld_coin",
+        "admits_a_losing_lot",
+        "claims_the_new_coin_gate_changed",
+        "drops_support_strength_to_weak",
+        "drops_to_a_single_support_source",
+        "widens_the_anchor_band",
+        "allows_a_market_order",
+        "raises_the_per_coin_cap",
+        "raises_the_tier_cap",
+        "allows_repeat_placements",
+        "drops_the_forecast_obligation",
+        "softens_the_retirement_median",
+        "softens_the_retirement_quartile",
+        "drops_the_review_date",
+        "keeps_batching_through_a_crash",
+        "loosens_the_crash_trigger",
+        "raises_the_per_order_cap",
+        "drops_the_new_coin_exclusion",
+        "leaks_into_the_equity_lanes",
+    ],
+)
+def test_s139_held_majors_support_net_mutants_are_rejected(mutate):
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(
+            _rule_mutant(_HELD_MAJORS_RULE_KEY, mutate)
+        )
+
+
+def test_s139_new_rules_reject_typo_keys():
+    for key in (_ETF_RULE_KEY, _HELD_MAJORS_RULE_KEY):
+        raw = _raw()
+        raw["decision_rules"][key]["bogus"] = True
+        with pytest.raises(ValidationError):
+            TradingPolicyDocument.model_validate(raw)
+
+
+def test_s139_leaves_the_crypto_and_kr_approval_caps_untouched():
+    """No cap is raised by §139차; the tier rides the existing approval lane."""
+
+    baseline = yaml.safe_load(_ROB1289_BASELINE.read_text(encoding="utf-8"))
+    current = _raw()
+
+    current_auto = deepcopy(current["order_proposals"]["auto_approve"])
+    baseline_auto = deepcopy(baseline["order_proposals"]["auto_approve"])
+    for path, baseline_value, _current_value in _ROB1292_ALLOWED_POLICY_DELTAS:
+        suffix = path.removeprefix("order_proposals.auto_approve.")
+        _policy_path_set(current_auto, suffix, baseline_value)
+    assert current_auto == baseline_auto
+
+    # The new-coin discovery gates §139차 promises not to touch.
+    for key in (
+        "buy.deep_limit_pct_range",
+        "buy.per_symbol_notional_krw_range",
+        "sell.loss_guard_min_multiple",
+    ):
+        assert current["thresholds"][key] == baseline["thresholds"][key]
+    assert (
+        current["market_rules"]["crypto"]["no_chasing"]
+        == baseline["market_rules"]["crypto"]["no_chasing"]
+    )
+    assert (
+        current["market_rules"]["crypto"]["recovery_gate"]
+        == baseline["market_rules"]["crypto"]["recovery_gate"]
+    )

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -2110,6 +2110,24 @@ def test_s139_held_majors_support_net_mutants_are_rejected(mutate):
         )
 
 
+@pytest.mark.parametrize("rule_key", [_ETF_RULE_KEY, _HELD_MAJORS_RULE_KEY])
+def test_s139_renaming_a_tier_id_cannot_bypass_its_validators(rule_key):
+    """B2 — the per-tier pins key off the tier id; the key binds it.
+
+    Before this binding, renaming the tier while keeping the rule key made
+    every §139차 validator return early, so a policy surface still named
+    ``buy.held_majors_support_net`` could carry an unpinned tier.
+    """
+
+    raw = _raw()
+    rule = raw["decision_rules"][rule_key]
+    original_id = rule["tiers"][0]["id"]
+    rule["tiers"][0]["id"] = f"{original_id}_v2"
+
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
 def test_s139_new_rules_reject_typo_keys():
     for key in (_ETF_RULE_KEY, _HELD_MAJORS_RULE_KEY):
         raw = _raw()

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -27,6 +27,8 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
         "buy.preplanned_support_ladder",
         "buy.winner_pullback_add",
         "buy.new_entry_overflow",
+        # §139차 — KR/US only; the crypto held-majors tier must not appear here.
+        "buy.index_etf_candidate",
     }
     reserve = view["decision_rules"]["buy.support_reserve_net"]
     assert reserve["discount_below_support_pct_range"] == [5, 10]


### PR DESCRIPTION
## 요약

매수 회고(`retro-buyside-multiweek-20260822.md`) 운영자 결정 5건 중 **정책 표면 3건**을
`config/trading_policy.yaml` `v2026-08-22.1` 로 내린다. 근거 원문 =
`operator-decisions-20260805-0830.md` §139차 ③④⑤.

**T2 — 신규 라이브 매수 티어(ⓒ)를 포함하므로 적대검증 1라운드 필수. 이 PR 은 draft 정지점.**

## ⓐ US `one_share_exception.absolute_ceiling_usd` 700 → 10000 (§139차 ④)

운영자 문언: *"입금해둔 게 상한, 덜 거래하려면 출금하겠다."* 이 숫자는 더 이상 리스크
상한을 표현하지 않고 **fat-finger 상한**(BRK.A/NVR급)으로만 남는다.

실질 경계 = ① 계좌 현금 ② per-order 자동승인 캡 **USD 1,500** (초과 1주는 카드).
두 경계 모두 이 PR 에서 **변경 없음** (테스트로 핀).

반대 증거는 지우지 않고 YAML 주석에 기록: 상향은 SNDK(1주 \$1,237.92 → +25.67%, MFE
+43.82%)를 통과시켰겠지만 **AVGO(1주 \$416.05 → −11.58%)도 통과시켰을 것**이다.
n=2 · 평균 +7.04% — 표본은 승격 근거가 아니며, 이 변경은 실측이 아니라 운영자의
자산배분 권한 행사다.

## ⓑ `buy.index_etf_candidate` 신설 (§139차 ③)

지수 ETF(KR 069500류 · US VOO/IVV류)를 발굴 유니버스의 **동등 후보**로 편입.

- 회고 §4-ⓔ가 기각한 것은 *"N회차 연속 후보 0이면 유휴 현금 X%를 ETF에"* 라는 **자산배분
  규칙**이고, 그 기각은 유효하다 — 같은 창에서 KR 069500 +9.62% / US VOO −0.51% 로
  **부호가 반대**였고 사후 시장 선택은 hindsight다. 그래서 이 티어는 배분을 만들지 않고
  **같은 게이트로 경쟁**만 시킨다 (`idle_cash_allocation_rule: false`,
  `slot_reserved_for_etf: false`, `promoted_when_candidate_set_empty: false`).
- ETF 에 **구조적으로 부재**한 게이트(`honest_upside` · analyst)는 *면제*가 아니라
  **부적용**(`not_applicable_structurally_absent`)으로 선언 — 어떤 개별주도 이 완화를
  상속하지 못한다.
- RSI · 지지 강도 · 지지 거리 게이트는 **동일 임계로 적용**. 사이징은 표준 트랜치이며
  ETF 전용 배수 없음.
- `exclusions: [leveraged_etf, inverse_etf]` — 3배 레버리지·인버스 제외 스탠스 유지
  (기존 `user_stances` 문언과 일치).

## ⓒ `buy.held_majors_support_net` 신설 — 사전등록 **라이브** 티어, 한시 (§139차 ⑤)

| 항목 | 값 |
|---|---|
| eligibility | 보유 중 **AND** 미실현손익 > 0 (crypto 한정) |
| anchor | `moderate` 이상 **AND** 독립 소스 ≥ 2, 현재가 대비 `[-12%, -3%]` |
| 집행 | resting **LIMIT**, GTC(Upbit 관례), **기존** 자동승인 캡 경유 |
| sizing | 코인당 ≤ 300,000 KRW · 티어 총 ≤ 900,000 KRW · (코인, 지지레벨)당 1회/정책버전 |
| 채점 의무 | 배치마다 `forecast_save` (touch / fill / D+20) |
| **폐지 조건 (사전 확정)** | **2026-09-19** 채점 — 체결 코호트 D+20 중앙값 ≥ 0 **AND** 하위 4분위 > −8% 미달 시 **폐지** |
| crash 국면 | 24h −10% 급락 시 **신규 배치 중지** (preplanned ladder 의 `keep` **아님**) |

- **신규 코인 발굴 게이트는 불변**이며 이 티어와 무관하다 — 미보유 코인을 절대 편입할 수
  없고 손실 lot 을 물타기하지 않는다(`exclusions` 로 고정).
- **자동승인 캡 상향 없음**: 코인당 300k 는 crypto per-order 캡 1,000,000 KRW 아래.
- 반대 증거를 YAML 에 병기: **ROB-1031 지지 터치 후 붕괴율 60%·D+20 중앙값 음수**,
  **XRP 2026-08-22 02:00봉 고가 1,842 → 03:00봉 저가 1,688, 1시간 −8.36% 플러시**.
  운영자 문언(*"상승장이라면 지지선에 매수 걸면 돈 벌 거잖아"*)도 함께 인용 — 가설이기
  때문에 4주 채점 게이트가 붙는다.

## 스키마 / 서비스 변경

1. **`PolicyDecisionRule.markets` (optional) 추가** — 브리프 범위를 넘는 유일한 추가이며
   의도적이다. 기존 `get_policy_for` 의 decision-rule 필터는 **lane 만** 보므로, 스코프
   선언이 없으면 crypto **라이브** 티어가 `get_trading_policy(market="kr", lane="buy")`
   응답에 그대로 실려 KR 세션에 오적용될 수 있다. 미선언 = 전 시장(기존 rule 전부
   동작 불변), `markets: []` 는 라이브 티어를 조용히 끄는 사고이므로 **거부**.
   소비자 뷰에서는 `lanes` 와 동일하게 **제거되어 에코되지 않는다**.
   → 검증자 판정 요청 항목.
2. **두 신규 rule 의 하드 인바리언트를 `model_validator` 로 기계 검증** — 폐지 조건 완화,
   캡 상향, 게이트 면제, 밴드 확대, market 누출, 채점 의무 삭제 등이 **빌드 실패**가 된다.

## 테스트

- 신규 파일 없음(기존 3개 파일만 수정) → `ci_shards` 등록 불필요.
- §139차 블록: 파싱 계약 + **뮤턴트 28종 거부**(ETF 9 · held_majors 19) + 시장 스코프
  + 보존 테스트 델타 열거.
- 보존 테스트(`test_rob_1289_preserves_all_preexisting_policy_keys_and_values`)는 여전히
  **닫힌 동치**: 추가 rule 2개 + `absolute_ceiling_usd` 델타 1개를 명시 제거한 뒤
  나머지 전 키/값이 ROB-1289 baseline 과 일치해야 통과.
- `test_s139_leaves_the_crypto_and_kr_approval_caps_untouched` — 자동승인 캡·crypto
  `no_chasing`/`recovery_gate`·`deep_limit_pct_range`·손실가드 불변 증명.

로컬: `tests/schemas/test_trading_policy_schema.py` + `tests/services/test_trading_policy_service.py`
+ `tests/mcp_server/test_trading_policy_tool.py` **151 passed**, 정책 인접 스위트
(order_proposals·posture·forecast·fanout·profiles 등) **1331 passed**, `ruff format`/`ruff check`/`ty` clean.

## 안전 경계

- **브로커 / 주문 / 감시 mutation 0.** YAML + 스키마 + 테스트만.
- 자동승인 캡 상향 0 · 신규 코인 발굴 게이트 완화 0 · 스케줄러 등록 0 · 마이그레이션 0.
- ⓒ 는 정책 표면의 **사전등록**이며, 이 PR 은 어떤 주문도 배치하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)