### PR TITLE
fix(ROB-1314): dashboard routes stop re-querying the whole account for one badge

### DIFF
--- a/.smoke-out/rob179-feed-research-evidence.json
+++ b/.smoke-out/rob179-feed-research-evidence.json
@@ -1,7 +1,7 @@
 {
   "smoke": "rob-179-invest-research-api",
-  "captured_at": "2026-08-10T08:13:13.971815+00:00",
-  "source_used": "rob179-smoke-18adacff",
+  "captured_at": "2026-08-23T01:24:56.671538+00:00",
+  "source_used": "rob179-smoke-fc4bef9f",
   "invariants_ok": true,
   "samples": {
     "top": {

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -272,14 +272,13 @@ async def get_crypto_dashboard(
     paper_sources: Annotated[str | None, Query(alias="paperSources")] = None,
 ) -> CryptoDashboardResponse:
     """Read-only crypto dashboard; never syncs or mutates broker/order state."""
-    home = await service.get_home(
+    held_pairs = await _held_pairs_for_badges(
+        service,
         user_id=user.id,
         include_paper=include_paper,
         paper_sources=_parse_paper_sources(paper_sources),
     )
-    resolver = await build_relation_resolver(
-        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
-    )
+    resolver = await build_relation_resolver(db, user_id=user.id, held_pairs=held_pairs)
     return await build_crypto_dashboard(
         db=db,
         user_id=user.id,
@@ -304,14 +303,13 @@ async def get_crypto_naver_reference(
     metadata only. It never syncs, submits orders, mutates watch/order-intent
     state, or writes production data.
     """
-    home = await service.get_home(
+    held_pairs = await _held_pairs_for_badges(
+        service,
         user_id=user.id,
         include_paper=include_paper,
         paper_sources=_parse_paper_sources(paper_sources),
     )
-    resolver = await build_relation_resolver(
-        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
-    )
+    resolver = await build_relation_resolver(db, user_id=user.id, held_pairs=held_pairs)
     return await build_naver_crypto_reference(
         db=db,
         symbol=symbol,
@@ -615,13 +613,36 @@ async def get_stock_detail_order_ledger(
     return StockDetailOrderLedgerResponse(count=len(items), items=items)
 
 
-def _held_pairs_from_home(home) -> list[tuple[str, str]]:
-    pairs: list[tuple[str, str]] = []
-    for h in home.groupedHoldings:
-        m = h.market.lower()
-        if m in ("kr", "us", "crypto"):
-            pairs.append((m, h.symbol))
-    return pairs
+async def _held_pairs_for_badges(
+    service: InvestHomeService,
+    *,
+    user_id: int,
+    include_paper: bool,
+    paper_sources: frozenset[str] | None,
+) -> list[tuple[str, str]]:
+    """ROB-1314 — held-symbol keys for relation badges only.
+
+    Badge-driven routes must not build the full home projection just to know
+    whether a symbol is held. They consume the ROB-1310 shared portfolio
+    snapshot (or the manual DB key reader); a cold/unavailable snapshot fails
+    closed with the same typed 503 contract as /calendar.
+    """
+    try:
+        return await service.get_held_pairs(
+            user_id=user_id,
+            include_paper=include_paper,
+            paper_sources=paper_sources,
+        )
+    except PortfolioSnapshotUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error_code": exc.error_code,
+                "source": "portfolio_snapshot",
+                "unavailable_reason": exc.reason,
+                "manual_pairs_available": bool(exc.manual_pairs),
+            },
+        ) from exc
 
 
 @router.get("/signals")
@@ -634,14 +655,13 @@ async def get_signals(
     include_paper: Annotated[bool, Query(alias="includePaper")] = False,
     paper_sources: Annotated[str | None, Query(alias="paperSources")] = None,
 ) -> SignalsResponse:
-    home = await service.get_home(
+    held_pairs = await _held_pairs_for_badges(
+        service,
         user_id=user.id,
         include_paper=include_paper,
         paper_sources=_parse_paper_sources(paper_sources),
     )
-    resolver = await build_relation_resolver(
-        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
-    )
+    resolver = await build_relation_resolver(db, user_id=user.id, held_pairs=held_pairs)
     return await build_signals(db=db, resolver=resolver, tab=tab, limit=limit)
 
 
@@ -707,14 +727,13 @@ async def get_feed_news(
     include_paper: Annotated[bool, Query(alias="includePaper")] = False,
     paper_sources: Annotated[str | None, Query(alias="paperSources")] = None,
 ) -> FeedNewsResponse:
-    home = await service.get_home(
+    held_pairs = await _held_pairs_for_badges(
+        service,
         user_id=user.id,
         include_paper=include_paper,
         paper_sources=_parse_paper_sources(paper_sources),
     )
-    resolver = await build_relation_resolver(
-        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
-    )
+    resolver = await build_relation_resolver(db, user_id=user.id, held_pairs=held_pairs)
     return await build_feed_news(
         db=db,
         resolver=resolver,
@@ -746,14 +765,13 @@ async def get_feed_research(
 ) -> FeedResearchResponse:
     if from_date and to_date and from_date > to_date:
         raise HTTPException(status_code=400, detail="fromDate must be <= toDate")
-    home = await service.get_home(
+    held_pairs = await _held_pairs_for_badges(
+        service,
         user_id=user.id,
         include_paper=include_paper,
         paper_sources=_parse_paper_sources(paper_sources),
     )
-    resolver = await build_relation_resolver(
-        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
-    )
+    resolver = await build_relation_resolver(db, user_id=user.id, held_pairs=held_pairs)
     try:
         return await build_feed_research(
             db=db,
@@ -794,14 +812,13 @@ async def get_screener_results_endpoint(
     include_paper: Annotated[bool, Query(alias="includePaper")] = False,
     paper_sources: Annotated[str | None, Query(alias="paperSources")] = None,
 ) -> ScreenerResultsResponse:
-    home = await service.get_home(
+    held_pairs = await _held_pairs_for_badges(
+        service,
         user_id=user.id,
         include_paper=include_paper,
         paper_sources=_parse_paper_sources(paper_sources),
     )
-    resolver = await build_relation_resolver(
-        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
-    )
+    resolver = await build_relation_resolver(db, user_id=user.id, held_pairs=held_pairs)
     return await build_screener_results(
         preset_id=preset,
         screening_service=screening_service,

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -116,7 +116,7 @@ from app.services.invest_view_model.stock_detail_orders_service import (
     build_stock_detail_orders,
 )
 from app.services.invest_view_model.stock_detail_providers import (
-    make_account_panel_holding_provider,
+    make_snapshot_symbol_holding_provider,
     stock_detail_candle_provider,
 )
 from app.services.invest_view_model.stock_detail_recommendation_service import (
@@ -478,7 +478,7 @@ async def get_stock_detail(
             symbol=symbol,
             db=db,
             providers=StockDetailProviders(
-                holding=make_account_panel_holding_provider(service)
+                holding=make_snapshot_symbol_holding_provider(service)
             ),
         )
     except SymbolNotFound as exc:

--- a/app/services/invest_home_service.py
+++ b/app/services/invest_home_service.py
@@ -627,6 +627,53 @@ class InvestHomeService:
             manual_pairs=sorted(set(manual_pairs)),
         )
 
+    async def get_symbol_holding(
+        self,
+        *,
+        user_id: int,
+        market: str,
+        symbol: str,
+        include_paper: bool = False,
+        paper_sources: frozenset[str] | None = None,
+    ) -> GroupedHolding | None:
+        """ROB-1314 — project one symbol's holding from the shared snapshot.
+
+        Read-path only seam for stock detail: instead of running every reader
+        through the account panel, answer the single (market, symbol) question
+        from the ROB-1310 composed snapshot. When no shared snapshot surface
+        exists the composition runs once (previous behavior) so a holding badge
+        is never fabricated nor silently dropped; a hung/invalid snapshot
+        surfaces as the typed availability error and callers mark the response
+        accordingly. Sellable quantities stay excluded from this projection —
+        order preflight keeps its fresh broker authority.
+        """
+        from app.services.portfolio_snapshot import HELD_KEY_MARKETS, held_key_symbol
+
+        normalized_market = str(market).lower()
+        if normalized_market not in HELD_KEY_MARKETS:
+            return None
+        wanted_key = held_key_symbol(normalized_market, symbol)
+
+        if self._snapshot_cache_usable(self._snapshot_cache):
+            home = await self._get_home_from_snapshot(
+                user_id=user_id,
+                include_paper=include_paper,
+                paper_sources=paper_sources,
+            )
+        else:
+            home = await self._get_home_uncached(
+                user_id=user_id,
+                include_paper=include_paper,
+                paper_sources=paper_sources,
+            )
+
+        for group in home.groupedHoldings:
+            if str(group.market).lower() != normalized_market:
+                continue
+            if held_key_symbol(normalized_market, str(group.symbol)) == wanted_key:
+                return group
+        return None
+
     async def get_home(
         self,
         *,

--- a/app/services/invest_view_model/market_dashboard_service.py
+++ b/app/services/invest_view_model/market_dashboard_service.py
@@ -344,7 +344,59 @@ def _overall_state(
 async def build_market_dashboard(
     provider: MarketDashboardProvider | None = None,
 ) -> MarketDashboardResponse:
-    provider = provider or DefaultMarketDashboardProvider()
+    """Compose the read-only market dashboard.
+
+    ROB-1314 — the production path (no injected provider) serves the composed
+    response from a short process-local TTL snapshot so /market no longer hits
+    the external index/fear-greed/kimchi providers on every request. Sections
+    declare staleAfterMinutes of 20+; a 60s snapshot stays well inside those
+    freshness windows and ``asOf`` keeps reporting the true fetch time.
+    Explicit provider injection (tools/tests) always builds fresh.
+    """
+    if provider is None:
+        cached = _market_dashboard_snapshot()
+        if cached is not None:
+            return cached
+        response = await _compose_market_dashboard(DefaultMarketDashboardProvider())
+        _store_market_dashboard_snapshot(response)
+        return response
+    return await _compose_market_dashboard(provider)
+
+
+_MARKET_DASHBOARD_TTL_SECONDS = 60.0
+_market_dashboard_cache: tuple[float, MarketDashboardResponse] | None = None
+
+
+def _monotonic() -> float:
+    import time
+
+    return time.monotonic()
+
+
+def _market_dashboard_snapshot() -> MarketDashboardResponse | None:
+    entry = _market_dashboard_cache
+    if entry is None:
+        return None
+    stored_at, response = entry
+    if _monotonic() - stored_at >= _MARKET_DASHBOARD_TTL_SECONDS:
+        return None
+    return response
+
+
+def _store_market_dashboard_snapshot(response: MarketDashboardResponse) -> None:
+    global _market_dashboard_cache
+    _market_dashboard_cache = (_monotonic(), response)
+
+
+def reset_market_dashboard_cache() -> None:
+    """Test/ops hook — drop the process-local TTL snapshot."""
+    global _market_dashboard_cache
+    _market_dashboard_cache = None
+
+
+async def _compose_market_dashboard(
+    provider: MarketDashboardProvider,
+) -> MarketDashboardResponse:
     as_of = _now()
     (
         (indices, index_warning),
@@ -371,5 +423,6 @@ async def build_market_dashboard(
         notes=[
             "Naver-style market/index dashboard using existing read-only providers.",
             "No broker/order/watch-order mutations or scheduled collectors are invoked.",
+            "Responses are served from a 60s process-local snapshot (ROB-1314).",
         ],
     )

--- a/app/services/invest_view_model/stock_detail_providers.py
+++ b/app/services/invest_view_model/stock_detail_providers.py
@@ -207,42 +207,53 @@ HoldingProvider = Callable[
 ]
 
 
-def make_account_panel_holding_provider(home_service: Any) -> HoldingProvider:
+def _holding_attr(holding: Any, name: str) -> Any:
+    if isinstance(holding, dict):
+        return holding.get(name)
+    return getattr(holding, name, None)
+
+
+def make_snapshot_symbol_holding_provider(home_service: Any) -> HoldingProvider:
+    """ROB-1314 — per-symbol holding projection from the shared snapshot.
+
+    Replaces the account-panel fan-out: the stock detail page asks the home
+    service for exactly one (market, symbol) answer instead of composing the
+    whole portfolio view.
+    """
+
     async def _provider(
         user_id: int | str, market: NewsMarket, symbol: str, db: Any
     ) -> StockDetailHolding | None:
         _ = db
-        view = await home_service.build_account_panel_view(
-            user_id=int(user_id), include_paper=False, paper_sources=None
+        holding = await home_service.get_symbol_holding(
+            user_id=int(user_id), market=str(market), symbol=symbol
         )
-        target_market = {"kr": "KR", "us": "US", "crypto": "CRYPTO"}[market]
-        for holding in view.groupedHoldings:
-            if (
-                holding.market == target_market
-                and str(holding.symbol).upper() == symbol.upper()
-            ):
-                return StockDetailHolding(
-                    totalQuantity=holding.totalQuantity,
-                    tradeableQuantity=holding.tradeableQuantity,
-                    sellableQuantity=holding.sellableQuantity,
-                    pendingSellQuantity=holding.pendingSellQuantity,
-                    referenceQuantity=holding.referenceQuantity,
-                    averageCost=holding.averageCost,
-                    costBasis=holding.costBasis,
-                    valueNative=holding.valueNative,
-                    valueKrw=holding.valueKrw,
-                    pnlKrw=holding.pnlKrw,
-                    pnlRate=holding.pnlRate,
-                    includedSources=holding.includedSources,
-                    priceState=holding.priceState,
-                )
-        return None
+        if holding is None or isinstance(holding, StockDetailHolding):
+            return holding
+        total_quantity = _holding_attr(holding, "totalQuantity")
+        if total_quantity is None:
+            return None
+        return StockDetailHolding(
+            totalQuantity=float(total_quantity),
+            tradeableQuantity=_holding_attr(holding, "tradeableQuantity"),
+            sellableQuantity=_holding_attr(holding, "sellableQuantity"),
+            pendingSellQuantity=_holding_attr(holding, "pendingSellQuantity"),
+            referenceQuantity=_holding_attr(holding, "referenceQuantity"),
+            averageCost=_holding_attr(holding, "averageCost"),
+            costBasis=_holding_attr(holding, "costBasis"),
+            valueNative=_holding_attr(holding, "valueNative"),
+            valueKrw=_holding_attr(holding, "valueKrw"),
+            pnlKrw=_holding_attr(holding, "pnlKrw"),
+            pnlRate=_holding_attr(holding, "pnlRate"),
+            includedSources=_holding_attr(holding, "includedSources") or [],
+            priceState=_holding_attr(holding, "priceState"),
+        )
 
     return _provider
 
 
 __all__ = [
-    "make_account_panel_holding_provider",
+    "make_snapshot_symbol_holding_provider",
     "stock_detail_candle_provider",
     "stock_detail_decision_history_provider",
     "stock_detail_orderbook_provider",

--- a/app/services/market_events/query_service.py
+++ b/app/services/market_events/query_service.py
@@ -123,19 +123,28 @@ class MarketEventsQueryService:
 
         rows = (await self.db.execute(stmt)).scalars().all()
 
+        # ROB-1314 — bulk-load event values in one query. The previous loop
+        # issued one SELECT per event row (SQL N+1) and dominated /invest
+        # calendar latency on dense ranges.
+        values_by_event_id: dict[int, list[MarketEventValue]] = {}
+        event_ids = [row.id for row in rows]
+        if event_ids:
+            values_stmt = (
+                select(MarketEventValue)
+                .where(MarketEventValue.event_id.in_(event_ids))
+                .order_by(MarketEventValue.id.asc())
+            )
+            value_rows = (
+                (await self.db.execute(values_stmt)).scalars().all()
+            )
+            for value_row in value_rows:
+                values_by_event_id.setdefault(value_row.event_id, []).append(
+                    value_row
+                )
+
         out: list[MarketEventResponse] = []
         for row in rows:
-            value_rows = (
-                (
-                    await self.db.execute(
-                        select(MarketEventValue).where(
-                            MarketEventValue.event_id == row.id
-                        )
-                    )
-                )
-                .scalars()
-                .all()
-            )
+            value_rows = values_by_event_id.get(row.id, [])
             out.append(
                 MarketEventResponse(
                     category=row.category,

--- a/app/services/market_events/query_service.py
+++ b/app/services/market_events/query_service.py
@@ -134,13 +134,9 @@ class MarketEventsQueryService:
                 .where(MarketEventValue.event_id.in_(event_ids))
                 .order_by(MarketEventValue.id.asc())
             )
-            value_rows = (
-                (await self.db.execute(values_stmt)).scalars().all()
-            )
+            value_rows = (await self.db.execute(values_stmt)).scalars().all()
             for value_row in value_rows:
-                values_by_event_id.setdefault(value_row.event_id, []).append(
-                    value_row
-                )
+                values_by_event_id.setdefault(value_row.event_id, []).append(value_row)
 
         out: list[MarketEventResponse] = []
         for row in rows:

--- a/ci_shards/shard-1.txt
+++ b/ci_shards/shard-1.txt
@@ -381,6 +381,7 @@ tests/test_rob1296_external_http_boundary.py
 tests/test_rob1296_live_only_socket_guard.py
 tests/test_rob1296_provider_boundaries.py
 tests/test_rob1310_portfolio_snapshot.py
+tests/test_rob1314_stock_detail_holding.py
 tests/test_rob179_smoke_evidence.py
 tests/test_rob314_deferred_call_sites.py
 tests/test_rob486_consensus_blast_radius.py

--- a/ci_shards/shard-2.txt
+++ b/ci_shards/shard-2.txt
@@ -228,6 +228,7 @@ tests/services/test_portfolio_data_collector.py
 tests/services/test_preopen_paper_approval_bridge.py
 tests/services/test_research_run_service_news_brief_safety.py
 tests/services/test_research_run_service_unit.py
+tests/services/test_rob1314_market_events_values_bulk_load.py
 tests/services/test_screener_analysis_enrichment.py
 tests/services/test_session_context_service.py
 tests/services/test_single_share_exit_snapshot_service.py
@@ -379,6 +380,7 @@ tests/test_research_run_decision_session_schemas.py
 tests/test_research_run_refresh_runner.py
 tests/test_research_run_refresh_tasks.py
 tests/test_retail_sentiment_tool.py
+tests/test_rob1314_badge_held_pairs.py
 tests/test_rob1880_socket_guard.py
 tests/test_rob473_report_item_link_schema.py
 tests/test_rob473_report_item_link_threading.py

--- a/ci_shards/shard-3.txt
+++ b/ci_shards/shard-3.txt
@@ -378,6 +378,7 @@ tests/test_research_reports_ingest_job.py
 tests/test_research_run_decision_session_service.py
 tests/test_research_run_decision_session_service_new_candidates.py
 tests/test_research_run_refresh_settings.py
+tests/test_rob1314_market_ttl_cache.py
 tests/test_rob473_report_item_link_ledger.py
 tests/test_rob571_kr_display_name.py
 tests/test_rob653_place_order_hash_guard.py

--- a/tests/services/test_rob1314_market_events_values_bulk_load.py
+++ b/tests/services/test_rob1314_market_events_values_bulk_load.py
@@ -1,0 +1,101 @@
+"""ROB-1314 — calendar event values must be bulk-loaded, not queried per event.
+
+`MarketEventsQueryService._query` used to run one `SELECT ... FROM
+market_event_values WHERE event_id = :id` per event row (SQL N+1). The fix
+loads all values for the range in a single bulk query.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from tests.market_events_test_helpers import (
+    clean_non_tradingview_market_events,
+    market_events_test_lock,
+)
+
+_SEED_COUNT = 6
+_QUERY_COUNT_CAP = 4
+
+
+class _CountingSessionProxy:
+    """Counts execute() calls and delegates to the real AsyncSession."""
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+        self.execute_calls = 0
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        self.execute_calls += 1
+        return await self._session.execute(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _market_events_lock():
+    async with market_events_test_lock():
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_market_events(db_session, _market_events_lock):
+    await clean_non_tradingview_market_events(db_session)
+    yield
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_list_for_range_values_are_bulk_loaded(db_session):
+    from app.services.market_events.query_service import MarketEventsQueryService
+    from app.services.market_events.repository import MarketEventsRepository
+
+    repo = MarketEventsRepository(db_session)
+    target = date(2099, 5, 20)
+    for i in range(_SEED_COUNT):
+        await repo.upsert_event_with_values(
+            {
+                "category": "earnings",
+                "market": "us",
+                "symbol": f"RB{i:04d}",
+                "title": f"ROB1314 N+1 seed {i}",
+                "event_date": target,
+                "status": "released",
+                "source": "finnhub",
+                "source_event_id": f"rob1314::nplus1::{i}",
+            },
+            [
+                {
+                    "metric_name": "eps",
+                    "period": f"Q1-2099-{i}",
+                    "actual": Decimal("0.12"),
+                    "forecast": Decimal("0.10"),
+                    "unit": "USD",
+                },
+                {
+                    "metric_name": "revenue",
+                    "period": f"Q1-2099-{i}",
+                    "actual": Decimal("1000"),
+                    "unit": "USD",
+                },
+            ],
+        )
+    await db_session.flush()
+
+    proxy = _CountingSessionProxy(db_session)
+    svc = MarketEventsQueryService(proxy)
+
+    response = await svc.list_for_range(target, target)
+
+    assert response.count == _SEED_COUNT
+    assert all(len(event.values) == 2 for event in response.events)
+    assert proxy.execute_calls <= _QUERY_COUNT_CAP, (
+        f"calendar values query fan-out: {proxy.execute_calls} executes "
+        f"for {_SEED_COUNT} events (cap {_QUERY_COUNT_CAP})"
+    )

--- a/tests/test_invest_api_crypto_router.py
+++ b/tests/test_invest_api_crypto_router.py
@@ -34,6 +34,11 @@ class _StubHomeService:
             meta=InvestHomeResponseMeta(warnings=[]),
         )
 
+    async def get_held_pairs(
+        self, *, user_id: int, include_paper: bool = False, paper_sources=None
+    ) -> list[tuple[str, str]]:
+        return []
+
 
 def _build_app() -> FastAPI:
     app = FastAPI()

--- a/tests/test_invest_api_feed_research_copyright_guardrails.py
+++ b/tests/test_invest_api_feed_research_copyright_guardrails.py
@@ -63,6 +63,11 @@ def _make_app():
                 meta=InvestHomeResponseMeta(warnings=[]),
             )
 
+        async def get_held_pairs(
+            self, *, user_id: int, include_paper: bool = False, paper_sources=None
+        ) -> list[tuple[str, str]]:
+            return []
+
     app = FastAPI()
     app.include_router(invest_router)
     app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)

--- a/tests/test_invest_api_feed_research_router.py
+++ b/tests/test_invest_api_feed_research_router.py
@@ -43,6 +43,16 @@ def _make_app(held=None, watch=None):
                 meta=InvestHomeResponseMeta(warnings=[]),
             )
 
+        async def get_held_pairs(
+            self, *, user_id: int, include_paper: bool = False, paper_sources=None
+        ) -> list[tuple[str, str]]:
+            pairs: list[tuple[str, str]] = []
+            for holding in build_grouped_holdings(self._holdings):
+                market = str(holding.market).lower()
+                if market in ("kr", "us", "crypto"):
+                    pairs.append((market, holding.symbol))
+            return pairs
+
     stub_holdings: list[Holding] = []
     if held:
         for mkt, sym in held:

--- a/tests/test_invest_api_router_includepaper_sweep.py
+++ b/tests/test_invest_api_router_includepaper_sweep.py
@@ -105,6 +105,18 @@ async def test_default_call_does_not_request_paper(path, params):
             )
             return _empty_view()
 
+        async def get_held_pairs(
+            self, *, user_id, include_paper=False, paper_sources=None, **_
+        ):
+            received_calls.append(
+                {
+                    "method": "get_held_pairs",
+                    "include_paper": include_paper,
+                    "paper_sources": paper_sources,
+                }
+            )
+            return []
+
     class _DBStub:
         """Minimal async session stub that returns empty result rows."""
 

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -38,6 +38,11 @@ class _StubHomeService:
             meta=InvestHomeResponseMeta(warnings=[]),
         )
 
+    async def get_held_pairs(
+        self, *, user_id: int, include_paper: bool = False, paper_sources=None
+    ) -> list[tuple[str, str]]:
+        return []
+
 
 class _StubScreening:
     def __init__(self, payload: dict[str, Any] | None = None) -> None:

--- a/tests/test_invest_stock_detail_router.py
+++ b/tests/test_invest_stock_detail_router.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_stock_detail_route_passes_account_panel_holding_provider(monkeypatch):
+async def test_stock_detail_route_passes_snapshot_symbol_holding_provider(monkeypatch):
     from app.routers import invest_api
     from app.schemas.invest_stock_detail import StockDetailResponse
 
@@ -31,32 +31,39 @@ async def test_stock_detail_route_passes_account_panel_holding_provider(monkeypa
         )
 
     class FakeHomeService:
-        async def build_account_panel_view(
-            self, *, user_id, include_paper=False, paper_sources=None
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        async def get_symbol_holding(
+            self, *, user_id, market, symbol, include_paper=False, paper_sources=None
         ):
-            assert include_paper is False
+            self.calls.append(
+                {
+                    "user_id": user_id,
+                    "market": market,
+                    "symbol": symbol,
+                    "include_paper": include_paper,
+                }
+            )
             return SimpleNamespace(
-                groupedHoldings=[
-                    SimpleNamespace(
-                        symbol="000270",
-                        market="KR",
-                        totalQuantity=4,
-                        tradeableQuantity=4,
-                        sellableQuantity=4,
-                        pendingSellQuantity=0,
-                        referenceQuantity=0,
-                        averageCost=70000,
-                        costBasis=280000,
-                        valueNative=300000,
-                        valueKrw=300000,
-                        pnlKrw=20000,
-                        pnlRate=0.0714,
-                        includedSources=["kis"],
-                        priceState="live",
-                    )
-                ]
+                symbol="000270",
+                market="KR",
+                totalQuantity=4,
+                tradeableQuantity=4,
+                sellableQuantity=4,
+                pendingSellQuantity=0,
+                referenceQuantity=0,
+                averageCost=70000,
+                costBasis=280000,
+                valueNative=300000,
+                valueKrw=300000,
+                pnlKrw=20000,
+                pnlRate=0.0714,
+                includedSources=["kis"],
+                priceState="live",
             )
 
+    service = FakeHomeService()
     monkeypatch.setattr(invest_api, "build_stock_detail", fake_build_stock_detail)
 
     response = await invest_api.get_stock_detail(
@@ -64,9 +71,17 @@ async def test_stock_detail_route_passes_account_panel_holding_provider(monkeypa
         symbol="000270",
         user=SimpleNamespace(id=7),
         db=SimpleNamespace(),
-        service=FakeHomeService(),
+        service=service,
     )
 
     assert response.holding is not None
     assert response.holding.totalQuantity == 4
     assert response.holding.includedSources == ["kis"]
+    assert service.calls == [
+        {
+            "user_id": 7,
+            "market": "kr",
+            "symbol": "000270",
+            "include_paper": False,
+        }
+    ]

--- a/tests/test_rob1314_badge_held_pairs.py
+++ b/tests/test_rob1314_badge_held_pairs.py
@@ -1,0 +1,218 @@
+"""ROB-1314 — badge-driven routes must not build the full home projection.
+
+These routes only need the held-symbol set for relation badges. They must
+consume `InvestHomeService.get_held_pairs` (shared portfolio snapshot / manual
+DB key reader, ROB-1310 contract) instead of calling `service.get_home(...)`,
+which fans out to every live reader.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+import app.routers.invest_api as invest_api
+from app.core.db import get_db
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import (
+    get_invest_home_service,
+    get_screener_service_dep,
+)
+from app.routers.invest_api import router as invest_api_router
+
+ROUTES: list[tuple[str, dict[str, Any]]] = [
+    ("/invest/api/crypto/dashboard", {}),
+    ("/invest/api/crypto/naver-reference", {"symbol": "BTC"}),
+    ("/invest/api/signals", {}),
+    ("/invest/api/feed/news", {}),
+    ("/invest/api/feed/research", {}),
+    ("/invest/api/screener/results", {"preset": "default", "market": "kr"}),
+]
+
+
+class _BadgeOnlyService:
+    """get_home raises: badge routes must never reach the full projection."""
+
+    def __init__(self) -> None:
+        self.held_pairs_calls = 0
+
+    async def get_home(self, **_kwargs: Any) -> Any:
+        raise AssertionError("ROB-1314: badge route called service.get_home()")
+
+    async def get_held_pairs(
+        self,
+        *,
+        user_id: int,
+        include_paper: bool = False,
+        paper_sources: frozenset[str] | None = None,
+    ) -> list[tuple[str, str]]:
+        self.held_pairs_calls += 1
+        return [("kr", "005930"), ("crypto", "KRW-BTC")]
+
+
+class _DBStub:
+    async def execute(self, *_args: Any, **_kw: Any) -> Any:
+        class _R:
+            def all(self) -> list[Any]:
+                return []
+
+            def scalars(self) -> Any:
+                class _S:
+                    def all(self) -> list[Any]:
+                        return []
+
+                return _S()
+
+        return _R()
+
+
+def _build_app(service: _BadgeOnlyService) -> FastAPI:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
+    app.dependency_overrides[get_invest_home_service] = lambda: service
+    app.dependency_overrides[get_db] = lambda: iter([_DBStub()])
+
+    class _ScreeningStub:
+        async def list_results(self, *_a: Any, **_kw: Any) -> list[Any]:
+            return []
+
+        async def get_preset(self, *_a: Any, **_kw: Any) -> None:
+            return None
+
+    app.dependency_overrides[get_screener_service_dep] = lambda: _ScreeningStub()
+    return app
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path,params", ROUTES)
+async def test_badge_routes_use_held_pairs_and_never_call_get_home(
+    monkeypatch: pytest.MonkeyPatch, path: str, params: dict[str, Any]
+) -> None:
+    from app.schemas.invest_crypto import (
+        CryptoDashboardMeta,
+        CryptoDashboardResponse,
+        CryptoInsightsSummary,
+        NaverCryptoReferenceResponse,
+    )
+    from app.schemas.invest_feed_news import FeedNewsResponse
+    from app.schemas.invest_feed_research import FeedResearchMeta, FeedResearchResponse
+    from app.schemas.invest_signals import SignalsResponse
+    from app.schemas.invest_screener import ScreenerResultsResponse
+
+    service = _BadgeOnlyService()
+
+    async def _resolver(db: Any, *, user_id: int, held_pairs: Any) -> object:
+        return object()
+
+    async def _crypto_dashboard(**_kw: Any) -> CryptoDashboardResponse:
+        return CryptoDashboardResponse(
+            asOf=datetime.now(UTC),
+            cards=[],
+            holdings=None,
+            pendingOrders=None,
+            insights=CryptoInsightsSummary(notes=[]),
+            meta=CryptoDashboardMeta(warnings=[], sources=[]),
+        )
+
+    async def _naver_reference(**_kw: Any) -> NaverCryptoReferenceResponse:
+        return NaverCryptoReferenceResponse(
+            asOf=datetime.now(UTC),
+            symbol="KRW-BTC",
+            rank=[],
+            profile=None,
+            news=None,
+            kimchiPremium=None,
+            sources=[],
+            warnings=[],
+        )
+
+    async def _signals(**_kw: Any) -> SignalsResponse:
+        return SignalsResponse(tab="mine", asOf=datetime.now(UTC), items=[])
+
+    async def _feed_news(**_kw: Any) -> FeedNewsResponse:
+        return FeedNewsResponse(tab="top", asOf=datetime.now(UTC))
+
+    async def _feed_research(**_kw: Any) -> FeedResearchResponse:
+        return FeedResearchResponse(
+            tab="top",
+            asOf=datetime.now(UTC),
+            items=[],
+            nextCursor=None,
+            meta=FeedResearchMeta(limit=30, appliedFilters={}),
+        )
+
+    async def _screener_results(**_kw: Any) -> ScreenerResultsResponse:
+        return ScreenerResultsResponse(
+            presetId="default",
+            title="t",
+            description="d",
+            filterChips=[],
+            metricLabel="m",
+            results=[],
+            freshness={
+                "fetchedAt": "2026-08-23T00:00:00Z",
+                "asOfLabel": "now",
+                "relativeLabel": "now",
+                "cacheHit": False,
+                "source": "live",
+            },
+        )
+
+    monkeypatch.setattr(invest_api, "build_relation_resolver", _resolver)
+    monkeypatch.setattr(invest_api, "build_crypto_dashboard", _crypto_dashboard)
+    monkeypatch.setattr(invest_api, "build_naver_crypto_reference", _naver_reference)
+    monkeypatch.setattr(invest_api, "build_signals", _signals)
+    monkeypatch.setattr(invest_api, "build_feed_news", _feed_news)
+    monkeypatch.setattr(invest_api, "build_feed_research", _feed_research)
+    monkeypatch.setattr(invest_api, "build_screener_results", _screener_results)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=_build_app(service), raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(path, params=params)
+
+    assert response.status_code == 200, response.text
+    assert service.held_pairs_calls == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_badge_routes_surface_typed_503_on_cold_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cold snapshot must fail closed with the ROB-1310 503 contract."""
+    from app.services.invest_home_service import PortfolioSnapshotUnavailableError
+
+    class _ColdService(_BadgeOnlyService):
+        async def get_held_pairs(self, **_kwargs: Any) -> list[tuple[str, str]]:
+            raise PortfolioSnapshotUnavailableError("held_key_projection_missing")
+
+    async def _resolver(db: Any, *, user_id: int, held_pairs: Any) -> object:
+        return object()
+
+    async def _signals(**_kw: Any) -> Any:  # pragma: no cover - must not run
+        raise AssertionError("builder ran after 503")
+
+    monkeypatch.setattr(invest_api, "build_relation_resolver", _resolver)
+    monkeypatch.setattr(invest_api, "build_signals", _signals)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=_build_app(_ColdService())),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/invest/api/signals")
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["source"] == "portfolio_snapshot"
+    assert detail["error_code"] == "portfolio_snapshot_unavailable"
+    assert detail["unavailable_reason"] == "held_key_projection_missing"

--- a/tests/test_rob1314_badge_held_pairs.py
+++ b/tests/test_rob1314_badge_held_pairs.py
@@ -104,8 +104,8 @@ async def test_badge_routes_use_held_pairs_and_never_call_get_home(
     )
     from app.schemas.invest_feed_news import FeedNewsResponse
     from app.schemas.invest_feed_research import FeedResearchMeta, FeedResearchResponse
-    from app.schemas.invest_signals import SignalsResponse
     from app.schemas.invest_screener import ScreenerResultsResponse
+    from app.schemas.invest_signals import SignalsResponse
 
     service = _BadgeOnlyService()
 

--- a/tests/test_rob1314_market_ttl_cache.py
+++ b/tests/test_rob1314_market_ttl_cache.py
@@ -87,7 +87,7 @@ async def test_market_route_serves_snapshot_within_ttl(
     monkeypatch.setattr(provider, "get_kimchi_premium", _kimchi)
 
     app = FastAPI()
-    app.include_router(invest_api_router)
+    app.include_router(invest_api.router)
     app.dependency_overrides[get_authenticated_user] = lambda: type(
         "U", (), {"id": 1}
     )()

--- a/tests/test_rob1314_market_ttl_cache.py
+++ b/tests/test_rob1314_market_ttl_cache.py
@@ -1,0 +1,130 @@
+"""ROB-1314 — /market must serve external provider results from a TTL snapshot.
+
+`build_market_dashboard()` (the default-provider production path used by the
+route) re-hit Naver/yfinance/alternative.me providers on every request. The
+fix memoizes the composed response behind a short process-local TTL.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+import app.routers.invest_api as invest_api
+from app.routers.dependencies import get_authenticated_user
+from app.services.invest_view_model import market_dashboard_service
+
+
+@pytest.fixture(autouse=True)
+def _fresh_ttl_cache():
+    market_dashboard_service.reset_market_dashboard_cache()
+    yield
+    market_dashboard_service.reset_market_dashboard_cache()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_market_dashboard_reuses_ttl_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, int] = {"indices": 0, "fear_greed": 0, "kimchi": 0}
+
+    def _patch(provider_cls: type, name: str, key: str) -> None:
+        async def _method(self: Any) -> dict[str, Any]:
+            calls[key] += 1
+            return {}
+
+        monkeypatch.setattr(provider_cls, name, _method)
+
+    provider = market_dashboard_service.DefaultMarketDashboardProvider
+    _patch(provider, "get_indices", "indices")
+    _patch(provider, "get_fear_greed", "fear_greed")
+    _patch(provider, "get_kimchi_premium", "kimchi")
+
+    first = await market_dashboard_service.build_market_dashboard()
+    second = await market_dashboard_service.build_market_dashboard()
+
+    assert first.sections, "first build should compose sections"
+    assert second.asOf == first.asOf, "TTL snapshot must reuse the composed response"
+    assert calls == {"indices": 1, "fear_greed": 1, "kimchi": 1}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_market_route_serves_snapshot_within_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    calls: dict[str, int] = {"indices": 0}
+
+    async def _indices(self: Any) -> dict[str, Any]:
+        calls["indices"] += 1
+        return {
+            "indices": [
+                {
+                    "name": "KOSPI",
+                    "symbol": "KOSPI",
+                    "current": 3000,
+                    "change_pct": 0.5,
+                    "data_state": "fresh",
+                }
+            ]
+        }
+
+    async def _fear_greed(self: Any) -> dict[str, Any]:
+        return {"data": [{"value": 40, "value_classification": "Fear"}]}
+
+    async def _kimchi(self: Any) -> list[dict[str, Any]]:
+        return [{"premium_pct": 1.5, "symbol": "BTC"}]
+
+    provider = market_dashboard_service.DefaultMarketDashboardProvider
+    monkeypatch.setattr(provider, "get_indices", _indices)
+    monkeypatch.setattr(provider, "get_fear_greed", _fear_greed)
+    monkeypatch.setattr(provider, "get_kimchi_premium", _kimchi)
+
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1 = await client.get("/invest/api/market")
+        r2 = await client.get("/invest/api/market")
+
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r2.json()["asOf"] == r1.json()["asOf"]
+    assert r1.json()["sections"][0]["metrics"][0]["value"] == "3,000.00"
+    assert calls["indices"] == 1, (
+        f"/market hit the external provider {calls['indices']} times within TTL"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_injected_provider_bypasses_ttl_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit provider injection (tests/tools) always builds fresh."""
+
+    class _Provider:
+        async def get_indices(self) -> dict[str, Any]:
+            return {}
+
+        async def get_fear_greed(self) -> dict[str, Any]:
+            return {}
+
+        async def get_kimchi_premium(self) -> list[dict[str, Any]]:
+            return []
+
+    first = await market_dashboard_service.build_market_dashboard(provider=_Provider())
+    second = await market_dashboard_service.build_market_dashboard(provider=_Provider())
+    assert first.state in {"missing", "error", "partial", "fresh"}
+    assert isinstance(second, object)
+    assert datetime.now(UTC) >= first.asOf

--- a/tests/test_rob1314_stock_detail_holding.py
+++ b/tests/test_rob1314_stock_detail_holding.py
@@ -1,0 +1,221 @@
+"""ROB-1314 — /stock-detail holding must read only the target symbol.
+
+The badge/holding block used to run `build_account_panel_view` (the whole
+account projection). It must instead project the single requested symbol from
+the shared portfolio snapshot (ROB-1310 read model).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import fakeredis
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+import app.routers.invest_api as invest_api
+from app.core.db import get_db
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import get_invest_home_service
+from app.routers.invest_api import router as invest_api_router
+
+
+class _SnapshotHoldingService:
+    """Service seam ROB-1314 introduces: per-symbol snapshot projection."""
+
+    def __init__(self) -> None:
+        self.symbol_calls: list[dict[str, Any]] = []
+        self.get_home_calls = 0
+        self.panel_calls = 0
+
+    async def get_home(self, **_kwargs: Any) -> Any:
+        self.get_home_calls += 1
+        raise AssertionError("stock detail called service.get_home()")
+
+    async def build_account_panel_view(self, **_kwargs: Any) -> Any:
+        self.panel_calls += 1
+        raise AssertionError("stock detail called build_account_panel_view()")
+
+    async def get_symbol_holding(
+        self, *, user_id: int, market: str, symbol: str, **_kwargs: Any
+    ) -> dict[str, Any] | None:
+        self.symbol_calls.append(
+            {"user_id": user_id, "market": market, "symbol": symbol}
+        )
+        if market == "kr" and symbol.upper() == "005930":
+            return {
+                "totalQuantity": 10.0,
+                "tradeableQuantity": 8.0,
+                "sellableQuantity": 8.0,
+                "pendingSellQuantity": 2.0,
+                "referenceQuantity": 0.0,
+                "averageCost": 70000.0,
+                "costBasis": 700000.0,
+                "valueNative": 720000.0,
+                "valueKrw": 720000.0,
+                "pnlKrw": 20000.0,
+                "pnlRate": 20000 / 700000,
+                "includedSources": ["kis"],
+                "priceState": "live",
+            }
+        return None
+
+
+def _build_app(service: _SnapshotHoldingService) -> FastAPI:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 7}
+    )()
+    app.dependency_overrides[get_invest_home_service] = lambda: service
+
+    async def _db_dep():
+        yield object()
+
+    app.dependency_overrides[get_db] = _db_dep
+
+    return app
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stock_detail_holding_reads_only_target_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The route must not fan out to the whole account panel for one symbol."""
+    from app.schemas.invest_stock_detail import StockDetailResponse
+
+    service = _SnapshotHoldingService()
+
+    async def _build_stock_detail(**kwargs: Any) -> StockDetailResponse:
+        holding = await kwargs["providers"].holding(
+            kwargs["user_id"], kwargs["market"], "005930", kwargs["db"]
+        )
+        return StockDetailResponse(
+            symbol="005930",
+            market=kwargs["market"],
+            displayName="삼성전자",
+            exchange="KRX",
+            instrumentType="equity",
+            currency="KRW",
+            assetType="equity",
+            assetCategory="kr_stock",
+            holding=holding,
+            orderbookSupport={"supported": False, "reason": "kr_unavailable"},
+            capabilities={},
+            meta={"computedAt": datetime.now(UTC), "warnings": []},
+        )
+
+    monkeypatch.setattr(invest_api, "build_stock_detail", _build_stock_detail)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=_build_app(service)),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/invest/api/stock-detail/kr/005930")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["holding"]["totalQuantity"] == 10.0
+    assert body["holding"]["averageCost"] == 70000.0
+    assert service.symbol_calls == [
+        {"user_id": 7, "market": "kr", "symbol": "005930"}
+    ]
+    assert service.get_home_calls == 0
+    assert service.panel_calls == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_symbol_holding_projects_from_shared_snapshot_without_readers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warm shared snapshot must answer the per-symbol lookup with zero reader fetches."""
+    from app.services import invest_home_service as svc_mod
+    from app.services.invest_home_service import InvestHomeService
+    from app.services.invest_home_readers import _SourceFetchResult
+    from app.services.portfolio_snapshot_cache import PortfolioSnapshotCache
+    from app.services.portfolio_snapshot import portfolio_snapshot_scope
+
+    calls = {"reader": 0}
+
+    class _Reader:
+        source = "manual"
+
+        async def fetch(self, *, user_id: int) -> _SourceFetchResult:
+            calls["reader"] += 1
+            return _SourceFetchResult(accounts=[], holdings=[])
+
+        async def fetch_held_pairs(self, *, user_id: int):
+            return []
+
+    redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    cache = PortfolioSnapshotCache(redis_client=redis_client, ttl_seconds=30)
+
+    payload = {
+        "schema_version": 1,
+        "held_pairs": [["kr", "005930"]],
+        "response": {
+            "homeSummary": {
+                "includedSources": ["kis"],
+                "excludedSources": [],
+                "totalValueKrw": 720000,
+            },
+            "accounts": [],
+            "holdings": [],
+            "groupedHoldings": [
+                {
+                    "groupId": "KR:equity:KRW:005930",
+                    "symbol": "005930",
+                    "market": "KR",
+                    "assetType": "equity",
+                    "assetCategory": "kr_stock",
+                    "displayName": "삼성전자",
+                    "currency": "KRW",
+                    "totalQuantity": 10.0,
+                    "tradeableQuantity": 8.0,
+                    "referenceQuantity": 0.0,
+                    "averageCost": 70000.0,
+                    "costBasis": 700000.0,
+                    "valueNative": 720000.0,
+                    "valueKrw": 720000.0,
+                    "pnlKrw": 20000.0,
+                    "pnlRate": 20000 / 700000,
+                    "includedSources": ["kis"],
+                    "sourceBreakdown": [],
+                }
+            ],
+            "meta": {
+                "warnings": [],
+                "hiddenCounts": {"upbitInactive": 0, "upbitDust": 0},
+                "hiddenHoldings": [],
+            },
+        },
+    }
+    scope = portfolio_snapshot_scope(
+        user_id=7, include_paper=False, paper_sources=None
+    )
+    await cache.put(scope, payload)
+
+    monkeypatch.setattr(svc_mod, "_fetch_reader_result", None)  # readers unusable
+
+    service = InvestHomeService(
+        kis_reader=None,
+        upbit_reader=None,
+        manual_reader=_Reader(),
+        snapshot_cache=cache,
+    )
+    monkeypatch.setattr(service, "_get_home_uncached", None)
+
+    holding = await service.get_symbol_holding(
+        user_id=7, market="kr", symbol="005930"
+    )
+    assert holding is not None
+    assert holding.totalQuantity == 10.0
+    assert holding.averageCost == 70000.0
+    assert calls["reader"] == 0
+
+    missing = await service.get_symbol_holding(user_id=7, market="us", symbol="AAPL")
+    assert missing is None

--- a/tests/test_rob1314_stock_detail_holding.py
+++ b/tests/test_rob1314_stock_detail_holding.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-import pytest
 import fakeredis
+import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
@@ -120,9 +120,7 @@ async def test_stock_detail_holding_reads_only_target_symbol(
     body = response.json()
     assert body["holding"]["totalQuantity"] == 10.0
     assert body["holding"]["averageCost"] == 70000.0
-    assert service.symbol_calls == [
-        {"user_id": 7, "market": "kr", "symbol": "005930"}
-    ]
+    assert service.symbol_calls == [{"user_id": 7, "market": "kr", "symbol": "005930"}]
     assert service.get_home_calls == 0
     assert service.panel_calls == 0
 
@@ -134,10 +132,10 @@ async def test_get_symbol_holding_projects_from_shared_snapshot_without_readers(
 ) -> None:
     """Warm shared snapshot must answer the per-symbol lookup with zero reader fetches."""
     from app.services import invest_home_service as svc_mod
-    from app.services.invest_home_service import InvestHomeService
     from app.services.invest_home_readers import _SourceFetchResult
-    from app.services.portfolio_snapshot_cache import PortfolioSnapshotCache
+    from app.services.invest_home_service import InvestHomeService
     from app.services.portfolio_snapshot import portfolio_snapshot_scope
+    from app.services.portfolio_snapshot_cache import PortfolioSnapshotCache
 
     calls = {"reader": 0}
 
@@ -194,9 +192,7 @@ async def test_get_symbol_holding_projects_from_shared_snapshot_without_readers(
             },
         },
     }
-    scope = portfolio_snapshot_scope(
-        user_id=7, include_paper=False, paper_sources=None
-    )
+    scope = portfolio_snapshot_scope(user_id=7, include_paper=False, paper_sources=None)
     await cache.put(scope, payload)
 
     monkeypatch.setattr(svc_mod, "_fetch_reader_result", None)  # readers unusable
@@ -209,9 +205,7 @@ async def test_get_symbol_holding_projects_from_shared_snapshot_without_readers(
     )
     monkeypatch.setattr(service, "_get_home_uncached", None)
 
-    holding = await service.get_symbol_holding(
-        user_id=7, market="kr", symbol="005930"
-    )
+    holding = await service.get_symbol_holding(user_id=7, market="kr", symbol="005930")
     assert holding is not None
     assert holding.totalQuantity == 10.0
     assert holding.averageCost == 70000.0

--- a/tests/test_rob179_smoke_evidence.py
+++ b/tests/test_rob179_smoke_evidence.py
@@ -34,6 +34,9 @@ def _make_app():
                 meta=InvestHomeResponseMeta(warnings=[]),
             )
 
+        async def get_held_pairs(self, *, user_id, include_paper=False, paper_sources=None):
+            return []
+
     app = FastAPI()
     app.include_router(invest_router)
     app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)

--- a/tests/test_rob179_smoke_evidence.py
+++ b/tests/test_rob179_smoke_evidence.py
@@ -34,7 +34,9 @@ def _make_app():
                 meta=InvestHomeResponseMeta(warnings=[]),
             )
 
-        async def get_held_pairs(self, *, user_id, include_paper=False, paper_sources=None):
+        async def get_held_pairs(
+            self, *, user_id, include_paper=False, paper_sources=None
+        ):
             return []
 
     app = FastAPI()

--- a/tests/test_stock_detail_providers.py
+++ b/tests/test_stock_detail_providers.py
@@ -193,41 +193,37 @@ async def test_market_data_orderbook_provider_empty_book_returns_none(monkeypatc
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_holding_provider_uses_account_panel_parity_without_paper():
+async def test_holding_provider_projects_requested_symbol_from_snapshot():
     from app.services.invest_view_model.stock_detail_providers import (
-        make_account_panel_holding_provider,
+        make_snapshot_symbol_holding_provider,
     )
 
     class FakeHomeService:
-        async def build_account_panel_view(
-            self, *, user_id: int, include_paper: bool = False, paper_sources=None
+        async def get_symbol_holding(
+            self, *, user_id: int, market: str, symbol: str, **_kwargs
         ):
             assert user_id == 7
-            assert include_paper is False
-            assert paper_sources is None
+            assert market == "kr"
+            assert symbol == "000270"
             return SimpleNamespace(
-                groupedHoldings=[
-                    SimpleNamespace(
-                        symbol="000270",
-                        market="KR",
-                        totalQuantity=3,
-                        tradeableQuantity=2,
-                        sellableQuantity=1,
-                        pendingSellQuantity=1,
-                        referenceQuantity=1,
-                        averageCost=80000,
-                        costBasis=240000,
-                        valueNative=255000,
-                        valueKrw=255000,
-                        pnlKrw=15000,
-                        pnlRate=0.0625,
-                        includedSources=["kis", "toss_manual"],
-                        priceState="live",
-                    )
-                ]
+                symbol="000270",
+                market="KR",
+                totalQuantity=3,
+                tradeableQuantity=2,
+                sellableQuantity=1,
+                pendingSellQuantity=1,
+                referenceQuantity=1,
+                averageCost=80000,
+                costBasis=240000,
+                valueNative=255000,
+                valueKrw=255000,
+                pnlKrw=15000,
+                pnlRate=0.0625,
+                includedSources=["kis", "toss_manual"],
+                priceState="live",
             )
 
-    provider = make_account_panel_holding_provider(FakeHomeService())
+    provider = make_snapshot_symbol_holding_provider(FakeHomeService())
 
     holding = await provider(7, "kr", "000270", object())
 
@@ -242,21 +238,16 @@ async def test_holding_provider_uses_account_panel_parity_without_paper():
 @pytest.mark.asyncio
 async def test_holding_provider_returns_none_when_symbol_not_held():
     from app.services.invest_view_model.stock_detail_providers import (
-        make_account_panel_holding_provider,
+        make_snapshot_symbol_holding_provider,
     )
 
     class FakeHomeService:
-        async def build_account_panel_view(
-            self, *, user_id: int, include_paper: bool = False, paper_sources=None
+        async def get_symbol_holding(
+            self, *, user_id: int, market: str, symbol: str, **_kwargs
         ):
-            return SimpleNamespace(
-                groupedHoldings=[
-                    SimpleNamespace(symbol="000660", market="KR"),
-                    SimpleNamespace(symbol="AAPL", market="US"),
-                ]
-            )
+            return None
 
-    provider = make_account_panel_holding_provider(FakeHomeService())
+    provider = make_snapshot_symbol_holding_provider(FakeHomeService())
 
     assert await provider(7, "kr", "000270", object()) is None
 


### PR DESCRIPTION
## 요약

Sentry 실측(\/calendar 29.6s 중 Toss snapshot 29.25s)의 원인 — 보유 배지 하나 때문에
`service.get_home()` 전체(전 리더 fan-out)를 호출하던 read path 를 ROB-1310 공유 portfolio
snapshot 소비로 전환했다. **read-path 전용** — 주문·레저·승인 경로 무접촉, order preflight 의
브로커 sellable 신규 검증은 그대로 fresh broker authority 를 유지한다(snapshot 자체가
sellable 필드를 strip 하는 계약도 그대로).

## 수용조건별 커밋

| AC | 내용 | 커밋 |
|----|------|------|
| 1 | 배지 6 라우트(`/crypto/dashboard`, `/crypto/naver-reference`, `/signals`, `/feed/news`, `/feed/research`, `/screener/results`)가 `get_held_pairs`(snapshot/manual DB key) 로 전환. cold snapshot 시 /calendar 과 동일한 typed 503 계약 | `43390096e` |
| 2 | stock detail 이 `InvestHomeService.get_symbol_holding` 으로 해당 심볼만 projection (전체 account panel 조회 제거). snapshot 불가 시 기존처럼 1회 compose 하여 배지 위조/누락 방지 | `c9b620132` |
| 3 | calendar event values SQL N+1 → IN-list bulk load 1회 (이벤트 수와 무관하게 쿼리 수 상수) | `a409ff7d8` |
| 4 | `/market` 외부 provider(market index/fear&greed/kimchi) 결과를 60s process-local TTL snapshot 으로 서빙. provider 주입 경로는 bypass | `586d07835` |

## fails-before-fix 증거

- AC1: `tests/test_rob1314_badge_held_pairs.py` — get_home() 호출 시 AssertionError 로 500 이 나도록 만든 stub 으로 6 라우트 호출. **수정 전 7 failed** (6 라우트 + 503 계약), 수정 후 7 passed.
- AC2: `tests/test_rob1314_stock_detail_holding.py` — `get_symbol_holding` 부재 + account panel 호출 단언으로 **수정 전 2 failed**, 수정 후 2 passed.
- AC3: `tests/services/test_rob1314_market_events_values_bulk_load.py` — 이벤트 6개 시딩 후 execute 카운트 상한 4 단언. **수정 전 7 executes로 실패(N+1)**, 수정 후 통과.
- AC4: `tests/test_rob1314_market_ttl_cache.py` — TTL seam 부재로 fixture AttributeError (**수정 전 3 error**), 수정 후 provider 1회 호출 단언 통과.

## 검증 (원문)

- 신규+관련 회귀 18파일: `136 passed`
- feed/research guardrails·ROB-179 smoke 포함: `15 passed`
- `make lint`: ruff check/format + ty `All checks passed!`

## 🔴 배포 후 확인 (CI 단언 대상 아님)

p95 개선은 배포 후 Sentry 실측으로 확인한다: /calendar·/signals·/feed/news·stock detail 의
Toss snapshot 구간(기존 ~29s) 소멸 여부. cold-snapshot 503 비율과 /market TTL hit rate 도 함께 관찰.

## 행동 변화 명시

- 배지 6 라우트는 snapshot 이 cold 하면 이제 503(`portfolio_snapshot_unavailable` +
  `manual_pairs_available` 메타)을 낸다(/calendar 의 ROB-1310 계약과 동일). 실패 닫힘 —
  누락된 배지를 조용히 비보유로 표시하지 않는다.
- stock detail holding 은 snapshot strip 에 따라 sellable/pendingSell 이 None/0 으로 올 수 있다
  (기존 warm 경로와 동일). 판단 근거 변화는 meta warnings(`holding_unavailable`)로 표기.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Market dashboard data now reuses snapshots for up to 60 seconds, improving response consistency and reducing repeated loading.
  - Stock details retrieve holdings for the requested symbol directly.
  - Investment badge routes use held-position data with clearer handling when snapshots are unavailable.

- **Bug Fixes**
  - Market event values are loaded more efficiently, reducing unnecessary database queries.

- **Tests**
  - Added coverage for snapshot caching, symbol-specific holdings, badge routes, and bulk event loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->