### PR TITLE
fix(policy): §142차 — breakeven 밴드 경계 충돌 국소 수리 (versioned bugfix)

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -70,8 +70,87 @@ class PolicyDecisionRuleTier(BaseModel):
 
 
 BREAKEVEN_EXTENSION_LADDER_TIER_ID = "breakeven_extension_ladder"
+BREAKEVEN_RESERVE_TRIM_TIER_ID = "sell.breakeven_reserve_trim"
 NO_RESISTANCE_REFERENCE_EXCLUSION = "no_resistance_reference"
 _RESISTANCE_CONDITION_MARKER = "resistance_near_pct"
+
+# §142차 (2026-08-23) — break-even band edge repair, machine-pinned.
+#
+# Two sell anchors are defined as average_cost × sell.loss_guard_min_multiple
+# (1.01). That is EXACTLY the §40차 break-even band edge
+# (order_proposals.auto_approve.breakeven_band_pct = 1), and
+# ``classify_sell_profit`` compares that band INCLUSIVELY
+# (``abs(distance_from_avg) <= band``). Whenever average_cost × 1.01 already
+# sits on the market tick grid the ceil snap is a no-op, the rung sits on the
+# boundary, and it is classified ``breakeven_band`` instead of ``take_profit``
+# -- so the tier's own ``submission_contract`` can never be satisfied.
+#
+# The repair is local to the two anchors: their EFFECTIVE value is the max of
+# the tick-ceiled raw anchor and the first valid tick STRICTLY above the band
+# edge. The inclusive comparison in the classifier is deliberately NOT changed
+# -- other consumers of that comparison were not audited, and a global
+# ``<=`` -> ``<`` edit is out of scope (GPT Pro checkpoint #3, Q4).
+BREAKEVEN_BAND_POLICY_KEY = "order_proposals.auto_approve.breakeven_band_pct"
+_BAND_CLEARING_OPERAND = (
+    "first_valid_tick_strictly_above_average_cost_times_one_plus_breakeven_band"
+)
+_S142_ANCHOR_REASON = "section_40_breakeven_band_comparison_is_inclusive"
+_S142_ANCHOR_VERSION = "2026-08-23.1"
+
+
+def _validate_band_clearing_anchor(
+    conditions: dict[str, RuleConditionValue],
+    *,
+    tier_id: str,
+    prefix: str,
+    raw_operand: str,
+) -> None:
+    """Pin the §142차 effective-anchor contract on one tier.
+
+    Every invariant the operator forbade drifting is asserted, so a later edit
+    that silently drops the band-clearing operand, re-points the band key, or
+    back-dates the fix fails the build instead of shipping.
+    """
+
+    if conditions.get(f"{prefix}_operator") != "max":
+        raise ValueError(
+            f"{tier_id} requires {prefix}_operator: max -- the repair may only "
+            "raise the anchor, never lower it"
+        )
+    operands = conditions.get(f"{prefix}_operands")
+    if operands != [raw_operand, _BAND_CLEARING_OPERAND]:
+        raise ValueError(
+            f"{tier_id} requires {prefix}_operands "
+            f"{[raw_operand, _BAND_CLEARING_OPERAND]}"
+        )
+    if conditions.get(f"{prefix}_band_policy_key") != BREAKEVEN_BAND_POLICY_KEY:
+        raise ValueError(
+            f"{tier_id} must derive its band edge from {BREAKEVEN_BAND_POLICY_KEY}, "
+            "not a literal"
+        )
+    if conditions.get(f"{prefix}_reason") != _S142_ANCHOR_REASON:
+        raise ValueError(
+            f"{tier_id} must record {prefix}_reason: {_S142_ANCHOR_REASON}"
+        )
+    # The repair buys its way out of the boundary by moving the RUNG, not by
+    # loosening the classifier. If a later edit claims the comparison changed,
+    # this pin is the thing that has to be deleted first.
+    if conditions.get(f"{prefix}_band_comparison_unchanged") is not True:
+        raise ValueError(
+            f"{tier_id} must declare {prefix}_band_comparison_unchanged: true -- "
+            "the §40차 inclusive band comparison is not changed by this repair"
+        )
+    if conditions.get(f"{prefix}_since_policy_version") != _S142_ANCHOR_VERSION:
+        raise ValueError(
+            f"{tier_id} must stamp {prefix}_since_policy_version: "
+            f"{_S142_ANCHOR_VERSION}"
+        )
+    if conditions.get(f"{prefix}_retroactive") is not False:
+        raise ValueError(
+            f"{tier_id} must declare {prefix}_retroactive: false -- placements "
+            "made under an earlier policy version are not re-anchored"
+        )
+
 
 # §139차 (2026-08-22) — the two tiers added by §139차 are the first decision
 # rules that are not meaningful in every market: the index-ETF admission is a
@@ -546,6 +625,45 @@ class PolicyDecisionRule(BaseModel):
                 "(tick_snap_direction: ceil)"
             )
 
+        # §142차 — rung 1 sits exactly on the §40차 break-even band edge, which
+        # is compared inclusively; clear it by one tick and no more.
+        _validate_band_clearing_anchor(
+            conditions,
+            tier_id=BREAKEVEN_EXTENSION_LADDER_TIER_ID,
+            prefix="tier1_effective_anchor",
+            raw_operand="tick_ceil_average_cost_times_lowest_multiple",
+        )
+        # Scope pin: rungs 2 and 3 are far outside the band and must not be
+        # dragged into this repair.
+        if conditions.get("tier1_effective_anchor_scope") != "lowest_rung_only":
+            raise ValueError(
+                f"{BREAKEVEN_EXTENSION_LADDER_TIER_ID} must declare "
+                "tier1_effective_anchor_scope: lowest_rung_only"
+            )
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_breakeven_reserve_trim_clears_the_band_edge(
+        self,
+    ) -> PolicyDecisionRule:
+        """§142차 — the reserve-trim post-max anchor has the same conflict.
+
+        Its anchor is ``max(average_cost × loss_guard, d7_compliant_lowest_price)``
+        snapped up onto the tick grid. When the guard operand wins the max the
+        result is the break-even band edge itself, so the identical repair
+        applies. When the D7 operand wins, the band-clearing operand is inert.
+        """
+
+        tier = self._tier_by_id(BREAKEVEN_RESERVE_TRIM_TIER_ID)
+        if tier is None:
+            return self
+        _validate_band_clearing_anchor(
+            tier.conditions,
+            tier_id=BREAKEVEN_RESERVE_TRIM_TIER_ID,
+            prefix="post_max_effective_anchor",
+            raw_operand="tick_ceil_post_max_anchor",
+        )
         return self
 
 

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -13,9 +13,20 @@
 # one_share 절대상한 철폐, 지수 ETF 유니버스 동등 편입, crypto 보유
 # 메이저 지지선 사전 그물(한시·4주 채점). 세 개 모두 게이트를 낮추지
 # 않고, 세 번째는 배치 전에 폐지 조건을 문서에 고정해 둔다.
