### PR TITLE
feat(auto-approve): §145차 — crypto 주문당 자동승인 캡 100만→500만 (일일 500만→1000만)

### DIFF
--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -24,9 +24,9 @@
 # 올린다. 🔴 classify_sell_profit 의 전역 포함 비교(<=)는 건드리지 않는다
 # (밴드 분류기의 다른 소비자 전수검토 없이 <= → < 변경 금지). 신규 티어·임계
 # 완화·수량 규칙 변경 0.
-version: "2026-08-23.1"
+version: "2026-08-23.2"
 captured_as_of: "2026-08-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change); §127차 concurrent-new-entry slots 1→2 and buy.winner_pullback_add pre-registered tier 2026-08-21 (operator decision in claude-mock session; breakout chase remains forbidden); §129차 buy.new_entry_overflow cash-conditioned overflow slots at 0.5x sizing 2026-08-21 (operator decision in claude-mock session; no gate relaxed); §133차 KR per-order auto-approve cap 2M 2026-08-21 (single-share high-priced KR exits structurally carded — SK하이닉스 1,776,000 measured case, §65차 US twin; daily cap unchanged); §136차 A(k) two add symbols per market + owned-symbol add exempt from new-entry symbol cap 2026-08-21 (operator directive to deploy idle Upbit KRW; measured blocker from 2026-08-21 20:20 session; k_used retained at 0.10 — k is the averaging-target parameter, and raising it flips A_limit non-positive, the opposite of expansion); §139차 buy-side retrospective decisions 2026-08-22 (operator decisions in claude-mock session, sourced from retro-buyside-multiweek-20260822.md): US one_share_exception absolute_ceiling_usd 700 -> 10000 (operator: deposited cash is the ceiling; the real boundary is cash plus the USD 1,500 per-order auto-approve cap, and the AVGO -11.58% counter-evidence is retained), buy.index_etf_candidate equal-candidate universe admission for broad index ETFs with structurally-absent gates declared not-applicable rather than waived, and buy.held_majors_support_net time-boxed pre-registered LIVE crypto tier for profitable held coins (<=300k KRW per coin, <=900k KRW tier, scored 2026-09-19 and retired unless the filled cohort D+20 median >= 0 and lower quartile > -8%; ROB-1031 60% post-touch breakdown and the XRP -8.36% one-hour flush recorded as counter-evidence). No gate relaxed for new-coin discovery; no approval cap raised. §142차 breakeven band boundary repair 2026-08-23 (GPT Pro checkpoint #3 Q4 permitted class 'policy-clause contradiction resolution'; versioned bugfix, NOT retroactive — cohorts and forecasts stamped with an earlier policy version keep the anchor they were placed under): the §115차 breakeven_extension_ladder tier-1 anchor and the §44차 sell.breakeven_reserve_trim post-max anchor now resolve to max(tick_ceil(raw anchor), first valid tick STRICTLY above average_cost × (1 + order_proposals.auto_approve.breakeven_band_pct / 100)), because the §40차 break-even band comparison is inclusive (|distance| <= band) and a rung that lands exactly on avg × 1.01 was classified breakeven_band instead of take_profit whenever the tick ceil was a no-op. The §40차 classifier itself is unchanged — the inclusive comparison stays inclusive globally — and no threshold, cap, tier, sizing rule, or exclusion is added or relaxed."
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key; ROB-999/Fable governance advisory 2026-07-22 Q3 #4/#6; operator theme-cap direction 2026-07-22; KR single-share full-exit far-lane shadow seed 2026-07-23; GPT Pro trading retrospective Phase 2.5 advisory received 2026-07-25; operator D2/D5/D7 momentum-spike, single-share, and minimum-benefit decisions captured 2026-07-27; posture-v1 ROB-1090 transition contract approved 2026-07-27; ROB-1106 posture-v1 shadow stage 1 default-off contract 2026-07-28; operator drift removal 2026-08-08 (Phase 2.5 rules 01-09/11-14 and profit_realization advisory tier removed — unvalidated advisory hypotheses; rule 10 retained as D5 disposition owner); AUTO-APPROVE-EXPAND §40차 profit-take classification inputs 2026-08-12 (breakeven_band_pct, round_trip_cost_bps — consumed only under ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded, default off); operator §45/§46 buy.support_reserve_net literal policy/consumer contract 2026-08-12 (no proposal-service or broker mutation implementation); verify-r1 S1/S2/S3 completion 2026-08-12 (priority rules, A_limit<=0 NO_ORDER, playbook structure; no execution-surface change) §44차 breakeven reserve trim advisory tier 2026-08-12 (existing loss guard, near-breakeven, and D7 keys reused; no execution guard change) §44차 closeout 2026-08-12 (post-max tick ceil, machine sell-lane tier, and D7 consumer-estimate limits); §115차 breakeven extension ladder fallback tier for zero-fresh-named-resistance holdings 2026-08-20 (ROB-1298; existing loss guard multiple and existing trim sizing reused; no exclusion removal, no gate change); §127차 concurrent-new-entry slots 1→2 and buy.winner_pullback_add pre-registered tier 2026-08-21 (operator decision in claude-mock session; breakout chase remains forbidden); §129차 buy.new_entry_overflow cash-conditioned overflow slots at 0.5x sizing 2026-08-21 (operator decision in claude-mock session; no gate relaxed); §133차 KR per-order auto-approve cap 2M 2026-08-21 (single-share high-priced KR exits structurally carded — SK하이닉스 1,776,000 measured case, §65차 US twin; daily cap unchanged); §136차 A(k) two add symbols per market + owned-symbol add exempt from new-entry symbol cap 2026-08-21 (operator directive to deploy idle Upbit KRW; measured blocker from 2026-08-21 20:20 session; k_used retained at 0.10 — k is the averaging-target parameter, and raising it flips A_limit non-positive, the opposite of expansion); §139차 buy-side retrospective decisions 2026-08-22 (operator decisions in claude-mock session, sourced from retro-buyside-multiweek-20260822.md): US one_share_exception absolute_ceiling_usd 700 -> 10000 (operator: deposited cash is the ceiling; the real boundary is cash plus the USD 1,500 per-order auto-approve cap, and the AVGO -11.58% counter-evidence is retained), buy.index_etf_candidate equal-candidate universe admission for broad index ETFs with structurally-absent gates declared not-applicable rather than waived, and buy.held_majors_support_net time-boxed pre-registered LIVE crypto tier for profitable held coins (<=300k KRW per coin, <=900k KRW tier, scored 2026-09-19 and retired unless the filled cohort D+20 median >= 0 and lower quartile > -8%; ROB-1031 60% post-touch breakdown and the XRP -8.36% one-hour flush recorded as counter-evidence). No gate relaxed for new-coin discovery; no approval cap raised. §142차 breakeven band boundary repair 2026-08-23 (GPT Pro checkpoint #3 Q4 permitted class 'policy-clause contradiction resolution'; versioned bugfix, NOT retroactive — cohorts and forecasts stamped with an earlier policy version keep the anchor they were placed under): the §115차 breakeven_extension_ladder tier-1 anchor and the §44차 sell.breakeven_reserve_trim post-max anchor now resolve to max(tick_ceil(raw anchor), first valid tick STRICTLY above average_cost × (1 + order_proposals.auto_approve.breakeven_band_pct / 100)), because the §40차 break-even band comparison is inclusive (|distance| <= band) and a rung that lands exactly on avg × 1.01 was classified breakeven_band instead of take_profit whenever the tick ceil was a no-op. The §40차 classifier itself is unchanged — the inclusive comparison stays inclusive globally — and no threshold, cap, tier, sizing rule, or exclusion is added or relaxed. §145차 crypto per-order auto-approve cap 1M -> 5M and daily cap 5M -> 10M 2026-08-23 (operator decision in claude-mock session: \"100만 초과도 자동이었으면 해\"): the averaging-down A_limit band the §136차 add lane produces runs past 1M (XRP ~2.93M at the -5% conversion point, measured 2026-08-23), so every such add was structurally carded. The §71차 lesson is kept by raising the daily cap in proportion (5M -> 10M) so the first auto-approved add does not demote the rest of the day to cards. Per §106차 the per-order cap remains the maximum-loss boundary of one automation error; the operator re-defined that boundary at 5M. The real ceiling stays the Upbit orderable cash (§144차 trigger reserve plus JIT deposit), and a short-of-cash proposal still emits deferred_with_condition plus a deposit alert before any order. min_distance, resting-only, tag scan, loss guard, and the no-partial-fill rule are unchanged, and no KR or US cap moves."
 
 authority:
   scope: judgment_policy_only
