### PR TITLE
fix(kiwoom): wire token Redis through Settings

### DIFF
--- a/app/services/brokers/kiwoom/auth.py
+++ b/app/services/brokers/kiwoom/auth.py
@@ -15,12 +15,11 @@ import datetime as dt
 import hashlib
 import json
 import logging
-import os
 import random
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, Protocol
 
 import httpx
 import redis.asyncio as redis
@@ -32,8 +31,6 @@ _log = logging.getLogger(__name__)
 TOKEN_LOCK_TTL_SECONDS: Final[int] = 30
 TOKEN_WAIT_TIMEOUT_SECONDS: float = 5.0
 TOKEN_WAIT_POLL_SECONDS: float = 0.05
-
-_redis_client: redis.Redis | None = None
 
 _REDIS_MAX_CONNECTIONS_DEFAULT: Final[int] = 20
 _REDIS_SOCKET_TIMEOUT_DEFAULT: Final[float] = 5.0
@@ -51,34 +48,53 @@ class KiwoomTokenIssuanceUnavailable(RuntimeError):
 
 
 class KiwoomRedisConfigurationError(RuntimeError):
-    """Raised with env names only when scoped Redis configuration is invalid."""
+    """Raised with setting names only when scoped Redis configuration is invalid."""
 
 
-def _positive_number_env(name: str, default: float) -> float:
-    raw = os.getenv(name)
-    if raw is None or not raw.strip():
+class _RedisSettings(Protocol):
+    redis_max_connections: int
+    redis_socket_timeout: float
+    redis_socket_connect_timeout: float
+
+    def get_redis_url(self) -> str: ...
+
+
+def _positive_number_setting(name: str, value: object, default: float) -> float:
+    if value is None:
         return default
     try:
-        value = float(raw)
-    except ValueError as exc:
-        raise KiwoomRedisConfigurationError(f"invalid numeric env: {name}") from exc
-    if value <= 0:
-        raise KiwoomRedisConfigurationError(f"non-positive numeric env: {name}")
-    return value
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise KiwoomRedisConfigurationError(f"invalid numeric setting: {name}") from exc
+    if numeric <= 0:
+        raise KiwoomRedisConfigurationError(f"non-positive numeric setting: {name}")
+    return numeric
 
 
-def _redis_client_from_env() -> redis.Redis:
-    redis_url = str(os.getenv("REDIS_URL", "")).strip()
+def redis_client_from_settings(settings_obj: _RedisSettings) -> redis.Redis:
+    """Build Kiwoom's mandatory Redis client from the canonical Settings path.
+
+    The OAuth cache is deliberately not optional: a missing or unreachable Redis
+    still prevents token resolution before a broker request is dispatched.
+    """
+
+    redis_url = str(settings_obj.get_redis_url() or "").strip()
     if not redis_url:
-        raise KiwoomRedisConfigurationError("missing required env: REDIS_URL")
-    max_connections = _positive_number_env(
-        "REDIS_MAX_CONNECTIONS", float(_REDIS_MAX_CONNECTIONS_DEFAULT)
+        raise KiwoomRedisConfigurationError("missing required setting: REDIS_URL")
+    max_connections = _positive_number_setting(
+        "REDIS_MAX_CONNECTIONS",
+        getattr(settings_obj, "redis_max_connections", None),
+        float(_REDIS_MAX_CONNECTIONS_DEFAULT),
     )
-    socket_timeout = _positive_number_env(
-        "REDIS_SOCKET_TIMEOUT", _REDIS_SOCKET_TIMEOUT_DEFAULT
+    socket_timeout = _positive_number_setting(
+        "REDIS_SOCKET_TIMEOUT",
+        getattr(settings_obj, "redis_socket_timeout", None),
+        _REDIS_SOCKET_TIMEOUT_DEFAULT,
     )
-    socket_connect_timeout = _positive_number_env(
-        "REDIS_SOCKET_CONNECT_TIMEOUT", _REDIS_SOCKET_CONNECT_TIMEOUT_DEFAULT
+    socket_connect_timeout = _positive_number_setting(
+        "REDIS_SOCKET_CONNECT_TIMEOUT",
+        getattr(settings_obj, "redis_socket_connect_timeout", None),
+        _REDIS_SOCKET_CONNECT_TIMEOUT_DEFAULT,
     )
     return redis.from_url(
         redis_url,
@@ -87,13 +103,6 @@ def _redis_client_from_env() -> redis.Redis:
         socket_connect_timeout=socket_connect_timeout,
         decode_responses=True,
     )
-
-
-async def _get_redis_client() -> redis.Redis:
-    global _redis_client
-    if _redis_client is None:
-        _redis_client = _redis_client_from_env()
-    return _redis_client
 
 
 def _client_fingerprint(app_key: str) -> str:
@@ -114,6 +123,7 @@ class KiwoomAuthClient:
         transport: httpx.BaseTransport | None = None,
         timeout: float = constants.DEFAULT_TIMEOUT,
         redis_client: redis.Redis | None = None,
+        redis_settings: _RedisSettings | None = None,
     ) -> None:
         if str(base_url).rstrip("/") != constants.MOCK_BASE_URL:
             raise ValueError(
@@ -125,6 +135,7 @@ class KiwoomAuthClient:
         self._transport = transport
         self._timeout = timeout
         self._redis_client = redis_client
+        self._redis_settings = redis_settings
         namespace = f"kiwoom:oauth:{_client_fingerprint(app_key)}"
         self.token_key = f"{namespace}:access_token"
         self.lock_key = f"{namespace}:lock"
@@ -148,7 +159,12 @@ class KiwoomAuthClient:
     async def _get_redis(self) -> redis.Redis:
         if self._redis_client is not None:
             return self._redis_client
-        return await _get_redis_client()
+        if self._redis_settings is None:
+            raise KiwoomRedisConfigurationError(
+                "missing required Settings-backed Redis configuration"
+            )
+        self._redis_client = redis_client_from_settings(self._redis_settings)
+        return self._redis_client
 
     async def _get_cached_token(self) -> str | None:
         redis_client = await self._get_redis()

--- a/app/services/brokers/kiwoom/auth.py
+++ b/app/services/brokers/kiwoom/auth.py
@@ -35,6 +35,7 @@ TOKEN_WAIT_POLL_SECONDS: float = 0.05
 _REDIS_MAX_CONNECTIONS_DEFAULT: Final[int] = 20
 _REDIS_SOCKET_TIMEOUT_DEFAULT: Final[float] = 5.0
 _REDIS_SOCKET_CONNECT_TIMEOUT_DEFAULT: Final[float] = 5.0
+_settings_redis_clients: dict[tuple[str, int, float, float], redis.Redis] = {}
 
 
 @dataclass(frozen=True)
@@ -96,13 +97,16 @@ def redis_client_from_settings(settings_obj: _RedisSettings) -> redis.Redis:
         getattr(settings_obj, "redis_socket_connect_timeout", None),
         _REDIS_SOCKET_CONNECT_TIMEOUT_DEFAULT,
     )
-    return redis.from_url(
-        redis_url,
-        max_connections=int(max_connections),
-        socket_timeout=socket_timeout,
-        socket_connect_timeout=socket_connect_timeout,
-        decode_responses=True,
-    )
+    key = (redis_url, int(max_connections), socket_timeout, socket_connect_timeout)
+    if key not in _settings_redis_clients:
+        _settings_redis_clients[key] = redis.from_url(
+            redis_url,
+            max_connections=int(max_connections),
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            decode_responses=True,
+        )
+    return _settings_redis_clients[key]
 
 
 def _client_fingerprint(app_key: str) -> str:

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -151,6 +151,7 @@ class KiwoomMockClient:
         app_secret: str,
         account_no: str,
         timeout: float = constants.DEFAULT_TIMEOUT,
+        redis_settings: Any | None = None,
     ) -> None:
         if str(base_url).rstrip("/") != constants.MOCK_BASE_URL:
             raise KiwoomEndpointError(
@@ -169,6 +170,7 @@ class KiwoomMockClient:
             app_secret=app_secret,
             transport=None,
             timeout=timeout,
+            redis_settings=redis_settings,
         )
         self._token_override: str | None = None
 
@@ -182,11 +184,13 @@ class KiwoomMockClient:
                 "Kiwoom mock account is disabled or missing required configuration: "
                 + ", ".join(missing)
             )
+        _assert_distinct_kr_us_identities(settings)
         return cls(
             base_url=str(settings.kiwoom_mock_base_url).rstrip("/"),
             app_key=str(settings.kiwoom_mock_app_key),
             app_secret=str(settings.kiwoom_mock_app_secret),
             account_no=str(settings.kiwoom_mock_account_no),
+            redis_settings=settings,
         )
 
     def set_transport_for_test(
@@ -356,3 +360,24 @@ class KiwoomMockClient:
                 ) from exc
             raise
         return response
+
+
+def _assert_distinct_kr_us_identities(settings_obj: Any) -> None:
+    """Reject a KR factory wired to the US app identity or account.
+
+    Exact equality is intentional: a matching configured identity is unsafe,
+    while an absent optional opposite-lane setting is not inferred as a match.
+    """
+
+    kr_app_key = str(getattr(settings_obj, "kiwoom_mock_app_key", "") or "").strip()
+    us_app_key = str(getattr(settings_obj, "kiwoom_mock_us_app_key", "") or "").strip()
+    kr_account = str(getattr(settings_obj, "kiwoom_mock_account_no", "") or "").strip()
+    us_account = str(
+        getattr(settings_obj, "kiwoom_mock_us_account_no", "") or ""
+    ).strip()
+    if (us_app_key and kr_app_key == us_app_key) or (
+        us_account and kr_account == us_account
+    ):
+        raise KiwoomConfigurationError(
+            "Kiwoom KR and US mock credential/account identities must be distinct"
+        )

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -151,6 +151,7 @@ class KiwoomMockClient:
         app_secret: str,
         account_no: str,
         timeout: float = constants.DEFAULT_TIMEOUT,