-version: "2026-08-22.1"
+# §142차 (2026-08-23): 정책 절 간 모순 1건 해소(versioned bugfix, 소급 적용
+# 금지). §115차 래더 1단 앵커(평단×1.01)와 §44차 reserve-trim post-max 앵커는
+# §40차 breakeven_band_pct=1% 의 **포함 비교**(|distance| <= band)와 경계에서
+# 충돌한다 — 평단×1.01 이 이미 틱 배수면 tick ceil 이 no-op 이라 매도 rung 이
+# 밴드 경계에 그대로 앉고, take_profit 이 breakeven_band 로 강등되어 §40차
+# 자동승인 레인에 영원히 진입하지 못한다(검증자 실측: avg 4,000,000 KRW →
+# raw 4,040,000 → ceil no-op → eligible=False reason='breakeven_band').
+# 수리는 국소적이다: 두 앵커의 실효값을 밴드 상단 위 첫 유효 틱까지만 밀어
+# 올린다. 🔴 classify_sell_profit 의 전역 포함 비교(<=)는 건드리지 않는다
+# (밴드 분류기의 다른 소비자 전수검토 없이 <= → < 변경 금지). 신규 티어·임계
+# 완화·수량 규칙 변경 0.
+version: "2026-08-23.1"
 captured_as_of: "2026-08-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change); §127차 concurrent-new-entry slots 1→2 and buy.winner_pullback_add pre-registered tier 2026-08-21 (operator decision in claude-mock session; breakout chase remains forbidden); §129차 buy.new_entry_overflow cash-conditioned overflow slots at 0.5x sizing 2026-08-21 (operator decision in claude-mock session; no gate relaxed); §133차 KR per-order auto-approve cap 2M 2026-08-21 (single-share high-priced KR exits structurally carded — SK하이닉스 1,776,000 measured case, §65차 US twin; daily cap unchanged); §136차 A(k) two add symbols per market + owned-symbol add exempt from new-entry symbol cap 2026-08-21 (operator directive to deploy idle Upbit KRW; measured blocker from 2026-08-21 20:20 session; k_used retained at 0.10 — k is the averaging-target parameter, and raising it flips A_limit non-positive, the opposite of expansion); §139차 buy-side retrospective decisions 2026-08-22 (operator decisions in claude-mock session, sourced from retro-buyside-multiweek-20260822.md): US one_share_exception absolute_ceiling_usd 700 -> 10000 (operator: deposited cash is the ceiling; the real boundary is cash plus the USD 1,500 per-order auto-approve cap, and the AVGO -11.58% counter-evidence is retained), buy.index_etf_candidate equal-candidate universe admission for broad index ETFs with structurally-absent gates declared not-applicable rather than waived, and buy.held_majors_support_net time-boxed pre-registered LIVE crypto tier for profitable held coins (<=300k KRW per coin, <=900k KRW tier, scored 2026-09-19 and retired unless the filled cohort D+20 median >= 0 and lower quartile > -8%; ROB-1031 60% post-touch breakdown and the XRP -8.36% one-hour flush recorded as counter-evidence). No gate relaxed for new-coin discovery; no approval cap raised."
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change); §127차 concurrent-new-entry slots 1→2 and buy.winner_pullback_add pre-registered tier 2026-08-21 (operator decision in claude-mock session; breakout chase remains forbidden); §129차 buy.new_entry_overflow cash-conditioned overflow slots at 0.5x sizing 2026-08-21 (operator decision in claude-mock session; no gate relaxed); §133차 KR per-order auto-approve cap 2M 2026-08-21 (single-share high-priced KR exits structurally carded — SK하이닉스 1,776,000 measured case, §65차 US twin; daily cap unchanged); §136차 A(k) two add symbols per market + owned-symbol add exempt from new-entry symbol cap 2026-08-21 (operator directive to deploy idle Upbit KRW; measured blocker from 2026-08-21 20:20 session; k_used retained at 0.10 — k is the averaging-target parameter, and raising it flips A_limit non-positive, the opposite of expansion); §139차 buy-side retrospective decisions 2026-08-22 (operator decisions in claude-mock session, sourced from retro-buyside-multiweek-20260822.md): US one_share_exception absolute_ceiling_usd 700 -> 10000 (operator: deposited cash is the ceiling; the real boundary is cash plus the USD 1,500 per-order auto-approve cap, and the AVGO -11.58% counter-evidence is retained), buy.index_etf_candidate equal-candidate universe admission for broad index ETFs with structurally-absent gates declared not-applicable rather than waived, and buy.held_majors_support_net time-boxed pre-registered LIVE crypto tier for profitable held coins (<=300k KRW per coin, <=900k KRW tier, scored 2026-09-19 and retired unless the filled cohort D+20 median >= 0 and lower quartile > -8%; ROB-1031 60% post-touch breakdown and the XRP -8.36% one-hour flush recorded as counter-evidence). No gate relaxed for new-coin discovery; no approval cap raised. §142차 breakeven band boundary repair 2026-08-23 (GPT Pro checkpoint #3 Q4 permitted class 'policy-clause contradiction resolution'; versioned bugfix, NOT retroactive — cohorts and forecasts stamped with an earlier policy version keep the anchor they were placed under): the §115차 breakeven_extension_ladder tier-1 anchor and the §44차 sell.breakeven_reserve_trim post-max anchor now resolve to max(tick_ceil(raw anchor), first valid tick STRICTLY above average_cost × (1 + order_proposals.auto_approve.breakeven_band_pct / 100)), because the §40차 break-even band comparison is inclusive (|distance| <= band) and a rung that lands exactly on avg × 1.01 was classified breakeven_band instead of take_profit whenever the tick ceil was a no-op. The §40차 classifier itself is unchanged — the inclusive comparison stays inclusive globally — and no threshold, cap, tier, sizing rule, or exclusion is added or relaxed."
 
 authority:
   scope: judgment_policy_only
@@ -627,7 +638,16 @@ decision_rules:
       breakeven_extension_ladder is the last-resort fallback for a holding with
       zero fresh named resistance: it is reached only after every named-
       resistance tier has failed to match, never instead of one, and it does not
-      remove or weaken the no_resistance_reference exclusion.
+      remove or weaken the no_resistance_reference exclusion. §142차 (2026-08-23)
+      resolves one contradiction between clauses: both breakeven_extension_ladder
+      rung 1 and the sell.breakeven_reserve_trim post-max anchor can land exactly
+      on the §40차 break-even band edge (average_cost × 1.01), and that band is
+      compared inclusively, so such a rung is downgraded to breakeven_band and
+      can never be auto-approved. Their EFFECTIVE anchors are therefore the max
+      of the tick-ceiled raw anchor and the first valid tick strictly above the
+      band edge. This is a versioned bugfix, is not applied retroactively, adds
+      no tier, relaxes no threshold, changes no sizing rule, and does not change
+      the inclusive band comparison for any other consumer.
     tiers:
       - id: de_minimis_trim_watch
         conditions:
@@ -653,6 +673,22 @@ decision_rules:
           d7_scope_semantics: one_share_net_realized_gain_not_total_trim
           d7_estimation_limit_semantics: consumer_estimated_fees_and_taxes_required_no_fee_or_tax_model_added_by_this_tier
           post_max_tick_snap_direction: ceil
+          # §142차 (2026-08-23) — versioned bugfix, not retroactive. The
+          # post-max anchor can resolve to average_cost × loss_guard (when the
+          # guard operand wins the max), which is exactly the §40차 break-even
+          # band edge; the band comparison is INCLUSIVE, so such a rung is
+          # classified breakeven_band and never reaches the auto-approve lane.
+          # The effective anchor is therefore pushed to the first valid tick
+          # strictly above the band edge — and no further.
+          post_max_effective_anchor_operator: max
+          post_max_effective_anchor_operands:
+            - tick_ceil_post_max_anchor
+            - first_valid_tick_strictly_above_average_cost_times_one_plus_breakeven_band
+          post_max_effective_anchor_band_policy_key: order_proposals.auto_approve.breakeven_band_pct
+          post_max_effective_anchor_reason: section_40_breakeven_band_comparison_is_inclusive
+          post_max_effective_anchor_band_comparison_unchanged: true
+          post_max_effective_anchor_since_policy_version: "2026-08-23.1"
+          post_max_effective_anchor_retroactive: false
           resting_limit_order: true
           time_in_force: DAY
           regeneration: daily_rep
@@ -735,6 +771,27 @@ decision_rules:
           rungs_max: 3
           tick_snap_direction: ceil
           tick_grid: market_native_sell_side_tick_grid
+          # §142차 (2026-08-23) — versioned bugfix, not retroactive. Rung 1 is
+          # average_cost × 1.01, which IS the §40차 break-even band edge
+          # (breakeven_band_pct = 1). classify_sell_profit compares inclusively
+          # (|distance| <= band), so whenever average_cost × 1.01 already sits
+          # on the tick grid the ceil snap is a no-op and rung 1 is downgraded
+          # from take_profit to breakeven_band — the §115차 net can never be
+          # auto-submitted. Measured: avg 4,000,000 KRW → raw 4,040,000 →
+          # ceil no-op → eligible=False reason='breakeven_band'.
+          # Rungs 2 and 3 (1.05 / 1.10) sit far outside the band and are
+          # untouched; this repair applies to rung 1 only and lifts it by at
+          # most one tick above the band edge.
+          tier1_effective_anchor_operator: max
+          tier1_effective_anchor_operands:
+            - tick_ceil_average_cost_times_lowest_multiple
+            - first_valid_tick_strictly_above_average_cost_times_one_plus_breakeven_band
+          tier1_effective_anchor_band_policy_key: order_proposals.auto_approve.breakeven_band_pct
+          tier1_effective_anchor_reason: section_40_breakeven_band_comparison_is_inclusive
+          tier1_effective_anchor_band_comparison_unchanged: true
+          tier1_effective_anchor_scope: lowest_rung_only
+          tier1_effective_anchor_since_policy_version: "2026-08-23.1"
+          tier1_effective_anchor_retroactive: false
           resting_limit_order: true
           time_in_force: DAY
           regeneration: daily_rep

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -334,6 +334,19 @@ lanes:
           operator: max
           operands: [average_cost_times_loss_guard, d7_compliant_lowest_price]
           post_max_tick_snap_direction: ceil
+          # §142차 (2026-08-23) — average_cost × loss_guard IS the §40차
+          # break-even band edge, and that band is compared inclusively, so a
+          # rung landing on it is downgraded to breakeven_band. The effective
+          # anchor clears the edge by one tick; nothing else changes.
+          post_max_effective_anchor:
+            operator: max
+            operands:
+              - tick_ceil_post_max_anchor
+              - first_valid_tick_strictly_above_average_cost_times_one_plus_breakeven_band
+            band_policy_key: order_proposals.auto_approve.breakeven_band_pct
+            band_comparison_unchanged: true
+            since_policy_version: "2026-08-23.1"
+            retroactive: false
         sizing: existing_trim_rule
         time_in_force: DAY
         regeneration: daily_rep

--- a/docs/runbooks/order-proposal-auto-approve-expand.md
+++ b/docs/runbooks/order-proposal-auto-approve-expand.md
@@ -65,6 +65,22 @@ verdict the shipped mode reaches.
    → `breakeven_band`. Ahead of the sign test on purpose: §40차 sends the band
    to a human *whatever the sign*, so a sell 0.5% above cost is still a human's
    call. The band is inclusive — exactly ±1% is inside it.
+
+   > 🔴 **§142차 (2026-08-23) — the inclusive edge is a producer problem, not a
+   > classifier problem.** Two sell tiers anchor at `average_cost × 1.01`
+   > (`sell.loss_guard_min_multiple`), which *is* this edge when
+   > `breakeven_band_pct = 1`. Whenever `average_cost × 1.01` already sits on the
+   > market tick grid the ceil snap is a no-op and the rung lands exactly on the
+   > boundary, so it is classified `breakeven_band` and can never be auto-approved
+   > (measured: avg 4,000,000 KRW → 4,040,000 → `eligible=False
+   > reason='breakeven_band'`). The repair moved the **rungs**:
+   > `decision_rules.sell.trim_preplace` now declares an effective anchor of
+   > `max(tick_ceil(raw anchor), first valid tick strictly above the band edge)`
+   > for `breakeven_extension_ladder` rung 1 and for the
+   > `sell.breakeven_reserve_trim` post-max anchor. **This comparison stayed
+   > inclusive on purpose** — changing `<=` to `<` here would silently re-classify
+   > every other consumer of the band and was explicitly out of scope. If you are
+   > adding a new sell producer, clear the edge on the producer side.
 3. **net P&L strictly positive.**
    `net = (limit − avg) × qty − max(limit, avg) × qty × round_trip_cost_bps / 10000`.
    `net > 0` → `take_profit`; `net == 0` → `expected_pnl_not_positive`. Exactly

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -219,7 +219,7 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
     }
     # advisory keys are echoed with the same version/content_hash stamp as
     # every other section of the response (ROB-932).