@@ -83,7 +83,17 @@ order_proposals:
       # auto-approve (25/25 sell proposals carded on 2026-08-13). 800 admits
       # one-share exits while still capping multi-share notional.
       us: 1500
-      crypto: 1000000
+      # §145차 (2026-08-23): 1000000 → 5000000. 운영자 결정 — "100만 초과도
+      # 자동이었으면 해". §136차 A(k) add 레인이 만드는 물타기 A_limit 구간이
+      # 100만을 넘어가서(2026-08-23 실측 −5% 전환점 기준 XRP ≈ 293만, SOL ≈
+      # 532만은 여전히 초과) 그 구간 전체가 구조적으로 카드로 강등됐다. §106차
+      # 원칙("per-order 캡 = 자동화 오류 1회의 최대 손실 경계")은 그대로 두고,
+      # 운영자가 그 경계를 500만으로 재정의한 것이다. 실질 상한은 여전히 업비트
+      # 가용 현금(§144차 트리거 리저브 ~270만 + JIT 입금)이며, 현금이 모자라면
+      # deferred_with_condition + 입금 알림이 주문보다 먼저 나간다.
+      # 불변: min_distance 3% · resting-only(marketable은 카드) · 태그 스캔 ·
+      # 손실가드 · 부분체결 금지. kr/us 캡은 건드리지 않는다.
+      crypto: 5000000
     daily_cap:
       kr: 5000000
       # §71차 (2026-08-14): 800 -> 5000. The §65차 same-value pairing was wrong