+        redis_client: Any | None = None,
         redis_settings: Any | None = None,
     ) -> None:
         if str(base_url).rstrip("/") != constants.MOCK_BASE_URL:
@@ -170,6 +171,7 @@ class KiwoomMockClient:
             app_secret=app_secret,
             transport=None,
             timeout=timeout,
+            redis_client=redis_client,
             redis_settings=redis_settings,
         )
         self._token_override: str | None = None
@@ -184,7 +186,7 @@ class KiwoomMockClient:
                 "Kiwoom mock account is disabled or missing required configuration: "
                 + ", ".join(missing)
             )
-        _assert_distinct_kr_us_identities(settings)
+        assert_distinct_kr_us_identities(settings)
         return cls(
             base_url=str(settings.kiwoom_mock_base_url).rstrip("/"),
             app_key=str(settings.kiwoom_mock_app_key),
@@ -362,7 +364,7 @@ class KiwoomMockClient:
         return response
 
 
-def _assert_distinct_kr_us_identities(settings_obj: Any) -> None:
+def assert_distinct_kr_us_identities(settings_obj: Any) -> None:
     """Reject a KR factory wired to the US app identity or account.
 
     Exact equality is intentional: a matching configured identity is unsafe,
@@ -371,12 +373,20 @@ def _assert_distinct_kr_us_identities(settings_obj: Any) -> None:
 
     kr_app_key = str(getattr(settings_obj, "kiwoom_mock_app_key", "") or "").strip()
     us_app_key = str(getattr(settings_obj, "kiwoom_mock_us_app_key", "") or "").strip()
+    kr_app_secret = str(
+        getattr(settings_obj, "kiwoom_mock_app_secret", "") or ""
+    ).strip()
+    us_app_secret = str(
+        getattr(settings_obj, "kiwoom_mock_us_app_secret", "") or ""
+    ).strip()
     kr_account = str(getattr(settings_obj, "kiwoom_mock_account_no", "") or "").strip()
     us_account = str(
         getattr(settings_obj, "kiwoom_mock_us_account_no", "") or ""
     ).strip()
-    if (us_app_key and kr_app_key == us_app_key) or (
-        us_account and kr_account == us_account
+    if (
+        (us_app_key and kr_app_key == us_app_key)
+        or (us_app_secret and kr_app_secret == us_app_secret)
+        or (us_account and kr_account == us_account)
     ):
         raise KiwoomConfigurationError(
             "Kiwoom KR and US mock credential/account identities must be distinct"

--- a/app/services/brokers/kiwoom/us_client.py
+++ b/app/services/brokers/kiwoom/us_client.py
@@ -11,6 +11,7 @@ from app.services.brokers.kiwoom import constants
 from app.services.brokers.kiwoom.client import (
     KiwoomConfigurationError,
     KiwoomMockClient,
+    assert_distinct_kr_us_identities,
 )
 
 
@@ -58,6 +59,7 @@ class KiwoomMockUsClient(KiwoomMockClient):
         app_secret: str,
         account_no: str,
         timeout: float = constants.DEFAULT_TIMEOUT,
+        redis_client: Any | None = None,
         redis_settings: Any | None = None,
         rate_limit_clock: Callable[[], float] = time.monotonic,
         rate_limit_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
@@ -68,6 +70,7 @@ class KiwoomMockUsClient(KiwoomMockClient):
             app_secret=app_secret,
             account_no=account_no,
             timeout=timeout,
+            redis_client=redis_client,
             redis_settings=redis_settings,
         )
         self._tr_rate_limiter = _PerTrRateLimiter(
@@ -88,32 +91,11 @@ class KiwoomMockUsClient(KiwoomMockClient):
                 "Kiwoom US mock account is disabled or missing required "
                 "configuration: " + ", ".join(missing)
             )
-        _assert_distinct_kr_us_identities(settings)
+        assert_distinct_kr_us_identities(settings)
         return cls(
             base_url=str(settings.kiwoom_mock_base_url).rstrip("/"),
             app_key=str(settings.kiwoom_mock_us_app_key),
             app_secret=str(settings.kiwoom_mock_us_app_secret),
             account_no=str(settings.kiwoom_mock_us_account_no),
             redis_settings=settings,
-        )
-
-
-def _assert_distinct_kr_us_identities(settings_obj: Any) -> None:
-    """Reject a US factory wired to the KR app identity or account.
-
-    The checks intentionally use exact equality on canonical Settings values;
-    neither secret nor account value is included in the failure surface.
-    """
-
-    kr_app_key = str(getattr(settings_obj, "kiwoom_mock_app_key", "") or "").strip()
-    us_app_key = str(getattr(settings_obj, "kiwoom_mock_us_app_key", "") or "").strip()
-    kr_account = str(getattr(settings_obj, "kiwoom_mock_account_no", "") or "").strip()
-    us_account = str(
-        getattr(settings_obj, "kiwoom_mock_us_account_no", "") or ""
-    ).strip()
-    if (kr_app_key and kr_app_key == us_app_key) or (
-        kr_account and kr_account == us_account
-    ):
-        raise KiwoomConfigurationError(
-            "Kiwoom KR and US mock credential/account identities must be distinct"
         )

--- a/app/services/brokers/kiwoom/us_client.py
+++ b/app/services/brokers/kiwoom/us_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Awaitable, Callable
-from typing import Self
+from typing import Any, Self
 
 from app.services.brokers.kiwoom import constants
 from app.services.brokers.kiwoom.client import (
@@ -58,6 +58,7 @@ class KiwoomMockUsClient(KiwoomMockClient):
         app_secret: str,
         account_no: str,
         timeout: float = constants.DEFAULT_TIMEOUT,
+        redis_settings: Any | None = None,
         rate_limit_clock: Callable[[], float] = time.monotonic,
         rate_limit_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     ) -> None:
@@ -67,6 +68,7 @@ class KiwoomMockUsClient(KiwoomMockClient):
             app_secret=app_secret,
             account_no=account_no,
             timeout=timeout,
+            redis_settings=redis_settings,
         )
         self._tr_rate_limiter = _PerTrRateLimiter(
             clock=rate_limit_clock,
@@ -86,9 +88,32 @@ class KiwoomMockUsClient(KiwoomMockClient):
                 "Kiwoom US mock account is disabled or missing required "
                 "configuration: " + ", ".join(missing)
             )
+        _assert_distinct_kr_us_identities(settings)
         return cls(
             base_url=str(settings.kiwoom_mock_base_url).rstrip("/"),
             app_key=str(settings.kiwoom_mock_us_app_key),
             app_secret=str(settings.kiwoom_mock_us_app_secret),
             account_no=str(settings.kiwoom_mock_us_account_no),
+            redis_settings=settings,
+        )
+
+
+def _assert_distinct_kr_us_identities(settings_obj: Any) -> None:
+    """Reject a US factory wired to the KR app identity or account.
+
+    The checks intentionally use exact equality on canonical Settings values;
+    neither secret nor account value is included in the failure surface.
+    """
+
+    kr_app_key = str(getattr(settings_obj, "kiwoom_mock_app_key", "") or "").strip()
+    us_app_key = str(getattr(settings_obj, "kiwoom_mock_us_app_key", "") or "").strip()
+    kr_account = str(getattr(settings_obj, "kiwoom_mock_account_no", "") or "").strip()
+    us_account = str(
+        getattr(settings_obj, "kiwoom_mock_us_account_no", "") or ""
+    ).strip()
+    if (kr_app_key and kr_app_key == us_app_key) or (
+        kr_account and kr_account == us_account
+    ):
+        raise KiwoomConfigurationError(
+            "Kiwoom KR and US mock credential/account identities must be distinct"
         )

--- a/ci_shards/shard-4.txt
+++ b/ci_shards/shard-4.txt
@@ -319,6 +319,7 @@ tests/test_kis_mock_signal_migration_additive.py
 tests/test_kis_request_error_retry_policy.py
 tests/test_kiwoom_auth_token_cache.py
 tests/test_kiwoom_chart_compare.py
+tests/test_kiwoom_g1_canonical_wiring.py
 tests/test_kiwoom_mock_us_config.py
 tests/test_kr_live_quote.py
 tests/test_kr_news_relevance_service.py

--- a/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
+++ b/docs/contracts/rob-1264-kiwoom-coordination-adapter.md
@@ -155,7 +155,11 @@ After ACK the exact Kiwoom order number is persisted as J2B
 5. J3A grant still owned
 
 A live-character client behind a mock-looking caller fails before
-transport. `app/services/brokers/kiwoom/client.py` is not modified.
+transport. G1 (PR #1946) modifies `app/services/brokers/kiwoom/client.py`
+only to wire Redis through Settings and preserve isolated injected clients;
+J3C coordination remains unintroduced. The whole-file SHA-256 drift pin in
+`tests/services/mock_integration/test_kiwoom_coordination_adapter.py` is the
+review gate for subsequent transport changes (`7c68b03e5e99582071207ce7518891ec8d50d733a06cb356b48414f06bf15a93`).
 
 ---
 

--- a/docs/runbooks/b0x-kr-kiwoom-cycle.md
+++ b/docs/runbooks/b0x-kr-kiwoom-cycle.md
@@ -180,10 +180,9 @@ exit 2 + `cancel_unconfirmed`, 그리고 실제로 취소 자체는 성공해 �
 ## 7. 실행
 
 ```bash
-# 자격증명은 배포 env 파일에서. REDIS_URL 은 OAuth 토큰 캐시용으로 프로세스
-# 환경에 필요하다(pydantic settings 가 아니라 os.environ 에서 읽는다).
+# 자격증명과 Redis 설정은 배포 env 파일에서 Settings가 읽는다. 별도 process
+# REDIS_URL export는 필요하지 않으며, 값은 출력하지 않는다.
 export ENV_FILE=/path/to/.env.prod.native
-export REDIS_URL="$(grep -m1 '^REDIS_URL=' "$ENV_FILE" | cut -d= -f2-)"
 
 # ① 읽기 전용 준비상태 프로브 (주문 없음)
 B0X_KR_KIWOOM_ENABLED=true uv run python -m scripts.run_b0x_kr_kiwoom_cycle --readiness

--- a/scripts/kiwoom_live_readonly_compare.py
+++ b/scripts/kiwoom_live_readonly_compare.py
@@ -165,6 +165,20 @@ async def _timed(pacer: Pacer, side: str, label: str, coro_fn, interval=None):
         return None, exc
 
 
+def _build_isolated_mock_client(
+    *, client_factory: Any, constants: Any, creds: dict[str, str], redis_client: Any
+) -> Any:
+    """Build the mock chart leg with its caller-owned isolated Redis client."""
+
+    return client_factory(
+        base_url=constants.MOCK_BASE_URL,
+        app_key=creds["KIWOOM_MOCK_APP_KEY"],
+        app_secret=creds["KIWOOM_MOCK_APP_SECRET"],
+        account_no="",
+        redis_client=redis_client,
+    )
+
+
 async def run(args: argparse.Namespace) -> int:
     env_file = Path(args.env_file)
     creds = _load_scoped_env(env_file)
@@ -197,11 +211,14 @@ async def run(args: argparse.Namespace) -> int:
     if "prod" in os.environ.get("ENV_FILE", ""):
         raise SystemExit("refusing to run with a production ENV_FILE")
 
-    # OAuth tokens are cached in Redis. Point that at a throwaway instance so
-    # this read-only comparison never writes keys into the deployment's shared
-    # cache (which holds ~24k live OHLCV entries).
+    # OAuth tokens are cached in Redis. A confirmed comparison must name a
+    # throwaway instance; neither leg may write deployment shared-cache keys.
+    if args.confirm_live_read and not args.redis_url:
+        raise SystemExit("--redis-url is required with --confirm-live-read")
     if args.redis_url:
         os.environ["REDIS_URL"] = args.redis_url
+
+    import redis.asyncio as redis
 
     from app.services.brokers.kiwoom import constants
     from app.services.brokers.kiwoom.chart_compare import (
@@ -232,13 +249,14 @@ async def run(args: argparse.Namespace) -> int:
         return 0
 
     live = KiwoomLiveReadOnlyClient.from_app_settings()
+    isolated_redis = redis.from_url(args.redis_url, decode_responses=True)
     # Chart TRs ignore the account number; the scoped env has none, so an empty
     # string is passed rather than sourcing one from anywhere.
-    mock = KiwoomMockClient(
-        base_url=constants.MOCK_BASE_URL,
-        app_key=creds["KIWOOM_MOCK_APP_KEY"],
-        app_secret=creds["KIWOOM_MOCK_APP_SECRET"],
-        account_no="",
+    mock = _build_isolated_mock_client(
+        client_factory=KiwoomMockClient,
+        constants=constants,
+        creds=creds,
+        redis_client=isolated_redis,
     )
 
     def mock_chart(api_id: str, body: dict[str, Any]):

--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -1149,23 +1149,15 @@ def test_no_j3a_sql_or_reason_enum_copied() -> None:
     assert "class CoordinationReasonCode" not in source
 
 
-# SHA-256 of app/services/brokers/kiwoom/client.py at the J3C dispatch
-# base (origin/main 03beecc5f). Git history is not consulted: CI checkouts
-# are shallow and merge-base/origin/main are not guaranteed to exist.
-_KIWOOM_CLIENT_PY_SHA256: str = (
-    "b9bb2ce3c9cb09cb6ba3013f11a370807d05115ce4c4e0f1af824e45e5c75334"
-)
+def test_client_py_keeps_j3c_coordination_out_of_transport() -> None:
+    """G1 may wire canonical Redis, but must not import J3C coordination."""
 
-
-def test_client_py_unchanged_in_this_job() -> None:
-    import hashlib
-
-    digest = hashlib.sha256(
-        (
-            REPO_ROOT / "app" / "services" / "brokers" / "kiwoom" / "client.py"
-        ).read_bytes()
-    ).hexdigest()
-    assert digest == _KIWOOM_CLIENT_PY_SHA256
+    source = (
+        REPO_ROOT / "app" / "services" / "brokers" / "kiwoom" / "client.py"
+    ).read_text(encoding="utf-8")
+    assert "KiwoomAuthClient" in source
+    assert "pg_try_advisory_lock" not in source
+    assert "CoordinationReasonCode" not in source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
+++ b/tests/services/mock_integration/test_kiwoom_coordination_adapter.py
@@ -1149,6 +1149,22 @@ def test_no_j3a_sql_or_reason_enum_copied() -> None:
     assert "class CoordinationReasonCode" not in source
 
 
+_KIWOOM_CLIENT_PY_SHA256: str = (
+    "7c68b03e5e99582071207ce7518891ec8d50d733a06cb356b48414f06bf15a93"
+)
+
+
+def test_client_py_matches_reviewed_g1_transport_pin() -> None:
+    import hashlib
+
+    digest = hashlib.sha256(
+        (
+            REPO_ROOT / "app" / "services" / "brokers" / "kiwoom" / "client.py"
+        ).read_bytes()
+    ).hexdigest()
+    assert digest == _KIWOOM_CLIENT_PY_SHA256
+
+
 def test_client_py_keeps_j3c_coordination_out_of_transport() -> None:
     """G1 may wire canonical Redis, but must not import J3C coordination."""
 

--- a/tests/test_kiwoom_auth_token_cache.py
+++ b/tests/test_kiwoom_auth_token_cache.py
@@ -7,8 +7,8 @@ import asyncio
 import datetime as dt
 import json
 import logging
-import sys
 import time
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -66,7 +66,7 @@ class _FakeRedis:
 
 
 @pytest.mark.asyncio
-async def test_scoped_redis_env_does_not_import_global_settings(
+async def test_scoped_redis_uses_explicit_settings_configuration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake = _FakeRedis()
@@ -77,15 +77,15 @@ async def test_scoped_redis_env_does_not_import_global_settings(
         captured.update(kwargs)
         return fake
 
-    monkeypatch.setenv("REDIS_URL", "redis://scoped.invalid:6379/0")
-    monkeypatch.delenv("REDIS_MAX_CONNECTIONS", raising=False)
-    monkeypatch.delenv("REDIS_SOCKET_TIMEOUT", raising=False)
-    monkeypatch.delenv("REDIS_SOCKET_CONNECT_TIMEOUT", raising=False)
     monkeypatch.setattr(auth_module.redis, "from_url", from_url)
-    monkeypatch.setattr(auth_module, "_redis_client", None)
-    monkeypatch.delitem(sys.modules, "app.core.config", raising=False)
+    settings_obj = SimpleNamespace(
+        get_redis_url=lambda: "redis://scoped.invalid:6379/0",
+        redis_max_connections=20,
+        redis_socket_timeout=5.0,
+        redis_socket_connect_timeout=5.0,
+    )
 
-    client = await auth_module._get_redis_client()
+    client = auth_module.redis_client_from_settings(settings_obj)
 
     assert client is fake
     assert captured == {
@@ -95,14 +95,18 @@ async def test_scoped_redis_env_does_not_import_global_settings(
         "socket_connect_timeout": 5.0,
         "decode_responses": True,
     }
-    assert "app.core.config" not in sys.modules
 
 
-def test_scoped_redis_env_requires_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("REDIS_URL", raising=False)
+def test_scoped_redis_settings_requires_url() -> None:
+    settings_obj = SimpleNamespace(
+        get_redis_url=lambda: "",
+        redis_max_connections=20,
+        redis_socket_timeout=5.0,
+        redis_socket_connect_timeout=5.0,
+    )
 
     with pytest.raises(KiwoomRedisConfigurationError, match="REDIS_URL"):
-        auth_module._redis_client_from_env()
+        auth_module.redis_client_from_settings(settings_obj)
 
 
 @pytest.fixture

--- a/tests/test_kiwoom_g1_canonical_wiring.py
+++ b/tests/test_kiwoom_g1_canonical_wiring.py
@@ -1,0 +1,185 @@
+"""G1 wiring: Settings-backed Redis remains a closed pre-dispatch boundary."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from app.services.brokers.kiwoom import auth as auth_module
+from app.services.brokers.kiwoom import constants
+from app.services.brokers.kiwoom.client import (
+    KiwoomConfigurationError,
+    KiwoomMockClient,
+    KiwoomPreDispatchError,
+)
+from app.services.brokers.kiwoom.us_client import KiwoomMockUsClient
+
+
+class _FakeRedis:
+    async def get(self, _key: str) -> None:
+        return None
+
+
+class _UnavailableRedis:
+    async def get(self, _key: str) -> None:
+        raise OSError("redis transport unavailable")
+
+
+def _configure_distinct_lanes(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.core import config as cfg
+
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_enabled", True)
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_app_key", "KR-APP-KEY")
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_app_secret", "KR-APP-SECRET")
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_account_no", "KR-ACCOUNT-001")
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_us_enabled", True)
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_us_app_key", "US-APP-KEY")
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_us_app_secret", "US-APP-SECRET")
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_us_account_no", "US-ACCOUNT-001")
+
+
+@pytest.mark.asyncio
+async def test_kr_and_us_factories_use_settings_redis_not_process_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ENV_FILE-loaded Settings path, not REDIS_URL export, owns wiring."""
+
+    from app.core import config as cfg
+
+    _configure_distinct_lanes(monkeypatch)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    seen: list[tuple[str, dict[str, object]]] = []
+
+    def from_url(url: str, **kwargs: object) -> _FakeRedis:
+        seen.append((url, kwargs))
+        return _FakeRedis()
+
+    monkeypatch.setattr(auth_module.redis, "from_url", from_url)
+    kr_client = KiwoomMockClient.from_app_settings()
+    us_client = KiwoomMockUsClient.from_app_settings()
+
+    assert kr_client._auth._redis_settings is cfg.settings
+    assert us_client._auth._redis_settings is cfg.settings
+    await kr_client._auth._get_redis()
+    await us_client._auth._get_redis()
+    assert [url for url, _kwargs in seen] == [
+        cfg.settings.get_redis_url(),
+        cfg.settings.get_redis_url(),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_m1_missing_settings_redis_blocks_before_order_dispatch() -> None:
+    """M1: no Settings-backed Redis configuration cannot open an order path."""
+
+    dispatches = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal dispatches
+        dispatches += 1
+        return httpx.Response(200, json={"return_code": 0})
+
+    client = KiwoomMockClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="KR-APP-KEY",
+        app_secret="KR-APP-SECRET",
+        account_no="KR-ACCOUNT-001",
+    )
+    client._transport = httpx.MockTransport(handler)
+
+    with pytest.raises(KiwoomPreDispatchError) as exc_info:
+        await client.post_api(
+            api_id=constants.ORDER_BUY_API_ID,
+            path=constants.ORDER_PATH,
+            body={},
+        )
+
+    assert exc_info.value.stage == "token_resolution"
+    assert exc_info.value.cause_type == "KiwoomRedisConfigurationError"
+    assert dispatches == 0
+
+
+@pytest.mark.asyncio
+async def test_m2_unreachable_redis_blocks_before_order_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M2: a configured but unavailable Redis still fails closed."""
+
+    _configure_distinct_lanes(monkeypatch)
+    monkeypatch.setattr(
+        auth_module.redis, "from_url", lambda *_a, **_kw: _UnavailableRedis()
+    )
+    dispatches = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal dispatches
+        dispatches += 1
+        return httpx.Response(200, json={"return_code": 0})
+
+    client = KiwoomMockClient.from_app_settings()
+    client._transport = httpx.MockTransport(handler)
+
+    with pytest.raises(KiwoomPreDispatchError) as exc_info:
+        await client.post_api(
+            api_id=constants.ORDER_BUY_API_ID,
+            path=constants.ORDER_PATH,
+            body={},
+        )
+
+    assert exc_info.value.stage == "token_resolution"
+    assert exc_info.value.cause_type == "OSError"
+    assert dispatches == 0
+
+
+@pytest.mark.parametrize("lane", ["kr", "us"])
+def test_m3_cross_lane_identity_equality_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, lane: str
+) -> None:
+    """M3: exact equality proves either lane cannot be wired to the other."""
+
+    _configure_distinct_lanes(monkeypatch)
+    from app.core import config as cfg
+
+    if lane == "kr":
+        monkeypatch.setattr(cfg.settings, "kiwoom_mock_us_app_key", "KR-APP-KEY")
+        factory = KiwoomMockClient.from_app_settings
+    else:
+        monkeypatch.setattr(cfg.settings, "kiwoom_mock_app_key", "US-APP-KEY")
+        factory = KiwoomMockUsClient.from_app_settings
+
+    with pytest.raises(KiwoomConfigurationError, match="identities must be distinct"):
+        factory()
+
+
+@pytest.mark.asyncio
+async def test_m4_predispatch_failure_never_logs_or_renders_secrets(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """M4: redacted pre-dispatch errors keep both secret and account values out."""
+
+    _configure_distinct_lanes(monkeypatch)
+    monkeypatch.setattr(
+        auth_module.redis, "from_url", lambda *_a, **_kw: _UnavailableRedis()
+    )
+    client = KiwoomMockClient.from_app_settings()
+    caplog.set_level(logging.DEBUG, logger="app.services.brokers.kiwoom")
+
+    with pytest.raises(KiwoomPreDispatchError) as exc_info:
+        await client.post_api(
+            api_id=constants.ORDER_BUY_API_ID,
+            path=constants.ORDER_PATH,
+            body={},
+        )
+
+    rendered = "\n".join(
+        [str(exc_info.value), *(r.getMessage() for r in caplog.records)]
+    )
+    for forbidden in (
+        "KR-APP-SECRET",
+        "US-APP-SECRET",
+        "KR-ACCOUNT-001",
+        "US-ACCOUNT-001",
+    ):
+        assert forbidden not in rendered

--- a/tests/test_kiwoom_g1_canonical_wiring.py
+++ b/tests/test_kiwoom_g1_canonical_wiring.py
@@ -50,6 +50,7 @@ async def test_kr_and_us_factories_use_settings_redis_not_process_env(
 
     _configure_distinct_lanes(monkeypatch)
     monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setattr(auth_module, "_settings_redis_clients", {})
     seen: list[tuple[str, dict[str, object]]] = []
 
     def from_url(url: str, **kwargs: object) -> _FakeRedis:
@@ -64,10 +65,7 @@ async def test_kr_and_us_factories_use_settings_redis_not_process_env(
     assert us_client._auth._redis_settings is cfg.settings
     await kr_client._auth._get_redis()
     await us_client._auth._get_redis()
-    assert [url for url, _kwargs in seen] == [
-        cfg.settings.get_redis_url(),
-        cfg.settings.get_redis_url(),
-    ]
+    assert [url for url, _kwargs in seen] == [cfg.settings.get_redis_url()]
 
 
 @pytest.mark.asyncio
@@ -151,6 +149,48 @@ def test_m3_cross_lane_identity_equality_is_rejected(
 
     with pytest.raises(KiwoomConfigurationError, match="identities must be distinct"):
         factory()
+
+
+@pytest.mark.parametrize("lane", ["kr", "us"])
+def test_cross_lane_secret_identity_equality_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, lane: str
+) -> None:
+    _configure_distinct_lanes(monkeypatch)
+    from app.core import config as cfg
+
+    if lane == "kr":
+        monkeypatch.setattr(cfg.settings, "kiwoom_mock_us_app_secret", "KR-APP-SECRET")
+        factory = KiwoomMockClient.from_app_settings
+    else:
+        monkeypatch.setattr(cfg.settings, "kiwoom_mock_app_secret", "US-APP-SECRET")
+        factory = KiwoomMockUsClient.from_app_settings
+
+    with pytest.raises(KiwoomConfigurationError, match="identities must be distinct"):
+        factory()
+
+
+def test_compare_mock_leg_receives_caller_owned_isolated_redis() -> None:
+    from scripts.kiwoom_live_readonly_compare import _build_isolated_mock_client
+
+    isolated_redis = object()
+    captured: dict[str, object] = {}
+
+    def factory(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    constants_obj = type(
+        "Constants", (), {"MOCK_BASE_URL": "https://mockapi.kiwoom.com"}
+    )
+    _build_isolated_mock_client(
+        client_factory=factory,
+        constants=constants_obj,
+        creds={"KIWOOM_MOCK_APP_KEY": "key", "KIWOOM_MOCK_APP_SECRET": "secret"},
+        redis_client=isolated_redis,
+    )
+
+    assert captured["redis_client"] is isolated_redis
+    assert "redis_settings" not in captured
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- route Kiwoom OAuth Redis configuration through canonical Settings for KR and US factories
- retain fail-closed token resolution when Redis is missing or unreachable
- reject exact KR/US configured identity reuse and add offline mutant coverage

## Verification
- focused offline suite: 78 passed in 3.01s
- make lint: passed
- alembic heads: single head

Full non-live suite was executed: 23285 passed, 50 failed, 13 skipped, 8 deselected. Failures are recorded in the implementation artifact and include shared production ENV/default assumptions and absent worktree .venv.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redis configuration is now loaded through application settings.
  - Mock clients support isolated Redis connections for safer comparisons and testing.
- **Bug Fixes**
  - Missing, invalid, or unavailable Redis configuration now fails safely before trading actions.
  - Korean and US credentials, secrets, and account identities must be distinct.
  - Error messages and logs avoid exposing sensitive credentials or account details.
- **Documentation**
  - Updated deployment guidance to describe settings-based credential and Redis configuration.
  - Clarified integration safeguards and live read-only comparison requirements.
- **Tests**
  - Expanded coverage for configuration validation, isolation, fail-closed behavior, and sensitive-data redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->