-    assert out["version"] == "2026-08-22.1"
+    assert out["version"] == "2026-08-23.1"
     assert out["content_hash"]
 
 

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,7 +15,11 @@ from app.schemas.trading_policy import (
     SupportReserveNetDecisionRule,
     TradingPolicyDocument,
 )
-from app.services.order_proposals.auto_approve import _VETO_CAPABLE_ACCOUNT_MARKETS
+from app.services.order_proposals.auto_approve import (
+    _VETO_CAPABLE_ACCOUNT_MARKETS,
+    AutoApproveLimits,
+    classify_sell_profit,
+)
 from app.services.trading_policy_service import load_trading_policy
 
 _CONFIG = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
@@ -35,6 +39,20 @@ _ROB1298_ADDITIVE_TIE_BREAK_KEYS = (
     "breakeven_extension_fallback_order",
     "breakeven_extension_exclusion_retained",
     "breakeven_extension_minimum_benefit",
+)
+
+# §142차 (2026-08-23) — the ONLY delta this bugfix makes to a pre-existing
+# tier: seven additive condition keys on sell.breakeven_reserve_trim that
+# declare the effective post-max anchor. No pre-existing key or value is
+# touched, which is what the closed-equivalence test below re-proves.
+_S142_RESERVE_TRIM_ADDITIVE_CONDITION_KEYS = (
+    "post_max_effective_anchor_operator",
+    "post_max_effective_anchor_operands",
+    "post_max_effective_anchor_band_policy_key",
+    "post_max_effective_anchor_reason",
+    "post_max_effective_anchor_band_comparison_unchanged",
+    "post_max_effective_anchor_since_policy_version",
+    "post_max_effective_anchor_retroactive",
 )
 
 _ROB1292_ALLOWED_POLICY_DELTAS = (
@@ -160,6 +178,62 @@ def _breakeven_reserve_trim_post_max_tick_snap(
     return (anchor / tick_size).to_integral_value(rounding=rounding) * tick_size
 
 
+def _breakeven_band_pct(policy_key: str) -> Decimal:
+    """Resolve the §40차 band from its declared dotted policy key."""
+
+    value = _raw()
+    for part in policy_key.split("."):
+        value = value[part]
+    return Decimal(str(value))
+
+
+def _first_valid_tick_strictly_above(market: str, value: Decimal) -> Decimal:
+    """Smallest price on the market grid that is > ``value`` (never ==)."""
+
+    tick = _market_tick(market, value)
+    snapped = (value / tick).to_integral_value(rounding=ROUND_CEILING) * tick
+    if snapped <= value:
+        snapped += tick
+    # A band-boundary crossing must still land on the grid that governs the
+    # resulting price; every KRX/Upbit band boundary is a multiple of the
+    # coarser tick, so this holds -- assert it rather than assume it.
+    assert snapped % _market_tick(market, snapped) == 0, (market, value, snapped)
+    return snapped
+
+
+def _band_clearing_effective_anchor(
+    conditions,
+    *,
+    prefix: str,
+    market: str,
+    average_cost: Decimal,
+    tick_ceiled_raw_anchor: Decimal,
+    raw_operand: str,
+) -> Decimal:
+    """Test-only interpreter for the §142차 effective-anchor contract.
+
+    Nothing is invented here: the operator, the operand names, and the band
+    policy key are all read out of the YAML tier.
+    """
+
+    band_pct = _breakeven_band_pct(
+        str(conditions[f"{prefix}_band_policy_key"]),
+    )
+    band_edge = average_cost * (Decimal("1") + band_pct / Decimal("100"))
+    operands = {
+        raw_operand: tick_ceiled_raw_anchor,
+        "first_valid_tick_strictly_above_average_cost_"
+        "times_one_plus_breakeven_band": _first_valid_tick_strictly_above(
+            market, band_edge
+        ),
+    }
+    resolved = [operands[str(name)] for name in conditions[f"{prefix}_operands"]]
+    operator = conditions[f"{prefix}_operator"]
+    if operator == "max":
+        return max(resolved)
+    raise AssertionError(f"unsupported effective-anchor operator: {operator!r}")
+
+
 def _breakeven_reserve_trim_triggered(
     tier,
     *,
@@ -184,7 +258,7 @@ def _breakeven_reserve_trim_triggered(
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
-    assert doc.version == "2026-08-22.1"
+    assert doc.version == "2026-08-23.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -545,6 +619,24 @@ def test_breakeven_reserve_trim_policy_contract_is_machine_readable():
             "consumer_estimated_fees_and_taxes_required_no_fee_or_tax_model_added_by_this_tier"
         ),
         "post_max_tick_snap_direction": "ceil",
+        # §142차 (2026-08-23) — break-even band edge repair.
+        "post_max_effective_anchor_operator": "max",
+        "post_max_effective_anchor_operands": [
+            "tick_ceil_post_max_anchor",
+            (
+                "first_valid_tick_strictly_above_average_cost_"
+                "times_one_plus_breakeven_band"
+            ),
+        ],
+        "post_max_effective_anchor_band_policy_key": (
+            "order_proposals.auto_approve.breakeven_band_pct"
+        ),
+        "post_max_effective_anchor_reason": (
+            "section_40_breakeven_band_comparison_is_inclusive"
+        ),
+        "post_max_effective_anchor_band_comparison_unchanged": True,
+        "post_max_effective_anchor_since_policy_version": "2026-08-23.1",
+        "post_max_effective_anchor_retroactive": False,
         "resting_limit_order": True,
         "time_in_force": "DAY",
         "regeneration": "daily_rep",
@@ -677,6 +769,23 @@ def test_sell_lane_machine_block_adds_breakeven_reserve_trim_without_tool_or_gat
                 "d7_compliant_lowest_price",
             ],
             "post_max_tick_snap_direction": "ceil",
+            # §142차 (2026-08-23) — the playbook's machine block carries the
+            # same effective anchor as the policy tier, or a session reading
+            # only the playbook would keep placing rungs on the band edge.
+            "post_max_effective_anchor": {
+                "operator": "max",
+                "operands": [
+                    "tick_ceil_post_max_anchor",
+                    (
+                        "first_valid_tick_strictly_above_average_cost_"
+                        "times_one_plus_breakeven_band"
+                    ),
+                ],
+                "band_policy_key": ("order_proposals.auto_approve.breakeven_band_pct"),
+                "band_comparison_unchanged": True,
+                "since_policy_version": "2026-08-23.1",
+                "retroactive": False,
+            },
         },
         "sizing": "existing_trim_rule",
         "time_in_force": "DAY",
@@ -1013,6 +1122,20 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
     baseline_trim["tie_breaks"]["tier_priority"] = current_trim["tie_breaks"][
         "tier_priority"
     ]
+    # §142차 (2026-08-23) KEY_DIFF — the effective post-max anchor keys are new
+    # on sell.breakeven_reserve_trim and are now required by the schema, so the
+    # baseline copy is given the current values before parsing. Assert they are
+    # genuinely absent from the baseline first, then strip them from BOTH dumps
+    # below so the remaining comparison stays a closed equivalence.
+    baseline_reserve_trim = baseline_trim["tiers"][1]
+    current_reserve_trim = current_trim["tiers"][1]
+    assert baseline_reserve_trim["id"] == "sell.breakeven_reserve_trim"
+    assert current_reserve_trim["id"] == "sell.breakeven_reserve_trim"
+    for key in _S142_RESERVE_TRIM_ADDITIVE_CONDITION_KEYS:
+        assert key not in baseline_reserve_trim["conditions"]
+        baseline_reserve_trim["conditions"][key] = current_reserve_trim["conditions"][
+            key
+        ]
     # §136차 (2026-08-21) — A(k) 사이징/커버리지 델타. 현행 스키마 핀(k 0.20,
     # Literal[2], 신설 면제 키)이 baseline을 파싱할 수 있도록 사전 패치하되,
     # baseline 원값을 먼저 고정 확인한다.
@@ -1119,6 +1242,26 @@ def test_rob_1289_preserves_all_preexisting_policy_keys_and_values():
             .endswith("> watch_zone > breakeven_extension_ladder")
         )
         del trim["semantics"]