@@ -94,7 +104,12 @@ order_proposals:
       # 5000 covers an observed full trim session (~10% of book/day/account);
       # the $800 per-order cap and per-rung veto cards remain the guardrails.
       us: 20000
-      crypto: 5000000
+      # §145차 (2026-08-23): 5000000 → 10000000. per-order 상향에 비례해서
+      # 함께 올린다 — §71차 교훈(일일캡이 주문당캡에 붙어 있으면 첫 자동승인
+      # 1건이 캡을 대부분 소진하고 이후 주문이 전부 카드로 강등됨)이 crypto
+      # 레인에서 재현되지 않도록 하기 위한 것이며, 일일캡은 승인 레인을
+      # 좁히는 장치가 아니라는 §106차 규정을 따른다.
+      crypto: 10000000
     # AUTO-APPROVE-EXPAND (§40차) — inputs to the profit-take classification,
     # consumed only when ORDER_PROPOSALS_AUTO_APPROVE_MODE=expanded.
     #
@@ -538,7 +553,8 @@ decision_rules:
   # (authority.scope: judgment_policy_only — §115차/§127차/§129차와 같은 구조).
   # 아래 조건을 읽어 주문을 만들거나 막는 코드는 레포에 없다. 세션이 판단으로
   # 적용하고, 결과 주문에 걸리는 유일한 코드 경계는 서버측 자동승인 게이트다:
-  # crypto per-order 100만 KRW 초과는 자동승인 불가 → 카드(수동 승인)로 내려간다.
+  # crypto per-order 자동승인 캡 초과는 자동승인 불가 → 카드(수동 승인)로
+  # 내려간다(§139차 당시 100만, §145차 2026-08-23 이후 500만).
   # 그 아래의 30만/90만·(코인,지지레벨)당 1회·급락 중지·forecast 의무는 전부
   # 세션 계약이며 기계 가드가 아니다 — 무시하는 세션을 레포가 멈추지 못한다.
   # 그래서 대응 절이 운영자 레포(auto_trader-operator live/CLAUDE.md)에 있다.
@@ -556,9 +572,11 @@ decision_rules:
       an order. "LIVE" describes the funds, not an armed executor. The
       session applies the conditions as judgment, and the only code-enforced
       boundary on a resulting order is the server-side auto-approve gate — a
