### PR TITLE
test(D2): unbind the r8 authority tests from the wall clock (ROB-1316)

### DIFF
--- a/tests/services/brokers/binance/spot_demo/test_d2_r8_authority_registration.py
+++ b/tests/services/brokers/binance/spot_demo/test_d2_r8_authority_registration.py
@@ -96,6 +96,7 @@ SECTION_132_MANIFEST_SHA256 = (
 
 #: Well before the artifact's expiry, so the "it clears" cases assert an
 #: authority state rather than a wall-clock accident.
+D2_R8_EXPIRY_ISO = "2026-08-22T14:59:59+00:00"
 BEFORE_EXPIRY = dt.datetime(2026, 8, 21, 13, 0, tzinfo=dt.UTC)
 AFTER_EXPIRY = dt.datetime(2026, 8, 23, 0, 0, tzinfo=dt.UTC)
 
@@ -659,14 +660,38 @@ def test_m8_a_missing_third_order_is_refused_too(
 # --------------------------------------------------------------------------
 
 
+# ROB-1316: the shipped r8 authority expired 2026-08-22T14:59:59Z by design, and
+# the expiry is deliberately evaluated against the real clock (a ``now_fn`` fixed
+# in the past must not revive a one-shot). So a test that needs a *live* dispatch
+# authority cannot pin the clock — it has to seal its own authority with a future
+# expiry. LIVE_EXPIRY is far-future on purpose: a near date would just re-arm the
+# same bomb this commit is defusing.
+LIVE_EXPIRY = "2099-12-31T23:59:59Z"
+
+
+def _live_authority(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Seal a copy of the shipped authority whose only change is a live expiry.
+
+    Registration is monkeypatched module state — the shipped ``Final[Mapping]``
+    is untouched, so this cannot authorize anything outside the test process.
+    """
+
+    payload = artifact_payload()
+    payload["expiry"] = LIVE_EXPIRY
+    return load_sealed_authority(write_authority(tmp_path, monkeypatch, payload))
+
+
 def _writer(
-    monkeypatch: pytest.MonkeyPatch, client: FakeExecutionClient
+    monkeypatch: pytest.MonkeyPatch,
+    client: FakeExecutionClient,
+    *,
+    authority=None,
 ) -> d2.D2RemediationSingleWriter:
     monkeypatch.setenv(D2_REMEDIATION_ENABLED_ENV, "true")
     lease, grant = make_lease()
     return d2.D2RemediationSingleWriter(
         execution_client=client,  # type: ignore[arg-type]
-        authority=load_sealed_authority(ARTIFACT),
+        authority=load_sealed_authority(ARTIFACT) if authority is None else authority,
         lease=lease,
         lease_grant=grant,
         ledger=FakeLedger(),
@@ -675,20 +700,31 @@ def _writer(
 
 @pytest.mark.asyncio
 async def test_the_dry_run_is_still_the_default_under_the_r8_authority(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """🔴 Authorizing dispatch did not make dispatch the default.
 
-    ``execute()`` with no argument mutates nothing, even now that the authority
-    is complete — which is the property most at risk from this cutover.
+    ``execute()`` with no argument mutates nothing *while dispatch is actually
+    authorized* — the property most at risk from this cutover. ROB-1316: the
+    shipped authority has since expired, and against an expired authority the
+    assertion is vacuous (nothing dispatches anyway), so this seals a live
+    authority to keep proving the risky case.
     """
 
     client = FakeExecutionClient()
-    report = await _writer(monkeypatch, client).execute()
+    writer = _writer(
+        monkeypatch, client, authority=_live_authority(tmp_path, monkeypatch)
+    )
+    assert writer.dispatch_block_reasons() == ()  # precondition: dispatch is armed
+    report = await writer.execute()
     assert isinstance(report, d2.D2DryRunReport)
     assert client.submit_calls == []
     assert report.broker_mutation_count == 0
     assert report.dispatch_block_reasons == ()
+    # ROB-1316: the armed-evidence assertion lives here now — it can only be made
+    # against a live authority, and the shipped one has lapsed.
+    assert report.as_evidence()["dispatch_authorized"] is True
 
 
 @pytest.mark.asyncio
@@ -733,10 +769,19 @@ async def test_the_dry_run_operations_are_the_three_contract_operations(
         tuple(op.operation_id for op in report.operations) == D2_ALLOWED_OPERATION_IDS
     )
     evidence = report.as_evidence()
-    assert evidence["dispatch_authorized"] is True
     assert evidence["broker_mutation_count"] == 0
     assert evidence["authority"]["payload_sha256"] == D2_R8_EXECUTION_AUTHORITY_SHA256
     assert evidence["pre_snapshot_hash"] == SECTION_132_PRE_SNAPSHOT_HASH
+    # ROB-1316: the shipped r8 authority lapsed at its sealed expiry, so evidence
+    # built from it reports dispatch as unauthorized and says why. The armed case
+    # is proven in ``test_the_dry_run_is_still_the_default_under_the_r8_authority``
+    # against a sealed live authority. Asserting the lapse here keeps this test
+    # bound to the real artifact instead of quietly re-arming it.
+    assert evidence["dispatch_authorized"] is False
+    assert any(
+        reason.startswith(f"authority expired at {D2_R8_EXPIRY_ISO}")
+        for reason in evidence["dispatch_block_reasons"]
+    )
 
 
 @pytest.mark.asyncio
@@ -783,9 +828,20 @@ async def test_a_backdated_clock_cannot_revive_the_expired_r8_authority(
     )
     # The expiry comparison uses the real clock, so this test says the same
     # thing before and after 2026-08-22: the seam is not wired to the gate.
+    # ROB-1316: compare the *decision*, not the rendered string — the reason text
+    # embeds ``now`` at microsecond precision, so two wall-clock reads a few
+    # hundred microseconds apart never compare equal once the authority expires.
     real_now = dt.datetime.now(dt.UTC)
     expected = load_sealed_authority(ARTIFACT).dispatch_block_reasons(now=real_now)
-    assert writer.dispatch_block_reasons() == expected
+    observed = writer.dispatch_block_reasons()
+    assert len(observed) == len(expected)
+    prefix = f"authority expired at {D2_R8_EXPIRY_ISO}"
+    if expected:
+        # Backdating now_fn to 2020 did not clear the real-clock expiry.
+        assert any(reason.startswith(prefix) for reason in observed)
+    assert [r.split(" (now ")[0] for r in observed] == [
+        r.split(" (now ")[0] for r in expected
+    ]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
main 이 2026-08-23 부터 빨간 상태였고, 그 때문에 열린 PR 전부가 막혀 있었다.

**원인**: 봉인된 r8 실행 권한이 **설계대로** `2026-08-22T14:59:59Z` 에 만료됐다. 프로덕션 코드는 정상 동작(fail-closed 차단)이고, 만료를 가정하지 않은 테스트 3건이 벽시계에 묶여 깨진 것.

🔴 **시계 고정은 해법이 아니다** — 만료 비교가 벽시계를 쓰는 건 의도적이다(과거로 고정한 `now_fn` 이 one-shot 권한을 되살리는 우회를 막기 위함, 코드 주석에 명시). 그래서:

| 테스트 | 조치 |
|---|---|
| dry-run-is-default | **미래 만료(2099) 권한을 자체 봉인**해 "dispatch 가 armed 인데도 dry-run 이 기본" 이라는 위험 케이스를 계속 증명 (만료 권한 상대로는 공허하게 통과할 뿐) |
| operations/evidence | 실 아티팩트에 **그대로 결속 유지**, 관측되는 만료 사실을 단언 (조용히 재무장하지 않음) |
| backdated-clock 가드 | 렌더된 문자열 대신 **판정**을 비교 — reason 텍스트가 `now` 를 마이크로초까지 담아, 만료 후에는 두 벽시계 읽기가 절대 같지 않았다 |

**권한 자체는 손대지 않았고 만료 상태 그대로다.** 재등록(§135차)이 필요하면 별도 운영자 결정.

**적대 검증**: 만료 검사를 `_now_fn` seam 으로 바꿔보면 backdated-clock 가드가 정확히 실패한다 — 우회 방지 속성이 살아있음을 확인.

검증: `54 passed` (파일 전체) · ruff/format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