+    # §142차 (2026-08-23) — the reserve-trim tier gains exactly the seven
+    # enumerated additive condition keys and nothing else. Pin their values
+    # here (a silent re-point of the band key or a back-dated stamp fails) and
+    # strip them; every other key on that tier must still match the baseline.
+    for dump in (normalized_current_dump, baseline_dump):
+        s142_tier = dump["decision_rules"]["sell.trim_preplace"]["tiers"][1]
+        assert s142_tier["id"] == "sell.breakeven_reserve_trim"
+        conditions = s142_tier["conditions"]
+        assert conditions["post_max_effective_anchor_operator"] == "max"
+        assert conditions["post_max_effective_anchor_band_policy_key"] == (
+            "order_proposals.auto_approve.breakeven_band_pct"
+        )
+        assert (
+            conditions["post_max_effective_anchor_since_policy_version"]
+            == "2026-08-23.1"
+        )
+        assert conditions["post_max_effective_anchor_retroactive"] is False
+        for key in _S142_RESERVE_TRIM_ADDITIVE_CONDITION_KEYS:
+            del conditions[key]
+
     for key in _ROB1298_ADDITIVE_TIE_BREAK_KEYS:
         assert (
             key
@@ -1307,7 +1450,32 @@ def _breakeven_extension_rungs(
         raw = average_cost * Decimal(str(multiple))
         tick = _market_tick(market, raw)
         rungs.append((raw / tick).to_integral_value(rounding=rounding) * tick)
+
+    # §142차 — rung 1 only: clear the inclusive §40차 break-even band edge.
+    assert conditions["tier1_effective_anchor_scope"] == "lowest_rung_only"
+    rungs[0] = _band_clearing_effective_anchor(
+        conditions,
+        prefix="tier1_effective_anchor",
+        market=market,
+        average_cost=average_cost,
+        tick_ceiled_raw_anchor=rungs[0],
+        raw_operand="tick_ceil_average_cost_times_lowest_multiple",
+    )
     return rungs
+
+
+def _breakeven_extension_rung_one_before_s142(
+    tier,
+    *,
+    market: str,
+    average_cost: Decimal,
+) -> Decimal:
+    """The pre-§142차 rung 1: tick_ceil(average_cost × lowest multiple)."""
+
+    multiple = Decimal(str(tier.conditions["anchor_average_cost_multiples"][0]))
+    raw = average_cost * multiple
+    tick = _market_tick(market, raw)
+    return (raw / tick).to_integral_value(rounding=ROUND_CEILING) * tick
 
 
 def _ladder_matches(tier, *, market: str, fresh_named_resistance_count: int) -> bool:
@@ -1642,7 +1810,383 @@ def test_rob_1298_leaves_loss_guard_d7_and_auto_approve_gates_untouched():
     baseline_trim = baseline["decision_rules"]["sell.trim_preplace"]
     current_trim = current["decision_rules"]["sell.trim_preplace"]
     assert current_trim["tiers"][0] == baseline_trim["tiers"][0]
-    assert current_trim["tiers"][1] == baseline_trim["tiers"][1]
+    # §142차 adds the enumerated effective-anchor keys to the reserve-trim
+    # tier; strip exactly those and the tier is still byte-identical to the
+    # ROB-1289 baseline (no threshold, operand, or gate key moved).
+    reserve_trim = deepcopy(current_trim["tiers"][1])
+    for key in _S142_RESERVE_TRIM_ADDITIVE_CONDITION_KEYS:
+        del reserve_trim["conditions"][key]
+    assert reserve_trim == baseline_trim["tiers"][1]
+
+
+# ---------------------------------------------------------------------------
+# §142차 (2026-08-23) — break-even band edge repair (versioned bugfix)
+# ---------------------------------------------------------------------------
+
+# The three boundary cases: an average cost whose × 1.01 lands EXACTLY on the
+# market tick grid, so the ceil snap is a no-op and the rung sits on the
+# inclusive §40차 band edge. The crypto row is the verifier's measured case
+# (checkpoint #3 packet §4-1: avg 4,000,000 -> raw 4,040,000 -> ceil no-op).
+_S142_BOUNDARY_CASES = (
+    ("crypto", Decimal("4000000"), Decimal("4040000"), Decimal("4041000")),
+    ("kr", Decimal("50000"), Decimal("50500"), Decimal("50600")),
+    ("us", Decimal("100.00"), Decimal("101.00"), Decimal("101.01")),
+)
+
+
+def _expanded_limits(doc: TradingPolicyDocument) -> AutoApproveLimits:
+    """§40차 classifier inputs, read from the shipped policy (not literals)."""
+
+    auto_approve = _raw()["order_proposals"]["auto_approve"]
+    return AutoApproveLimits(
+        min_distance_pct=Decimal(str(auto_approve["min_distance_pct"])),
+        per_order_cap=Decimal("1000000000"),
+        daily_cap=Decimal("1000000000"),
+        policy_version=doc.version,
+        mode="expanded",
+        breakeven_band_pct=Decimal(str(auto_approve["breakeven_band_pct"])),
+        round_trip_cost_bps=Decimal("90"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("market", "average_cost", "pre_s142_rung_one", "expected_rung_one"),
+    _S142_BOUNDARY_CASES,
+    ids=[case[0] for case in _S142_BOUNDARY_CASES],
+)
+def test_s142_boundary_rung_one_is_lifted_off_the_inclusive_band_edge(
+    market, average_cost, pre_s142_rung_one, expected_rung_one
+):
+    """AC — the defect reproduces, and the repair moves rung 1 one tick up."""
+
+    tier = _breakeven_extension_ladder_tier()
+
+    # The defect: before §142차 the ceil snap is a no-op on these averages, so
+    # rung 1 IS the band edge.
+    assert (
+        _breakeven_extension_rung_one_before_s142(
+            tier, market=market, average_cost=average_cost
+        )
+        == pre_s142_rung_one
+    )
+    band_pct = _breakeven_band_pct("order_proposals.auto_approve.breakeven_band_pct")
+    assert pre_s142_rung_one == average_cost * (
+        Decimal("1") + band_pct / Decimal("100")
+    )
+
+    # The repair: the effective rung 1 is the first valid tick strictly above.
+    rungs = _breakeven_extension_rungs(tier, market=market, average_cost=average_cost)
+    assert rungs[0] == expected_rung_one
+    assert rungs[0] > pre_s142_rung_one
+    # Lifted by exactly one tick -- the repair buys the minimum it needs.
+    assert rungs[0] - pre_s142_rung_one == _market_tick(market, pre_s142_rung_one)
+    # Rungs 2 and 3 are untouched and the ladder stays strictly ascending.
+    assert rungs == sorted(set(rungs))
+    assert (
+        rungs[1]
+        == _breakeven_extension_rungs(tier, market=market, average_cost=average_cost)[1]
+    )
+
+
+@pytest.mark.parametrize(
+    ("market", "average_cost", "pre_s142_rung_one", "expected_rung_one"),
+    _S142_BOUNDARY_CASES,
+    ids=[case[0] for case in _S142_BOUNDARY_CASES],
+)
+def test_s142_boundary_rung_one_flips_breakeven_band_to_take_profit(
+    market, average_cost, pre_s142_rung_one, expected_rung_one
+):
+    """The whole point: rung 1 can now satisfy its own submission_contract.
+
+    Run against the real §40차 classifier, not a re-implementation.
+    """
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    limits = _expanded_limits(doc)
+    preview = {"avg_buy_price": str(average_cost)}
+
+    before = classify_sell_profit(
+        limit_price=pre_s142_rung_one,
+        quantity=Decimal("100"),
+        preview=preview,
+        limits=limits,
+    )
+    assert before.verdict == "breakeven_band"
+
+    after = classify_sell_profit(
+        limit_price=expected_rung_one,
+        quantity=Decimal("100"),
+        preview=preview,
+        limits=limits,
+    )
+    assert after.verdict == "take_profit"
+
+
+def test_s142_leaves_the_inclusive_band_comparison_alone():
+    """🔴 The global ``<=`` is NOT changed -- only the rung moved.
+
+    A sell priced exactly on the band edge still classifies as breakeven_band
+    for every other consumer of the classifier. If this flips, the repair has
+    been widened past the §142차 authorization.
+    """
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    limits = _expanded_limits(doc)
+    average_cost = Decimal("4000000")
+    band_edge = average_cost * (
+        Decimal("1") + limits.breakeven_band_pct / Decimal("100")
+    )
+
+    for probe in (band_edge, average_cost - (band_edge - average_cost)):
+        verdict = classify_sell_profit(
+            limit_price=probe,
+            quantity=Decimal("1"),
+            preview={"avg_buy_price": str(average_cost)},
+            limits=limits,
+        )
+        assert verdict.verdict == "breakeven_band"
+
+    source = (
+        Path(policy_schema.__file__).resolve().parents[2]
+        / "app"
+        / "services"
+        / "order_proposals"
+        / "auto_approve.py"
+    ).read_text(encoding="utf-8")
+    assert "if abs(distance_from_avg) <= band:" in source
+
+
+@pytest.mark.parametrize(
+    ("market", "average_cost", "expected"),
+    [
+        # §115차 AC1 (ETH) and the KR/US cases: raw × 1.01 is NOT on the grid,
+        # so the ceil already cleared the band and §142차 changes nothing.
+        ("crypto", Decimal("3168337"), Decimal("3201000")),
+        ("kr", Decimal("71300"), Decimal("72100")),
+        ("us", Decimal("187.42"), Decimal("189.30")),
+    ],
+    ids=["crypto_eth", "kr", "us"],
+)
+def test_s142_non_boundary_rung_one_is_unchanged(market, average_cost, expected):
+    tier = _breakeven_extension_ladder_tier()
+    before = _breakeven_extension_rung_one_before_s142(
+        tier, market=market, average_cost=average_cost
+    )
+    after = _breakeven_extension_rungs(tier, market=market, average_cost=average_cost)[
+        0
+    ]
+
+    assert before == after == expected
+    band_pct = _breakeven_band_pct("order_proposals.auto_approve.breakeven_band_pct")
+    assert after > average_cost * (Decimal("1") + band_pct / Decimal("100"))
+
+
+def test_s142_reserve_trim_post_max_anchor_has_the_same_conflict_and_repair():
+    """MEASURED, then repaired -- the §44차 tier shares the defect.
+
+    Its post-max anchor is max(average_cost × loss_guard, d7 lowest price). When
+    the guard operand wins, the anchor IS average_cost × 1.01, i.e. the band
+    edge, and the ceil snap is a no-op on a grid-aligned average.
+    """
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    tier = _breakeven_reserve_trim_tier()
+    limits = _expanded_limits(doc)
+    average_cost = Decimal("4000000")
+    tick = _market_tick("crypto", average_cost * Decimal("1.01"))
+
+    # Guard operand wins the max (D7 price is below it).
+    anchor = _breakeven_reserve_trim_anchor(
+        tier,
+        average_cost=average_cost,
+        d7_compliant_lowest_price=Decimal("4010000"),
+    )
+    snapped = _breakeven_reserve_trim_post_max_tick_snap(
+        tier, anchor=anchor, tick_size=tick
+    )
+    assert snapped == Decimal("4040000")  # ceil is a no-op here
+    assert (
+        classify_sell_profit(
+            limit_price=snapped,
+            quantity=Decimal("1"),
+            preview={"avg_buy_price": str(average_cost)},
+            limits=limits,
+        ).verdict
+        == "breakeven_band"
+    )
+
+    effective = _band_clearing_effective_anchor(
+        tier.conditions,
+        prefix="post_max_effective_anchor",
+        market="crypto",
+        average_cost=average_cost,
+        tick_ceiled_raw_anchor=snapped,
+        raw_operand="tick_ceil_post_max_anchor",
+    )
+    assert effective == Decimal("4041000")
+    assert effective - snapped == tick
+    assert (
+        classify_sell_profit(
+            limit_price=effective,
+            quantity=Decimal("1"),
+            preview={"avg_buy_price": str(average_cost)},
+            limits=limits,
+        ).verdict
+        == "take_profit"
+    )
+
+
+def test_s142_reserve_trim_band_operand_is_inert_when_the_d7_floor_wins():
+    """No anchor is dragged upward when it already clears the band."""
+
+    tier = _breakeven_reserve_trim_tier()
+    average_cost = Decimal("4000000")
+    tick = Decimal("1000")
+
+    anchor = _breakeven_reserve_trim_anchor(
+        tier,
+        average_cost=average_cost,
+        d7_compliant_lowest_price=Decimal("4200000"),
+    )
+    snapped = _breakeven_reserve_trim_post_max_tick_snap(
+        tier, anchor=anchor, tick_size=tick
+    )
+    effective = _band_clearing_effective_anchor(
+        tier.conditions,
+        prefix="post_max_effective_anchor",
+        market="crypto",
+        average_cost=average_cost,
+        tick_ceiled_raw_anchor=snapped,
+        raw_operand="tick_ceil_post_max_anchor",
+    )
+
+    assert snapped == Decimal("4200000")
+    assert effective == snapped
+
+
+def test_s142_is_declared_versioned_and_not_retroactive():
+    """The bugfix is stamped, and it never re-anchors an older placement."""
+
+    doc = TradingPolicyDocument.model_validate(_raw())
+    assert doc.version == "2026-08-23.1"
+    assert "§142차 breakeven band boundary repair 2026-08-23" in doc.source
+    assert "NOT retroactive" in doc.source
+
+    ladder = _breakeven_extension_ladder_tier().conditions
+    reserve = _breakeven_reserve_trim_tier().conditions
+    assert ladder["tier1_effective_anchor_since_policy_version"] == "2026-08-23.1"
+    assert ladder["tier1_effective_anchor_retroactive"] is False
+    assert reserve["post_max_effective_anchor_since_policy_version"] == "2026-08-23.1"
+    assert reserve["post_max_effective_anchor_retroactive"] is False
+
+
+def test_s142_adds_no_tier_no_threshold_and_no_sizing_change():
+    """The permitted class is contradiction resolution -- nothing else."""
+
+    baseline = yaml.safe_load(_ROB1289_BASELINE.read_text(encoding="utf-8"))
+    current = _raw()
+
+    for key in (
+        "sell.loss_guard_min_multiple",
+        "sell.breakeven_near_pct",
+        "sell.trim_min_expected_net_realized_gain_krw",
+    ):
+        assert current["thresholds"][key] == baseline["thresholds"][key]
+    assert (
+        current["order_proposals"]["auto_approve"]["breakeven_band_pct"]
+        == baseline["order_proposals"]["auto_approve"]["breakeven_band_pct"]
+    )
+
+    current_trim = current["decision_rules"]["sell.trim_preplace"]
+    assert [tier["id"] for tier in current_trim["tiers"]] == [
+        "de_minimis_trim_watch",
+        "sell.breakeven_reserve_trim",
+        "single_share_full_exit_review",
+        "momentum_spike_profit_ladder",
+        "rsi_confirmed_resistance",
+        "ultra_near_resistance",
+        "watch_zone",
+        "breakeven_extension_ladder",
+    ]
+    for tier in current_trim["tiers"]:
+        if tier["id"] in ("sell.breakeven_reserve_trim", "breakeven_extension_ladder"):
+            assert tier["sizing"] == "existing_trim_rule"
+    assert current_trim["exclusions"] == ["no_resistance_reference", "composite_gates"]
+    # The ladder's own multiples are untouched: the repair moves the effective
+    # rung, not the declared multiple.
+    ladder = current_trim["tiers"][-1]["conditions"]
+    assert ladder["anchor_average_cost_multiples"] == [1.01, 1.05, 1.10]
+    assert ladder["anchor_lowest_rung_policy_key"] == "sell.loss_guard_min_multiple"
+
+
+def _s142_mutant(tier_index: int, key: str, value) -> dict:
+    raw = _raw()
+    raw["decision_rules"]["sell.trim_preplace"]["tiers"][tier_index]["conditions"][
+        key
+    ] = value
+    return raw
+
+
+def _s142_dropped(tier_index: int, key: str) -> dict:
+    raw = _raw()
+    del raw["decision_rules"]["sell.trim_preplace"]["tiers"][tier_index]["conditions"][
+        key
+    ]
+    return raw
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda: _s142_dropped(-1, "tier1_effective_anchor_operands"),
+        lambda: _s142_mutant(-1, "tier1_effective_anchor_operator", "min"),
+        lambda: _s142_mutant(
+            -1,
+            "tier1_effective_anchor_operands",
+            ["tick_ceil_average_cost_times_lowest_multiple"],
+        ),
+        lambda: _s142_mutant(
+            -1, "tier1_effective_anchor_band_policy_key", "sell.breakeven_near_pct"
+        ),
+        lambda: _s142_mutant(-1, "tier1_effective_anchor_retroactive", True),
+        lambda: _s142_mutant(
+            -1, "tier1_effective_anchor_since_policy_version", "2026-08-22.1"
+        ),
+        lambda: _s142_mutant(
+            -1, "tier1_effective_anchor_band_comparison_unchanged", False
+        ),
+        lambda: _s142_mutant(-1, "tier1_effective_anchor_scope", "all_rungs"),
+        lambda: _s142_dropped(1, "post_max_effective_anchor_operator"),
+        lambda: _s142_mutant(1, "post_max_effective_anchor_operator", "min"),
+        lambda: _s142_mutant(
+            1,
+            "post_max_effective_anchor_operands",
+            [
+                "first_valid_tick_strictly_above_average_cost_"
+                "times_one_plus_breakeven_band",
+                "tick_ceil_post_max_anchor",
+            ],
+        ),
+        lambda: _s142_mutant(1, "post_max_effective_anchor_retroactive", True),
+    ],
+    ids=[
+        "ladder_operands_dropped",
+        "ladder_operator_min",
+        "ladder_band_operand_removed",
+        "ladder_band_key_repointed",
+        "ladder_claims_retroactive",
+        "ladder_backdated_stamp",
+        "ladder_claims_comparison_changed",
+        "ladder_scope_widened",
+        "reserve_operator_dropped",
+        "reserve_operator_min",
+        "reserve_operands_reordered",
+        "reserve_claims_retroactive",
+    ],
+)
+def test_s142_mutants_are_rejected(build):
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(build())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 무엇 / 왜

§115차 `breakeven_extension_ladder` 1단 앵커(평단×1.01)와 §44차
`sell.breakeven_reserve_trim` post-max 앵커가 §40차 `breakeven_band_pct = 1%` 의
**포함 비교**(`abs(distance_from_avg) <= band`)와 경계에서 충돌한다.
평단×1.01 이 **이미 틱 배수**면 tick ceil 이 no-op 이라 매도 rung 이 밴드 경계에
그대로 앉고, `take_profit` 이 아니라 `breakeven_band` 로 강등된다 — 두 티어가 스스로
선언한 `submission_contract: section_40_auto_approve_with_veto` 를 영원히 만족할 수 없다.

GPT Pro 체크포인트 #3 Q4 가 명시 허용한 항목("정책 절 간 모순 해소")이며, 권고된
국소안을 그대로 구현했다.

## 실측 (실제 `classify_sell_profit` 사용, 재구현 아님)

| 시장 | 평단 | raw 1단 | tick ceil | 수리 전 판정 | 수리 후 1단 | 수리 후 판정 |
|---|---|---|---|---|---|---|
| crypto | 4,000,000 | 4,040,000 | **no-op** | `breakeven_band` | 4,041,000 | `take_profit` |
| kr | 50,000 | 50,500 | **no-op** | `breakeven_band` | 50,600 | `take_profit` |
| us | 100.00 | 101.00 | **no-op** | `breakeven_band` | 101.01 | `take_profit` |

crypto 행은 체크포인트 패킷 §4-1 검증자 실측치 그대로다.
**비경계는 불변**: ETH 3,168,337 → 3,201,000 · KR 71,300 → 72,100 · US 187.42 → 189.30
(§115차 기존 테스트 값 그대로 green).

`sell.breakeven_reserve_trim` post-max 경로도 **같은 충돌을 갖는 것으로 실측 확인**
(guard 피연산자가 max 를 이기고 grid 정렬 평단이면 동일하게 `breakeven_band`) →
브리프가 지시한 대로 동일 수리 적용. D7 피연산자가 이기면 두 번째 피연산자는 무력(inert).

## 수리

```
effective = max(tick_ceil(raw anchor),
                first valid tick STRICTLY above average_cost × (1 + breakeven_band_pct/100))
```

- 래더는 **1단만** (`tier1_effective_anchor_scope: lowest_rung_only`) — 2·3단(1.05/1.10)은
  밴드 밖이라 무관.
- 밴드 상단 위 **정확히 한 틱**만 올린다(테스트가 lift == 1 tick 을 핀).
- 밴드 값은 리터럴이 아니라 `order_proposals.auto_approve.breakeven_band_pct` 를 인용.
- 🔴 **`classify_sell_profit` 의 전역 포함 비교(`<=`)는 손대지 않았다.** 밴드 분류기의
  다른 소비자 전수검토 없이 `<= → <` 변경은 범위 밖(테스트가 소스에 `<=` 가 남아 있는지와
  경계 정확 매도가 여전히 `breakeven_band` 인지 둘 다 핀).
- policy version `2026-08-22.1` → `2026-08-23.1`, `source` 기록, **소급 적용 금지** 명시
  (`*_retroactive: false` 를 스키마 validator 가 강제).

## 안전 경계

브로커 mutation 0 · 스케줄러 등록 0 · 신규 티어 0 · 임계/캡 완화 0 · 수량(sizing) 규칙 변경 0 ·
마이그레이션 0. 정책 YAML 은 advisory judgment metadata 이고 런타임 코드가 이 앵커를
계산하지 않는다(소비자 = out-of-process MCP 세션).

## 테스트

- 신규 §142차 섹션(경계 3시장 × 2 · 비경계 3 · reserve-trim 충돌+수리 · 밴드 비교 불변 ·
  versioned/non-retroactive · "티어·임계·사이징 무변경" · **mutant 12종 거부**)
- 기존 §115차/§44차 테스트 전부 green (rung 인터프리터가 이제 실제 선언된 실효 앵커를 해석)
- `tests/schemas/test_trading_policy_schema.py` 151 passed ·
  policy/order_proposals/mcp_server 인접 스위트 green
- ROB-1289 closed-equivalence 테스트: reserve-trim 의 **가산 7키만** 델타로 열거,
  나머지 전 키/값은 baseline 과 여전히 일치

## 잔여 (이 PR 범위 밖, 보고용)

- 수리 후 1단이 2단을 추월할 수 있는 병리적 틱/평단 조합은 **관측되지 않았으나** 기계
  불변식으로 강제하지는 않았다(밴드 1% vs 배수 간격 4~5%). 필요하면 별건.
- 세션 프롬프트/운영자 레포 문언에 이 실효 앵커를 반영하는 작업은 이 레포 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012S13h6DAhducGAoFT5nqzk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Policy Updates**
  - Improved break-even handling for sell reserve-trim and extension-ladder anchors.
  - Anchors now move to the first valid price tick strictly above the inclusive break-even boundary when required.
  - Existing thresholds, sizing, exclusions, higher ladder levels, and comparison behavior remain unchanged.
  - Applies from policy version `2026-08-23.1` and is not retroactive.

- **Documentation**
  - Updated trading guidance and operational runbooks to reflect the revised boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->