-      crypto order above the 1,000,000 KRW per-order cap cannot auto-approve
-      and falls back to a manual card. Everything below that line — the
-      300,000 KRW per-coin cap, the 900,000 KRW tier total, the
+      crypto order above the 5,000,000 KRW per-order cap cannot auto-approve
+      and falls back to a manual card (that cap read 1,000,000 KRW when this
+      tier was armed; §145차 2026-08-23 raised it, which widens the lane and
+      does not narrow this tier's own 300,000/900,000 KRW session caps).
+      Everything below that line — the 300,000 KRW per-coin cap, the 900,000 KRW tier total, the
       one-placement-per-(coin, support level) rule, the crash-day suspension,
       and the forecast obligation — is a SESSION CONTRACT, not a machine
       guard; the repo will not stop a session that ignores it, which is why
@@ -575,10 +593,10 @@ decision_rules:
       -12% and -3% of the current price. Sizing is capped at 300,000 KRW per
       coin and 900,000 KRW across the whole tier, at most one placement per
       (coin, support level) per policy version. Orders route through the
-      EXISTING auto-approve path — each is far below the 1,000,000 KRW crypto
-      per-order cap, so no new approval surface is created and no cap is
-      raised. Crypto orders rest GTC by Upbit convention; DAY is not used
-      here. Every placement records a forecast (touch / fill / D+20 outcome).
+      EXISTING auto-approve path — each is far below the crypto per-order cap
+      (1,000,000 KRW when §139차 armed this tier, 5,000,000 KRW since §145차),
+      so this tier creates no new approval surface and raised no cap itself.
+      Crypto orders rest GTC by Upbit convention; DAY is not used here. Every placement records a forecast (touch / fill / D+20 outcome).
       On 2026-09-19 the tier is RETIRED unless the FILLED cohort's D+20
       median is >= 0 AND its lower quartile is > -8%; those two numbers are
       fixed in advance and may not be reinterpreted at scoring time. During a

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -219,7 +219,7 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
     }
     # advisory keys are echoed with the same version/content_hash stamp as
     # every other section of the response (ROB-932).
-    assert out["version"] == "2026-08-23.1"
+    assert out["version"] == "2026-08-23.2"
     assert out["content_hash"]
 
 

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -58,10 +58,13 @@ _S142_RESERVE_TRIM_ADDITIVE_CONDITION_KEYS = (
 _ROB1292_ALLOWED_POLICY_DELTAS = (
     ("order_proposals.auto_approve.per_order_cap.kr", 400000, 2000000),
     ("order_proposals.auto_approve.per_order_cap.us", 800, 1500),
-    ("order_proposals.auto_approve.per_order_cap.crypto", 100000, 1000000),
+    # §145차 (2026-08-23): 1000000 -> 5000000 (operator cap re-definition).
+    ("order_proposals.auto_approve.per_order_cap.crypto", 100000, 5000000),
     ("order_proposals.auto_approve.daily_cap.kr", 400000, 5000000),
     ("order_proposals.auto_approve.daily_cap.us", 5000, 20000),
-    ("order_proposals.auto_approve.daily_cap.crypto", 300000, 5000000),
+    # §145차 (2026-08-23): 5000000 -> 10000000, kept proportional to the
+    # per-order cap so the §71차 demotion does not reappear on the crypto lane.
+    ("order_proposals.auto_approve.daily_cap.crypto", 300000, 10000000),
 )
 
 # §139차 (2026-08-22) — value deltas outside the auto-approve block. Kept in a
@@ -258,7 +261,7 @@ def _breakeven_reserve_trim_triggered(
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
     assert doc.version == load_trading_policy().version
-    assert doc.version == "2026-08-23.1"
+    assert doc.version == "2026-08-23.2"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -2068,7 +2071,7 @@ def test_s142_is_declared_versioned_and_not_retroactive():
     """The bugfix is stamped, and it never re-anchors an older placement."""
 
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-08-23.1"
+    assert doc.version == "2026-08-23.2"
     assert "§142차 breakeven band boundary repair 2026-08-23" in doc.source
     assert "NOT retroactive" in doc.source
 
@@ -2383,8 +2386,8 @@ def test_s139_held_majors_semantics_does_not_overclaim_enforcement():
     # "Major" is not claimed to be machine-checked, because it is not.
     assert "no coin allowlist or classifier" in semantics
     # And the named boundary is the one that is really enforced in code.
-    assert "1,000,000 KRW per-order cap" in semantics
-    assert doc.order_proposals.auto_approve.per_order_cap["crypto"] == 1000000
+    assert "5,000,000 KRW per-order cap" in semantics
+    assert doc.order_proposals.auto_approve.per_order_cap["crypto"] == 5000000
 
 
 def test_s139_held_majors_is_scoped_out_of_the_equity_lanes():

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -1296,9 +1296,12 @@ def test_policy_caps_match_the_operator_declared_limits():
     # per-order caps remain the maximum-loss boundary for one automation error.
     assert (kr.per_order_cap, kr.daily_cap) == (Decimal("2000000"), Decimal("5000000"))
     assert (us.per_order_cap, us.daily_cap) == (Decimal("1500"), Decimal("20000"))
+    # §145차 (2026-08-19 caps re-opened on the crypto lane 2026-08-23): the
+    # operator re-defined the one-automation-error boundary at 5M, with the
+    # daily cap kept proportional so the §71차 demotion cannot reappear.
     assert (crypto.per_order_cap, crypto.daily_cap) == (
-        Decimal("1000000"),
         Decimal("5000000"),
+        Decimal("10000000"),
     )
 
 


### PR DESCRIPTION
## 무엇

운영자 §145차 결정(claude-mock 세션 — "100만 초과도 자동이었으면 해")을 `config/trading_policy.yaml` 에 반영한다. **정책 YAML 값 변경 + 버전 스탬프 + 테스트 핀 갱신이 전부**다. 코드 로직·마이그레이션·새 표면 0.

| 키 | 이전 | 이후 |
|---|---|---|
| `order_proposals.auto_approve.per_order_cap.crypto` | 1,000,000 | **5,000,000** |
| `order_proposals.auto_approve.daily_cap.crypto` | 5,000,000 | **10,000,000** |
| `version` | `2026-08-23.1` | **`2026-08-23.2`** |

`source` 는 append-only 로 §145차 항목을 덧붙였다(닫힌 동치성 테스트가 baseline 을 prefix 로 요구).

## 왜

- §136차 A(k) add 레인이 만드는 **물타기 A_limit 구간이 100만을 넘어간다** — 2026-08-23 실측 −5% 전환점 기준 XRP ≈ 293만. 그 구간 전체가 구조적으로 카드(수동 승인)로 강등돼 있었다. (SOL ≈ 532만은 상향 후에도 여전히 캡 초과 → 카드 유지.)
- 일일캡은 **§71차 교훈**(일일캡이 주문당캡에 붙어 있으면 첫 자동승인 1건이 캡을 대부분 소진하고 이후 주문이 전부 카드로 강등)에 따라 비례 상향.
- **§106차 원칙은 유지**: per-order 캡 = 자동화 오류 1회의 최대 손실 경계. 운영자가 그 경계를 500만으로 재정의한 것이지, 경계 개념을 없앤 게 아니다.

## 폭발반경

실질 상한은 여전히 **업비트 가용 현금**(§144차 트리거 리저브 ~270만 + JIT 입금)이다. 현금이 모자라면 `deferred_with_condition` + 입금 알림이 주문보다 먼저 나가므로 캡 상향의 단독 폭발반경은 제한적이다.

## 불변

`min_distance` 3% · resting-only(marketable 은 카드) · 태그 스캔 · 손실가드 · 부분체결 금지 · breakeven 밴드 · **KR/US 캡** · 신규코인 발굴 게이트 · 티어/사이징 규칙 — 전부 그대로.

## 문언 일관성 (주의해서 볼 곳)

§139차 `buy.held_majors_support_net` 의 semantics 산문과 그 위 한글 주석이 **"코드가 실제로 강제하는 유일한 경계"로 1,000,000 KRW 를 명시**하고 있었다. 캡이 바뀐 뒤에도 그대로 두면 세션이 읽는 문언이 사실과 어긋나므로 현행값(5,000,000)으로 갱신하되, **§139차 자신은 캡을 올리지 않았다는 이력**("that cap read 1,000,000 KRW when this tier was armed" / "raised no cap itself")은 문언에 보존했다. `per_order_cap_raised: false` 조건 키는 §139차의 선언이므로 불변이며, 이 티어 자체의 30만/90만 세션 캡도 불변이다.

§142차 `*_since_policy_version: "2026-08-23.1"` 앵커 2곳은 **"그 버전 이후 적용" 표식**이므로 의도적으로 올리지 않았다.

## 테스트

- `tests/schemas/test_trading_policy_schema.py` — `_ROB1292_ALLOWED_POLICY_DELTAS` 의 crypto 두 항목 갱신(ROB-1289 baseline 대비 허용 델타 표; 이 표를 소비하는 닫힌 동치성 테스트 3곳이 자동으로 따라온다) + `version` 핀 2곳 + §139차 문언 assert
- `tests/services/order_proposals/test_auto_approve.py` — 라이브 캡 핀 (`test_policy_caps_match_the_operator_declared_limits`)
- `tests/mcp_server/test_trading_policy_tool.py` — `version` echo 핀

전수 grep 으로 확인한 잔여 핀 없음(`docs/` 에는 캡 수치가 없어 갱신 대상 아님).

로컬 결과: `2,879 passed` (정책 스키마·MCP 툴·order_proposals 전체·정책 소비자 테스트 17개 파일 + b0x sidecar / watch_trigger_repricing / toss_loss_cut). `ruff format` / `ruff check` 통과. **CI exact-head 확인 전이므로 draft.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LTbNaSuZ6nmGdY85FmF5w
