### PR TITLE
feat(invest): §144차 매수 계획(트리거 보드) — read-only 자금 대조 보드

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ from app.routers import (
     invest_api,
     invest_app_spa,
     invest_artifacts,
+    invest_buy_plan,
     invest_fills,
     invest_forecasts,
     invest_funding,
@@ -216,6 +217,7 @@ def create_app() -> FastAPI:
     app.include_router(invest_fills.router)
     app.include_router(invest_open_orders.router)
     app.include_router(invest_watches.router)
+    app.include_router(invest_buy_plan.router)
     app.include_router(invest_retrospectives.router)
     app.include_router(invest_forecasts.router)
     app.include_router(invest_funding.router)

--- a/app/routers/invest_buy_plan.py
+++ b/app/routers/invest_buy_plan.py
@@ -1,0 +1,51 @@
+"""Read-only /invest 매수 계획 (트리거 보드) endpoint — §144차.
+
+GET only. The handler composes existing read models and the operator-owned
+policy file; no route here reaches an order, proposal, watch, or broker
+mutation path.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.invest_buy_plan import BuyPlanResponse
+from app.services.invest_view_model.buy_plan.service import BuyPlanService
+
+router = APIRouter(
+    prefix="/trading/api/invest/buy-plan",
+    tags=["invest-buy-plan"],
+)
+
+Market = Literal["all", "kr", "us", "crypto"]
+
+
+def get_buy_plan_service(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> BuyPlanService:
+    # Imported lazily for the same reason as invest_api.get_invest_home_service:
+    # importing this router module must not drag in the KIS/Upbit reader chain.
+    from app.routers.invest_api import get_invest_home_service
+    from app.services.current_orders_service import CurrentOrdersService
+    from app.services.invest_view_model.watch_panel_service import WatchPanelService
+
+    return BuyPlanService(
+        home_service=get_invest_home_service(db),
+        watch_service=WatchPanelService(db=db),
+        open_orders_service=CurrentOrdersService(db=db),
+    )
+
+
+@router.get("")
+async def get_buy_plan(
+    user: Annotated[User, Depends(get_authenticated_user)],
+    service: Annotated[BuyPlanService, Depends(get_buy_plan_service)],
+    market: Annotated[Market, Query()] = "all",
+) -> BuyPlanResponse:
+    return await service.build(user_id=user.id, market=market)

--- a/app/schemas/invest_buy_plan.py
+++ b/app/schemas/invest_buy_plan.py
@@ -30,6 +30,13 @@ GateConditionState = Literal["met", "not_met", "unavailable"]
 # leaves the gate un-passable but also un-proven.
 GateState = Literal["open", "closed", "indeterminate"]
 FundingVerdict = Literal["sufficient", "shortfall", "unknown"]
+# A read model that told us it was incomplete. Kept as a first-class value so
+# a degraded upstream can never render as a confident zero (verify-r1 B3/B4).
+SourceState = Literal["ok", "degraded", "unavailable"]
+# Canonical broker identity for cash scoping (verify-r1 B1). Cash in one
+# broker cannot fund an order placed at another, so every reconciliation is
+# keyed by (broker, currency) and never by currency alone.
+FundingBroker = Literal["kis", "upbit", "toss", "unattributed"]
 
 
 def _decimal_str(value: Decimal | None) -> str | None:
@@ -47,6 +54,26 @@ class PolicyStamp(BaseModel):
 
     version: str
     content_hash: str
+
+
+class ApprovalContext(BaseModel):
+    """What the board can and cannot say about the auto-approval lane.
+
+    ``approval_lane`` on a row is a **cap-only** classification: it compares a
+    projected notional against the tier auto-submit ceiling and the per-order
+    auto-approve cap. Real dispatch additionally requires the master gate below
+    plus a set of conditions this read surface does not evaluate
+    (``unevaluated_conditions``). Publishing that gap is the whole point of
+    this object — "cap 이하 = 자동승인" is false (verify-r1 B6).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    master_gate_enabled: bool | None
+    master_gate_setting: str
+    master_gate_source: str
+    unevaluated_conditions: list[str] = Field(default_factory=list)
+    notice: str
 
 
 class ValueSource(BaseModel):
@@ -104,6 +131,7 @@ class AveragingTriggerRow(BuyPlanDecimalModel):
     # shown but excluded from the funding total.
     market_rank: int
     within_policy_add_cap: bool
+    funding_broker: FundingBroker
     notes: list[str] = Field(default_factory=list)
 
     @field_serializer(
@@ -154,9 +182,14 @@ class SupportNetRow(BuyPlanDecimalModel):
     eligible: bool
     ineligible_reason: str | None = None
     placements: list[SupportNetPlacement] = Field(default_factory=list)
-    placed_notional: Decimal
+    # ``None`` when a placement source was degraded/unavailable: an unknown
+    # amount is not zero, and a headroom computed from a partial order list
+    # would overstate what is still free to spend (verify-r1 B4).
+    placed_notional: Decimal | None = None
     per_symbol_cap_notional: Decimal
-    remaining_headroom_notional: Decimal
+    remaining_headroom_notional: Decimal | None = None
+    placements_state: SourceState = "ok"
+    placements_incomplete_reasons: list[str] = Field(default_factory=list)
 
     @field_serializer(
         "quantity",
@@ -179,8 +212,10 @@ class SupportNetTier(BuyPlanDecimalModel):
     currency: BuyPlanCurrency
     tier_cap_notional: Decimal | None = None
     per_symbol_cap_notional: Decimal | None = None
-    placed_notional: Decimal
+    placed_notional: Decimal | None = None
     remaining_notional: Decimal | None = None
+    placements_state: SourceState = "ok"
+    placements_incomplete_reasons: list[str] = Field(default_factory=list)
     distance_band_pct: list[Decimal] = Field(default_factory=list)
     review_date: str | None = None
     rows: list[SupportNetRow] = Field(default_factory=list)
@@ -218,6 +253,11 @@ class ActiveBuyWatchRow(BuyPlanDecimalModel):
     near_expiry: bool = False
     planned_notional: Decimal | None = None
     planned_notional_source: str | None = None
+    # Which broker account would have to hold this cash. ``unattributed`` means
+    # the watch's execution plan did not name one, so the amount cannot be
+    # charged to any single account's reserve (verify-r1 B1).
+    funding_broker: FundingBroker
+    account_mode: str | None = None
     approval_lane: ApprovalLane
     approval_lane_reason: ApprovalLaneReason
 
@@ -267,6 +307,9 @@ class CashAccountRow(BuyPlanDecimalModel):
     account_id: str
     display_name: str
     source: str
+    # Canonical broker this account belongs to; cash is only ever compared
+    # with requirements carrying the same broker (verify-r1 B1).
+    broker: FundingBroker
     currency: BuyPlanCurrency
     available_cash: Decimal | None = None
     available_cash_source: str
@@ -277,13 +320,32 @@ class CashAccountRow(BuyPlanDecimalModel):
         return _decimal_str(value)
 
 
-class CurrencyReconciliation(BuyPlanDecimalModel):
+class ScopeReconciliation(BuyPlanDecimalModel):
+    """Cash vs requirements for ONE (broker, currency) pair.
+
+    Scoping by broker is not cosmetic: KIS KRW cannot fill an Upbit order, so
+    a currency-only total can read ``sufficient`` while the account that must
+    place the order holds nothing (verify-r1 B1).
+
+    ``broker="unattributed"`` carries the requirements whose owning account
+    could not be resolved. They are never dropped from the board; instead they
+    hold every same-currency scope at ``unknown`` unless that scope's cash
+    covers its own requirements *plus* all of them.
+    """
+
+    scope_key: str
+    broker: FundingBroker
     currency: BuyPlanCurrency
+    account_ids: list[str] = Field(default_factory=list)
     available_cash: Decimal | None = None
     required_averaging_adds: Decimal
     required_support_net: Decimal
     required_active_watches: Decimal
     required_total: Decimal
+    unattributed_same_currency: Decimal
+    worst_case_required: Decimal
+    requirements_complete: bool = True
+    incomplete_reasons: list[str] = Field(default_factory=list)
     verdict: FundingVerdict
     shortfall: Decimal | None = None
     notes: list[str] = Field(default_factory=list)
@@ -294,8 +356,24 @@ class CurrencyReconciliation(BuyPlanDecimalModel):
         "required_support_net",
         "required_active_watches",
         "required_total",
+        "unattributed_same_currency",
+        "worst_case_required",
         "shortfall",
     )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class UnattributedRequirement(BuyPlanDecimalModel):
+    """One requirement the board could not pin to a broker account."""
+
+    kind: Literal["averaging_add", "support_net", "active_watch"]
+    label: str
+    currency: BuyPlanCurrency
+    amount: Decimal | None = None
+    reason: str
+
+    @field_serializer("amount")
     def _ser(self, value: Decimal | None) -> str | None:
         return _decimal_str(value)
 
@@ -304,7 +382,9 @@ class BuyPlanFunding(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     accounts: list[CashAccountRow] = Field(default_factory=list)
-    currencies: list[CurrencyReconciliation] = Field(default_factory=list)
+    scopes: list[ScopeReconciliation] = Field(default_factory=list)
+    unattributed: list[UnattributedRequirement] = Field(default_factory=list)
+    source_warnings: list[str] = Field(default_factory=list)
 
 
 class BuyPlanResponse(BaseModel):
@@ -314,6 +394,7 @@ class BuyPlanResponse(BaseModel):
     policy: PolicyStamp
     cache_ttl_seconds: int
     approximation_notice: str
+    approval_context: ApprovalContext
     market: Literal["all", "kr", "us", "crypto"]
     averaging_triggers: list[AveragingTriggerRow] = Field(default_factory=list)
     support_net: SupportNetTier

--- a/app/schemas/invest_buy_plan.py
+++ b/app/schemas/invest_buy_plan.py
@@ -1,0 +1,324 @@
+"""Read-only schemas for the /invest 매수 계획 (트리거 보드) — §144차.
+
+Every number on this board is a **display approximation of the policy
+formula**, not a session verdict and not an order. The response therefore
+carries its own provenance: the policy ``version``/``content_hash`` it was
+computed against, the calculation time, and an explicit per-field source list.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
+
+BuyPlanMarket = Literal["kr", "us", "crypto"]
+BuyPlanCurrency = Literal["KRW", "USD"]
+ApprovalLane = Literal["auto_submit", "human_card"]
+ApprovalLaneReason = Literal[
+    "within_tier_auto_submit_notional",
+    "above_tier_auto_submit_notional",
+    "above_per_order_auto_approve_cap",
+    "notional_unavailable",
+]
+PlacementForm = Literal["resting_order", "watch"]
+GateConditionState = Literal["met", "not_met", "unavailable"]
+# ``indeterminate`` is not a softer "closed": the policy says a missing
+# threshold must not be inferred or counted as met, so an unreadable input
+# leaves the gate un-passable but also un-proven.
+GateState = Literal["open", "closed", "indeterminate"]
+FundingVerdict = Literal["sufficient", "shortfall", "unknown"]
+
+
+def _decimal_str(value: Decimal | None) -> str | None:
+    return None if value is None else format(value, "f")
+
+
+class BuyPlanDecimalModel(BaseModel):
+    """Base that serialises every Decimal field as an exact string."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class PolicyStamp(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: str
+    content_hash: str
+
+
+class ValueSource(BaseModel):
+    """Where one block of the board got its numbers from."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    source: str
+    note: str | None = None
+
+
+class AveragingSampleRow(BuyPlanDecimalModel):
+    """One sampled depth below the A(k) turn point."""
+
+    offset_from_turn_point_pct: Decimal
+    price: Decimal
+    additional_notional: Decimal
+    target_average_price: Decimal
+    approval_lane: ApprovalLane
+    approval_lane_reason: ApprovalLaneReason
+
+    @field_serializer(
+        "offset_from_turn_point_pct",
+        "price",
+        "additional_notional",
+        "target_average_price",
+    )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class AveragingTriggerRow(BuyPlanDecimalModel):
+    """One underwater lot's 물타기 A(k) 전환점."""
+
+    market: BuyPlanMarket
+    symbol: str
+    symbol_name: str | None = None
+    currency: BuyPlanCurrency
+    account_sources: list[str] = Field(default_factory=list)
+    quantity: Decimal
+    average_price: Decimal
+    cost_basis: Decimal
+    current_price: Decimal
+    unrealized_pnl_pct: Decimal | None = None
+    k: Decimal
+    turn_point_price: Decimal
+    distance_to_turn_point_pct: Decimal
+    turn_point_reached: bool
+    samples: list[AveragingSampleRow] = Field(default_factory=list)
+    # The deeper sample — what to keep in reserve if this trigger fires.
+    reserve_plan_notional: Decimal
+    # Rank within its market by nearness to the turn point. The policy caps
+    # A(k) adds at ``max_add_symbols_per_market``; rows beyond the cap are
+    # shown but excluded from the funding total.
+    market_rank: int
+    within_policy_add_cap: bool
+    notes: list[str] = Field(default_factory=list)
+
+    @field_serializer(
+        "quantity",
+        "average_price",
+        "cost_basis",
+        "current_price",
+        "unrealized_pnl_pct",
+        "k",
+        "turn_point_price",
+        "distance_to_turn_point_pct",
+        "reserve_plan_notional",
+    )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class SupportNetPlacement(BuyPlanDecimalModel):
+    """One already-expressed rung of a support net — resting order or watch."""
+
+    form: PlacementForm
+    reference: str
+    anchor_price: Decimal | None = None
+    quantity: Decimal | None = None
+    notional: Decimal | None = None
+    distance_from_current_pct: Decimal | None = None
+    valid_until: dt.datetime | None = None
+    within_policy_distance_band: bool | None = None
+
+    @field_serializer(
+        "anchor_price", "quantity", "notional", "distance_from_current_pct"
+    )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class SupportNetRow(BuyPlanDecimalModel):
+    """One held coin's 지지 그물 티어 state."""
+
+    market: BuyPlanMarket
+    symbol: str
+    symbol_name: str | None = None
+    currency: BuyPlanCurrency
+    quantity: Decimal
+    average_price: Decimal | None = None
+    current_price: Decimal | None = None
+    unrealized_pnl_pct: Decimal | None = None
+    eligible: bool
+    ineligible_reason: str | None = None
+    placements: list[SupportNetPlacement] = Field(default_factory=list)
+    placed_notional: Decimal
+    per_symbol_cap_notional: Decimal
+    remaining_headroom_notional: Decimal
+
+    @field_serializer(
+        "quantity",
+        "average_price",
+        "current_price",
+        "unrealized_pnl_pct",
+        "placed_notional",
+        "per_symbol_cap_notional",
+        "remaining_headroom_notional",
+    )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class SupportNetTier(BuyPlanDecimalModel):
+    """Tier-level totals for ``buy.held_majors_support_net``."""
+
+    policy_key: str
+    enabled: bool
+    currency: BuyPlanCurrency
+    tier_cap_notional: Decimal | None = None
+    per_symbol_cap_notional: Decimal | None = None
+    placed_notional: Decimal
+    remaining_notional: Decimal | None = None
+    distance_band_pct: list[Decimal] = Field(default_factory=list)
+    review_date: str | None = None
+    rows: list[SupportNetRow] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+    @field_serializer(
+        "tier_cap_notional",
+        "per_symbol_cap_notional",
+        "placed_notional",
+        "remaining_notional",
+    )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+    @field_serializer("distance_band_pct")
+    def _ser_band(self, value: list[Decimal]) -> list[str]:
+        return [format(v, "f") for v in value]
+
+
+class ActiveBuyWatchRow(BuyPlanDecimalModel):
+    """An active buy-side watch — cash that becomes needed when it fires."""
+
+    market: BuyPlanMarket
+    symbol: str
+    symbol_name: str | None = None
+    currency: BuyPlanCurrency
+    alert_uuid: str
+    metric: str
+    operator: Literal["above", "below", "between"]
+    threshold: Decimal
+    threshold_high: Decimal | None = None
+    current_price: Decimal | None = None
+    distance_to_threshold_pct: Decimal | None = None
+    valid_until: dt.datetime
+    near_expiry: bool = False
+    planned_notional: Decimal | None = None
+    planned_notional_source: str | None = None
+    approval_lane: ApprovalLane
+    approval_lane_reason: ApprovalLaneReason
+
+    @field_serializer(
+        "threshold",
+        "threshold_high",
+        "current_price",
+        "distance_to_threshold_pct",
+        "planned_notional",
+    )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class DiscoveryGateCondition(BuyPlanDecimalModel):
+    condition_id: str
+    metric: str
+    comparison: str | None = None
+    threshold: Decimal | None = None
+    unit: str | None = None
+    current_value: Decimal | None = None
+    state: GateConditionState
+    source: str | None = None
+    note: str | None = None
+
+    @field_serializer("threshold", "current_value")
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class DiscoveryGateRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: BuyPlanMarket
+    gate_key: str
+    state: GateState
+    min_conditions_met: int
+    of: int
+    met_count: int
+    unavailable_count: int
+    semantics: str | None = None
+    conditions: list[DiscoveryGateCondition] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class CashAccountRow(BuyPlanDecimalModel):
+    account_id: str
+    display_name: str
+    source: str
+    currency: BuyPlanCurrency
+    available_cash: Decimal | None = None
+    available_cash_source: str
+    included_in_reserve: bool
+
+    @field_serializer("available_cash")
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class CurrencyReconciliation(BuyPlanDecimalModel):
+    currency: BuyPlanCurrency
+    available_cash: Decimal | None = None
+    required_averaging_adds: Decimal
+    required_support_net: Decimal
+    required_active_watches: Decimal
+    required_total: Decimal
+    verdict: FundingVerdict
+    shortfall: Decimal | None = None
+    notes: list[str] = Field(default_factory=list)
+
+    @field_serializer(
+        "available_cash",
+        "required_averaging_adds",
+        "required_support_net",
+        "required_active_watches",
+        "required_total",
+        "shortfall",
+    )
+    def _ser(self, value: Decimal | None) -> str | None:
+        return _decimal_str(value)
+
+
+class BuyPlanFunding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    accounts: list[CashAccountRow] = Field(default_factory=list)
+    currencies: list[CurrencyReconciliation] = Field(default_factory=list)
+
+
+class BuyPlanResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    as_of: dt.datetime
+    policy: PolicyStamp
+    cache_ttl_seconds: int
+    approximation_notice: str
+    market: Literal["all", "kr", "us", "crypto"]
+    averaging_triggers: list[AveragingTriggerRow] = Field(default_factory=list)
+    support_net: SupportNetTier
+    active_buy_watches: list[ActiveBuyWatchRow] = Field(default_factory=list)
+    discovery_gates: list[DiscoveryGateRow] = Field(default_factory=list)
+    funding: BuyPlanFunding
+    value_sources: list[ValueSource] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)

--- a/app/schemas/invest_buy_plan.py
+++ b/app/schemas/invest_buy_plan.py
@@ -56,6 +56,22 @@ class PolicyStamp(BaseModel):
     content_hash: str
 
 
+class ApprovalCondition(BaseModel):
+    """One auto-approval gate this board does not evaluate.
+
+    ``code`` is the literal ``reject(...)`` reason from
+    ``order_proposals.auto_approve.evaluate_auto_approve_eligibility``; a
+    contract test extracts those literals from the source and fails if this
+    list stops covering them. A partial list is its own lie — it reads as
+    "these are the only things we skipped".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    label: str
+
+
 class ApprovalContext(BaseModel):
     """What the board can and cannot say about the auto-approval lane.
 
@@ -72,7 +88,8 @@ class ApprovalContext(BaseModel):
     master_gate_enabled: bool | None
     master_gate_setting: str
     master_gate_source: str
-    unevaluated_conditions: list[str] = Field(default_factory=list)
+    unevaluated_conditions: list[ApprovalCondition] = Field(default_factory=list)
+    evaluated_conditions: list[ApprovalCondition] = Field(default_factory=list)
     notice: str
 
 
@@ -132,6 +149,7 @@ class AveragingTriggerRow(BuyPlanDecimalModel):
     market_rank: int
     within_policy_add_cap: bool
     funding_broker: FundingBroker
+    funding_broker_reason: str | None = None
     notes: list[str] = Field(default_factory=list)
 
     @field_serializer(
@@ -257,6 +275,10 @@ class ActiveBuyWatchRow(BuyPlanDecimalModel):
     # the watch's execution plan did not name one, so the amount cannot be
     # charged to any single account's reserve (verify-r1 B1).
     funding_broker: FundingBroker
+    # Why attribution failed, verbatim. Collapsing every failure into "no
+    # account_mode" hid genuinely wrong values like ``kiwoom_mock``
+    # (verify-r2 SHOULD-3).
+    funding_broker_reason: str | None = None
     account_mode: str | None = None
     approval_lane: ApprovalLane
     approval_lane_reason: ApprovalLaneReason
@@ -327,10 +349,16 @@ class ScopeReconciliation(BuyPlanDecimalModel):
     a currency-only total can read ``sufficient`` while the account that must
     place the order holds nothing (verify-r1 B1).
 
-    ``broker="unattributed"`` carries the requirements whose owning account
-    could not be resolved. They are never dropped from the board; instead they
-    hold every same-currency scope at ``unknown`` unless that scope's cash
-    covers its own requirements *plus* all of them.
+    ``broker="unattributed"`` is a real destination row carrying the
+    requirements whose owning account could not be resolved. It always exists
+    when such a requirement exists, including for a currency or broker that
+    has no cash account at all — otherwise an unresolved need could reach no
+    verdict anywhere on the board (verify-r2 B1 (b)/(d)).
+
+    A scope with same-currency unattributed money can never read
+    ``sufficient``: that money may land at a *different* broker, so this
+    account covering it proves nothing about the account that will actually
+    place the order (verify-r2 B1 (a)).
     """
 
     scope_key: str
@@ -343,7 +371,11 @@ class ScopeReconciliation(BuyPlanDecimalModel):
     required_active_watches: Decimal
     required_total: Decimal
     unattributed_same_currency: Decimal
-    worst_case_required: Decimal
+    # Deliberately NOT called a worst case. The true worst case is that the
+    # unattributed money lands on an account with no cash, which is a
+    # different scope entirely — this number only answers the conditional
+    # "if all of it landed here" (verify-r2 3-1(e)).
+    upper_bound_if_all_unattributed_lands_here: Decimal
     requirements_complete: bool = True
     incomplete_reasons: list[str] = Field(default_factory=list)
     verdict: FundingVerdict
@@ -357,7 +389,7 @@ class ScopeReconciliation(BuyPlanDecimalModel):
         "required_active_watches",
         "required_total",
         "unattributed_same_currency",
-        "worst_case_required",
+        "upper_bound_if_all_unattributed_lands_here",
         "shortfall",
     )
     def _ser(self, value: Decimal | None) -> str | None:

--- a/app/services/invest_view_model/buy_plan/__init__.py
+++ b/app/services/invest_view_model/buy_plan/__init__.py
@@ -1,0 +1,26 @@
+"""Read-only "매수 계획 (트리거 보드)" aggregate for /invest (§144차).
+
+The package is split so the arithmetic is testable without a database, a
+broker, or a network: :mod:`computation` is pure, :mod:`service` does the
+reads. Nothing here mutates a broker, an order, a watch, or a proposal — the
+whole surface is a projection of existing read models plus the operator-owned
+``config/trading_policy.yaml``.
+"""
+
+from app.services.invest_view_model.buy_plan.computation import (
+    APPROXIMATION_NOTICE,
+    AveragingSample,
+    AveragingTurnPoint,
+    approval_lane_for,
+    averaging_additional_notional,
+    averaging_turn_point,
+)
+
+__all__ = [
+    "APPROXIMATION_NOTICE",
+    "AveragingSample",
+    "AveragingTurnPoint",
+    "approval_lane_for",
+    "averaging_additional_notional",
+    "averaging_turn_point",
+]

--- a/app/services/invest_view_model/buy_plan/computation.py
+++ b/app/services/invest_view_model/buy_plan/computation.py
@@ -1,0 +1,219 @@
+"""Pure arithmetic behind the /invest 매수 계획 board (§144차).
+
+Everything in this module is a **display approximation of the policy
+formula**, not a reproduction of a session's verdict. A session weighs support
+quality, R-931 review state, sector concentration, crash-day state and much
+else that this module deliberately does not model; the numbers here answer one
+narrower question the operator asked — *"이 트리거가 걸리면 돈이 얼마나
+필요한가"* — so cash can be moved in advance.
+
+No database, broker, network, clock, or environment access lives here.
+
+Averaging-down (물타기) arithmetic
+---------------------------------
+``config/trading_policy.yaml`` → ``decision_rules['buy.support_reserve_net']
+.add_candidate`` fixes ``k_used`` and ``a_limit_lte_zero: NO_ORDER``. The
+notional that pulls a position's average cost down to within ``k`` of the fill
+price ``p`` is
+
+    A(p) = C · (1 − (p/P)·(1+k)) / k
+
+with ``C`` the cost basis and ``P`` the current average price — the same
+formula as ``scripts/policy_table/core/averaging.py``; a parity test pins the
+two implementations together so they cannot drift.
+
+A(p) is positive only while ``p < P/(1+k)``. That boundary is the **turn
+point** ``P*``: above it the policy says NO_ORDER, below it an add becomes
+arithmetically meaningful and grows as price falls. ``P*`` is what the board
+shows as the trigger price, and the requested cash curve is sampled at fixed
+offsets below it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, localcontext
+from typing import Final, Literal
+
+# Mirrors research.kr_corpus.d3_engine.constants, which
+# scripts/policy_table/core/averaging.py runs under. Restated rather than
+# imported so app/ does not depend on research/ or scripts/; the parity test
+# proves the two agree.
+DECIMAL_PRECISION: Final = 50
+
+APPROXIMATION_NOTICE: Final = (
+    "이 보드의 수치는 정책 산식의 표시용 근사입니다. 판정 정본은 회차이며, "
+    "여기서 계산된 금액·트리거가 주문을 만들거나 승인하지 않습니다."
+)
+
+# Sampled offsets below the turn point. The turn point itself is where
+# A(p) == 0, so it is useless as a cash estimate — the board reports the two
+# representative depths the operator asked for instead.
+TURN_POINT_SAMPLE_OFFSETS_PCT: Final = (Decimal("-1"), Decimal("-3"))
+
+ApprovalLane = Literal["auto_submit", "human_card"]
+
+# Closed vocabulary. A new reason must be added here rather than passed
+# through as free text, so the frontend can never render an unlabelled lane.
+ApprovalLaneReason = Literal[
+    "within_tier_auto_submit_notional",
+    "above_tier_auto_submit_notional",
+    "above_per_order_auto_approve_cap",
+    "notional_unavailable",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AveragingSample:
+    """One point on the A(k) cash curve below the turn point."""
+
+    offset_from_turn_point_pct: Decimal
+    price: Decimal
+    additional_notional: Decimal
+    target_average_price: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class AveragingTurnPoint:
+    """Where an underwater lot becomes an arithmetically valid A(k) add."""
+
+    k: Decimal
+    average_price: Decimal
+    cost_basis: Decimal
+    current_price: Decimal
+    turn_point_price: Decimal
+    # Signed: positive = price still above the turn point (NO_ORDER today),
+    # negative = already past it. Percent of the turn point price.
+    distance_to_turn_point_pct: Decimal
+    reached: bool
+    samples: tuple[AveragingSample, ...]
+
+
+def averaging_additional_notional(
+    *,
+    cost_basis: Decimal,
+    average_price: Decimal,
+    price: Decimal,
+    k: Decimal,
+) -> Decimal:
+    """A(p) clamped at zero — the policy's ``a_limit_lte_zero: NO_ORDER``.
+
+    A non-positive raw value means the average is already within ``k`` of
+    ``price``; the tier then places no order at all, so zero is the honest
+    projection rather than a negative "credit".
+    """
+
+    if cost_basis <= 0 or average_price <= 0 or price <= 0:
+        raise ValueError("cost_basis, average_price and price must be positive")
+    if k <= 0:
+        raise ValueError("k must be positive")
+
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        ratio = price / average_price
+        raw = cost_basis * (Decimal(1) - ratio * (Decimal(1) + k)) / k
+
+    return raw if raw > 0 else Decimal(0)
+
+
+def turn_point_price(*, average_price: Decimal, k: Decimal) -> Decimal:
+    """``P* = P / (1 + k)`` — the price where A(k) crosses zero."""
+
+    if average_price <= 0:
+        raise ValueError("average_price must be positive")
+    if k <= 0:
+        raise ValueError("k must be positive")
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        return average_price / (Decimal(1) + k)
+
+
+def averaging_turn_point(
+    *,
+    cost_basis: Decimal,
+    average_price: Decimal,
+    current_price: Decimal,
+    k: Decimal,
+    sample_offsets_pct: tuple[Decimal, ...] = TURN_POINT_SAMPLE_OFFSETS_PCT,
+) -> AveragingTurnPoint:
+    """Full turn-point projection for one underwater lot."""
+
+    if cost_basis <= 0 or average_price <= 0 or current_price <= 0:
+        raise ValueError("cost_basis, average_price and current_price must be positive")
+    if k <= 0:
+        raise ValueError("k must be positive")
+
+    p_star = turn_point_price(average_price=average_price, k=k)
+
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        distance_pct = (current_price - p_star) / p_star * Decimal(100)
+        samples = tuple(
+            _sample(
+                cost_basis=cost_basis,
+                average_price=average_price,
+                k=k,
+                turn_point=p_star,
+                offset_pct=offset,
+            )
+            for offset in sample_offsets_pct
+        )
+
+    return AveragingTurnPoint(
+        k=k,
+        average_price=average_price,
+        cost_basis=cost_basis,
+        current_price=current_price,
+        turn_point_price=p_star,
+        distance_to_turn_point_pct=distance_pct,
+        # Exactly at the turn point A(k) == 0, which the policy calls
+        # NO_ORDER — so "reached" requires strictly below.
+        reached=current_price < p_star,
+        samples=samples,
+    )
+
+
+def _sample(
+    *,
+    cost_basis: Decimal,
+    average_price: Decimal,
+    k: Decimal,
+    turn_point: Decimal,
+    offset_pct: Decimal,
+) -> AveragingSample:
+    price = turn_point * (Decimal(1) + offset_pct / Decimal(100))
+    return AveragingSample(
+        offset_from_turn_point_pct=offset_pct,
+        price=price,
+        additional_notional=averaging_additional_notional(
+            cost_basis=cost_basis,
+            average_price=average_price,
+            price=price,
+            k=k,
+        ),
+        target_average_price=price * (Decimal(1) + k),
+    )
+
+
+def approval_lane_for(
+    *,
+    notional: Decimal | None,
+    tier_auto_submit_notional: Decimal | None,
+    per_order_auto_approve_cap: Decimal | None,
+) -> tuple[ApprovalLane, ApprovalLaneReason]:
+    """Classify a projected order into 자동승인 vs 카드.
+
+    Fail-closed in both directions: an unknown notional, an unknown tier
+    ceiling, or an unknown per-order cap all resolve to ``human_card``. The
+    board must never show 자동승인 for something it could not actually check.
+    """
+
+    if notional is None or notional <= 0:
+        return "human_card", "notional_unavailable"
+    if per_order_auto_approve_cap is None or tier_auto_submit_notional is None:
+        return "human_card", "notional_unavailable"
+    if notional > per_order_auto_approve_cap:
+        return "human_card", "above_per_order_auto_approve_cap"
+    if notional > tier_auto_submit_notional:
+        return "human_card", "above_tier_auto_submit_notional"
+    return "auto_submit", "within_tier_auto_submit_notional"

--- a/app/services/invest_view_model/buy_plan/gate_inputs.py
+++ b/app/services/invest_view_model/buy_plan/gate_inputs.py
@@ -1,0 +1,195 @@
+"""Discovery-gate metric readers for the 매수 계획 board (§144차).
+
+``config/trading_policy.yaml`` → ``market_rules.crypto.recovery_gate`` names
+two metrics by id. This module resolves exactly those two and nothing else:
+
+``alt_breadth_24h`` (``upbit_alt_breadth_24h``)
+    Share of KRW-quoted alts outperforming KRW-BTC over 24h, from the official
+    Upbit Open API ticker via :func:`app.services.external.upbit_index
+    .fetch_upbit_altseason`. That function's own docstring defines breadth in
+    exactly the policy's terms, so no re-derivation happens here.
+
+``btc_long_short_ratio``
+    Binance ``globalLongShortAccountRatio`` and ``topLongShortPositionRatio``.
+    The policy says "both report inputs should remain at or below the
+    threshold", so the resolved value is the **maximum** of the two legs —
+    comparing that single number with ``lte`` reproduces the two-leg rule. If
+    either leg is missing the value is ``None``, never the surviving leg.
+
+Both readers are fail-open to ``None``. The policy's
+``missing_or_null_threshold: do_not_infer_or_count_as_met`` then makes a
+``None`` an ``unavailable`` condition, which cannot count toward the gate — so
+a dead upstream leaves the gate un-passable rather than silently open.
+
+The board is a read surface, so results are cached for
+``GATE_CACHE_TTL_SECONDS`` to keep a page refresh from fanning out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+GATE_CACHE_TTL_SECONDS: Final = 180
+
+ALT_BREADTH_SOURCE: Final = "upbit_open_api_ticker_derived"
+LONG_SHORT_SOURCE: Final = "binance_global_account+binance_top_trader_position"
+
+
+@dataclass(frozen=True, slots=True)
+class GateMetricReading:
+    """One resolved (or unresolved) gate metric."""
+
+    metric: str
+    value: Decimal | None
+    source: str
+    note: str | None = None
+
+
+_cache: dict[str, tuple[float, GateMetricReading]] = {}
+_cache_lock = asyncio.Lock()
+
+
+def _reset_cache_for_tests() -> None:
+    _cache.clear()
+
+
+def _to_decimal(value: object) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+async def _cached(
+    key: str,
+    producer: Callable[[], Awaitable[GateMetricReading]],
+    *,
+    now: float,
+) -> GateMetricReading:
+    """Serve a fresh-enough reading, else produce one and store it.
+
+    ``producer`` is a factory rather than an already-created coroutine so a
+    cache hit does not leave an un-awaited coroutine behind.
+    """
+
+    async with _cache_lock:
+        hit = _cache.get(key)
+        if hit is not None and now - hit[0] < GATE_CACHE_TTL_SECONDS:
+            return hit[1]
+    reading = await producer()
+    async with _cache_lock:
+        _cache[key] = (now, reading)
+    return reading
+
+
+async def read_alt_breadth_24h(*, now: float | None = None) -> GateMetricReading:
+    """Percent of KRW alts outperforming BTC over 24h, or ``None``."""
+
+    return await _cached(
+        "alt_breadth_24h", _read_alt_breadth_24h, now=now or time.monotonic()
+    )
+
+
+async def _read_alt_breadth_24h() -> GateMetricReading:
+    try:
+        from app.services.external.upbit_index import fetch_upbit_altseason
+
+        payload = await fetch_upbit_altseason()
+    except Exception as exc:  # noqa: BLE001 — fail-open by contract
+        logger.warning("buy_plan: alt breadth unavailable: %s", exc)
+        return GateMetricReading(
+            metric="upbit_alt_breadth_24h",
+            value=None,
+            source=ALT_BREADTH_SOURCE,
+            note=f"조회 실패: {exc}",
+        )
+
+    breadth = (payload or {}).get("breadth") if isinstance(payload, dict) else None
+    fraction = _to_decimal((breadth or {}).get("alts_beating_btc_pct"))
+    if fraction is None:
+        return GateMetricReading(
+            metric="upbit_alt_breadth_24h",
+            value=None,
+            source=ALT_BREADTH_SOURCE,
+            note="Upbit 티커에서 breadth를 산출하지 못했습니다.",
+        )
+    total = (breadth or {}).get("alts_total")
+    beating = (breadth or {}).get("alts_beating_btc")
+    return GateMetricReading(
+        metric="upbit_alt_breadth_24h",
+        # The upstream reports a 0..1 fraction; the policy threshold is in
+        # percent, so convert once here rather than at the comparison site.
+        value=fraction * Decimal(100),
+        source=ALT_BREADTH_SOURCE,
+        note=f"{beating}/{total} alts > KRW-BTC (24h)"
+        if total is not None and beating is not None
+        else None,
+    )
+
+
+async def read_btc_long_short_ratio(*, now: float | None = None) -> GateMetricReading:
+    """The worse (higher) of the two Binance long/short legs, or ``None``."""
+
+    return await _cached(
+        "btc_long_short_ratio",
+        _read_btc_long_short_ratio,
+        now=now or time.monotonic(),
+    )
+
+
+async def _read_btc_long_short_ratio() -> GateMetricReading:
+    try:
+        from app.mcp_server.tooling.fundamentals._crypto import (
+            handle_get_long_short_ratio,
+        )
+
+        payload = await handle_get_long_short_ratio("BTC", "1h", 1)
+    except Exception as exc:  # noqa: BLE001 — fail-open by contract
+        logger.warning("buy_plan: long/short ratio unavailable: %s", exc)
+        return GateMetricReading(
+            metric="btc_long_short_ratio",
+            value=None,
+            source=LONG_SHORT_SOURCE,
+            note=f"조회 실패: {exc}",
+        )
+
+    if not isinstance(payload, dict) or payload.get("error"):
+        return GateMetricReading(
+            metric="btc_long_short_ratio",
+            value=None,
+            source=LONG_SHORT_SOURCE,
+            note="Binance 롱숏 비율 응답을 해석하지 못했습니다.",
+        )
+
+    legs = [
+        _to_decimal((payload.get(key) or {}).get("ratio"))
+        for key in ("global_account", "top_position")
+    ]
+    if any(leg is None for leg in legs):
+        # Deliberately not "use whichever leg answered": the policy asks both
+        # reports to sit at or below the threshold, so one leg cannot stand in
+        # for the pair without weakening the gate.
+        return GateMetricReading(
+            metric="btc_long_short_ratio",
+            value=None,
+            source=LONG_SHORT_SOURCE,
+            note="두 리포트 중 하나가 비어 있어 판정 불가(한쪽만으로 대체하지 않음).",
+        )
+
+    resolved = max(leg for leg in legs if leg is not None)
+    return GateMetricReading(
+        metric="btc_long_short_ratio",
+        value=resolved,
+        source=LONG_SHORT_SOURCE,
+        note="global_account / top_position 중 더 높은 값",
+    )

--- a/app/services/invest_view_model/buy_plan/service.py
+++ b/app/services/invest_view_model/buy_plan/service.py
@@ -761,7 +761,11 @@ async def _build_discovery_gates(*, policy: Any) -> list[DiscoveryGateRow]:
                 unit=condition.unit,
                 current_value=value,
                 state=state,  # type: ignore[arg-type]
-                source=reading.source if reading is not None else None,
+                # Provenance comes from the policy's own ``sources`` list, not
+                # from a constant duplicated in the reader — the policy file is
+                # what declares which upstreams this metric is allowed to come
+                # from, so it cannot drift out of sync with the gate.
+                source="+".join(condition.sources) if condition.sources else None,
                 note=reading.note
                 if reading is not None
                 else "이 지표를 읽는 소스가 배선돼 있지 않습니다.",
@@ -987,8 +991,9 @@ def _value_sources() -> list[ValueSource]:
         ),
         ValueSource(
             field="discovery_gates[].conditions[].current_value",
-            source="upbit_open_api_ticker (breadth) / binance futures data (long-short)",
-            note=f"캐시 {GATE_CACHE_TTL_SECONDS}초.",
+            source="market_rules.crypto.recovery_gate.conditions[].sources "
+            "(정책이 선언한 업스트림)",
+            note=f"캐시 {GATE_CACHE_TTL_SECONDS}초. 확인 불가 조건은 충족으로 세지 않습니다.",
         ),
         ValueSource(
             field="funding.accounts[].available_cash",

--- a/app/services/invest_view_model/buy_plan/service.py
+++ b/app/services/invest_view_model/buy_plan/service.py
@@ -21,6 +21,7 @@ from typing import Any, Final
 
 from app.schemas.invest_buy_plan import (
     ActiveBuyWatchRow,
+    ApprovalCondition,
     ApprovalContext,
     AveragingSampleRow,
     AveragingTriggerRow,
@@ -100,17 +101,37 @@ _BROKER_BY_ACCOUNT_MODE: Final[dict[str, FundingBroker]] = {
 }
 UNATTRIBUTED: Final[FundingBroker] = "unattributed"
 
-# Conditions that gate a real auto-submission and that this read surface does
-# NOT evaluate. Published verbatim so the board never implies it checked them
-# (verify-r1 B6; source: order_proposals.auto_approve.evaluate_auto_approve_eligibility).
-AUTO_APPROVE_UNEVALUATED_CONDITIONS: Final[tuple[str, ...]] = (
-    "fresh preview 존재",
-    "limit-only (비-marketable) 주문",
-    "veto 가능한 계좌·시장",
-    "tag scan",
-    "thesis 요건",
-    "일일 누적 cap 잔여",
-    "distance / marketability 조건",
+# Every gate ``evaluate_auto_approve_eligibility`` can reject on, split by
+# whether this read surface actually evaluates it.
+#
+# The codes are that function's literal ``reject(...)`` reasons;
+# ``tests/.../test_service.py::test_s1_...`` extracts them from its source and
+# fails if this split stops covering the real set. verify-r2 SHOULD-1 found
+# the old seven-item list short by six gates — an incomplete list still reads
+# as "these are the only things we skipped", which is the same lie in a
+# smaller font.
+AUTO_APPROVE_EVALUATED_CONDITIONS: Final[tuple[tuple[str, str], ...]] = (
+    ("per_order_cap_exceeded", "건당 자동승인 상한"),
+)
+AUTO_APPROVE_UNEVALUATED_CONDITIONS: Final[tuple[tuple[str, str], ...]] = (
+    ("unknown_auto_approve_mode", "자동승인 모드 인식 가능 여부"),
+    ("action_not_supported", "지원되는 action (place/replace/cancel)"),
+    ("target_evidence_missing", "replace·cancel 대상 주문 증거"),
+    ("order_type_not_limit", "limit 주문 여부"),
+    ("loss_cut_intent", "손절 의도 아님"),
+    ("exit_intent_present", "청산 의도 아님"),
+    ("account_not_veto_capable", "veto 가능한 계좌·시장"),
+    ("approval_required_tag", "승인 필요 태그 스캔"),
+    ("thesis_required_for_veto_card", "veto 카드용 thesis 존재"),
+    ("preview_guard_failed", "fresh preview 성공"),
+    ("price_or_quantity_missing", "가격·수량 확보"),
+    ("daily_cap_exceeded", "일일 누적 cap 잔여"),
+    ("side_not_supported", "지원되는 매매구분"),
+    ("distance_below_minimum", "최소 이격 거리"),
+    ("marketable_not_resting", "비-marketable(대기형) 주문"),
+    ("breakeven_band", "매도 breakeven 밴드 밖"),
+    ("expected_pnl_not_positive", "매도 기대손익 > 0"),
+    ("sell_classification_unavailable", "매도 분류 가능"),
 )
 
 
@@ -457,7 +478,14 @@ def _approval_context() -> ApprovalContext:
         master_gate_enabled=enabled,
         master_gate_setting=setting,
         master_gate_source=source,
-        unevaluated_conditions=list(AUTO_APPROVE_UNEVALUATED_CONDITIONS),
+        unevaluated_conditions=[
+            ApprovalCondition(code=code, label=label)
+            for code, label in AUTO_APPROVE_UNEVALUATED_CONDITIONS
+        ],
+        evaluated_conditions=[
+            ApprovalCondition(code=code, label=label)
+            for code, label in AUTO_APPROVE_EVALUATED_CONDITIONS
+        ],
         notice=notice,
     )
 
@@ -648,6 +676,7 @@ def _build_averaging_rows(
                 market_rank=0,
                 within_policy_add_cap=False,
                 funding_broker=lot_broker or UNATTRIBUTED,
+                funding_broker_reason=lot_broker_reason,
                 notes=notes,
             )
         )
@@ -948,7 +977,7 @@ def _build_active_buy_watches(
         currency: BuyPlanCurrency = "USD" if alert.market == "us" else "KRW"
         notional, source = _planned_notional(alert)
         raw_mode = (alert.max_action or {}).get("account_mode")
-        broker, _ = _broker_from_account_mode(raw_mode)
+        broker, broker_reason = _broker_from_account_mode(raw_mode)
         lane, reason = approval_lane_for(
             notional=notional,
             tier_auto_submit_notional=_tier_auto_submit_notional(rule, currency),
@@ -981,6 +1010,7 @@ def _build_active_buy_watches(
                 planned_notional=notional,
                 planned_notional_source=source,
                 funding_broker=broker or UNATTRIBUTED,
+                funding_broker_reason=broker_reason,
                 account_mode=raw_mode if isinstance(raw_mode, str) else None,
                 approval_lane=lane,
                 approval_lane_reason=reason,
@@ -1113,8 +1143,12 @@ def _requirements(
                 broker=None
                 if row.funding_broker == UNATTRIBUTED
                 else row.funding_broker,
+                # The row carries the concrete reason (an unmapped source name,
+                # a split lot); collapsing it to one generic sentence hid real
+                # misconfiguration (verify-r2 SHOULD-3).
                 unattributed_reason=(
-                    "보유의 계좌 소스를 하나의 브로커로 확정하지 못했습니다."
+                    row.funding_broker_reason
+                    or "보유의 계좌 소스를 확정하지 못했습니다."
                     if row.funding_broker == UNATTRIBUTED
                     else None
                 ),
@@ -1141,7 +1175,8 @@ def _requirements(
                 if row.funding_broker == UNATTRIBUTED
                 else row.funding_broker,
                 unattributed_reason=(
-                    "워치 max_action이 실행 계좌(account_mode)를 지정하지 않았습니다."
+                    row.funding_broker_reason
+                    or "워치 max_action이 실행 계좌(account_mode)를 지정하지 않았습니다."
                     if row.funding_broker == UNATTRIBUTED
                     else None
                 ),
@@ -1207,10 +1242,14 @@ def _build_funding(
         if row.included_in_reserve:
             scope_keys.add((row.broker, row.currency))
     for req in requirements:
-        if req.broker is not None:
-            scope_keys.add((req.broker, req.currency))
+        # An unresolved requirement gets its own destination row rather than
+        # being folded into whichever broker happens to hold that currency.
+        # Without this, a currency with no cash account (unattributed USD on a
+        # KRW-only book) reached no verdict at all, and a broker with no row
+        # left the operator no account to fund (verify-r2 B1 (b)/(d)).
+        scope_keys.add((req.broker or UNATTRIBUTED, req.currency))
     if not scope_keys:
-        scope_keys.add(("unattributed", "KRW"))
+        scope_keys.add((UNATTRIBUTED, "KRW"))
 
     # Requirement-side incompleteness is symmetric with the cash-side hold that
     # already existed: an unknown requirement must never fold to zero
@@ -1238,7 +1277,9 @@ def _build_funding(
             "active_watch": Decimal(0),
         }
         for req in requirements:
-            if req.broker != broker or req.currency != currency or req.amount is None:
+            if (req.broker or UNATTRIBUTED) != broker or req.currency != currency:
+                continue
+            if req.amount is None:
                 continue
             by_kind[req.kind] += req.amount
         attributed_total = sum(by_kind.values(), Decimal(0))
@@ -1251,17 +1292,26 @@ def _build_funding(
             incomplete.append(
                 f"{currency} 소요액 중 금액을 확정하지 못한 항목이 있습니다."
             )
-        if broker == UNATTRIBUTED and not rows:
+        if broker == UNATTRIBUTED:
             incomplete.append(
-                "이 행은 귀속 계좌를 확정하지 못한 소요액 모음입니다 — 대조할 현금이 없습니다."
+                "이 행은 귀속 계좌를 확정하지 못한 소요액 모음입니다 — 어느 계좌에서 "
+                "나갈지 모르므로 대조할 현금이 없습니다."
             )
 
-        unattributed_amount = unattributed_by_currency[currency]
-        worst_case = attributed_total + unattributed_amount
+        # A real broker scope is measured against the unattributed pool; the
+        # unattributed destination row already *contains* that pool, so adding
+        # it again would double-count it.
+        unattributed_amount = (
+            Decimal(0) if broker == UNATTRIBUTED else unattributed_by_currency[currency]
+        )
+        unattributed_present = broker != UNATTRIBUTED and (
+            unattributed_amount > 0 or unattributed_unknown_amount[currency]
+        )
+        upper_bound = attributed_total + unattributed_amount
         verdict, shortfall = _scope_verdict(
             available=available,
             attributed=attributed_total,
-            worst_case=worst_case,
+            unattributed_present=unattributed_present,
             incomplete=bool(incomplete),
         )
 
@@ -1271,10 +1321,11 @@ def _build_funding(
             "물타기 합계는 정책의 시장별 add 상한 안에 드는 행만 더합니다.",
             "이미 걸린 지정가는 브로커가 현금을 묶고 있어 합계에서 제외했습니다.",
         ]
-        if unattributed_amount > 0 or unattributed_unknown_amount[currency]:
+        if unattributed_present:
             notes.append(
-                "귀속 계좌를 확정하지 못한 소요액이 있어, 이 계좌 현금이 그 전액까지 "
-                "덮지 못하면 판정을 보류합니다."
+                "귀속 계좌를 확정하지 못한 소요액이 있어 이 계좌 판정을 보류합니다 — "
+                "그 돈은 다른 브로커로 나갈 수 있으므로, 여기 현금이 그 금액을 덮는다는 "
+                "사실은 실제 실행 계좌에 대해 아무것도 증명하지 않습니다."
             )
         scopes.append(
             ScopeReconciliation(
@@ -1288,7 +1339,7 @@ def _build_funding(
                 required_active_watches=by_kind["active_watch"],
                 required_total=attributed_total,
                 unattributed_same_currency=unattributed_amount,
-                worst_case_required=worst_case,
+                upper_bound_if_all_unattributed_lands_here=upper_bound,
                 requirements_complete=not incomplete,
                 incomplete_reasons=sorted(set(incomplete)),
                 verdict=verdict,  # type: ignore[arg-type]
@@ -1330,14 +1381,22 @@ def _scope_verdict(
     *,
     available: Decimal | None,
     attributed: Decimal,
-    worst_case: Decimal,
+    unattributed_present: bool,
     incomplete: bool,
 ) -> tuple[str, Decimal | None]:
     """Decide one scope, refusing to round any unknown down to zero.
 
     A shortfall is still reported when the *known* requirement already exceeds
     the cash: that deficit is proven regardless of what else is missing, and
-    suppressing it would be its own kind of dishonesty.
+    suppressing it would be its own kind of dishonesty. It is a lower bound,
+    which the UI says out loud when the requirement side is incomplete.
+
+    ``sufficient`` requires that nothing about this scope is unresolved. In
+    particular an earlier version treated "this account could cover the whole
+    unattributed pool" as proof of sufficiency; that is false, because the
+    unattributed money may be destined for a *different* broker whose account
+    is empty — which is the very mistake the broker scoping was introduced to
+    prevent (verify-r2 B1 (a)).
     """
 
     if available is None:
@@ -1346,9 +1405,7 @@ def _scope_verdict(
         return "shortfall", attributed - available
     if incomplete:
         return "unknown", None
-    if worst_case > available:
-        # The attributed part fits but the unattributed part may not, and the
-        # board cannot say which account it lands on.
+    if unattributed_present:
         return "unknown", None
     return "sufficient", Decimal(0)
 

--- a/app/services/invest_view_model/buy_plan/service.py
+++ b/app/services/invest_view_model/buy_plan/service.py
@@ -1,0 +1,1003 @@
+"""Aggregate the /invest 매수 계획 board (§144차).
+
+Read-only by construction: this service composes four existing read models
+(``InvestHomeService`` holdings + cash, ``WatchPanelService`` alerts,
+``CurrentOrdersService`` resting orders, ``config/trading_policy.yaml``) plus
+two public market-data metrics. It never imports an order, proposal, watch, or
+broker mutation path.
+
+The board answers one operator question — *"트리거가 걸리면 돈이 얼마나
+필요하고, 지금 계좌에 있는가"* — so cash can be moved in advance. It does not
+reproduce a session's verdict; see ``computation.APPROXIMATION_NOTICE``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any, Final
+
+from app.schemas.invest_buy_plan import (
+    ActiveBuyWatchRow,
+    AveragingSampleRow,
+    AveragingTriggerRow,
+    BuyPlanCurrency,
+    BuyPlanFunding,
+    BuyPlanMarket,
+    BuyPlanResponse,
+    CashAccountRow,
+    CurrencyReconciliation,
+    DiscoveryGateCondition,
+    DiscoveryGateRow,
+    PolicyStamp,
+    SupportNetPlacement,
+    SupportNetRow,
+    SupportNetTier,
+    ValueSource,
+)
+from app.schemas.invest_home import Account, GroupedHolding, InvestHomeResponse
+from app.schemas.invest_watches import WatchAlertRow, WatchesResponse
+from app.schemas.open_orders import OpenOrdersResponse
+from app.services.invest_view_model.buy_plan.computation import (
+    APPROXIMATION_NOTICE,
+    approval_lane_for,
+    averaging_turn_point,
+)
+from app.services.invest_view_model.buy_plan.gate_inputs import (
+    GATE_CACHE_TTL_SECONDS,
+    GateMetricReading,
+    read_alt_breadth_24h,
+    read_btc_long_short_ratio,
+)
+from app.services.trading_policy_service import (
+    load_trading_policy,
+    policy_version_stamp,
+)
+
+logger = logging.getLogger(__name__)
+
+MarketFilter = str
+
+CACHE_TTL_SECONDS: Final = GATE_CACHE_TTL_SECONDS
+
+SUPPORT_RESERVE_NET_KEY: Final = "buy.support_reserve_net"
+HELD_MAJORS_SUPPORT_NET_KEY: Final = "buy.held_majors_support_net"
+HELD_MAJORS_TIER_ID: Final = "held_majors_support_net"
+CRYPTO_RECOVERY_GATE_KEY: Final = "market_rules.crypto.recovery_gate"
+
+# Only live broker cash can actually be moved and spent by an order. Manual
+# and paper accounts are reference rows on this board's sibling surfaces; a
+# reserve verdict built on them would tell the operator to move money they do
+# not have in the account that would place the order.
+_RESERVE_ACCOUNT_KINDS: Final = frozenset({"live"})
+
+_MARKET_BY_GROUP: Final[dict[str, BuyPlanMarket]] = {
+    "KR": "kr",
+    "US": "us",
+    "CRYPTO": "crypto",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _TradeableLot:
+    """The tradeable slice of one grouped holding.
+
+    Manual/reference sources are excluded: their quantity is not sellable or
+    addable through a broker, so folding them into the average would move the
+    turn point to a price no order can act on.
+    """
+
+    market: BuyPlanMarket
+    symbol: str
+    symbol_name: str | None
+    currency: BuyPlanCurrency
+    quantity: Decimal
+    cost_basis: Decimal
+    average_price: Decimal
+    current_price: Decimal | None
+    unrealized_pnl_pct: Decimal | None
+    account_sources: list[str]
+    price_state: str
+    excluded_reference_quantity: Decimal
+
+
+def _dec(value: object) -> Decimal | None:
+    """Convert a read-model float to Decimal without inventing precision."""
+
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def crypto_base_symbol(symbol: str) -> str:
+    """``KRW-XRP`` / ``xrp`` → ``XRP``.
+
+    Holdings key crypto by base currency while open orders and watches key it
+    by the Upbit market pair, so both sides are folded to the base token
+    before matching.
+    """
+
+    token = (symbol or "").strip().upper()
+    if "-" in token:
+        return token.split("-", 1)[1]
+    return token
+
+
+def _match_key(market: BuyPlanMarket, symbol: str) -> str:
+    if market == "crypto":
+        return f"crypto:{crypto_base_symbol(symbol)}"
+    return f"{market}:{(symbol or '').strip().upper()}"
+
+
+class BuyPlanService:
+    """Compose the 매수 계획 board from existing read models."""
+
+    def __init__(
+        self,
+        *,
+        home_service: Any,
+        watch_service: Any,
+        open_orders_service: Any,
+    ) -> None:
+        self._home = home_service
+        self._watches = watch_service
+        self._open_orders = open_orders_service
+
+    async def build(
+        self,
+        *,
+        user_id: int,
+        market: MarketFilter = "all",
+        now: dt.datetime | None = None,
+    ) -> BuyPlanResponse:
+        as_of = now or dt.datetime.now(dt.UTC)
+        warnings: list[str] = []
+
+        policy = load_trading_policy()
+        stamp = policy_version_stamp()
+
+        home = await self._safe_home(user_id=user_id, warnings=warnings)
+        watches = await self._safe_watches(warnings=warnings)
+        open_orders = await self._safe_open_orders(warnings=warnings)
+
+        lots = _tradeable_lots(home, warnings=warnings)
+        wanted = _wanted_markets(market)
+        scoped_lots = [lot for lot in lots if lot.market in wanted]
+
+        averaging = _build_averaging_rows(scoped_lots, policy=policy)
+        support_net = _build_support_net(
+            [lot for lot in scoped_lots if lot.market == "crypto"],
+            policy=policy,
+            open_orders=open_orders,
+            watches=watches,
+            crypto_in_scope="crypto" in wanted,
+        )
+        buy_watches = _build_active_buy_watches(watches, policy=policy, wanted=wanted)
+        gates = (
+            await _build_discovery_gates(policy=policy) if "crypto" in wanted else []
+        )
+        funding = _build_funding(
+            home,
+            averaging=averaging,
+            support_net=support_net,
+            buy_watches=buy_watches,
+            warnings=warnings,
+        )
+
+        return BuyPlanResponse(
+            as_of=as_of,
+            policy=PolicyStamp(
+                version=stamp["version"], content_hash=stamp["content_hash"]
+            ),
+            cache_ttl_seconds=CACHE_TTL_SECONDS,
+            approximation_notice=APPROXIMATION_NOTICE,
+            market=market if market in {"all", "kr", "us", "crypto"} else "all",
+            averaging_triggers=averaging,
+            support_net=support_net,
+            active_buy_watches=buy_watches,
+            discovery_gates=gates,
+            funding=funding,
+            value_sources=_value_sources(),
+            warnings=warnings,
+        )
+
+    async def _safe_home(
+        self, *, user_id: int, warnings: list[str]
+    ) -> InvestHomeResponse | None:
+        try:
+            return await self._home.get_home(user_id=user_id)
+        except Exception as exc:  # noqa: BLE001 — one dead reader must not 500 the board
+            logger.warning("buy_plan: holdings/cash unavailable: %s", exc)
+            warnings.append(f"보유·현금 조회 실패 — 자금 대조 불가: {exc}")
+            return None
+
+    async def _safe_watches(self, *, warnings: list[str]) -> WatchesResponse | None:
+        try:
+            return await self._watches.list_watches(market="all", status="active")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("buy_plan: watches unavailable: %s", exc)
+            warnings.append(f"워치 조회 실패 — 활성 매수 워치 누락: {exc}")
+            return None
+
+    async def _safe_open_orders(
+        self, *, warnings: list[str]
+    ) -> OpenOrdersResponse | None:
+        try:
+            return await self._open_orders.list_open_orders(market="all")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("buy_plan: open orders unavailable: %s", exc)
+            warnings.append(
+                f"미체결 주문 조회 실패 — 그물에 이미 걸린 주문이 누락됐을 수 있습니다: {exc}"
+            )
+            return None
+
+
+def _wanted_markets(market: MarketFilter) -> frozenset[BuyPlanMarket]:
+    if market in {"kr", "us", "crypto"}:
+        return frozenset({market})  # type: ignore[arg-type]
+    return frozenset({"kr", "us", "crypto"})
+
+
+def _tradeable_lots(
+    home: InvestHomeResponse | None, *, warnings: list[str]
+) -> list[_TradeableLot]:
+    if home is None:
+        return []
+    lots: list[_TradeableLot] = []
+    for group in home.groupedHoldings:
+        lot = _lot_from_group(group)
+        if lot is not None:
+            lots.append(lot)
+    if not lots and home.groupedHoldings:
+        warnings.append("거래 가능한 보유가 없어 트리거 행이 비었습니다.")
+    return lots
+
+
+def _lot_from_group(group: GroupedHolding) -> _TradeableLot | None:
+    market = _MARKET_BY_GROUP.get(group.market)
+    if market is None:
+        return None
+
+    quantity = Decimal(0)
+    cost_basis = Decimal(0)
+    sources: list[str] = []
+    reference_quantity = Decimal(0)
+    for part in group.sourceBreakdown:
+        part_qty = _dec(part.quantity) or Decimal(0)
+        if not part.isTradeable:
+            reference_quantity += part_qty
+            continue
+        if part_qty <= 0:
+            continue
+        part_cost = _dec(part.costBasis)
+        if part_cost is None:
+            avg = _dec(part.averageCost)
+            part_cost = avg * part_qty if avg is not None else None
+        if part_cost is None or part_cost <= 0:
+            # No usable cost basis for this slice — A(k) is undefined without
+            # it, so the slice is dropped rather than guessed at.
+            continue
+        quantity += part_qty
+        cost_basis += part_cost
+        sources.append(str(part.source))
+
+    if quantity <= 0 or cost_basis <= 0:
+        return None
+
+    total_quantity = _dec(group.totalQuantity) or Decimal(0)
+    value_native = _dec(group.valueNative)
+    current_price = (
+        value_native / total_quantity
+        if value_native is not None and total_quantity > 0
+        else None
+    )
+    pnl_rate = _dec(group.pnlRate)
+    return _TradeableLot(
+        market=market,
+        symbol=group.symbol,
+        symbol_name=group.displayName,
+        currency="KRW" if group.currency == "KRW" else "USD",
+        quantity=quantity,
+        cost_basis=cost_basis,
+        average_price=cost_basis / quantity,
+        current_price=current_price,
+        # pnlRate is the group-level rate the rest of /invest already shows;
+        # reusing it keeps this board consistent with the holdings table
+        # instead of publishing a second, subtly different P&L number.
+        unrealized_pnl_pct=pnl_rate * Decimal(100) if pnl_rate is not None else None,
+        account_sources=sorted(set(sources)),
+        price_state=group.priceState,
+        excluded_reference_quantity=reference_quantity,
+    )
+
+
+def _support_reserve_net_rule(policy: Any) -> Any | None:
+    return policy.decision_rules.get(SUPPORT_RESERVE_NET_KEY)
+
+
+def _per_order_auto_approve_cap(policy: Any, market: BuyPlanMarket) -> Decimal | None:
+    caps = policy.order_proposals.auto_approve.per_order_cap
+    value = caps.get(market)
+    return _dec(value)
+
+
+def _tier_auto_submit_notional(rule: Any, currency: BuyPlanCurrency) -> Decimal | None:
+    if rule is None:
+        return None
+    notional = getattr(rule, "auto_submit_notional", None)
+    if notional is None:
+        return None
+    return _dec(notional.krw if currency == "KRW" else notional.usd)
+
+
+def _build_averaging_rows(
+    lots: list[_TradeableLot], *, policy: Any
+) -> list[AveragingTriggerRow]:
+    """One row per underwater tradeable lot, ranked by nearness to its turn point."""
+
+    rule = _support_reserve_net_rule(policy)
+    add_candidate = getattr(rule, "add_candidate", None)
+    k = _dec(getattr(add_candidate, "k_used", None))
+    max_add_per_market = getattr(add_candidate, "max_add_symbols_per_market", None)
+    if k is None or k <= 0:
+        return []
+
+    rows: list[AveragingTriggerRow] = []
+    for lot in lots:
+        if lot.current_price is None or lot.current_price <= 0:
+            continue
+        projection = averaging_turn_point(
+            cost_basis=lot.cost_basis,
+            average_price=lot.average_price,
+            current_price=lot.current_price,
+            k=k,
+        )
+        cap = _per_order_auto_approve_cap(policy, lot.market)
+        tier_ceiling = _tier_auto_submit_notional(rule, lot.currency)
+        samples: list[AveragingSampleRow] = []
+        for sample in projection.samples:
+            lane, reason = approval_lane_for(
+                notional=sample.additional_notional,
+                tier_auto_submit_notional=tier_ceiling,
+                per_order_auto_approve_cap=cap,
+            )
+            samples.append(
+                AveragingSampleRow(
+                    offset_from_turn_point_pct=sample.offset_from_turn_point_pct,
+                    price=sample.price,
+                    additional_notional=sample.additional_notional,
+                    target_average_price=sample.target_average_price,
+                    approval_lane=lane,
+                    approval_lane_reason=reason,
+                )
+            )
+        if not samples:
+            continue
+
+        notes: list[str] = []
+        if lot.price_state != "live":
+            notes.append(
+                f"현재가 상태 {lot.price_state} — 전환점 거리는 그만큼 오래된 값입니다."
+            )
+        if lot.excluded_reference_quantity > 0:
+            notes.append(
+                "수동/참고 보유 수량은 평단·전환점 계산에서 제외했습니다"
+                f" (제외 수량 {format(lot.excluded_reference_quantity, 'f')})."
+            )
+
+        rows.append(
+            AveragingTriggerRow(
+                market=lot.market,
+                symbol=lot.symbol,
+                symbol_name=lot.symbol_name,
+                currency=lot.currency,
+                account_sources=lot.account_sources,
+                quantity=lot.quantity,
+                average_price=lot.average_price,
+                cost_basis=lot.cost_basis,
+                current_price=lot.current_price,
+                unrealized_pnl_pct=lot.unrealized_pnl_pct,
+                k=projection.k,
+                turn_point_price=projection.turn_point_price,
+                distance_to_turn_point_pct=projection.distance_to_turn_point_pct,
+                turn_point_reached=projection.reached,
+                samples=samples,
+                # The deeper sample is the conservative reserve: if the price
+                # keeps falling past the turn point, this is the larger of the
+                # two published cash needs.
+                reserve_plan_notional=max(
+                    sample.additional_notional for sample in projection.samples
+                ),
+                market_rank=0,
+                within_policy_add_cap=False,
+                notes=notes,
+            )
+        )
+
+    # Nearest to (or deepest past) the turn point first — that is the order in
+    # which these triggers actually become live. The policy's own ranking
+    # (support strength, R-931 state, sector delta) needs inputs this board
+    # does not read, so the basis is stated in value_sources rather than
+    # dressed up as the policy sort.
+    rows.sort(key=lambda row: (row.market, row.distance_to_turn_point_pct))
+    ranked: list[AveragingTriggerRow] = []
+    per_market: dict[str, int] = {}
+    for row in rows:
+        rank = per_market.get(row.market, 0) + 1
+        per_market[row.market] = rank
+        within_cap = (
+            rank <= int(max_add_per_market) if max_add_per_market is not None else False
+        )
+        ranked.append(
+            row.model_copy(
+                update={"market_rank": rank, "within_policy_add_cap": within_cap}
+            )
+        )
+    ranked.sort(key=lambda row: (row.distance_to_turn_point_pct, row.symbol))
+    return ranked
+
+
+def _held_majors_tier(policy: Any) -> tuple[Any, dict[str, Any]] | tuple[None, dict]:
+    rule = policy.decision_rules.get(HELD_MAJORS_SUPPORT_NET_KEY)
+    if rule is None:
+        return None, {}
+    for tier in getattr(rule, "tiers", []) or []:
+        if getattr(tier, "id", None) == HELD_MAJORS_TIER_ID:
+            conditions = getattr(tier, "conditions", {}) or {}
+            if not isinstance(conditions, dict):
+                conditions = dict(conditions)
+            return rule, conditions
+    return rule, {}
+
+
+def _build_support_net(
+    crypto_lots: list[_TradeableLot],
+    *,
+    policy: Any,
+    open_orders: OpenOrdersResponse | None,
+    watches: WatchesResponse | None,
+    crypto_in_scope: bool,
+) -> SupportNetTier:
+    rule, conditions = _held_majors_tier(policy)
+    per_symbol_cap = _dec(conditions.get("max_notional_krw_per_coin"))
+    tier_cap = _dec(conditions.get("max_notional_krw_per_tier"))
+    band_raw = conditions.get("support_distance_from_current_pct_range") or []
+    band = [d for d in (_dec(v) for v in band_raw) if d is not None]
+    review_date = conditions.get("review_date")
+    notes: list[str] = []
+    if rule is None:
+        notes.append(
+            f"정책에 {HELD_MAJORS_SUPPORT_NET_KEY} 티어가 없습니다 — 은퇴했거나 미등록."
+        )
+
+    resting = _resting_buy_by_symbol(open_orders)
+    watch_rungs = _buy_watch_by_symbol(watches)
+
+    rows: list[SupportNetRow] = []
+    placed_total = Decimal(0)
+    if crypto_in_scope and rule is not None:
+        for lot in sorted(crypto_lots, key=lambda item: item.symbol):
+            key = _match_key("crypto", lot.symbol)
+            placements = [
+                *resting.get(key, ()),
+                *watch_rungs.get(key, ()),
+            ]
+            placements = [
+                _annotate_placement(p, current_price=lot.current_price, band=band)
+                for p in placements
+            ]
+            placed = sum(
+                (p.notional for p in placements if p.notional is not None),
+                Decimal(0),
+            )
+            placed_total += placed
+            eligible, reason = _support_net_eligibility(lot)
+            headroom = (
+                max(per_symbol_cap - placed, Decimal(0))
+                if per_symbol_cap is not None and eligible
+                else Decimal(0)
+            )
+            rows.append(
+                SupportNetRow(
+                    market="crypto",
+                    symbol=lot.symbol,
+                    symbol_name=lot.symbol_name,
+                    currency=lot.currency,
+                    quantity=lot.quantity,
+                    average_price=lot.average_price,
+                    current_price=lot.current_price,
+                    unrealized_pnl_pct=lot.unrealized_pnl_pct,
+                    eligible=eligible,
+                    ineligible_reason=reason,
+                    placements=placements,
+                    placed_notional=placed,
+                    per_symbol_cap_notional=per_symbol_cap or Decimal(0),
+                    remaining_headroom_notional=headroom,
+                )
+            )
+
+    remaining = (
+        max(tier_cap - placed_total, Decimal(0)) if tier_cap is not None else None
+    )
+    if rule is not None:
+        notes.append(
+            "그물 대상 판정(‘메이저’)은 세션 판단이며 기계 allowlist가 없습니다 — "
+            "여기서는 보유·이익권 두 조건만 기계로 확인합니다."
+        )
+        notes.append(
+            "이미 걸린 지정가(주문 상시형)는 브로커가 현금을 이미 묶고 있으므로 "
+            "추가 입금 대상이 아닙니다. 워치형만 신규 소요액으로 집계합니다."
+        )
+    return SupportNetTier(
+        policy_key=HELD_MAJORS_SUPPORT_NET_KEY,
+        enabled=rule is not None and crypto_in_scope,
+        currency="KRW",
+        tier_cap_notional=tier_cap,
+        per_symbol_cap_notional=per_symbol_cap,
+        placed_notional=placed_total,
+        remaining_notional=remaining,
+        distance_band_pct=band,
+        review_date=str(review_date) if review_date is not None else None,
+        rows=rows,
+        notes=notes,
+    )
+
+
+def _support_net_eligibility(lot: _TradeableLot) -> tuple[bool, str | None]:
+    """The two conditions the policy actually expresses in machine terms."""
+
+    if lot.quantity <= 0:
+        return False, "보유 수량 없음"
+    if lot.unrealized_pnl_pct is None:
+        return False, "평가손익 확인 불가 — 이익권 판정 불가"
+    if lot.unrealized_pnl_pct <= 0:
+        return False, "이익권 아님 (평가손익 ≤ 0)"
+    return True, None
+
+
+def _annotate_placement(
+    placement: SupportNetPlacement,
+    *,
+    current_price: Decimal | None,
+    band: list[Decimal],
+) -> SupportNetPlacement:
+    if placement.anchor_price is None or current_price is None or current_price <= 0:
+        return placement
+    distance = (placement.anchor_price - current_price) / current_price * Decimal(100)
+    within = None
+    if len(band) == 2:
+        low, high = min(band), max(band)
+        within = low <= distance <= high
+    return placement.model_copy(
+        update={
+            "distance_from_current_pct": distance,
+            "within_policy_distance_band": within,
+        }
+    )
+
+
+def _resting_buy_by_symbol(
+    open_orders: OpenOrdersResponse | None,
+) -> dict[str, list[SupportNetPlacement]]:
+    out: dict[str, list[SupportNetPlacement]] = {}
+    if open_orders is None:
+        return out
+    for order in open_orders.items:
+        if order.side != "buy":
+            continue
+        market = order.market
+        remaining = order.remaining_qty
+        if remaining is None:
+            remaining = order.quantity
+        notional = (
+            order.price * remaining
+            if order.price is not None and remaining is not None
+            else None
+        )
+        key = _match_key(market, order.symbol)
+        out.setdefault(key, []).append(
+            SupportNetPlacement(
+                form="resting_order",
+                reference=f"{order.broker}:{order.order_no}",
+                anchor_price=order.price,
+                quantity=remaining,
+                notional=notional,
+            )
+        )
+    return out
+
+
+def _buy_watch_by_symbol(
+    watches: WatchesResponse | None,
+) -> dict[str, list[SupportNetPlacement]]:
+    out: dict[str, list[SupportNetPlacement]] = {}
+    if watches is None:
+        return out
+    for alert in watches.items:
+        if not _is_buy_watch(alert):
+            continue
+        notional, _ = _planned_notional(alert)
+        key = _match_key(alert.market, alert.symbol)
+        out.setdefault(key, []).append(
+            SupportNetPlacement(
+                form="watch",
+                reference=str(alert.alert_uuid),
+                anchor_price=alert.threshold,
+                quantity=_dec((alert.max_action or {}).get("quantity")),
+                notional=notional,
+                valid_until=alert.valid_until,
+            )
+        )
+    return out
+
+
+def _is_buy_watch(alert: WatchAlertRow) -> bool:
+    """Buy-side only.
+
+    ``max_action.side`` is the typed execution-plan field (CLAUDE.md item
+    contract) and is authoritative when present. ``intent`` is the fallback for
+    older rows that predate ``max_action``.
+    """
+
+    side = str((alert.max_action or {}).get("side") or "").strip().lower()
+    if side in {"buy", "sell"}:
+        return side == "buy"
+    return alert.intent == "buy_review"
+
+
+def _planned_notional(alert: WatchAlertRow) -> tuple[Decimal | None, str | None]:
+    """Cash this watch would need if it fired, from its own execution plan."""
+
+    action = alert.max_action or {}
+    for key in ("notional", "amount_krw"):
+        value = _dec(action.get(key))
+        if value is not None and value > 0:
+            return value, f"max_action.{key}"
+    quantity = _dec(action.get("quantity"))
+    if quantity is not None and quantity > 0:
+        price = _dec(action.get("limit_price")) or _dec(action.get("limit_price_hint"))
+        if price is None:
+            # The threshold is the level the watch fires at, so it is the
+            # closest thing to a fill price this read model has. Labelled so
+            # the UI can show it as an estimate, not a plan value.
+            price = alert.threshold
+        if price is not None and price > 0:
+            return quantity * price, "max_action.quantity × 트리거 레벨"
+    return None, None
+
+
+def _build_active_buy_watches(
+    watches: WatchesResponse | None,
+    *,
+    policy: Any,
+    wanted: frozenset[BuyPlanMarket],
+) -> list[ActiveBuyWatchRow]:
+    if watches is None:
+        return []
+    rule = _support_reserve_net_rule(policy)
+    rows: list[ActiveBuyWatchRow] = []
+    for alert in watches.items:
+        if alert.market not in wanted or not _is_buy_watch(alert):
+            continue
+        currency: BuyPlanCurrency = "USD" if alert.market == "us" else "KRW"
+        notional, source = _planned_notional(alert)
+        lane, reason = approval_lane_for(
+            notional=notional,
+            tier_auto_submit_notional=_tier_auto_submit_notional(rule, currency),
+            per_order_auto_approve_cap=_per_order_auto_approve_cap(
+                policy, alert.market
+            ),
+        )
+        distance = None
+        if alert.current_price is not None and alert.current_price > 0:
+            distance = (
+                (alert.threshold - alert.current_price)
+                / alert.current_price
+                * Decimal(100)
+            )
+        rows.append(
+            ActiveBuyWatchRow(
+                market=alert.market,
+                symbol=alert.symbol,
+                symbol_name=alert.symbol_name,
+                currency=currency,
+                alert_uuid=str(alert.alert_uuid),
+                metric=alert.metric,
+                operator=alert.operator,
+                threshold=alert.threshold,
+                threshold_high=alert.threshold_high,
+                current_price=alert.current_price,
+                distance_to_threshold_pct=distance,
+                valid_until=alert.valid_until,
+                near_expiry=alert.near_expiry,
+                planned_notional=notional,
+                planned_notional_source=source,
+                approval_lane=lane,
+                approval_lane_reason=reason,
+            )
+        )
+    rows.sort(key=lambda row: (row.valid_until, row.symbol))
+    return rows
+
+
+async def _build_discovery_gates(*, policy: Any) -> list[DiscoveryGateRow]:
+    crypto_rules = policy.market_rules.get("crypto")
+    gate = getattr(crypto_rules, "recovery_gate", None)
+    if gate is None:
+        return []
+
+    readings: dict[str, GateMetricReading] = {}
+    breadth = await read_alt_breadth_24h()
+    readings[breadth.metric] = breadth
+    lsr = await read_btc_long_short_ratio()
+    readings[lsr.metric] = lsr
+
+    conditions: list[DiscoveryGateCondition] = []
+    met = 0
+    unavailable = 0
+    for condition in gate.conditions:
+        reading = readings.get(condition.metric)
+        threshold = _dec(condition.threshold)
+        value = reading.value if reading is not None else None
+        if value is None or threshold is None or not condition.operator:
+            state = "unavailable"
+            unavailable += 1
+        else:
+            passed = _compare(condition.operator, value, threshold)
+            state = "met" if passed else "not_met"
+            if passed:
+                met += 1
+        conditions.append(
+            DiscoveryGateCondition(
+                condition_id=condition.id,
+                metric=condition.metric,
+                comparison=condition.operator,
+                threshold=threshold,
+                unit=condition.unit,
+                current_value=value,
+                state=state,  # type: ignore[arg-type]
+                source=reading.source if reading is not None else None,
+                note=reading.note
+                if reading is not None
+                else "이 지표를 읽는 소스가 배선돼 있지 않습니다.",
+            )
+        )
+
+    if unavailable:
+        # policy: missing_or_null_threshold = do_not_infer_or_count_as_met.
+        # An unreadable input can never be counted toward the gate, so the
+        # honest states are "already open on what we could read" or
+        # "indeterminate" — never "open" by assumption.
+        state = "open" if met >= gate.min_conditions_met else "indeterminate"
+    else:
+        state = "open" if met >= gate.min_conditions_met else "closed"
+
+    notes = [
+        f"미확인 조건은 충족으로 세지 않습니다 ({gate.missing_or_null_threshold}).",
+    ]
+    if getattr(gate, "advisory", False):
+        notes.append("이 게이트는 advisory입니다 — 코드가 주문을 막지 않습니다.")
+
+    return [
+        DiscoveryGateRow(
+            market="crypto",
+            gate_key=CRYPTO_RECOVERY_GATE_KEY,
+            state=state,  # type: ignore[arg-type]
+            min_conditions_met=gate.min_conditions_met,
+            of=gate.of,
+            met_count=met,
+            unavailable_count=unavailable,
+            semantics=gate.semantics,
+            conditions=conditions,
+            notes=notes,
+        )
+    ]
+
+
+def _compare(operator: str, value: Decimal, threshold: Decimal) -> bool:
+    if operator == "gt":
+        return value > threshold
+    if operator == "gte":
+        return value >= threshold
+    if operator == "lt":
+        return value < threshold
+    if operator == "lte":
+        return value <= threshold
+    if operator == "eq":
+        return value == threshold
+    # An operator this board does not implement must not silently pass.
+    return False
+
+
+def _build_funding(
+    home: InvestHomeResponse | None,
+    *,
+    averaging: list[AveragingTriggerRow],
+    support_net: SupportNetTier,
+    buy_watches: list[ActiveBuyWatchRow],
+    warnings: list[str],
+) -> BuyPlanFunding:
+    accounts = _cash_accounts(home)
+    available: dict[str, Decimal | None] = {}
+    for currency in ("KRW", "USD"):
+        rows = [
+            row
+            for row in accounts
+            if row.currency == currency and row.included_in_reserve
+        ]
+        known = [row.available_cash for row in rows if row.available_cash is not None]
+        if not rows:
+            available[currency] = None
+        elif len(known) != len(rows):
+            # A partially-known total would understate what is available and
+            # could send the operator to deposit money they already hold.
+            available[currency] = None
+            warnings.append(
+                f"{currency} 가용 현금이 일부 계좌에서 확인되지 않아 대조를 보류합니다."
+            )
+        else:
+            available[currency] = sum(known, Decimal(0))
+
+    currencies: list[CurrencyReconciliation] = []
+    for currency in ("KRW", "USD"):
+        adds = sum(
+            (
+                row.reserve_plan_notional
+                for row in averaging
+                if row.currency == currency and row.within_policy_add_cap
+            ),
+            Decimal(0),
+        )
+        # Resting orders already hold broker cash; only the watch-form rungs
+        # of the support net are money that still has to be there.
+        net = (
+            sum(
+                (
+                    placement.notional or Decimal(0)
+                    for row in support_net.rows
+                    if row.currency == currency and row.eligible
+                    for placement in row.placements
+                    if placement.form == "watch"
+                ),
+                Decimal(0),
+            )
+            if currency == "KRW"
+            else Decimal(0)
+        )
+        watch_total = sum(
+            (
+                row.planned_notional or Decimal(0)
+                for row in buy_watches
+                if row.currency == currency
+            ),
+            Decimal(0),
+        )
+        # A crypto support-net rung is also an active buy watch, so counting
+        # both would double-book the same KRW.
+        watch_total = max(watch_total - net, Decimal(0))
+        total = adds + net + watch_total
+        cash = available[currency]
+        if cash is None:
+            verdict = "unknown"
+            shortfall = None
+        elif cash >= total:
+            verdict = "sufficient"
+            shortfall = Decimal(0)
+        else:
+            verdict = "shortfall"
+            shortfall = total - cash
+        notes = [
+            "물타기 합계는 정책의 시장별 add 상한(max_add_symbols_per_market) "
+            "안에 드는 행만 더합니다.",
+            "이미 걸린 지정가는 브로커가 현금을 묶고 있어 합계에서 제외했습니다.",
+        ]
+        currencies.append(
+            CurrencyReconciliation(
+                currency=currency,  # type: ignore[arg-type]
+                available_cash=cash,
+                required_averaging_adds=adds,
+                required_support_net=net,
+                required_active_watches=watch_total,
+                required_total=total,
+                verdict=verdict,  # type: ignore[arg-type]
+                shortfall=shortfall,
+                notes=notes,
+            )
+        )
+    return BuyPlanFunding(accounts=accounts, currencies=currencies)
+
+
+def _cash_accounts(home: InvestHomeResponse | None) -> list[CashAccountRow]:
+    if home is None:
+        return []
+    rows: list[CashAccountRow] = []
+    for account in home.accounts:
+        included = account.accountKind in _RESERVE_ACCOUNT_KINDS
+        resolved = {
+            currency: _account_cash(account, currency) for currency in ("KRW", "USD")
+        }
+        reported_any = any(cash is not None for cash, _ in resolved.values())
+        for currency, (cash, source) in resolved.items():
+            # A KRW-only account legitimately has no USD line, so a missing
+            # currency on an account that reported *something* is just absence.
+            # A live account that reported nothing at all is a failed read —
+            # it is published as unknown so the reserve verdict goes unknown
+            # rather than quietly totalling the accounts that did answer.
+            if cash is None and (not included or reported_any):
+                continue
+            rows.append(
+                CashAccountRow(
+                    account_id=account.accountId,
+                    display_name=account.displayName,
+                    source=account.source,
+                    currency=currency,  # type: ignore[arg-type]
+                    available_cash=cash,
+                    available_cash_source=source or "unavailable",
+                    included_in_reserve=included,
+                )
+            )
+    return rows
+
+
+def _account_cash(account: Account, currency: str) -> tuple[Decimal | None, str | None]:
+    """Prefer buying power, fall back to the cash balance.
+
+    ``buyingPower`` is what the broker says is actually orderable (settlement
+    and pending orders already netted); ``cashBalances`` is the raw balance.
+    Reporting which one answered keeps the difference visible.
+    """
+
+    buying = _dec(getattr(account.buyingPower, currency.lower(), None))
+    if buying is not None:
+        return buying, "buyingPower"
+    balance = _dec(getattr(account.cashBalances, currency.lower(), None))
+    if balance is not None:
+        return balance, "cashBalances"
+    return None, None
+
+
+def _value_sources() -> list[ValueSource]:
+    return [
+        ValueSource(
+            field="averaging_triggers.*",
+            source="InvestHomeService 보유 + config/trading_policy.yaml "
+            "decision_rules['buy.support_reserve_net'].add_candidate.k_used",
+            note="A(p) = C·(1 − (p/P)·(1+k))/k, 전환점 P* = P/(1+k).",
+        ),
+        ValueSource(
+            field="averaging_triggers[].market_rank",
+            source="이 보드의 표시용 정렬 — 전환점까지의 거리",
+            note="정책의 same_intent_class_sort_order(지지강도·R-931·섹터 증분)는 "
+            "여기서 읽지 않는 입력이 필요해 재현하지 않았습니다.",
+        ),
+        ValueSource(
+            field="support_net.*",
+            source="config/trading_policy.yaml "
+            "decision_rules['buy.held_majors_support_net'] + CurrentOrdersService "
+            "미체결 + WatchPanelService 활성 워치",
+        ),
+        ValueSource(
+            field="active_buy_watches[].planned_notional",
+            source="InvestmentWatchAlert.max_action (typed execution plan)",
+        ),
+        ValueSource(
+            field="discovery_gates[].conditions[].current_value",
+            source="upbit_open_api_ticker (breadth) / binance futures data (long-short)",
+            note=f"캐시 {GATE_CACHE_TTL_SECONDS}초.",
+        ),
+        ValueSource(
+            field="funding.accounts[].available_cash",
+            source="InvestHomeService Account.buyingPower ?? Account.cashBalances",
+            note="live 계좌만 리저브에 포함합니다.",
+        ),
+        ValueSource(
+            field="*.approval_lane",
+            source="config/trading_policy.yaml order_proposals.auto_approve.per_order_cap "
+            "+ decision_rules['buy.support_reserve_net'].auto_submit_notional",
+        ),
+    ]

--- a/app/services/invest_view_model/buy_plan/service.py
+++ b/app/services/invest_view_model/buy_plan/service.py
@@ -21,6 +21,7 @@ from typing import Any, Final
 
 from app.schemas.invest_buy_plan import (
     ActiveBuyWatchRow,
+    ApprovalContext,
     AveragingSampleRow,
     AveragingTriggerRow,
     BuyPlanCurrency,
@@ -28,13 +29,16 @@ from app.schemas.invest_buy_plan import (
     BuyPlanMarket,
     BuyPlanResponse,
     CashAccountRow,
-    CurrencyReconciliation,
     DiscoveryGateCondition,
     DiscoveryGateRow,
+    FundingBroker,
     PolicyStamp,
+    ScopeReconciliation,
+    SourceState,
     SupportNetPlacement,
     SupportNetRow,
     SupportNetTier,
+    UnattributedRequirement,
     ValueSource,
 )
 from app.schemas.invest_home import Account, GroupedHolding, InvestHomeResponse
@@ -78,6 +82,66 @@ _MARKET_BY_GROUP: Final[dict[str, BuyPlanMarket]] = {
     "US": "us",
     "CRYPTO": "crypto",
 }
+
+# Cash held at one broker cannot fill an order placed at another, so every
+# requirement is resolved to a broker before it is compared with cash
+# (verify-r1 B1). Both maps are deliberately closed: an account source or an
+# account_mode that is not listed resolves to ``None`` and its requirement
+# becomes ``unattributed`` rather than being charged to an arbitrary scope.
+_BROKER_BY_ACCOUNT_SOURCE: Final[dict[str, FundingBroker]] = {
+    "kis": "kis",
+    "upbit": "upbit",
+    "toss_api": "toss",
+}
+_BROKER_BY_ACCOUNT_MODE: Final[dict[str, FundingBroker]] = {
+    "kis_live": "kis",
+    "upbit": "upbit",
+    "toss_live": "toss",
+}
+UNATTRIBUTED: Final[FundingBroker] = "unattributed"
+
+# Conditions that gate a real auto-submission and that this read surface does
+# NOT evaluate. Published verbatim so the board never implies it checked them
+# (verify-r1 B6; source: order_proposals.auto_approve.evaluate_auto_approve_eligibility).
+AUTO_APPROVE_UNEVALUATED_CONDITIONS: Final[tuple[str, ...]] = (
+    "fresh preview 존재",
+    "limit-only (비-marketable) 주문",
+    "veto 가능한 계좌·시장",
+    "tag scan",
+    "thesis 요건",
+    "일일 누적 cap 잔여",
+    "distance / marketability 조건",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceHealth:
+    """What one upstream read model said about its own completeness.
+
+    ``ok`` is only claimed when the upstream actively said so. An exception, a
+    ``data_state`` other than ``ok``, or any warning it emitted all downgrade
+    it — a degraded upstream must never be rendered as a confident zero
+    (verify-r1 B2/B3/B4).
+    """
+
+    state: SourceState = "ok"
+    reasons: tuple[str, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        return self.state == "ok" and not self.reasons
+
+
+@dataclass(frozen=True, slots=True)
+class _Requirement:
+    """One projected cash need, with the account that would have to hold it."""
+
+    kind: str
+    label: str
+    currency: BuyPlanCurrency
+    amount: Decimal | None
+    broker: FundingBroker | None
+    unattributed_reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -161,9 +225,9 @@ class BuyPlanService:
         policy = load_trading_policy()
         stamp = policy_version_stamp()
 
-        home = await self._safe_home(user_id=user_id, warnings=warnings)
-        watches = await self._safe_watches(warnings=warnings)
-        open_orders = await self._safe_open_orders(warnings=warnings)
+        home, home_health = await self._safe_home(user_id=user_id, warnings=warnings)
+        watches, watch_health = await self._safe_watches(warnings=warnings)
+        open_orders, order_health = await self._safe_open_orders(warnings=warnings)
 
         lots = _tradeable_lots(home, warnings=warnings)
         wanted = _wanted_markets(market)
@@ -176,6 +240,8 @@ class BuyPlanService:
             open_orders=open_orders,
             watches=watches,
             crypto_in_scope="crypto" in wanted,
+            order_health=order_health,
+            watch_health=watch_health,
         )
         buy_watches = _build_active_buy_watches(watches, policy=policy, wanted=wanted)
         gates = (
@@ -186,6 +252,9 @@ class BuyPlanService:
             averaging=averaging,
             support_net=support_net,
             buy_watches=buy_watches,
+            home_health=home_health,
+            watch_health=watch_health,
+            order_health=order_health,
             warnings=warnings,
         )
 
@@ -196,6 +265,7 @@ class BuyPlanService:
             ),
             cache_ttl_seconds=CACHE_TTL_SECONDS,
             approximation_notice=APPROXIMATION_NOTICE,
+            approval_context=_approval_context(),
             market=market if market in {"all", "kr", "us", "crypto"} else "all",
             averaging_triggers=averaging,
             support_net=support_net,
@@ -208,33 +278,188 @@ class BuyPlanService:
 
     async def _safe_home(
         self, *, user_id: int, warnings: list[str]
-    ) -> InvestHomeResponse | None:
+    ) -> tuple[InvestHomeResponse | None, _SourceHealth]:
         try:
-            return await self._home.get_home(user_id=user_id)
+            home = await self._home.get_home(user_id=user_id)
         except Exception as exc:  # noqa: BLE001 — one dead reader must not 500 the board
             logger.warning("buy_plan: holdings/cash unavailable: %s", exc)
-            warnings.append(f"보유·현금 조회 실패 — 자금 대조 불가: {exc}")
-            return None
+            reason = f"보유·현금 조회 실패 — 자금 대조 불가: {exc}"
+            warnings.append(reason)
+            return None, _SourceHealth(state="unavailable", reasons=(reason,))
 
-    async def _safe_watches(self, *, warnings: list[str]) -> WatchesResponse | None:
+        # A partial failure does NOT raise: InvestHomeService returns a normal
+        # response with the dead source's accounts simply absent and a warning
+        # in meta. Reading only the exception path let a missing KIS account
+        # silently shrink the cash total (verify-r1 B2).
+        reasons = tuple(
+            f"보유·현금 소스 누락({warning.source}): {warning.message}"
+            for warning in home.meta.warnings
+        )
+        for reason in reasons:
+            warnings.append(reason)
+        return home, _SourceHealth(
+            state="degraded" if reasons else "ok", reasons=reasons
+        )
+
+    async def _safe_watches(
+        self, *, warnings: list[str]
+    ) -> tuple[WatchesResponse | None, _SourceHealth]:
         try:
-            return await self._watches.list_watches(market="all", status="active")
+            watches = await self._watches.list_watches(market="all", status="active")
         except Exception as exc:  # noqa: BLE001
             logger.warning("buy_plan: watches unavailable: %s", exc)
-            warnings.append(f"워치 조회 실패 — 활성 매수 워치 누락: {exc}")
-            return None
+            reason = f"워치 조회 실패 — 활성 매수 워치 누락: {exc}"
+            warnings.append(reason)
+            return None, _SourceHealth(state="unavailable", reasons=(reason,))
+        return watches, _watches_health(watches, warnings=warnings)
 
     async def _safe_open_orders(
         self, *, warnings: list[str]
-    ) -> OpenOrdersResponse | None:
+    ) -> tuple[OpenOrdersResponse | None, _SourceHealth]:
         try:
-            return await self._open_orders.list_open_orders(market="all")
+            orders = await self._open_orders.list_open_orders(market="all")
         except Exception as exc:  # noqa: BLE001
             logger.warning("buy_plan: open orders unavailable: %s", exc)
-            warnings.append(
-                f"미체결 주문 조회 실패 — 그물에 이미 걸린 주문이 누락됐을 수 있습니다: {exc}"
+            reason = f"미체결 주문 조회 실패 — 그물에 이미 걸린 주문이 누락됐을 수 있습니다: {exc}"
+            warnings.append(reason)
+            return None, _SourceHealth(state="unavailable", reasons=(reason,))
+        return orders, _open_orders_health(orders, warnings=warnings)
+
+
+def _watches_health(watches: WatchesResponse, *, warnings: list[str]) -> _SourceHealth:
+    """Trust the watch panel's own completeness signal.
+
+    ``WatchPanelService`` reports partial reads two ways: a non-``ok``
+    ``data_state``, and per-alert build failures surfaced as warnings with the
+    offending items dropped from ``items``. Either way the requirement side of
+    the board is short by an unknown amount (verify-r1 B3).
+    """
+
+    reasons: list[str] = []
+    if watches.data_state != "ok":
+        reasons.append(
+            f"워치 조회 상태 {watches.data_state} — 누락된 워치가 있을 수 있습니다."
+        )
+    for warning in watches.warnings:
+        reasons.append(f"워치 경고: {warning}")
+    for reason in reasons:
+        warnings.append(reason)
+    state: SourceState = "ok"
+    if watches.data_state == "unavailable":
+        state = "unavailable"
+    elif reasons:
+        state = "degraded"
+    return _SourceHealth(state=state, reasons=tuple(reasons))
+
+
+def _open_orders_health(
+    orders: OpenOrdersResponse, *, warnings: list[str]
+) -> _SourceHealth:
+    """Trust the open-order reader's own completeness signal.
+
+    An empty ``items`` from a degraded collector means "we could not see the
+    resting orders", not "there are none" — and the support net publishes both
+    committed notional and remaining headroom off that list (verify-r1 B4).
+    """
+
+    reasons: list[str] = []
+    if orders.data_state != "ok":
+        reasons.append(
+            f"미체결 주문 조회 상태 {orders.data_state} — 이미 걸린 주문이 누락됐을 수 있습니다."
+        )
+    for source in orders.sources:
+        if source.status != "ok":
+            reasons.append(
+                f"미체결 주문 소스 {source.broker}/{source.market} 상태 {source.status}"
+                + (f": {source.message}" if source.message else "")
             )
-            return None
+    for warning in orders.warnings:
+        reasons.append(f"미체결 주문 경고: {warning}")
+    for reason in reasons:
+        warnings.append(reason)
+    state: SourceState = "ok"
+    if orders.data_state == "unavailable":
+        state = "unavailable"
+    elif reasons:
+        state = "degraded"
+    return _SourceHealth(state=state, reasons=tuple(reasons))
+
+
+def _broker_from_account_sources(
+    sources: list[str],
+) -> tuple[FundingBroker | None, str | None]:
+    """Resolve a holding's tradeable sources to exactly one broker.
+
+    A lot split across two brokers has no single account that must fund the
+    add, so it is left unattributed instead of being charged to whichever
+    source happened to sort first.
+    """
+
+    if not sources:
+        return None, "보유의 계좌 소스를 확인하지 못했습니다."
+    resolved = {_BROKER_BY_ACCOUNT_SOURCE.get(source) for source in sources}
+    if None in resolved:
+        unknown = sorted(
+            source for source in sources if source not in _BROKER_BY_ACCOUNT_SOURCE
+        )
+        return None, f"매핑되지 않은 계좌 소스: {', '.join(unknown)}"
+    if len(resolved) != 1:
+        return None, "여러 브로커에 걸친 보유 — 어느 계좌가 낼지 확정 불가"
+    return next(iter(resolved)), None
+
+
+def _broker_from_account_mode(mode: object) -> tuple[FundingBroker | None, str | None]:
+    if not isinstance(mode, str) or not mode.strip():
+        return None, "워치 max_action에 account_mode가 없습니다."
+    resolved = _BROKER_BY_ACCOUNT_MODE.get(mode.strip())
+    if resolved is None:
+        return None, f"매핑되지 않은 account_mode: {mode.strip()}"
+    return resolved, None
+
+
+def _approval_context() -> ApprovalContext:
+    """Publish how far the board's approval-lane classification actually goes.
+
+    ``approval_lane`` compares notionals with two caps. Real dispatch consults
+    ``settings.ORDER_PROPOSALS_AUTO_APPROVE`` first (default False) and then a
+    further eligibility evaluation this surface never runs. Both facts ship in
+    the response so the UI cannot present a cap check as an approval decision
+    (verify-r1 B6).
+    """
+
+    setting = "ORDER_PROPOSALS_AUTO_APPROVE"
+    try:
+        from app.core.config import settings
+
+        enabled: bool | None = bool(getattr(settings, setting))
+        source = f"settings.{setting}"
+    except Exception as exc:  # noqa: BLE001 — unknown gate must read as unknown
+        logger.warning("buy_plan: auto-approve master gate unreadable: %s", exc)
+        enabled = None
+        source = f"settings.{setting} (읽기 실패)"
+
+    if enabled is False:
+        notice = (
+            "자동승인 마스터 게이트가 꺼져 있습니다 — 조건과 무관하게 전건이 "
+            "수동 승인 카드로 갑니다. 아래 레인 표시는 cap 기준 분류일 뿐입니다."
+        )
+    elif enabled is True:
+        notice = (
+            "자동승인 마스터 게이트는 켜져 있지만, 이 보드는 cap 두 개만 확인합니다 — "
+            "실제 자동제출에는 아래 조건이 더 필요하며 여기서 평가하지 않았습니다."
+        )
+    else:
+        notice = (
+            "자동승인 마스터 게이트 상태를 읽지 못했습니다 — 레인 표시를 "
+            "승인 예정으로 읽지 마십시오."
+        )
+    return ApprovalContext(
+        master_gate_enabled=enabled,
+        master_gate_setting=setting,
+        master_gate_source=source,
+        unevaluated_conditions=list(AUTO_APPROVE_UNEVALUATED_CONDITIONS),
+        notice=notice,
+    )
 
 
 def _wanted_markets(market: MarketFilter) -> frozenset[BuyPlanMarket]:
@@ -379,7 +604,14 @@ def _build_averaging_rows(
         if not samples:
             continue
 
+        lot_broker, lot_broker_reason = _broker_from_account_sources(
+            lot.account_sources
+        )
         notes: list[str] = []
+        if lot_broker is None and lot_broker_reason:
+            notes.append(
+                f"이 소요액을 어느 계좌가 낼지 확정하지 못했습니다 — {lot_broker_reason}"
+            )
         if lot.price_state != "live":
             notes.append(
                 f"현재가 상태 {lot.price_state} — 전환점 거리는 그만큼 오래된 값입니다."
@@ -415,6 +647,7 @@ def _build_averaging_rows(
                 ),
                 market_rank=0,
                 within_policy_add_cap=False,
+                funding_broker=lot_broker or UNATTRIBUTED,
                 notes=notes,
             )
         )
@@ -462,6 +695,8 @@ def _build_support_net(
     open_orders: OpenOrdersResponse | None,
     watches: WatchesResponse | None,
     crypto_in_scope: bool,
+    order_health: _SourceHealth,
+    watch_health: _SourceHealth,
 ) -> SupportNetTier:
     rule, conditions = _held_majors_tier(policy)
     per_symbol_cap = _dec(conditions.get("max_notional_krw_per_coin"))
@@ -477,6 +712,19 @@ def _build_support_net(
 
     resting = _resting_buy_by_symbol(open_orders)
     watch_rungs = _buy_watch_by_symbol(watches)
+
+    # Committed notional is the sum of what the placement sources could see.
+    # If either source said it was incomplete, that sum is a floor, not a
+    # total — and the headroom derived from it would be an over-estimate of
+    # what is still free to spend, so both are published as unknown
+    # (verify-r1 B4).
+    placements_reasons = [*order_health.reasons, *watch_health.reasons]
+    placements_confident = order_health.complete and watch_health.complete
+    placements_state: SourceState = "ok"
+    if "unavailable" in {order_health.state, watch_health.state}:
+        placements_state = "unavailable"
+    elif not placements_confident:
+        placements_state = "degraded"
 
     rows: list[SupportNetRow] = []
     placed_total = Decimal(0)
@@ -515,15 +763,21 @@ def _build_support_net(
                     eligible=eligible,
                     ineligible_reason=reason,
                     placements=placements,
-                    placed_notional=placed,
+                    placed_notional=placed if placements_confident else None,
                     per_symbol_cap_notional=per_symbol_cap or Decimal(0),
-                    remaining_headroom_notional=headroom,
+                    remaining_headroom_notional=(
+                        headroom if placements_confident else None
+                    ),
+                    placements_state=placements_state,
+                    placements_incomplete_reasons=list(placements_reasons),
                 )
             )
 
     remaining = (
         max(tier_cap - placed_total, Decimal(0)) if tier_cap is not None else None
     )
+    if not placements_confident:
+        remaining = None
     if rule is not None:
         notes.append(
             "그물 대상 판정(‘메이저’)은 세션 판단이며 기계 allowlist가 없습니다 — "
@@ -533,18 +787,25 @@ def _build_support_net(
             "이미 걸린 지정가(주문 상시형)는 브로커가 현금을 이미 묶고 있으므로 "
             "추가 입금 대상이 아닙니다. 워치형만 신규 소요액으로 집계합니다."
         )
+    if not placements_confident and crypto_in_scope and rule is not None:
+        notes.append(
+            "미체결/워치 소스가 불완전해 걸린 금액과 남은 여력을 확정하지 못했습니다 — "
+            "표시된 여력을 쓸 수 있는 돈으로 읽지 마십시오."
+        )
     return SupportNetTier(
         policy_key=HELD_MAJORS_SUPPORT_NET_KEY,
         enabled=rule is not None and crypto_in_scope,
         currency="KRW",
         tier_cap_notional=tier_cap,
         per_symbol_cap_notional=per_symbol_cap,
-        placed_notional=placed_total,
+        placed_notional=placed_total if placements_confident else None,
         remaining_notional=remaining,
         distance_band_pct=band,
         review_date=str(review_date) if review_date is not None else None,
         rows=rows,
         notes=notes,
+        placements_state=placements_state,
+        placements_incomplete_reasons=list(placements_reasons),
     )
 
 
@@ -686,6 +947,8 @@ def _build_active_buy_watches(
             continue
         currency: BuyPlanCurrency = "USD" if alert.market == "us" else "KRW"
         notional, source = _planned_notional(alert)
+        raw_mode = (alert.max_action or {}).get("account_mode")
+        broker, _ = _broker_from_account_mode(raw_mode)
         lane, reason = approval_lane_for(
             notional=notional,
             tier_auto_submit_notional=_tier_auto_submit_notional(rule, currency),
@@ -717,6 +980,8 @@ def _build_active_buy_watches(
                 near_expiry=alert.near_expiry,
                 planned_notional=notional,
                 planned_notional_source=source,
+                funding_broker=broker or UNATTRIBUTED,
+                account_mode=raw_mode if isinstance(raw_mode, str) else None,
                 approval_lane=lane,
                 approval_lane_reason=reason,
             )
@@ -818,102 +1083,274 @@ def _compare(operator: str, value: Decimal, threshold: Decimal) -> bool:
     return False
 
 
+def _requirements(
+    *,
+    averaging: list[AveragingTriggerRow],
+    support_net: SupportNetTier,
+    buy_watches: list[ActiveBuyWatchRow],
+) -> list[_Requirement]:
+    """Flatten the board's three requirement families into attributed amounts.
+
+    A watch that is also a support-net rung appears here exactly once, keyed by
+    its alert id. The previous version subtracted one total from the other,
+    which happened to work but could not say *which* account either belonged
+    to; identity-based de-duplication does both jobs at once.
+    """
+
+    out: list[_Requirement] = []
+
+    for row in averaging:
+        if not row.within_policy_add_cap:
+            # Outside the policy's per-market add cap — shown on the board but
+            # not money to reserve for.
+            continue
+        out.append(
+            _Requirement(
+                kind="averaging_add",
+                label=f"{row.symbol} 물타기 A(k)",
+                currency=row.currency,
+                amount=row.reserve_plan_notional,
+                broker=None
+                if row.funding_broker == UNATTRIBUTED
+                else row.funding_broker,
+                unattributed_reason=(
+                    "보유의 계좌 소스를 하나의 브로커로 확정하지 못했습니다."
+                    if row.funding_broker == UNATTRIBUTED
+                    else None
+                ),
+            )
+        )
+
+    rung_alert_ids = {
+        placement.reference
+        for row in support_net.rows
+        if row.eligible
+        for placement in row.placements
+        if placement.form == "watch"
+    }
+
+    for row in buy_watches:
+        kind = "support_net" if row.alert_uuid in rung_alert_ids else "active_watch"
+        out.append(
+            _Requirement(
+                kind=kind,
+                label=f"{row.symbol} 워치 {format(row.threshold, 'f')}",
+                currency=row.currency,
+                amount=row.planned_notional,
+                broker=None
+                if row.funding_broker == UNATTRIBUTED
+                else row.funding_broker,
+                unattributed_reason=(
+                    "워치 max_action이 실행 계좌(account_mode)를 지정하지 않았습니다."
+                    if row.funding_broker == UNATTRIBUTED
+                    else None
+                ),
+            )
+        )
+    return out
+
+
 def _build_funding(
     home: InvestHomeResponse | None,
     *,
     averaging: list[AveragingTriggerRow],
     support_net: SupportNetTier,
     buy_watches: list[ActiveBuyWatchRow],
+    home_health: _SourceHealth,
+    watch_health: _SourceHealth,
+    order_health: _SourceHealth,
     warnings: list[str],
 ) -> BuyPlanFunding:
     accounts = _cash_accounts(home)
-    available: dict[str, Decimal | None] = {}
-    for currency in ("KRW", "USD"):
+    requirements = _requirements(
+        averaging=averaging, support_net=support_net, buy_watches=buy_watches
+    )
+
+    # Requirements whose owning account could not be resolved are published,
+    # never dropped. They then hold every same-currency scope at ``unknown``
+    # unless that scope's cash covers its own needs plus all of them.
+    unattributed = [
+        UnattributedRequirement(
+            kind=req.kind,  # type: ignore[arg-type]
+            label=req.label,
+            currency=req.currency,
+            amount=req.amount,
+            reason=req.unattributed_reason or "귀속 계좌 불명",
+        )
+        for req in requirements
+        if req.broker is None
+    ]
+    unattributed_by_currency: dict[str, Decimal] = {
+        "KRW": Decimal(0),
+        "USD": Decimal(0),
+    }
+    unattributed_unknown_amount: dict[str, bool] = {"KRW": False, "USD": False}
+    for req in requirements:
+        if req.broker is not None:
+            continue
+        if req.amount is None:
+            unattributed_unknown_amount[req.currency] = True
+            continue
+        unattributed_by_currency[req.currency] += req.amount
+
+    # A requirement whose amount could not be resolved is also an unknown, and
+    # it must not read as zero.
+    amount_unknown_by_scope: dict[tuple[str, str], list[str]] = {}
+    for req in requirements:
+        if req.amount is None and req.broker is not None:
+            amount_unknown_by_scope.setdefault((req.broker, req.currency), []).append(
+                f"{req.label}: 소요 금액을 확정하지 못했습니다."
+            )
+
+    scope_keys: set[tuple[FundingBroker, BuyPlanCurrency]] = set()
+    for row in accounts:
+        if row.included_in_reserve:
+            scope_keys.add((row.broker, row.currency))
+    for req in requirements:
+        if req.broker is not None:
+            scope_keys.add((req.broker, req.currency))
+    if not scope_keys:
+        scope_keys.add(("unattributed", "KRW"))
+
+    # Requirement-side incompleteness is symmetric with the cash-side hold that
+    # already existed: an unknown requirement must never fold to zero
+    # (verify-r1 B3/B4).
+    shared_incomplete: list[str] = [
+        *home_health.reasons,
+        *watch_health.reasons,
+        *order_health.reasons,
+    ]
+
+    scopes: list[ScopeReconciliation] = []
+    for broker, currency in sorted(scope_keys):
         rows = [
             row
             for row in accounts
-            if row.currency == currency and row.included_in_reserve
+            if row.included_in_reserve
+            and row.broker == broker
+            and row.currency == currency
         ]
-        known = [row.available_cash for row in rows if row.available_cash is not None]
-        if not rows:
-            available[currency] = None
-        elif len(known) != len(rows):
-            # A partially-known total would understate what is available and
-            # could send the operator to deposit money they already hold.
-            available[currency] = None
-            warnings.append(
-                f"{currency} 가용 현금이 일부 계좌에서 확인되지 않아 대조를 보류합니다."
-            )
-        else:
-            available[currency] = sum(known, Decimal(0))
+        available = _scope_available_cash(rows, warnings=warnings)
 
-    currencies: list[CurrencyReconciliation] = []
-    for currency in ("KRW", "USD"):
-        adds = sum(
-            (
-                row.reserve_plan_notional
-                for row in averaging
-                if row.currency == currency and row.within_policy_add_cap
-            ),
-            Decimal(0),
-        )
-        # Resting orders already hold broker cash; only the watch-form rungs
-        # of the support net are money that still has to be there.
-        net = (
-            sum(
-                (
-                    placement.notional or Decimal(0)
-                    for row in support_net.rows
-                    if row.currency == currency and row.eligible
-                    for placement in row.placements
-                    if placement.form == "watch"
-                ),
-                Decimal(0),
+        by_kind: dict[str, Decimal] = {
+            "averaging_add": Decimal(0),
+            "support_net": Decimal(0),
+            "active_watch": Decimal(0),
+        }
+        for req in requirements:
+            if req.broker != broker or req.currency != currency or req.amount is None:
+                continue
+            by_kind[req.kind] += req.amount
+        attributed_total = sum(by_kind.values(), Decimal(0))
+
+        incomplete = [
+            *shared_incomplete,
+            *amount_unknown_by_scope.get((broker, currency), []),
+        ]
+        if unattributed_unknown_amount[currency]:
+            incomplete.append(
+                f"{currency} 소요액 중 금액을 확정하지 못한 항목이 있습니다."
             )
-            if currency == "KRW"
-            else Decimal(0)
+        if broker == UNATTRIBUTED and not rows:
+            incomplete.append(
+                "이 행은 귀속 계좌를 확정하지 못한 소요액 모음입니다 — 대조할 현금이 없습니다."
+            )
+
+        unattributed_amount = unattributed_by_currency[currency]
+        worst_case = attributed_total + unattributed_amount
+        verdict, shortfall = _scope_verdict(
+            available=available,
+            attributed=attributed_total,
+            worst_case=worst_case,
+            incomplete=bool(incomplete),
         )
-        watch_total = sum(
-            (
-                row.planned_notional or Decimal(0)
-                for row in buy_watches
-                if row.currency == currency
-            ),
-            Decimal(0),
-        )
-        # A crypto support-net rung is also an active buy watch, so counting
-        # both would double-book the same KRW.
-        watch_total = max(watch_total - net, Decimal(0))
-        total = adds + net + watch_total
-        cash = available[currency]
-        if cash is None:
-            verdict = "unknown"
-            shortfall = None
-        elif cash >= total:
-            verdict = "sufficient"
-            shortfall = Decimal(0)
-        else:
-            verdict = "shortfall"
-            shortfall = total - cash
+
         notes = [
-            "물타기 합계는 정책의 시장별 add 상한(max_add_symbols_per_market) "
-            "안에 드는 행만 더합니다.",
+            "다른 브로커 계좌의 같은 통화 현금은 이 판정에 포함하지 않습니다 — "
+            "그 돈으로 이 계좌의 주문을 낼 수 없습니다.",
+            "물타기 합계는 정책의 시장별 add 상한 안에 드는 행만 더합니다.",
             "이미 걸린 지정가는 브로커가 현금을 묶고 있어 합계에서 제외했습니다.",
         ]
-        currencies.append(
-            CurrencyReconciliation(
-                currency=currency,  # type: ignore[arg-type]
-                available_cash=cash,
-                required_averaging_adds=adds,
-                required_support_net=net,
-                required_active_watches=watch_total,
-                required_total=total,
+        if unattributed_amount > 0 or unattributed_unknown_amount[currency]:
+            notes.append(
+                "귀속 계좌를 확정하지 못한 소요액이 있어, 이 계좌 현금이 그 전액까지 "
+                "덮지 못하면 판정을 보류합니다."
+            )
+        scopes.append(
+            ScopeReconciliation(
+                scope_key=f"{broker}:{currency}",
+                broker=broker,
+                currency=currency,
+                account_ids=[row.account_id for row in rows],
+                available_cash=available,
+                required_averaging_adds=by_kind["averaging_add"],
+                required_support_net=by_kind["support_net"],
+                required_active_watches=by_kind["active_watch"],
+                required_total=attributed_total,
+                unattributed_same_currency=unattributed_amount,
+                worst_case_required=worst_case,
+                requirements_complete=not incomplete,
+                incomplete_reasons=sorted(set(incomplete)),
                 verdict=verdict,  # type: ignore[arg-type]
                 shortfall=shortfall,
                 notes=notes,
             )
         )
-    return BuyPlanFunding(accounts=accounts, currencies=currencies)
+
+    return BuyPlanFunding(
+        accounts=accounts,
+        scopes=scopes,
+        unattributed=unattributed,
+        source_warnings=sorted(set(shared_incomplete)),
+    )
+
+
+def _scope_available_cash(
+    rows: list[CashAccountRow], *, warnings: list[str]
+) -> Decimal | None:
+    """Total the scope's cash, or ``None`` if any account in it is unreadable.
+
+    A partially-known total understates what is available and would send the
+    operator to deposit money they already hold, so it is withheld instead.
+    """
+
+    if not rows:
+        return None
+    known = [row.available_cash for row in rows if row.available_cash is not None]
+    if len(known) != len(rows):
+        warnings.append(
+            f"{rows[0].broker}/{rows[0].currency} 가용 현금이 일부 계좌에서 "
+            "확인되지 않아 대조를 보류합니다."
+        )
+        return None
+    return sum(known, Decimal(0))
+
+
+def _scope_verdict(
+    *,
+    available: Decimal | None,
+    attributed: Decimal,
+    worst_case: Decimal,
+    incomplete: bool,
+) -> tuple[str, Decimal | None]:
+    """Decide one scope, refusing to round any unknown down to zero.
+
+    A shortfall is still reported when the *known* requirement already exceeds
+    the cash: that deficit is proven regardless of what else is missing, and
+    suppressing it would be its own kind of dishonesty.
+    """
+
+    if available is None:
+        return "unknown", None
+    if attributed > available:
+        return "shortfall", attributed - available
+    if incomplete:
+        return "unknown", None
+    if worst_case > available:
+        # The attributed part fits but the unattributed part may not, and the
+        # board cannot say which account it lands on.
+        return "unknown", None
+    return "sufficient", Decimal(0)
 
 
 def _cash_accounts(home: InvestHomeResponse | None) -> list[CashAccountRow]:
@@ -939,6 +1376,9 @@ def _cash_accounts(home: InvestHomeResponse | None) -> list[CashAccountRow]:
                     account_id=account.accountId,
                     display_name=account.displayName,
                     source=account.source,
+                    broker=_BROKER_BY_ACCOUNT_SOURCE.get(
+                        str(account.source), UNATTRIBUTED
+                    ),
                     currency=currency,  # type: ignore[arg-type]
                     available_cash=cash,
                     available_cash_source=source or "unavailable",
@@ -999,6 +1439,19 @@ def _value_sources() -> list[ValueSource]:
             field="funding.accounts[].available_cash",
             source="InvestHomeService Account.buyingPower ?? Account.cashBalances",
             note="live 계좌만 리저브에 포함합니다.",
+        ),
+        ValueSource(
+            field="funding.scopes[]",
+            source="(브로커, 통화) 쌍 — 보유 account source / 워치 max_action.account_mode",
+            note="다른 브로커의 같은 통화 현금은 합산하지 않습니다. 귀속을 확정하지 "
+            "못한 소요액은 funding.unattributed 로 올라가며 같은 통화 판정을 보류시킵니다.",
+        ),
+        ValueSource(
+            field="approval_context.master_gate_enabled",
+            source="settings.ORDER_PROPOSALS_AUTO_APPROVE",
+            note="행의 approval_lane 은 cap 두 개만 본 분류입니다 — 실제 자동제출 "
+            "조건은 approval_context.unevaluated_conditions 에 나열돼 있고 "
+            "이 보드는 그것들을 평가하지 않습니다.",
         ),
         ValueSource(
             field="*.approval_lane",

--- a/ci_shards/shard-1.txt
+++ b/ci_shards/shard-1.txt
@@ -142,6 +142,7 @@ tests/services/execution_outcomes/test_static_boundaries.py
 tests/services/invest_screener_snapshots/test_alerts.py
 tests/services/invest_screener_snapshots/test_freshness_dispatch.py
 tests/services/invest_screener_snapshots/test_freshness_us_session.py
+tests/services/invest_view_model/buy_plan/test_computation.py
 tests/services/invest_view_model/test_consecutive_gainers_public_loader.py
 tests/services/investment_reports/test_action_packet.py
 tests/services/investment_reports/test_bundle_news_citations.py

--- a/ci_shards/shard-2.txt
+++ b/ci_shards/shard-2.txt
@@ -129,6 +129,7 @@ tests/services/invalid_sample_eligibility/test_migration.py
 tests/services/invalid_sample_eligibility/test_pnl_eligibility_wiring.py
 tests/services/invalid_sample_eligibility/test_read_model.py
 tests/services/invest_screener_snapshots/test_freshness_kr_session.py
+tests/services/invest_view_model/buy_plan/test_service.py
 tests/services/investment_dimensions/test_fundamentals_evidence.py
 tests/services/investment_dimensions/test_news_evidence.py
 tests/services/investment_dimensions/test_sentiment_evidence.py

--- a/ci_shards/shard-3.txt
+++ b/ci_shards/shard-3.txt
@@ -59,6 +59,7 @@ tests/research/us_stage_b/test_verdict.py
 tests/research_contracts/test_dfc_2c_4h_v21.py
 tests/routers/test_alpaca_paper_ledger_router.py
 tests/routers/test_candidate_discovery.py
+tests/routers/test_invest_buy_plan_router.py
 tests/routers/test_invest_loss_cut_approvals.py
 tests/routers/test_investment_hermes_http_auth.py
 tests/routers/test_news_relevance_auth.py

--- a/frontend/invest/src/__tests__/BuyPlanRoute.test.tsx
+++ b/frontend/invest/src/__tests__/BuyPlanRoute.test.tsx
@@ -11,7 +11,7 @@ import * as buyPlanApi from "../api/buyPlan";
 import { BuyPlanRoute } from "../pages/BuyPlanRoute";
 import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import { mockRightRail } from "../test/mockRightRail";
-import type { BuyPlanResponse } from "../types/buyPlan";
+import type { BuyPlanResponse, ScopeReconciliation } from "../types/buyPlan";
 
 function setWidth(w: number) {
   Object.defineProperty(window, "innerWidth", {
@@ -31,6 +31,44 @@ function wrap(ui: React.ReactElement) {
   );
 }
 
+const UPBIT_KRW_SCOPE: ScopeReconciliation = {
+  scope_key: "upbit:KRW",
+  broker: "upbit",
+  currency: "KRW",
+  account_ids: ["upbit-1"],
+  available_cash: "200000",
+  required_averaging_adds: "340000",
+  required_support_net: "0",
+  required_active_watches: "0",
+  required_total: "340000",
+  unattributed_same_currency: "0",
+  upper_bound_if_all_unattributed_lands_here: "340000",
+  requirements_complete: true,
+  incomplete_reasons: [],
+  verdict: "shortfall",
+  shortfall: "140000",
+  notes: ["이미 걸린 지정가는 브로커가 현금을 묶고 있어 합계에서 제외했습니다."],
+};
+
+const KIS_KRW_SCOPE: ScopeReconciliation = {
+  scope_key: "kis:KRW",
+  broker: "kis",
+  currency: "KRW",
+  account_ids: ["kis-1"],
+  available_cash: "5000000",
+  required_averaging_adds: "0",
+  required_support_net: "0",
+  required_active_watches: "650000",
+  required_total: "650000",
+  unattributed_same_currency: "0",
+  upper_bound_if_all_unattributed_lands_here: "650000",
+  requirements_complete: true,
+  incomplete_reasons: [],
+  verdict: "sufficient",
+  shortfall: "0",
+  notes: [],
+};
+
 const READY: BuyPlanResponse = {
   as_of: "2026-08-23T03:00:00Z",
   policy: { version: "2026-08-23.1", content_hash: "abcdef0123456789" },
@@ -40,7 +78,14 @@ const READY: BuyPlanResponse = {
     master_gate_enabled: false,
     master_gate_setting: "ORDER_PROPOSALS_AUTO_APPROVE",
     master_gate_source: "settings.ORDER_PROPOSALS_AUTO_APPROVE",
-    unevaluated_conditions: ["fresh preview 존재", "tag scan", "일일 누적 cap 잔여"],
+    unevaluated_conditions: [
+      { code: "preview_guard_failed", label: "fresh preview 성공" },
+      { code: "approval_required_tag", label: "승인 필요 태그 스캔" },
+      { code: "daily_cap_exceeded", label: "일일 누적 cap 잔여" },
+    ],
+    evaluated_conditions: [
+      { code: "per_order_cap_exceeded", label: "건당 자동승인 상한" },
+    ],
     notice: "자동승인 마스터 게이트가 꺼져 있습니다 — 전건이 수동 승인 카드로 갑니다.",
   },
   market: "all",
@@ -82,6 +127,7 @@ const READY: BuyPlanResponse = {
       market_rank: 1,
       within_policy_add_cap: true,
       funding_broker: "upbit",
+      funding_broker_reason: null,
       notes: [],
     },
   ],
@@ -148,6 +194,7 @@ const READY: BuyPlanResponse = {
       planned_notional: "650000",
       planned_notional_source: "max_action.quantity × 트리거 레벨",
       funding_broker: "kis",
+      funding_broker_reason: null,
       account_mode: "kis_live",
       approval_lane: "human_card",
       approval_lane_reason: "above_tier_auto_submit_notional",
@@ -203,44 +250,7 @@ const READY: BuyPlanResponse = {
         included_in_reserve: true,
       },
     ],
-    scopes: [
-      {
-        scope_key: "upbit:KRW",
-        broker: "upbit",
-        currency: "KRW",
-        account_ids: ["upbit-1"],
-        available_cash: "200000",
-        required_averaging_adds: "340000",
-        required_support_net: "0",
-        required_active_watches: "0",
-        required_total: "340000",
-        unattributed_same_currency: "0",
-        worst_case_required: "340000",
-        requirements_complete: true,
-        incomplete_reasons: [],
-        verdict: "shortfall",
-        shortfall: "140000",
-        notes: ["이미 걸린 지정가는 브로커가 현금을 묶고 있어 합계에서 제외했습니다."],
-      },
-      {
-        scope_key: "kis:KRW",
-        broker: "kis",
-        currency: "KRW",
-        account_ids: ["kis-1"],
-        available_cash: "5000000",
-        required_averaging_adds: "0",
-        required_support_net: "0",
-        required_active_watches: "650000",
-        required_total: "650000",
-        unattributed_same_currency: "0",
-        worst_case_required: "650000",
-        requirements_complete: true,
-        incomplete_reasons: [],
-        verdict: "sufficient",
-        shortfall: "0",
-        notes: [],
-      },
-    ],
+    scopes: [UPBIT_KRW_SCOPE, KIS_KRW_SCOPE],
     unattributed: [],
     source_warnings: [],
   },
@@ -359,6 +369,144 @@ describe("BuyPlanRoute", () => {
     expect(
       screen.getByText(/이 화면은 주문·제안·워치를 만들거나 승인하지 않습니다/),
     ).toBeTruthy();
+  });
+
+  it("never greenlights a funded broker while money is unattributed", async () => {
+    // verify-r2 B1 (a): KIS holding the cash does not make it the account the
+    // order will use. Green anywhere here sends the operator past the deposit.
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue({
+      ...READY,
+      funding: {
+        ...READY.funding,
+        scopes: [
+          {
+            ...KIS_KRW_SCOPE,
+            available_cash: "1000000",
+            required_averaging_adds: "0",
+            required_active_watches: "0",
+            required_total: "0",
+            unattributed_same_currency: "330000",
+            upper_bound_if_all_unattributed_lands_here: "330000",
+            verdict: "unknown",
+            shortfall: null,
+          },
+        ],
+        unattributed: [
+          {
+            kind: "active_watch",
+            label: "KRW-XRP 워치 900",
+            currency: "KRW",
+            amount: "330000",
+            reason: "워치 max_action이 실행 계좌(account_mode)를 지정하지 않았습니다.",
+          },
+        ],
+      },
+    });
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() =>
+      expect(screen.getByText("귀속 미확정 소요가 있어 대조를 보류했습니다")).toBeTruthy(),
+    );
+    expect(screen.queryByText("리저브 충분")).toBeNull();
+  });
+
+  it("gives unattributed money its own destination row", async () => {
+    // verify-r2 B1 (b)/(d): a need bound for a broker or currency with no cash
+    // account used to reach no verdict anywhere on the board.
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue({
+      ...READY,
+      funding: {
+        ...READY.funding,
+        scopes: [
+          {
+            scope_key: "unattributed:USD",
+            broker: "unattributed",
+            currency: "USD",
+            account_ids: [],
+            available_cash: null,
+            required_averaging_adds: "0",
+            required_support_net: "0",
+            required_active_watches: "200",
+            required_total: "200",
+            unattributed_same_currency: "0",
+            upper_bound_if_all_unattributed_lands_here: "200",
+            requirements_complete: false,
+            incomplete_reasons: ["이 행은 귀속 계좌를 확정하지 못한 소요액 모음입니다"],
+            verdict: "unknown",
+            shortfall: null,
+            notes: [],
+          },
+        ],
+      },
+    });
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() => expect(screen.getByText("목적지 미확정 · USD")).toBeTruthy());
+    expect(
+      screen.getByText("어느 계좌에서 나갈지 확정하지 못해 대조할 수 없습니다"),
+    ).toBeTruthy();
+    expect(screen.getAllByText("$200.00").length).toBeGreaterThan(0);
+  });
+
+  it("calls an incomplete shortfall a minimum", async () => {
+    // verify-r2 SHOULD-4: the deficit is proven but is a floor.
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue({
+      ...READY,
+      funding: {
+        ...READY.funding,
+        scopes: [
+          {
+            ...UPBIT_KRW_SCOPE,
+            requirements_complete: false,
+            incomplete_reasons: ["워치 조회 상태 degraded"],
+          },
+        ],
+      },
+    });
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() =>
+      expect(screen.getByText("최소 ₩140,000 입금 필요")).toBeTruthy(),
+    );
+    expect(
+      screen.getByText(/이 금액은 하한이며 실제로는 더 필요할 수 있습니다/),
+    ).toBeTruthy();
+  });
+
+  it("does not style an unreadable master gate like an enabled one", async () => {
+    // verify-r2 SHOULD-2: null used to render exactly like ON.
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue({
+      ...READY,
+      approval_context: {
+        ...READY.approval_context,
+        master_gate_enabled: null,
+        master_gate_source: "settings.ORDER_PROPOSALS_AUTO_APPROVE (읽기 실패)",
+        notice: "자동승인 마스터 게이트 상태를 읽지 못했습니다.",
+      },
+    });
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() =>
+      expect(screen.getByText("자동승인 게이트 상태 불명")).toBeTruthy(),
+    );
+    expect(
+      screen.getAllByText("레인 판정 불가(게이트 상태 불명)").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("자동승인 가능(cap 기준)")).toBeNull();
+  });
+
+  it("lists every eligibility gate it did not evaluate", async () => {
+    // verify-r2 SHOULD-1: a short list still reads as a complete one.
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/이 보드가 확인하지 않은 자동제출 조건 \(3\)/),
+      ).toBeTruthy(),
+    );
+    expect(screen.getByTitle("preview_guard_failed")).toBeTruthy();
+    expect(screen.getByTitle("daily_cap_exceeded")).toBeTruthy();
   });
 
   it("surfaces a fetch failure instead of rendering an empty plan", async () => {

--- a/frontend/invest/src/__tests__/BuyPlanRoute.test.tsx
+++ b/frontend/invest/src/__tests__/BuyPlanRoute.test.tsx
@@ -36,6 +36,13 @@ const READY: BuyPlanResponse = {
   policy: { version: "2026-08-23.1", content_hash: "abcdef0123456789" },
   cache_ttl_seconds: 180,
   approximation_notice: "정책 산식의 표시용 근사입니다.",
+  approval_context: {
+    master_gate_enabled: false,
+    master_gate_setting: "ORDER_PROPOSALS_AUTO_APPROVE",
+    master_gate_source: "settings.ORDER_PROPOSALS_AUTO_APPROVE",
+    unevaluated_conditions: ["fresh preview 존재", "tag scan", "일일 누적 cap 잔여"],
+    notice: "자동승인 마스터 게이트가 꺼져 있습니다 — 전건이 수동 승인 카드로 갑니다.",
+  },
   market: "all",
   averaging_triggers: [
     {
@@ -74,6 +81,7 @@ const READY: BuyPlanResponse = {
       reserve_plan_notional: "340000",
       market_rank: 1,
       within_policy_add_cap: true,
+      funding_broker: "upbit",
       notes: [],
     },
   ],
@@ -114,8 +122,12 @@ const READY: BuyPlanResponse = {
         placed_notional: "110000",
         per_symbol_cap_notional: "300000",
         remaining_headroom_notional: "190000",
+        placements_state: "ok",
+        placements_incomplete_reasons: [],
       },
     ],
+    placements_state: "ok",
+    placements_incomplete_reasons: [],
     notes: [],
   },
   active_buy_watches: [
@@ -135,6 +147,8 @@ const READY: BuyPlanResponse = {
       near_expiry: false,
       planned_notional: "650000",
       planned_notional_source: "max_action.quantity × 트리거 레벨",
+      funding_broker: "kis",
+      account_mode: "kis_live",
       approval_lane: "human_card",
       approval_lane_reason: "above_tier_auto_submit_notional",
     },
@@ -182,36 +196,53 @@ const READY: BuyPlanResponse = {
         account_id: "upbit-1",
         display_name: "업비트",
         source: "upbit",
+        broker: "upbit",
         currency: "KRW",
         available_cash: "200000",
         available_cash_source: "cashBalances",
         included_in_reserve: true,
       },
     ],
-    currencies: [
+    scopes: [
       {
+        scope_key: "upbit:KRW",
+        broker: "upbit",
         currency: "KRW",
+        account_ids: ["upbit-1"],
         available_cash: "200000",
         required_averaging_adds: "340000",
         required_support_net: "0",
-        required_active_watches: "650000",
-        required_total: "990000",
+        required_active_watches: "0",
+        required_total: "340000",
+        unattributed_same_currency: "0",
+        worst_case_required: "340000",
+        requirements_complete: true,
+        incomplete_reasons: [],
         verdict: "shortfall",
-        shortfall: "790000",
+        shortfall: "140000",
         notes: ["이미 걸린 지정가는 브로커가 현금을 묶고 있어 합계에서 제외했습니다."],
       },
       {
-        currency: "USD",
-        available_cash: "1000",
+        scope_key: "kis:KRW",
+        broker: "kis",
+        currency: "KRW",
+        account_ids: ["kis-1"],
+        available_cash: "5000000",
         required_averaging_adds: "0",
         required_support_net: "0",
-        required_active_watches: "0",
-        required_total: "0",
+        required_active_watches: "650000",
+        required_total: "650000",
+        unattributed_same_currency: "0",
+        worst_case_required: "650000",
+        requirements_complete: true,
+        incomplete_reasons: [],
         verdict: "sufficient",
         shortfall: "0",
         notes: [],
       },
     ],
+    unattributed: [],
+    source_warnings: [],
   },
   value_sources: [
     { field: "averaging_triggers.*", source: "InvestHomeService + policy", note: null },
@@ -230,13 +261,54 @@ describe("BuyPlanRoute", () => {
     vi.restoreAllMocks();
   });
 
-  it("leads with the deposit amount when cash falls short", async () => {
+  it("leads with the deposit amount of the account that is actually short", async () => {
+    // verify-r1 B1: the shortfall belongs to the Upbit scope. A currency-only
+    // total would have netted it against the funded KIS account and shown
+    // 리저브 충분 for cash no Upbit order can spend.
     vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
     render(wrap(<BuyPlanRoute />));
 
-    await waitFor(() => expect(screen.getByText("₩790,000 입금 필요")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("₩140,000 입금 필요")).toBeTruthy());
+    expect(screen.getByText("업비트 · KRW")).toBeTruthy();
+    expect(screen.getByText("한국투자증권 · KRW")).toBeTruthy();
     expect(screen.getAllByText("입금 필요").length).toBeGreaterThan(0);
     expect(screen.getAllByText("리저브 충분").length).toBeGreaterThan(0);
+  });
+
+  it("never renders one broker's cash inside another broker's verdict", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() => expect(screen.getByText("업비트 · KRW")).toBeTruthy());
+    // 5,200,000 would be the KRW-only aggregate of both accounts.
+    expect(screen.queryByText("₩5,200,000")).toBeNull();
+  });
+
+  it("shows an unattributed requirement instead of dropping it", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue({
+      ...READY,
+      funding: {
+        ...READY.funding,
+        unattributed: [
+          {
+            kind: "active_watch",
+            label: "KRW-DOGE 워치 100",
+            currency: "KRW",
+            amount: "500000",
+            reason: "워치 max_action이 실행 계좌를 지정하지 않았습니다.",
+          },
+        ],
+      },
+    });
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("어느 계좌에서 나갈 돈인지 확정하지 못한 소요액"),
+      ).toBeTruthy(),
+    );
+    expect(screen.getByText("KRW-DOGE 워치 100")).toBeTruthy();
+    expect(screen.getByText("₩500,000")).toBeTruthy();
   });
 
   it("shows the turn point and both sampled cash amounts", async () => {
@@ -248,9 +320,13 @@ describe("BuyPlanRoute", () => {
     expect(screen.getByText("₩1,000")).toBeTruthy();
     expect(screen.getAllByText("₩110,000").length).toBeGreaterThan(0);
     expect(screen.getAllByText("₩340,000").length).toBeGreaterThan(0);
-    // The lane split must be visible per sample, not summarised away.
-    expect(screen.getByText("자동승인")).toBeTruthy();
-    expect(screen.getAllByText("카드(수동 승인)").length).toBeGreaterThan(0);
+    // Both samples keep their own cap-classification reason even though the
+    // master gate collapses both badges to a card.
+    const reasons = screen
+      .getAllByTitle(/한도/)
+      .map((node) => node.getAttribute("title") ?? "");
+    expect(reasons.some((r) => r.includes("티어 자동제출 한도 이내"))).toBe(true);
+    expect(reasons.some((r) => r.includes("티어 자동제출 한도 초과"))).toBe(true);
   });
 
   it("marks a resting rung as 주문 상시형", async () => {

--- a/frontend/invest/src/__tests__/BuyPlanRoute.test.tsx
+++ b/frontend/invest/src/__tests__/BuyPlanRoute.test.tsx
@@ -1,0 +1,296 @@
+// §144차 — /invest/buy-plan renders the funding verdict the operator acts on.
+//
+// The assertions target the sentences that change behaviour ("입금 필요",
+// "리저브 충분", 자동승인 vs 카드, 게이트 판정 불가) rather than layout, since
+// a wrong label here is what would cause a wrong cash transfer.
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as buyPlanApi from "../api/buyPlan";
+import { BuyPlanRoute } from "../pages/BuyPlanRoute";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
+import type { BuyPlanResponse } from "../types/buyPlan";
+
+function setWidth(w: number) {
+  Object.defineProperty(window, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: w,
+  });
+}
+
+function wrap(ui: React.ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/buy-plan"]}>
+        {ui}
+      </MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
+
+const READY: BuyPlanResponse = {
+  as_of: "2026-08-23T03:00:00Z",
+  policy: { version: "2026-08-23.1", content_hash: "abcdef0123456789" },
+  cache_ttl_seconds: 180,
+  approximation_notice: "정책 산식의 표시용 근사입니다.",
+  market: "all",
+  averaging_triggers: [
+    {
+      market: "crypto",
+      symbol: "XRP",
+      symbol_name: "리플",
+      currency: "KRW",
+      account_sources: ["upbit"],
+      quantity: "1000",
+      average_price: "1100",
+      cost_basis: "1100000",
+      current_price: "1050",
+      unrealized_pnl_pct: "-4.55",
+      k: "0.1",
+      turn_point_price: "1000",
+      distance_to_turn_point_pct: "5",
+      turn_point_reached: false,
+      samples: [
+        {
+          offset_from_turn_point_pct: "-1",
+          price: "990",
+          additional_notional: "110000",
+          target_average_price: "1089",
+          approval_lane: "auto_submit",
+          approval_lane_reason: "within_tier_auto_submit_notional",
+        },
+        {
+          offset_from_turn_point_pct: "-3",
+          price: "970",
+          additional_notional: "340000",
+          target_average_price: "1067",
+          approval_lane: "human_card",
+          approval_lane_reason: "above_tier_auto_submit_notional",
+        },
+      ],
+      reserve_plan_notional: "340000",
+      market_rank: 1,
+      within_policy_add_cap: true,
+      notes: [],
+    },
+  ],
+  support_net: {
+    policy_key: "buy.held_majors_support_net",
+    enabled: true,
+    currency: "KRW",
+    tier_cap_notional: "900000",
+    per_symbol_cap_notional: "300000",
+    placed_notional: "110000",
+    remaining_notional: "790000",
+    distance_band_pct: ["-12", "-3"],
+    review_date: "2026-09-19",
+    rows: [
+      {
+        market: "crypto",
+        symbol: "SOL",
+        symbol_name: "솔라나",
+        currency: "KRW",
+        quantity: "10",
+        average_price: "150000",
+        current_price: "180000",
+        unrealized_pnl_pct: "20",
+        eligible: true,
+        ineligible_reason: null,
+        placements: [
+          {
+            form: "resting_order",
+            reference: "upbit:o-1",
+            anchor_price: "165000",
+            quantity: "0.66",
+            notional: "110000",
+            distance_from_current_pct: "-8.33",
+            valid_until: null,
+            within_policy_distance_band: true,
+          },
+        ],
+        placed_notional: "110000",
+        per_symbol_cap_notional: "300000",
+        remaining_headroom_notional: "190000",
+      },
+    ],
+    notes: [],
+  },
+  active_buy_watches: [
+    {
+      market: "kr",
+      symbol: "005930",
+      symbol_name: "삼성전자",
+      currency: "KRW",
+      alert_uuid: "a1",
+      metric: "price_below",
+      operator: "below",
+      threshold: "65000",
+      threshold_high: null,
+      current_price: "70000",
+      distance_to_threshold_pct: "-7.14",
+      valid_until: "2026-09-01T00:00:00Z",
+      near_expiry: false,
+      planned_notional: "650000",
+      planned_notional_source: "max_action.quantity × 트리거 레벨",
+      approval_lane: "human_card",
+      approval_lane_reason: "above_tier_auto_submit_notional",
+    },
+  ],
+  discovery_gates: [
+    {
+      market: "crypto",
+      gate_key: "market_rules.crypto.recovery_gate",
+      state: "indeterminate",
+      min_conditions_met: 2,
+      of: 2,
+      met_count: 1,
+      unavailable_count: 1,
+      semantics: "reserve deployment recovery frame",
+      conditions: [
+        {
+          condition_id: "alt_breadth_24h",
+          metric: "upbit_alt_breadth_24h",
+          comparison: "gt",
+          threshold: "50",
+          unit: "percent",
+          current_value: null,
+          state: "unavailable",
+          source: "upbit_open_api_ticker_derived",
+          note: "조회 실패",
+        },
+        {
+          condition_id: "btc_long_short_ratio",
+          metric: "btc_long_short_ratio",
+          comparison: "lte",
+          threshold: "1.5",
+          unit: "ratio",
+          current_value: "1.2",
+          state: "met",
+          source: "binance",
+          note: null,
+        },
+      ],
+      notes: ["미확인 조건은 충족으로 세지 않습니다."],
+    },
+  ],
+  funding: {
+    accounts: [
+      {
+        account_id: "upbit-1",
+        display_name: "업비트",
+        source: "upbit",
+        currency: "KRW",
+        available_cash: "200000",
+        available_cash_source: "cashBalances",
+        included_in_reserve: true,
+      },
+    ],
+    currencies: [
+      {
+        currency: "KRW",
+        available_cash: "200000",
+        required_averaging_adds: "340000",
+        required_support_net: "0",
+        required_active_watches: "650000",
+        required_total: "990000",
+        verdict: "shortfall",
+        shortfall: "790000",
+        notes: ["이미 걸린 지정가는 브로커가 현금을 묶고 있어 합계에서 제외했습니다."],
+      },
+      {
+        currency: "USD",
+        available_cash: "1000",
+        required_averaging_adds: "0",
+        required_support_net: "0",
+        required_active_watches: "0",
+        required_total: "0",
+        verdict: "sufficient",
+        shortfall: "0",
+        notes: [],
+      },
+    ],
+  },
+  value_sources: [
+    { field: "averaging_triggers.*", source: "InvestHomeService + policy", note: null },
+  ],
+  warnings: [],
+};
+
+describe("BuyPlanRoute", () => {
+  beforeEach(() => {
+    mockRightRail();
+    setWidth(1400);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("leads with the deposit amount when cash falls short", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() => expect(screen.getByText("₩790,000 입금 필요")).toBeTruthy());
+    expect(screen.getAllByText("입금 필요").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("리저브 충분").length).toBeGreaterThan(0);
+  });
+
+  it("shows the turn point and both sampled cash amounts", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() => expect(screen.getByText("리플")).toBeTruthy());
+    expect(screen.getByText("전환점 P* (k=0.1)")).toBeTruthy();
+    expect(screen.getByText("₩1,000")).toBeTruthy();
+    expect(screen.getAllByText("₩110,000").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("₩340,000").length).toBeGreaterThan(0);
+    // The lane split must be visible per sample, not summarised away.
+    expect(screen.getByText("자동승인")).toBeTruthy();
+    expect(screen.getAllByText("카드(수동 승인)").length).toBeGreaterThan(0);
+  });
+
+  it("marks a resting rung as 주문 상시형", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() => expect(screen.getByText("솔라나")).toBeTruthy());
+    expect(screen.getByText("주문 상시형")).toBeTruthy();
+    expect(screen.getByText("이익권")).toBeTruthy();
+  });
+
+  it("renders an unreadable gate condition as 판정 불가, never as open", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() => expect(screen.getByText("판정 불가")).toBeTruthy());
+    expect(screen.getAllByText("확인 불가").length).toBeGreaterThan(0);
+    expect(screen.queryByText("열림")).toBeNull();
+  });
+
+  it("always states that the board is an approximation, not a verdict", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockResolvedValue(READY);
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("이 화면은 판정이 아니라 자금 준비용 근사입니다"),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.getByText(/이 화면은 주문·제안·워치를 만들거나 승인하지 않습니다/),
+    ).toBeTruthy();
+  });
+
+  it("surfaces a fetch failure instead of rendering an empty plan", async () => {
+    vi.spyOn(buyPlanApi, "fetchBuyPlan").mockRejectedValue(new Error("buy-plan 500"));
+    render(wrap(<BuyPlanRoute />));
+
+    await waitFor(() =>
+      expect(screen.getByText(/불러오지 못했습니다 — buy-plan 500/)).toBeTruthy(),
+    );
+  });
+});

--- a/frontend/invest/src/__tests__/buyPlanDecimal.test.ts
+++ b/frontend/invest/src/__tests__/buyPlanDecimal.test.ts
@@ -1,0 +1,111 @@
+// verify-r1 B5 — the board must render the exact amount the API sent.
+import { describe, expect, it } from "vitest";
+
+import {
+  compareDecimalStrings,
+  formatDecimalString,
+  parseDecimalString,
+  roundDecimal,
+} from "../components/buyPlan/decimal";
+import { money, pct, price, quantity } from "../components/buyPlan/format";
+
+describe("formatDecimalString", () => {
+  it("keeps integers beyond Number.MAX_SAFE_INTEGER exact", () => {
+    // The measured regression: Number("9007199254740993") === 9007199254740992.
+    expect(Number("9007199254740993")).toBe(9007199254740992);
+    expect(formatDecimalString("9007199254740993")).toBe("9,007,199,254,740,993");
+  });
+
+  it("does not lose digits on a very long amount", () => {
+    const raw = "123456789012345678901234567890";
+    expect(formatDecimalString(raw)).toBe("123,456,789,012,345,678,901,234,567,890");
+  });
+
+  it("groups small values without a separator", () => {
+    expect(formatDecimalString("0")).toBe("0");
+    expect(formatDecimalString("999")).toBe("999");
+    expect(formatDecimalString("1000")).toBe("1,000");
+  });
+
+  it("rounds half-up on magnitude and carries", () => {
+    expect(formatDecimalString("0.5")).toBe("1");
+    expect(formatDecimalString("0.4")).toBe("0");
+    expect(formatDecimalString("999.5")).toBe("1,000");
+    expect(formatDecimalString("-0.5")).toBe("-1");
+    expect(formatDecimalString("1.005", { maxFractionDigits: 2 })).toBe("1.01");
+  });
+
+  it("never renders a signed zero", () => {
+    expect(formatDecimalString("-0.004", { maxFractionDigits: 2 })).toBe("0.00");
+    expect(formatDecimalString("-0")).toBe("0");
+  });
+
+  it("returns null for input it cannot parse, so callers show a placeholder", () => {
+    for (const bad of ["", "   ", "abc", "1e5", "1.2.3", null, undefined]) {
+      expect(formatDecimalString(bad)).toBeNull();
+    }
+  });
+
+  it("parses sign, leading zeros and bare fractions", () => {
+    expect(parseDecimalString("-007.50")).toEqual({
+      negative: true,
+      int: "7",
+      frac: "50",
+    });
+    expect(parseDecimalString(".5")).toEqual({ negative: false, int: "0", frac: "5" });
+  });
+
+  it("pads the fraction when fewer digits arrived than requested", () => {
+    expect(roundDecimal({ negative: false, int: "1", frac: "5" }, 3)).toEqual({
+      negative: false,
+      int: "1",
+      frac: "500",
+    });
+  });
+});
+
+describe("board formatters", () => {
+  it("renders exact KRW past the float boundary", () => {
+    expect(money("9007199254740993", "KRW")).toBe("₩9,007,199,254,740,993");
+  });
+
+  it("keeps USD cents and KRW whole", () => {
+    expect(money("1234.567", "USD")).toBe("$1,234.57");
+    expect(money("1234.5", "KRW")).toBe("₩1,235");
+  });
+
+  it("keeps sub-won precision on cheap coins but trims clean prices", () => {
+    expect(price("0.42", "KRW")).toBe("₩0.42");
+    expect(price("1000", "KRW")).toBe("₩1,000");
+  });
+
+  it("signs percentages and drops the sign at zero", () => {
+    expect(pct("5")).toBe("+5.00%");
+    expect(pct("-7.143", 1)).toBe("-7.1%");
+    expect(pct("0")).toBe("0.00%");
+  });
+
+  it("renders a placeholder instead of zero for missing values", () => {
+    expect(money(null, "KRW")).toBe("-");
+    expect(price(undefined, "USD")).toBe("-");
+    expect(quantity(null)).toBe("-");
+    expect(pct(null)).toBe("-");
+  });
+
+  it("keeps long quantities exact", () => {
+    expect(quantity("0.00000001")).toBe("0.00000001");
+    expect(quantity("12345678901234567890.5")).toBe("12,345,678,901,234,567,890.5");
+  });
+});
+
+describe("compareDecimalStrings", () => {
+  it("orders past the float boundary", () => {
+    expect(compareDecimalStrings("9007199254740993", "9007199254740992")).toBe(1);
+    expect(compareDecimalStrings("-5", "3")).toBe(-1);
+    expect(compareDecimalStrings("1.10", "1.1")).toBe(0);
+  });
+
+  it("returns null when either side is unparseable", () => {
+    expect(compareDecimalStrings("abc", "1")).toBeNull();
+  });
+});

--- a/frontend/invest/src/api/buyPlan.ts
+++ b/frontend/invest/src/api/buyPlan.ts
@@ -1,0 +1,12 @@
+import type { BuyPlanMarketFilter, BuyPlanResponse } from "../types/buyPlan";
+
+const BASE = "/trading/api/invest/buy-plan";
+
+export async function fetchBuyPlan(
+  market: BuyPlanMarketFilter = "all",
+): Promise<BuyPlanResponse> {
+  const q = new URLSearchParams({ market });
+  const res = await fetch(`${BASE}?${q}`, { credentials: "include" });
+  if (!res.ok) throw new Error(`buy-plan ${res.status}`);
+  return res.json();
+}

--- a/frontend/invest/src/components/buyPlan/BuyPlanPageBody.tsx
+++ b/frontend/invest/src/components/buyPlan/BuyPlanPageBody.tsx
@@ -1,0 +1,184 @@
+// /invest/buy-plan — 매수 계획 (트리거 보드), §144차.
+//
+// One body for both shells, same pattern as WatchesPageBody. Read-only: this
+// page has no control that places, approves, or cancels anything.
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { fetchBuyPlan } from "../../api/buyPlan";
+import type { BuyPlanMarketFilter, BuyPlanResponse } from "../../types/buyPlan";
+import { PageSafetyNote } from "../PageSafetyNote";
+import { FundingBlock } from "./FundingBlock";
+import {
+  ActiveWatchBlock,
+  AveragingBlock,
+  DiscoveryGateBlock,
+  SupportNetBlock,
+} from "./TriggerBlocks";
+import { dateTime } from "./format";
+
+const MARKET_OPTIONS: { key: BuyPlanMarketFilter; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr", label: "국내" },
+  { key: "us", label: "미국" },
+  { key: "crypto", label: "코인" },
+];
+
+const VALID_MARKETS = MARKET_OPTIONS.map((o) => o.key);
+
+function paramOrDefault<T extends string>(
+  raw: string | null,
+  valid: readonly T[],
+  fallback: T,
+): T {
+  return raw && (valid as readonly string[]).includes(raw) ? (raw as T) : fallback;
+}
+
+function FilterRow({
+  value,
+  onChange,
+}: Readonly<{
+  value: BuyPlanMarketFilter;
+  onChange: (key: BuyPlanMarketFilter) => void;
+}>) {
+  return (
+    <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+      {MARKET_OPTIONS.map((option) => {
+        const active = value === option.key;
+        return (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => onChange(option.key)}
+            style={{
+              border: "none",
+              borderRadius: 999,
+              padding: "6px 12px",
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: "pointer",
+              fontFamily: "inherit",
+              background: active ? "var(--fg)" : "var(--surface-2)",
+              color: active ? "var(--bg)" : "var(--fg-2)",
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function BuyPlanPageBody() {
+  const [searchParams] = useSearchParams();
+  const [market, setMarket] = useState<BuyPlanMarketFilter>(() =>
+    paramOrDefault(searchParams.get("market"), VALID_MARKETS, "all"),
+  );
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; data: BuyPlanResponse }
+    | { status: "error"; message: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    fetchBuyPlan(market)
+      .then((data) => {
+        if (!cancelled) setState({ status: "ready", data });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [market]);
+
+  return (
+    <div style={{ display: "grid", gap: 18 }}>
+      <div style={{ display: "grid", gap: 10 }}>
+        <h1 style={{ margin: 0, fontSize: 20 }}>매수 계획</h1>
+        <FilterRow value={market} onChange={setMarket} />
+      </div>
+
+      <PageSafetyNote
+        routeId="buy-plan"
+        heading="이 화면은 판정이 아니라 자금 준비용 근사입니다"
+        tag="read-only"
+        items={[
+          "여기 숫자는 정책 산식의 표시용 근사이며, 매수 판정의 정본은 회차입니다.",
+          "이 화면은 주문·제안·워치를 만들거나 승인하지 않습니다.",
+          "이미 걸린 지정가는 브로커가 현금을 이미 묶고 있어 '입금 필요액'에서 제외했습니다.",
+        ]}
+      />
+
+      {state.status === "loading" && (
+        <p style={{ fontSize: 13, color: "var(--fg-2)" }}>불러오는 중…</p>
+      )}
+
+      {state.status === "error" && (
+        <p style={{ fontSize: 13, color: "var(--loss)" }}>
+          불러오지 못했습니다 — {state.message}
+        </p>
+      )}
+
+      {state.status === "ready" && (
+        <>
+          {state.data.warnings.length > 0 && (
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: 18,
+                fontSize: 12,
+                color: "var(--warn)",
+                display: "grid",
+                gap: 4,
+              }}
+            >
+              {state.data.warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          )}
+
+          <FundingBlock funding={state.data.funding} />
+          <AveragingBlock rows={state.data.averaging_triggers} />
+          <SupportNetBlock tier={state.data.support_net} />
+          <ActiveWatchBlock rows={state.data.active_buy_watches} />
+          <DiscoveryGateBlock rows={state.data.discovery_gates} />
+
+          <details>
+            <summary
+              style={{ cursor: "pointer", fontSize: 12, color: "var(--fg-2)" }}
+            >
+              값 출처 ({state.data.value_sources.length})
+            </summary>
+            <div style={{ display: "grid", gap: 6, marginTop: 8, fontSize: 11 }}>
+              {state.data.value_sources.map((source) => (
+                <div key={source.field}>
+                  <code style={{ color: "var(--fg)" }}>{source.field}</code>
+                  <span style={{ color: "var(--fg-2)" }}> ← {source.source}</span>
+                  {source.note && (
+                    <div style={{ color: "var(--fg-2)" }}>{source.note}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </details>
+
+          <footer style={{ fontSize: 11, color: "var(--fg-2)" }}>
+            정책 {state.data.policy.version} (
+            <code>{state.data.policy.content_hash.slice(0, 12)}</code>) · 계산{" "}
+            {dateTime(state.data.as_of)} · 캐시 {state.data.cache_ttl_seconds}초
+          </footer>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/buyPlan/BuyPlanPageBody.tsx
+++ b/frontend/invest/src/components/buyPlan/BuyPlanPageBody.tsx
@@ -10,6 +10,7 @@ import { PageSafetyNote } from "../PageSafetyNote";
 import { FundingBlock } from "./FundingBlock";
 import {
   ActiveWatchBlock,
+  ApprovalNotice,
   AveragingBlock,
   DiscoveryGateBlock,
   SupportNetBlock,
@@ -115,6 +116,8 @@ export function BuyPlanPageBody() {
           "여기 숫자는 정책 산식의 표시용 근사이며, 매수 판정의 정본은 회차입니다.",
           "이 화면은 주문·제안·워치를 만들거나 승인하지 않습니다.",
           "이미 걸린 지정가는 브로커가 현금을 이미 묶고 있어 '입금 필요액'에서 제외했습니다.",
+          "현금 대조는 계좌별입니다 — 다른 브로커의 같은 통화 잔고는 합산하지 않습니다.",
+          "레인 표시는 cap 기준 분류이며 승인 확정이 아닙니다.",
         ]}
       />
 
@@ -148,9 +151,16 @@ export function BuyPlanPageBody() {
           )}
 
           <FundingBlock funding={state.data.funding} />
-          <AveragingBlock rows={state.data.averaging_triggers} />
+          <ApprovalNotice approval={state.data.approval_context} />
+          <AveragingBlock
+            rows={state.data.averaging_triggers}
+            approval={state.data.approval_context}
+          />
           <SupportNetBlock tier={state.data.support_net} />
-          <ActiveWatchBlock rows={state.data.active_buy_watches} />
+          <ActiveWatchBlock
+            rows={state.data.active_buy_watches}
+            approval={state.data.approval_context}
+          />
           <DiscoveryGateBlock rows={state.data.discovery_gates} />
 
           <details>

--- a/frontend/invest/src/components/buyPlan/FundingBlock.tsx
+++ b/frontend/invest/src/components/buyPlan/FundingBlock.tsx
@@ -25,14 +25,25 @@ function verdictTone(row: ScopeReconciliation): "gain" | "warn" | "paper" {
 
 function verdictLine(row: ScopeReconciliation): { text: string; title?: string } {
   if (row.verdict === "shortfall") {
+    // With an incomplete requirement side the deficit is still proven, but it
+    // is a floor — more may be missing. Saying so is the difference between a
+    // number the operator can act on and one they can rely on (verify-r2
+    // SHOULD-4).
+    const prefix = row.requirements_complete ? "" : "최소 ";
     return {
-      text: `${money(row.shortfall, row.currency)} 입금 필요`,
+      text: `${prefix}${money(row.shortfall, row.currency)} 입금 필요`,
       title: exact(row.shortfall),
     };
   }
   if (row.verdict === "sufficient") return { text: "리저브 충분" };
+  if (row.broker === "unattributed") {
+    return { text: "어느 계좌에서 나갈지 확정하지 못해 대조할 수 없습니다" };
+  }
   if (row.available_cash === null) {
     return { text: "가용 현금을 확정하지 못해 대조를 보류했습니다" };
+  }
+  if (row.unattributed_same_currency !== "0") {
+    return { text: "귀속 미확정 소요가 있어 대조를 보류했습니다" };
   }
   return { text: "소요액을 확정하지 못해 대조를 보류했습니다" };
 }
@@ -78,7 +89,9 @@ function ScopeCard({ row }: Readonly<{ row: ScopeReconciliation }>) {
     <Card soft style={{ padding: 16, display: "grid", gap: 10 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
         <strong style={{ fontSize: 15 }}>
-          {FUNDING_BROKER_LABEL[row.broker]} · {row.currency}
+          {row.broker === "unattributed"
+            ? `목적지 미확정 · ${row.currency}`
+            : `${FUNDING_BROKER_LABEL[row.broker]} · ${row.currency}`}
         </strong>
         <Pill tone={verdictTone(row)} size="sm">
           {FUNDING_VERDICT_LABEL[row.verdict]}
@@ -90,6 +103,12 @@ function ScopeCard({ row }: Readonly<{ row: ScopeReconciliation }>) {
       <div style={{ fontSize: 18, fontWeight: 700 }} title={verdict.title}>
         {verdict.text}
       </div>
+      {row.verdict === "shortfall" && !row.requirements_complete && (
+        <p style={{ margin: 0, fontSize: 11, color: "var(--warn)" }}>
+          소요액 일부를 확인하지 못했습니다 — 이 금액은 하한이며 실제로는 더 필요할
+          수 있습니다.
+        </p>
+      )}
       <div style={{ display: "grid", gap: 4, fontSize: 12 }}>
         <BreakdownRow
           label="가용 현금 (이 계좌)"
@@ -144,8 +163,9 @@ function UnattributedBlock({
         </strong>
       </div>
       <p style={{ margin: 0, fontSize: 11, color: "var(--fg-2)" }}>
-        합계에서 빼지 않았습니다. 같은 통화 계좌의 현금이 이 금액까지 덮지 못하면
-        그 계좌 판정을 보류합니다.
+        합계에서 빼지 않았습니다. 이 돈은 어느 브로커로도 갈 수 있으므로, 같은 통화의
+        모든 계좌 판정을 보류시키고 위에 별도의 &quot;목적지 미확정&quot; 행으로도
+        올립니다.
       </p>
       <div style={{ display: "grid", gap: 4, fontSize: 12 }}>
         {rows.map((row) => (

--- a/frontend/invest/src/components/buyPlan/FundingBlock.tsx
+++ b/frontend/invest/src/components/buyPlan/FundingBlock.tsx
@@ -1,87 +1,168 @@
 // 자금 대조 블록 — §144차 요구사항 ②.
 //
-// This is the block the operator actually acts on ("돈을 옮겨두지"), so the
-// verdict line comes first and the breakdown explains it underneath.
+// This is the block the operator acts on ("돈을 옮겨두지"), so it leads with
+// the verdict and explains it underneath.
+//
+// Rows are one per (broker, currency), never per currency alone: KIS KRW
+// cannot fill an Upbit order, and totalling them let an empty Upbit account
+// read as 리저브 충분 off KIS cash (verify-r1 B1). Requirements whose owning
+// account could not be resolved get their own block and suspend any verdict
+// they could break.
 import { Card, Pill } from "../../ds";
-import type { BuyPlanFunding, CurrencyReconciliation } from "../../types/buyPlan";
-import { money } from "./format";
-import { FUNDING_VERDICT_LABEL } from "./labels";
+import type {
+  BuyPlanFunding,
+  ScopeReconciliation,
+  UnattributedRequirement,
+} from "../../types/buyPlan";
+import { exact, money } from "./format";
+import { FUNDING_BROKER_LABEL, FUNDING_VERDICT_LABEL } from "./labels";
 
-function verdictTone(row: CurrencyReconciliation): "gain" | "warn" | "paper" {
+function verdictTone(row: ScopeReconciliation): "gain" | "warn" | "paper" {
   if (row.verdict === "sufficient") return "gain";
   if (row.verdict === "shortfall") return "warn";
   return "paper";
 }
 
-function verdictLine(row: CurrencyReconciliation): string {
+function verdictLine(row: ScopeReconciliation): { text: string; title?: string } {
   if (row.verdict === "shortfall") {
-    return `${money(row.shortfall, row.currency)} 입금 필요`;
+    return {
+      text: `${money(row.shortfall, row.currency)} 입금 필요`,
+      title: exact(row.shortfall),
+    };
   }
-  if (row.verdict === "sufficient") return "리저브 충분";
-  return "가용 현금을 확정하지 못해 대조를 보류했습니다";
+  if (row.verdict === "sufficient") return { text: "리저브 충분" };
+  if (row.available_cash === null) {
+    return { text: "가용 현금을 확정하지 못해 대조를 보류했습니다" };
+  }
+  return { text: "소요액을 확정하지 못해 대조를 보류했습니다" };
 }
 
 function BreakdownRow({
   label,
   value,
-}: Readonly<{ label: string; value: string }>) {
+  title,
+}: Readonly<{ label: string; value: string; title?: string }>) {
   return (
     <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
       <span style={{ color: "var(--fg-2)" }}>{label}</span>
-      <span style={{ fontVariantNumeric: "tabular-nums" }}>{value}</span>
+      <span style={{ fontVariantNumeric: "tabular-nums" }} title={title}>
+        {value}
+      </span>
     </div>
   );
 }
 
-function CurrencyCard({ row }: Readonly<{ row: CurrencyReconciliation }>) {
+function ReasonList({ reasons }: Readonly<{ reasons: string[] }>) {
+  if (reasons.length === 0) return null;
+  return (
+    <ul
+      style={{
+        margin: 0,
+        paddingLeft: 16,
+        fontSize: 11,
+        color: "var(--fg-2)",
+        display: "grid",
+        gap: 2,
+      }}
+    >
+      {reasons.map((reason) => (
+        <li key={reason}>{reason}</li>
+      ))}
+    </ul>
+  );
+}
+
+function ScopeCard({ row }: Readonly<{ row: ScopeReconciliation }>) {
+  const verdict = verdictLine(row);
   return (
     <Card soft style={{ padding: 16, display: "grid", gap: 10 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <strong style={{ fontSize: 15 }}>{row.currency}</strong>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <strong style={{ fontSize: 15 }}>
+          {FUNDING_BROKER_LABEL[row.broker]} · {row.currency}
+        </strong>
         <Pill tone={verdictTone(row)} size="sm">
           {FUNDING_VERDICT_LABEL[row.verdict]}
         </Pill>
+        {!row.requirements_complete && (
+          <Pill tone="warn" size="sm">소요액 불완전</Pill>
+        )}
       </div>
-      <div style={{ fontSize: 18, fontWeight: 700 }}>{verdictLine(row)}</div>
+      <div style={{ fontSize: 18, fontWeight: 700 }} title={verdict.title}>
+        {verdict.text}
+      </div>
       <div style={{ display: "grid", gap: 4, fontSize: 12 }}>
         <BreakdownRow
-          label="가용 현금 (live 계좌)"
+          label="가용 현금 (이 계좌)"
           value={money(row.available_cash, row.currency)}
+          title={exact(row.available_cash)}
         />
         <BreakdownRow
-          label="트리거 소요 합계"
+          label="이 계좌 소요 합계"
           value={money(row.required_total, row.currency)}
+          title={exact(row.required_total)}
         />
         <div style={{ height: 1, background: "var(--border)", margin: "2px 0" }} />
         <BreakdownRow
           label="· 물타기 A(k)"
           value={money(row.required_averaging_adds, row.currency)}
+          title={exact(row.required_averaging_adds)}
         />
         <BreakdownRow
           label="· 지지 그물 (워치형)"
           value={money(row.required_support_net, row.currency)}
+          title={exact(row.required_support_net)}
         />
         <BreakdownRow
           label="· 그 밖의 활성 매수 워치"
           value={money(row.required_active_watches, row.currency)}
+          title={exact(row.required_active_watches)}
         />
+        {row.unattributed_same_currency !== "0" && (
+          <BreakdownRow
+            label="· 계좌 미확정 (최악의 경우 여기로)"
+            value={money(row.unattributed_same_currency, row.currency)}
+            title={exact(row.unattributed_same_currency)}
+          />
+        )}
       </div>
-      {row.notes.length > 0 && (
-        <ul
-          style={{
-            margin: 0,
-            paddingLeft: 16,
-            fontSize: 11,
-            color: "var(--fg-3, var(--fg-2))",
-            display: "grid",
-            gap: 2,
-          }}
-        >
-          {row.notes.map((note) => (
-            <li key={note}>{note}</li>
-          ))}
-        </ul>
-      )}
+      <ReasonList reasons={row.incomplete_reasons} />
+      <ReasonList reasons={row.notes} />
+    </Card>
+  );
+}
+
+function UnattributedBlock({
+  rows,
+}: Readonly<{ rows: UnattributedRequirement[] }>) {
+  if (rows.length === 0) return null;
+  return (
+    <Card style={{ padding: 16, display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Pill tone="warn" size="sm">계좌 미확정</Pill>
+        <strong style={{ fontSize: 13 }}>
+          어느 계좌에서 나갈 돈인지 확정하지 못한 소요액
+        </strong>
+      </div>
+      <p style={{ margin: 0, fontSize: 11, color: "var(--fg-2)" }}>
+        합계에서 빼지 않았습니다. 같은 통화 계좌의 현금이 이 금액까지 덮지 못하면
+        그 계좌 판정을 보류합니다.
+      </p>
+      <div style={{ display: "grid", gap: 4, fontSize: 12 }}>
+        {rows.map((row) => (
+          <div
+            key={`${row.kind}:${row.label}`}
+            style={{ display: "flex", justifyContent: "space-between", gap: 12 }}
+          >
+            <span title={row.reason}>{row.label}</span>
+            <span
+              style={{ fontVariantNumeric: "tabular-nums" }}
+              title={exact(row.amount)}
+            >
+              {money(row.amount, row.currency)}
+            </span>
+          </div>
+        ))}
+      </div>
     </Card>
   );
 }
@@ -91,17 +172,26 @@ export function FundingBlock({ funding }: Readonly<{ funding: BuyPlanFunding }>)
   return (
     <section style={{ display: "grid", gap: 12 }}>
       <h2 style={{ margin: 0, fontSize: 16 }}>자금 대조</h2>
+      {funding.source_warnings.length > 0 && (
+        <Card soft style={{ padding: 12 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 4 }}>
+            일부 소스가 불완전합니다 — 아래 숫자는 그만큼 덜 본 값입니다
+          </div>
+          <ReasonList reasons={funding.source_warnings} />
+        </Card>
+      )}
       <div
         style={{
           display: "grid",
           gap: 12,
-          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
         }}
       >
-        {funding.currencies.map((row) => (
-          <CurrencyCard key={row.currency} row={row} />
+        {funding.scopes.map((row) => (
+          <ScopeCard key={row.scope_key} row={row} />
         ))}
       </div>
+      <UnattributedBlock rows={funding.unattributed} />
       {included.length > 0 && (
         <details>
           <summary style={{ cursor: "pointer", fontSize: 12, color: "var(--fg-2)" }}>
@@ -121,7 +211,7 @@ export function FundingBlock({ funding }: Readonly<{ funding: BuyPlanFunding }>)
                 </span>
                 <span
                   style={{ fontVariantNumeric: "tabular-nums" }}
-                  title={account.available_cash ?? "확인 불가"}
+                  title={exact(account.available_cash) ?? "확인 불가"}
                 >
                   {money(account.available_cash, account.currency)}
                 </span>

--- a/frontend/invest/src/components/buyPlan/FundingBlock.tsx
+++ b/frontend/invest/src/components/buyPlan/FundingBlock.tsx
@@ -1,0 +1,135 @@
+// 자금 대조 블록 — §144차 요구사항 ②.
+//
+// This is the block the operator actually acts on ("돈을 옮겨두지"), so the
+// verdict line comes first and the breakdown explains it underneath.
+import { Card, Pill } from "../../ds";
+import type { BuyPlanFunding, CurrencyReconciliation } from "../../types/buyPlan";
+import { money } from "./format";
+import { FUNDING_VERDICT_LABEL } from "./labels";
+
+function verdictTone(row: CurrencyReconciliation): "gain" | "warn" | "paper" {
+  if (row.verdict === "sufficient") return "gain";
+  if (row.verdict === "shortfall") return "warn";
+  return "paper";
+}
+
+function verdictLine(row: CurrencyReconciliation): string {
+  if (row.verdict === "shortfall") {
+    return `${money(row.shortfall, row.currency)} 입금 필요`;
+  }
+  if (row.verdict === "sufficient") return "리저브 충분";
+  return "가용 현금을 확정하지 못해 대조를 보류했습니다";
+}
+
+function BreakdownRow({
+  label,
+  value,
+}: Readonly<{ label: string; value: string }>) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+      <span style={{ color: "var(--fg-2)" }}>{label}</span>
+      <span style={{ fontVariantNumeric: "tabular-nums" }}>{value}</span>
+    </div>
+  );
+}
+
+function CurrencyCard({ row }: Readonly<{ row: CurrencyReconciliation }>) {
+  return (
+    <Card soft style={{ padding: 16, display: "grid", gap: 10 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <strong style={{ fontSize: 15 }}>{row.currency}</strong>
+        <Pill tone={verdictTone(row)} size="sm">
+          {FUNDING_VERDICT_LABEL[row.verdict]}
+        </Pill>
+      </div>
+      <div style={{ fontSize: 18, fontWeight: 700 }}>{verdictLine(row)}</div>
+      <div style={{ display: "grid", gap: 4, fontSize: 12 }}>
+        <BreakdownRow
+          label="가용 현금 (live 계좌)"
+          value={money(row.available_cash, row.currency)}
+        />
+        <BreakdownRow
+          label="트리거 소요 합계"
+          value={money(row.required_total, row.currency)}
+        />
+        <div style={{ height: 1, background: "var(--border)", margin: "2px 0" }} />
+        <BreakdownRow
+          label="· 물타기 A(k)"
+          value={money(row.required_averaging_adds, row.currency)}
+        />
+        <BreakdownRow
+          label="· 지지 그물 (워치형)"
+          value={money(row.required_support_net, row.currency)}
+        />
+        <BreakdownRow
+          label="· 그 밖의 활성 매수 워치"
+          value={money(row.required_active_watches, row.currency)}
+        />
+      </div>
+      {row.notes.length > 0 && (
+        <ul
+          style={{
+            margin: 0,
+            paddingLeft: 16,
+            fontSize: 11,
+            color: "var(--fg-3, var(--fg-2))",
+            display: "grid",
+            gap: 2,
+          }}
+        >
+          {row.notes.map((note) => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+export function FundingBlock({ funding }: Readonly<{ funding: BuyPlanFunding }>) {
+  const included = funding.accounts.filter((a) => a.included_in_reserve);
+  return (
+    <section style={{ display: "grid", gap: 12 }}>
+      <h2 style={{ margin: 0, fontSize: 16 }}>자금 대조</h2>
+      <div
+        style={{
+          display: "grid",
+          gap: 12,
+          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+        }}
+      >
+        {funding.currencies.map((row) => (
+          <CurrencyCard key={row.currency} row={row} />
+        ))}
+      </div>
+      {included.length > 0 && (
+        <details>
+          <summary style={{ cursor: "pointer", fontSize: 12, color: "var(--fg-2)" }}>
+            계좌별 가용 현금 ({included.length})
+          </summary>
+          <div style={{ display: "grid", gap: 4, marginTop: 8, fontSize: 12 }}>
+            {included.map((account) => (
+              <div
+                key={`${account.account_id}:${account.currency}`}
+                style={{ display: "flex", justifyContent: "space-between", gap: 12 }}
+              >
+                <span>
+                  {account.display_name}{" "}
+                  <span style={{ color: "var(--fg-2)" }}>
+                    ({account.source} · {account.available_cash_source})
+                  </span>
+                </span>
+                <span
+                  style={{ fontVariantNumeric: "tabular-nums" }}
+                  title={account.available_cash ?? "확인 불가"}
+                >
+                  {money(account.available_cash, account.currency)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </section>
+  );
+}

--- a/frontend/invest/src/components/buyPlan/TriggerBlocks.tsx
+++ b/frontend/invest/src/components/buyPlan/TriggerBlocks.tsx
@@ -19,6 +19,7 @@ import { dateTime, exact, money, pct, price, quantity } from "./format";
 import {
   APPROVAL_LANE_LABEL,
   APPROVAL_LANE_LABEL_GATE_OFF,
+  APPROVAL_LANE_LABEL_GATE_UNKNOWN,
   APPROVAL_LANE_REASON_LABEL,
   COMPARISON_LABEL,
   FUNDING_BROKER_LABEL,
@@ -80,9 +81,16 @@ function LaneBadge({
   reason: AveragingSampleRow["approval_lane_reason"];
   approval: ApprovalContext;
 }>) {
-  const gateOff = approval.master_gate_enabled === false;
-  const label = gateOff ? APPROVAL_LANE_LABEL_GATE_OFF[lane] : APPROVAL_LANE_LABEL[lane];
-  const tone = !gateOff && lane === "auto_submit" ? "accent" : "warn";
+  // Three states, not two: unknown must not borrow the ON styling
+  // (verify-r2 SHOULD-2).
+  const gate = approval.master_gate_enabled;
+  const label =
+    gate === false
+      ? APPROVAL_LANE_LABEL_GATE_OFF[lane]
+      : gate === true
+        ? APPROVAL_LANE_LABEL[lane]
+        : APPROVAL_LANE_LABEL_GATE_UNKNOWN[lane];
+  const tone = gate === true && lane === "auto_submit" ? "accent" : "warn";
   return (
     <span title={`${APPROVAL_LANE_REASON_LABEL[reason]} · ${approval.notice}`}>
       <Pill tone={tone} size="sm">
@@ -128,7 +136,9 @@ export function ApprovalNotice({
             }}
           >
             {approval.unevaluated_conditions.map((condition) => (
-              <li key={condition}>{condition}</li>
+              <li key={condition.code} title={condition.code}>
+                {condition.label}
+              </li>
             ))}
           </ul>
         </details>
@@ -178,9 +188,14 @@ function AveragingCard({
             <Pill tone="paper" size="sm">add 상한 밖 · #{row.market_rank}</Pill>
           </span>
         )}
-        <Pill tone={row.funding_broker === "unattributed" ? "warn" : "paper"} size="sm">
-          {FUNDING_BROKER_LABEL[row.funding_broker]}
-        </Pill>
+        <span title={row.funding_broker_reason ?? undefined}>
+          <Pill
+            tone={row.funding_broker === "unattributed" ? "warn" : "paper"}
+            size="sm"
+          >
+            {FUNDING_BROKER_LABEL[row.funding_broker]}
+          </Pill>
+        </span>
       </div>
 
       <div
@@ -506,7 +521,13 @@ export function ActiveWatchBlock({
                   reason={row.approval_lane_reason}
                   approval={approval}
                 />
-                <span title={row.account_mode ?? "max_action에 account_mode가 없습니다"}>
+                <span
+                  title={
+                    row.funding_broker_reason ??
+                    row.account_mode ??
+                    "max_action에 account_mode가 없습니다"
+                  }
+                >
                   <Pill
                     tone={row.funding_broker === "unattributed" ? "warn" : "paper"}
                     size="sm"

--- a/frontend/invest/src/components/buyPlan/TriggerBlocks.tsx
+++ b/frontend/invest/src/components/buyPlan/TriggerBlocks.tsx
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom";
 import { Card, Pill } from "../../ds";
 import type {
   ActiveBuyWatchRow,
+  ApprovalContext,
   AveragingSampleRow,
   AveragingTriggerRow,
   DiscoveryGateRow,
@@ -14,14 +15,17 @@ import type {
   SupportNetRow,
   SupportNetTier,
 } from "../../types/buyPlan";
-import { dateTime, money, pct, price, quantity } from "./format";
+import { dateTime, exact, money, pct, price, quantity } from "./format";
 import {
   APPROVAL_LANE_LABEL,
+  APPROVAL_LANE_LABEL_GATE_OFF,
   APPROVAL_LANE_REASON_LABEL,
   COMPARISON_LABEL,
+  FUNDING_BROKER_LABEL,
   GATE_CONDITION_STATE_LABEL,
   GATE_STATE_LABEL,
   PLACEMENT_FORM_LABEL,
+  SOURCE_STATE_LABEL,
 } from "./labels";
 
 function SectionHeading({
@@ -64,19 +68,72 @@ function SymbolLink({
   );
 }
 
+// verify-r1 B6: with the master gate off, a cap-passing notional still ends
+// up as a manual card, so the badge must not promise an automatic submission
+// the operator would sit waiting for.
 function LaneBadge({
   lane,
   reason,
+  approval,
 }: Readonly<{
   lane: AveragingSampleRow["approval_lane"];
   reason: AveragingSampleRow["approval_lane_reason"];
+  approval: ApprovalContext;
 }>) {
+  const gateOff = approval.master_gate_enabled === false;
+  const label = gateOff ? APPROVAL_LANE_LABEL_GATE_OFF[lane] : APPROVAL_LANE_LABEL[lane];
+  const tone = !gateOff && lane === "auto_submit" ? "accent" : "warn";
   return (
-    <span title={APPROVAL_LANE_REASON_LABEL[reason]}>
-      <Pill tone={lane === "auto_submit" ? "accent" : "warn"} size="sm">
-        {APPROVAL_LANE_LABEL[lane]}
+    <span title={`${APPROVAL_LANE_REASON_LABEL[reason]} · ${approval.notice}`}>
+      <Pill tone={tone} size="sm">
+        {label}
       </Pill>
     </span>
+  );
+}
+
+export function ApprovalNotice({
+  approval,
+}: Readonly<{ approval: ApprovalContext }>) {
+  return (
+    <Card soft style={{ padding: 12, display: "grid", gap: 6 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <Pill
+          tone={approval.master_gate_enabled === true ? "accent" : "warn"}
+          size="sm"
+        >
+          {approval.master_gate_enabled === true
+            ? "자동승인 마스터 게이트 ON"
+            : approval.master_gate_enabled === false
+              ? "자동승인 마스터 게이트 OFF"
+              : "자동승인 게이트 상태 불명"}
+        </Pill>
+        <code style={{ fontSize: 11, color: "var(--fg-2)" }}>
+          {approval.master_gate_source}
+        </code>
+      </div>
+      <p style={{ margin: 0, fontSize: 12 }}>{approval.notice}</p>
+      {approval.unevaluated_conditions.length > 0 && (
+        <details>
+          <summary style={{ cursor: "pointer", fontSize: 11, color: "var(--fg-2)" }}>
+            이 보드가 확인하지 않은 자동제출 조건 (
+            {approval.unevaluated_conditions.length})
+          </summary>
+          <ul
+            style={{
+              margin: "6px 0 0",
+              paddingLeft: 16,
+              fontSize: 11,
+              color: "var(--fg-2)",
+            }}
+          >
+            {approval.unevaluated_conditions.map((condition) => (
+              <li key={condition}>{condition}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </Card>
   );
 }
 
@@ -98,7 +155,10 @@ function Field({
   );
 }
 
-function AveragingCard({ row }: Readonly<{ row: AveragingTriggerRow }>) {
+function AveragingCard({
+  row,
+  approval,
+}: Readonly<{ row: AveragingTriggerRow; approval: ApprovalContext }>) {
   return (
     <Card style={{ padding: 16, display: "grid", gap: 12 }}>
       <div
@@ -118,6 +178,9 @@ function AveragingCard({ row }: Readonly<{ row: AveragingTriggerRow }>) {
             <Pill tone="paper" size="sm">add 상한 밖 · #{row.market_rank}</Pill>
           </span>
         )}
+        <Pill tone={row.funding_broker === "unattributed" ? "warn" : "paper"} size="sm">
+          {FUNDING_BROKER_LABEL[row.funding_broker]}
+        </Pill>
       </div>
 
       <div
@@ -162,13 +225,14 @@ function AveragingCard({ row }: Readonly<{ row: AveragingTriggerRow }>) {
             <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
               <strong
                 style={{ fontVariantNumeric: "tabular-nums" }}
-                title={sample.additional_notional}
+                title={exact(sample.additional_notional)}
               >
                 {money(sample.additional_notional, row.currency)}
               </strong>
               <LaneBadge
                 lane={sample.approval_lane}
                 reason={sample.approval_lane_reason}
+                approval={approval}
               />
             </span>
           </div>
@@ -197,7 +261,8 @@ function AveragingCard({ row }: Readonly<{ row: AveragingTriggerRow }>) {
 
 export function AveragingBlock({
   rows,
-}: Readonly<{ rows: AveragingTriggerRow[] }>) {
+  approval,
+}: Readonly<{ rows: AveragingTriggerRow[]; approval: ApprovalContext }>) {
   return (
     <section style={{ display: "grid", gap: 12 }}>
       <SectionHeading
@@ -212,7 +277,11 @@ export function AveragingBlock({
       ) : (
         <div style={{ display: "grid", gap: 10 }}>
           {rows.map((row) => (
-            <AveragingCard key={`${row.market}:${row.symbol}`} row={row} />
+            <AveragingCard
+              key={`${row.market}:${row.symbol}`}
+              row={row}
+              approval={approval}
+            />
           ))}
         </div>
       )}
@@ -284,12 +353,12 @@ function SupportNetCard({ row }: Readonly<{ row: SupportNetRow }>) {
         <Field
           label="걸린 금액"
           value={money(row.placed_notional, row.currency)}
-          title={row.placed_notional}
+          title={exact(row.placed_notional) ?? "확인 불가"}
         />
         <Field
           label="남은 여력"
           value={money(row.remaining_headroom_notional, row.currency)}
-          title={row.remaining_headroom_notional}
+          title={exact(row.remaining_headroom_notional) ?? "확인 불가"}
         />
       </div>
       {row.placements.length > 0 ? (
@@ -300,8 +369,12 @@ function SupportNetCard({ row }: Readonly<{ row: SupportNetRow }>) {
             currency={row.currency}
           />
         ))}</div>
-      ) : (
+      ) : row.placements_state === "ok" ? (
         <span style={{ fontSize: 12, color: "var(--fg-2)" }}>걸린 그물 없음</span>
+      ) : (
+        <span style={{ fontSize: 12, color: "var(--warn)" }}>
+          걸린 그물을 확인하지 못했습니다 — 없다는 뜻이 아닙니다
+        </span>
       )}
     </Card>
   );
@@ -322,6 +395,26 @@ export function SupportNetBlock({ tier }: Readonly<{ tier: SupportNetTier }>) {
         </EmptyNote>
       ) : (
         <>
+          {tier.placements_state !== "ok" && (
+            <Card soft style={{ padding: 12, display: "grid", gap: 4 }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: "var(--warn)" }}>
+                걸린 주문·워치 조회 {SOURCE_STATE_LABEL[tier.placements_state]} — 걸린
+                금액과 남은 여력을 확정하지 못했습니다
+              </div>
+              <ul
+                style={{
+                  margin: 0,
+                  paddingLeft: 16,
+                  fontSize: 11,
+                  color: "var(--fg-2)",
+                }}
+              >
+                {tier.placements_incomplete_reasons.map((reason) => (
+                  <li key={reason}>{reason}</li>
+                ))}
+              </ul>
+            </Card>
+          )}
           <Card soft style={{ padding: 14, display: "flex", gap: 20, flexWrap: "wrap" }}>
             <Field
               label="티어 상한"
@@ -331,10 +424,15 @@ export function SupportNetBlock({ tier }: Readonly<{ tier: SupportNetTier }>) {
               label="코인당 상한"
               value={money(tier.per_symbol_cap_notional, tier.currency)}
             />
-            <Field label="걸린 합계" value={money(tier.placed_notional, tier.currency)} />
+            <Field
+              label="걸린 합계"
+              value={money(tier.placed_notional, tier.currency)}
+              title={exact(tier.placed_notional) ?? "확인 불가"}
+            />
             <Field
               label="티어 잔여"
               value={money(tier.remaining_notional, tier.currency)}
+              title={exact(tier.remaining_notional) ?? "확인 불가"}
             />
             {tier.distance_band_pct.length === 2 && (
               <Field
@@ -376,7 +474,8 @@ export function SupportNetBlock({ tier }: Readonly<{ tier: SupportNetTier }>) {
 
 export function ActiveWatchBlock({
   rows,
-}: Readonly<{ rows: ActiveBuyWatchRow[] }>) {
+  approval,
+}: Readonly<{ rows: ActiveBuyWatchRow[]; approval: ApprovalContext }>) {
   return (
     <section style={{ display: "grid", gap: 12 }}>
       <SectionHeading
@@ -402,7 +501,19 @@ export function ActiveWatchBlock({
                   symbol={row.symbol}
                   name={row.symbol_name}
                 />
-                <LaneBadge lane={row.approval_lane} reason={row.approval_lane_reason} />
+                <LaneBadge
+                  lane={row.approval_lane}
+                  reason={row.approval_lane_reason}
+                  approval={approval}
+                />
+                <span title={row.account_mode ?? "max_action에 account_mode가 없습니다"}>
+                  <Pill
+                    tone={row.funding_broker === "unattributed" ? "warn" : "paper"}
+                    size="sm"
+                  >
+                    {FUNDING_BROKER_LABEL[row.funding_broker]}
+                  </Pill>
+                </span>
                 {row.near_expiry && (
                   <Pill tone="warn" size="sm">만료 임박</Pill>
                 )}
@@ -417,14 +528,18 @@ export function ActiveWatchBlock({
                 <Field
                   label={`레벨 (${row.metric})`}
                   value={price(row.threshold, row.currency)}
-                  title={row.threshold}
+                  title={exact(row.threshold)}
                 />
                 <Field label="현재가" value={price(row.current_price, row.currency)} />
                 <Field label="레벨까지" value={pct(row.distance_to_threshold_pct)} />
                 <Field
                   label="예상 소요액"
                   value={money(row.planned_notional, row.currency)}
-                  title={row.planned_notional_source ?? "max_action에 금액이 없습니다"}
+                  title={
+                    exact(row.planned_notional)
+                      ? `${row.planned_notional} (${row.planned_notional_source})`
+                      : "max_action에 금액이 없습니다"
+                  }
                 />
                 <Field label="만료" value={dateTime(row.valid_until)} />
               </div>

--- a/frontend/invest/src/components/buyPlan/TriggerBlocks.tsx
+++ b/frontend/invest/src/components/buyPlan/TriggerBlocks.tsx
@@ -1,0 +1,528 @@
+// 트리거 행 블록 — §144차 요구사항 ①③④.
+//
+// One card per trigger. Cards rather than a wide table because the operator
+// reads this on a phone as often as on a desktop, and each row carries a small
+// cluster of related numbers (trigger price, distance, two cash samples).
+import { Link } from "react-router-dom";
+import { Card, Pill } from "../../ds";
+import type {
+  ActiveBuyWatchRow,
+  AveragingSampleRow,
+  AveragingTriggerRow,
+  DiscoveryGateRow,
+  SupportNetPlacement,
+  SupportNetRow,
+  SupportNetTier,
+} from "../../types/buyPlan";
+import { dateTime, money, pct, price, quantity } from "./format";
+import {
+  APPROVAL_LANE_LABEL,
+  APPROVAL_LANE_REASON_LABEL,
+  COMPARISON_LABEL,
+  GATE_CONDITION_STATE_LABEL,
+  GATE_STATE_LABEL,
+  PLACEMENT_FORM_LABEL,
+} from "./labels";
+
+function SectionHeading({
+  title,
+  subtitle,
+}: Readonly<{ title: string; subtitle?: string }>) {
+  return (
+    <div style={{ display: "grid", gap: 2 }}>
+      <h2 style={{ margin: 0, fontSize: 16 }}>{title}</h2>
+      {subtitle && (
+        <p style={{ margin: 0, fontSize: 12, color: "var(--fg-2)" }}>{subtitle}</p>
+      )}
+    </div>
+  );
+}
+
+function EmptyNote({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <Card soft style={{ padding: 14, fontSize: 12, color: "var(--fg-2)" }}>
+      {children}
+    </Card>
+  );
+}
+
+function SymbolLink({
+  market,
+  symbol,
+  name,
+}: Readonly<{ market: string; symbol: string; name: string | null }>) {
+  return (
+    <Link
+      to={`/stocks/${market}/${encodeURIComponent(symbol)}`}
+      style={{ color: "inherit", textDecoration: "none", fontWeight: 700 }}
+    >
+      {name || symbol}
+      <span style={{ color: "var(--fg-2)", fontWeight: 400, marginLeft: 6 }}>
+        {symbol}
+      </span>
+    </Link>
+  );
+}
+
+function LaneBadge({
+  lane,
+  reason,
+}: Readonly<{
+  lane: AveragingSampleRow["approval_lane"];
+  reason: AveragingSampleRow["approval_lane_reason"];
+}>) {
+  return (
+    <span title={APPROVAL_LANE_REASON_LABEL[reason]}>
+      <Pill tone={lane === "auto_submit" ? "accent" : "warn"} size="sm">
+        {APPROVAL_LANE_LABEL[lane]}
+      </Pill>
+    </span>
+  );
+}
+
+function Field({
+  label,
+  value,
+  title,
+}: Readonly<{ label: string; value: string; title?: string }>) {
+  return (
+    <div style={{ display: "grid", gap: 2 }}>
+      <span style={{ fontSize: 11, color: "var(--fg-2)" }}>{label}</span>
+      <span
+        style={{ fontSize: 13, fontVariantNumeric: "tabular-nums" }}
+        title={title}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function AveragingCard({ row }: Readonly<{ row: AveragingTriggerRow }>) {
+  return (
+    <Card style={{ padding: 16, display: "grid", gap: 12 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flexWrap: "wrap",
+        }}
+      >
+        <SymbolLink market={row.market} symbol={row.symbol} name={row.symbol_name} />
+        <Pill tone={row.turn_point_reached ? "accent" : "paper"} size="sm">
+          {row.turn_point_reached ? "전환점 도달" : "전환점 대기"}
+        </Pill>
+        {!row.within_policy_add_cap && (
+          <span title="정책의 시장별 add 상한 밖 — 자금 합계에 포함하지 않습니다.">
+            <Pill tone="paper" size="sm">add 상한 밖 · #{row.market_rank}</Pill>
+          </span>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gap: 10,
+          gridTemplateColumns: "repeat(auto-fit, minmax(96px, 1fr))",
+        }}
+      >
+        <Field
+          label={`전환점 P* (k=${row.k})`}
+          value={price(row.turn_point_price, row.currency)}
+          title={row.turn_point_price}
+        />
+        <Field label="현재가" value={price(row.current_price, row.currency)} />
+        <Field label="전환점까지" value={pct(row.distance_to_turn_point_pct)} />
+        <Field label="평단" value={price(row.average_price, row.currency)} />
+        <Field label="수량" value={quantity(row.quantity)} />
+        <Field label="평가손익" value={pct(row.unrealized_pnl_pct)} />
+      </div>
+
+      <div style={{ display: "grid", gap: 6 }}>
+        <span style={{ fontSize: 11, color: "var(--fg-2)" }}>
+          트리거 도달 시 예상 소요액
+        </span>
+        {row.samples.map((sample) => (
+          <div
+            key={sample.offset_from_turn_point_pct}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 10,
+              flexWrap: "wrap",
+              fontSize: 13,
+            }}
+          >
+            <span style={{ color: "var(--fg-2)" }}>
+              전환점 {pct(sample.offset_from_turn_point_pct, 0)} (
+              {price(sample.price, row.currency)})
+            </span>
+            <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <strong
+                style={{ fontVariantNumeric: "tabular-nums" }}
+                title={sample.additional_notional}
+              >
+                {money(sample.additional_notional, row.currency)}
+              </strong>
+              <LaneBadge
+                lane={sample.approval_lane}
+                reason={sample.approval_lane_reason}
+              />
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {row.notes.length > 0 && (
+        <ul
+          style={{
+            margin: 0,
+            paddingLeft: 16,
+            fontSize: 11,
+            color: "var(--fg-2)",
+            display: "grid",
+            gap: 2,
+          }}
+        >
+          {row.notes.map((note) => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+export function AveragingBlock({
+  rows,
+}: Readonly<{ rows: AveragingTriggerRow[] }>) {
+  return (
+    <section style={{ display: "grid", gap: 12 }}>
+      <SectionHeading
+        title="① 물타기 A(k) 전환점"
+        subtitle="평단이 제안가의 k 이내로 내려오는 데 필요한 금액. 전환점 위에서는 정책상 NO_ORDER."
+      />
+      {rows.length === 0 ? (
+        <EmptyNote>
+          물타기 전환점을 계산할 언더워터 보유가 없습니다 (또는 원가·현재가를 확인하지
+          못했습니다).
+        </EmptyNote>
+      ) : (
+        <div style={{ display: "grid", gap: 10 }}>
+          {rows.map((row) => (
+            <AveragingCard key={`${row.market}:${row.symbol}`} row={row} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PlacementLine({
+  placement,
+  currency,
+}: Readonly<{
+  placement: SupportNetPlacement;
+  currency: SupportNetRow["currency"];
+}>) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        gap: 10,
+        flexWrap: "wrap",
+        fontSize: 12,
+      }}
+    >
+      <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Pill tone={placement.form === "resting_order" ? "accent" : "paper"} size="sm">
+          {PLACEMENT_FORM_LABEL[placement.form]}
+        </Pill>
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>
+          {price(placement.anchor_price, currency)}
+        </span>
+        {placement.distance_from_current_pct && (
+          <span style={{ color: "var(--fg-2)" }}>
+            ({pct(placement.distance_from_current_pct, 1)}
+            {placement.within_policy_distance_band === false && " · 밴드 밖"})
+          </span>
+        )}
+      </span>
+      <span style={{ display: "flex", gap: 10, color: "var(--fg-2)" }}>
+        {placement.quantity && <span>{quantity(placement.quantity)}</span>}
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>
+          {money(placement.notional, currency)}
+        </span>
+        {placement.valid_until && <span>~{dateTime(placement.valid_until)}</span>}
+      </span>
+    </div>
+  );
+}
+
+function SupportNetCard({ row }: Readonly<{ row: SupportNetRow }>) {
+  return (
+    <Card style={{ padding: 16, display: "grid", gap: 10 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <SymbolLink market={row.market} symbol={row.symbol} name={row.symbol_name} />
+        <Pill tone={row.eligible ? "gain" : "paper"} size="sm">
+          {row.eligible ? "이익권" : (row.ineligible_reason ?? "대상 아님")}
+        </Pill>
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gap: 10,
+          gridTemplateColumns: "repeat(auto-fit, minmax(96px, 1fr))",
+        }}
+      >
+        <Field label="현재가" value={price(row.current_price, row.currency)} />
+        <Field label="평단" value={price(row.average_price, row.currency)} />
+        <Field label="평가손익" value={pct(row.unrealized_pnl_pct)} />
+        <Field
+          label="걸린 금액"
+          value={money(row.placed_notional, row.currency)}
+          title={row.placed_notional}
+        />
+        <Field
+          label="남은 여력"
+          value={money(row.remaining_headroom_notional, row.currency)}
+          title={row.remaining_headroom_notional}
+        />
+      </div>
+      {row.placements.length > 0 ? (
+        <div style={{ display: "grid", gap: 4 }}>{row.placements.map((placement) => (
+          <PlacementLine
+            key={`${placement.form}:${placement.reference}`}
+            placement={placement}
+            currency={row.currency}
+          />
+        ))}</div>
+      ) : (
+        <span style={{ fontSize: 12, color: "var(--fg-2)" }}>걸린 그물 없음</span>
+      )}
+    </Card>
+  );
+}
+
+export function SupportNetBlock({ tier }: Readonly<{ tier: SupportNetTier }>) {
+  return (
+    <section style={{ display: "grid", gap: 12 }}>
+      <SectionHeading
+        title="② 지지 그물 티어"
+        subtitle={`${tier.policy_key}${
+          tier.review_date ? ` · 채점 ${tier.review_date}` : ""
+        }`}
+      />
+      {!tier.enabled ? (
+        <EmptyNote>
+          이 시장 범위에서는 지지 그물 티어를 표시하지 않습니다.
+        </EmptyNote>
+      ) : (
+        <>
+          <Card soft style={{ padding: 14, display: "flex", gap: 20, flexWrap: "wrap" }}>
+            <Field
+              label="티어 상한"
+              value={money(tier.tier_cap_notional, tier.currency)}
+            />
+            <Field
+              label="코인당 상한"
+              value={money(tier.per_symbol_cap_notional, tier.currency)}
+            />
+            <Field label="걸린 합계" value={money(tier.placed_notional, tier.currency)} />
+            <Field
+              label="티어 잔여"
+              value={money(tier.remaining_notional, tier.currency)}
+            />
+            {tier.distance_band_pct.length === 2 && (
+              <Field
+                label="지지 거리 밴드"
+                value={`${tier.distance_band_pct[0]}% ~ ${tier.distance_band_pct[1]}%`}
+              />
+            )}
+          </Card>
+          {tier.rows.length === 0 ? (
+            <EmptyNote>해당 보유가 없습니다.</EmptyNote>
+          ) : (
+            <div style={{ display: "grid", gap: 10 }}>
+              {tier.rows.map((row) => (
+                <SupportNetCard key={row.symbol} row={row} />
+              ))}
+            </div>
+          )}
+          {tier.notes.length > 0 && (
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: 16,
+                fontSize: 11,
+                color: "var(--fg-2)",
+                display: "grid",
+                gap: 2,
+              }}
+            >
+              {tier.notes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+export function ActiveWatchBlock({
+  rows,
+}: Readonly<{ rows: ActiveBuyWatchRow[] }>) {
+  return (
+    <section style={{ display: "grid", gap: 12 }}>
+      <SectionHeading
+        title="③ 활성 매수 워치"
+        subtitle="발화하면 현금이 필요해지는 레벨. 금액은 워치의 max_action에서 옵니다."
+      />
+      {rows.length === 0 ? (
+        <EmptyNote>활성 매수 워치가 없습니다.</EmptyNote>
+      ) : (
+        <div style={{ display: "grid", gap: 8 }}>
+          {rows.map((row) => (
+            <Card key={row.alert_uuid} style={{ padding: 14, display: "grid", gap: 8 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  flexWrap: "wrap",
+                }}
+              >
+                <SymbolLink
+                  market={row.market}
+                  symbol={row.symbol}
+                  name={row.symbol_name}
+                />
+                <LaneBadge lane={row.approval_lane} reason={row.approval_lane_reason} />
+                {row.near_expiry && (
+                  <Pill tone="warn" size="sm">만료 임박</Pill>
+                )}
+              </div>
+              <div
+                style={{
+                  display: "grid",
+                  gap: 10,
+                  gridTemplateColumns: "repeat(auto-fit, minmax(96px, 1fr))",
+                }}
+              >
+                <Field
+                  label={`레벨 (${row.metric})`}
+                  value={price(row.threshold, row.currency)}
+                  title={row.threshold}
+                />
+                <Field label="현재가" value={price(row.current_price, row.currency)} />
+                <Field label="레벨까지" value={pct(row.distance_to_threshold_pct)} />
+                <Field
+                  label="예상 소요액"
+                  value={money(row.planned_notional, row.currency)}
+                  title={row.planned_notional_source ?? "max_action에 금액이 없습니다"}
+                />
+                <Field label="만료" value={dateTime(row.valid_until)} />
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function DiscoveryGateBlock({
+  rows,
+}: Readonly<{ rows: DiscoveryGateRow[] }>) {
+  if (rows.length === 0) return null;
+  return (
+    <section style={{ display: "grid", gap: 12 }}>
+      <SectionHeading
+        title="④ 발굴 게이트"
+        subtitle="신규 후보를 볼 수 있는 국면인지. 확인 불가 조건은 충족으로 세지 않습니다."
+      />
+      {rows.map((gate) => (
+        <Card key={gate.gate_key} style={{ padding: 16, display: "grid", gap: 10 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <Pill
+              tone={
+                gate.state === "open"
+                  ? "gain"
+                  : gate.state === "closed"
+                    ? "loss"
+                    : "warn"
+              }
+            >
+              {GATE_STATE_LABEL[gate.state]}
+            </Pill>
+            <span style={{ fontSize: 12, color: "var(--fg-2)" }}>
+              {gate.met_count}/{gate.of} 충족 (필요 {gate.min_conditions_met})
+              {gate.unavailable_count > 0 && ` · 확인 불가 ${gate.unavailable_count}`}
+            </span>
+          </div>
+          <div style={{ display: "grid", gap: 6 }}>
+            {gate.conditions.map((condition) => (
+              <div
+                key={condition.condition_id}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 10,
+                  flexWrap: "wrap",
+                  fontSize: 12,
+                }}
+                title={condition.note ?? undefined}
+              >
+                <span>
+                  <Pill
+                    tone={
+                      condition.state === "met"
+                        ? "gain"
+                        : condition.state === "not_met"
+                          ? "loss"
+                          : "warn"
+                    }
+                    size="sm"
+                  >
+                    {GATE_CONDITION_STATE_LABEL[condition.state]}
+                  </Pill>{" "}
+                  {condition.metric}
+                </span>
+                <span style={{ fontVariantNumeric: "tabular-nums" }}>
+                  {condition.current_value ?? "확인 불가"}
+                  {condition.unit === "percent" && condition.current_value ? "%" : ""}
+                  <span style={{ color: "var(--fg-2)" }}>
+                    {" "}
+                    (기준 {COMPARISON_LABEL[condition.comparison ?? ""] ?? condition.comparison}{" "}
+                    {condition.threshold})
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+          {gate.notes.length > 0 && (
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: 16,
+                fontSize: 11,
+                color: "var(--fg-2)",
+                display: "grid",
+                gap: 2,
+              }}
+            >
+              {gate.notes.map((note) => (
+                <li key={note}>{note}</li>
+              ))}
+            </ul>
+          )}
+        </Card>
+      ))}
+    </section>
+  );
+}

--- a/frontend/invest/src/components/buyPlan/decimal.ts
+++ b/frontend/invest/src/components/buyPlan/decimal.ts
@@ -1,0 +1,139 @@
+// Arbitrary-precision decimal string formatting for the 매수 계획 board.
+//
+// verify-r1 B5: the API sends money as exact decimal strings, but the board
+// used to render them through `Number()`. Beyond 2^53 that silently changes
+// the amount — `"9007199254740993"` rendered as `9,007,199,254,740,992`, so
+// the operator saw a deposit figure one won away from what the API computed.
+//
+// Nothing in this module converts to a JS number. Digits are carried as
+// strings from parse through rounding to grouping, so the rendered value is
+// exactly the value that arrived (or an explicitly rounded prefix of it).
+
+export interface ParsedDecimal {
+  negative: boolean;
+  /** Integer digits, no sign, no leading zeros (at least "0"). */
+  int: string;
+  /** Fractional digits, no trailing-zero trimming, possibly "". */
+  frac: string;
+}
+
+const DECIMAL_RE = /^([+-]?)(\d*)(?:\.(\d*))?$/;
+
+export function parseDecimalString(raw: string | null | undefined): ParsedDecimal | null {
+  if (raw === null || raw === undefined) return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const match = DECIMAL_RE.exec(trimmed);
+  if (!match) return null;
+  const [, sign, intRaw, fracRaw] = match;
+  const int = (intRaw ?? "").replace(/^0+(?=\d)/, "");
+  const frac = fracRaw ?? "";
+  if (int === "" && frac === "") return null;
+  return { negative: sign === "-", int: int === "" ? "0" : int, frac };
+}
+
+/** Add one unit to the last digit of a non-negative digit string. */
+function increment(digits: string): string {
+  const out = digits.split("");
+  let i = out.length - 1;
+  while (i >= 0) {
+    if (out[i] === "9") {
+      out[i] = "0";
+      i -= 1;
+      continue;
+    }
+    out[i] = String(Number(out[i]) + 1);
+    return out.join("");
+  }
+  return `1${out.join("")}`;
+}
+
+/**
+ * Round to `digits` fractional places, half-up on the magnitude.
+ *
+ * Half-up on magnitude (not toward +infinity) matches how the backend's
+ * Decimal context rounds, so a value formatted here and a value formatted
+ * server-side agree at the boundary.
+ */
+export function roundDecimal(parsed: ParsedDecimal, digits: number): ParsedDecimal {
+  const places = Math.max(0, Math.trunc(digits));
+  if (parsed.frac.length <= places) {
+    return { ...parsed, frac: parsed.frac.padEnd(places, "0") };
+  }
+  const keep = parsed.frac.slice(0, places);
+  const roundUp = parsed.frac.charCodeAt(places) >= 53; // '5'
+  let combined = `${parsed.int}${keep}`;
+  if (roundUp) combined = increment(combined);
+  // `increment` can grow the string by one digit (999 -> 1000); slicing from
+  // the right keeps the fractional width fixed either way.
+  const frac = places === 0 ? "" : combined.slice(combined.length - places);
+  const int = (places === 0 ? combined : combined.slice(0, combined.length - places)) || "0";
+  return { negative: parsed.negative, int: int.replace(/^0+(?=\d)/, ""), frac };
+}
+
+function groupInteger(int: string, separator: string): string {
+  let out = "";
+  for (let i = 0; i < int.length; i += 1) {
+    if (i > 0 && (int.length - i) % 3 === 0) out += separator;
+    out += int[i];
+  }
+  return out;
+}
+
+export interface FormatOptions {
+  /** Fractional digits to render. Extra digits are rounded away, half-up. */
+  maxFractionDigits?: number;
+  /** Drop trailing zeros in the fraction (prices/quantities, not money). */
+  trimFraction?: boolean;
+  /** Always show a leading `+` for positive values (percent deltas). */
+  explicitSign?: boolean;
+  separator?: string;
+}
+
+/**
+ * Format an exact decimal string for display without ever touching `Number`.
+ *
+ * Returns `null` for input this module cannot parse, so callers render their
+ * own placeholder rather than a misleading `0`.
+ */
+export function formatDecimalString(
+  raw: string | null | undefined,
+  options: FormatOptions = {},
+): string | null {
+  const {
+    maxFractionDigits = 0,
+    trimFraction = false,
+    explicitSign = false,
+    separator = ",",
+  } = options;
+  const parsed = parseDecimalString(raw);
+  if (parsed === null) return null;
+
+  const rounded = roundDecimal(parsed, maxFractionDigits);
+  let frac = rounded.frac;
+  if (trimFraction) frac = frac.replace(/0+$/, "");
+
+  const body = groupInteger(rounded.int, separator) + (frac ? `.${frac}` : "");
+  const isZero = rounded.int === "0" && /^0*$/.test(rounded.frac);
+  // Rounding can turn -0.004 into -0; "-0" reads as a real negative amount.
+  if (rounded.negative && !isZero) return `-${body}`;
+  if (explicitSign && !isZero && !rounded.negative) return `+${body}`;
+  return body;
+}
+
+/** Compare two decimal strings without converting either to a number. */
+export function compareDecimalStrings(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): number | null {
+  const left = parseDecimalString(a);
+  const right = parseDecimalString(b);
+  if (left === null || right === null) return null;
+  if (left.negative !== right.negative) return left.negative ? -1 : 1;
+  const width = Math.max(left.frac.length, right.frac.length);
+  const lv = `${left.int}${left.frac.padEnd(width, "0")}`;
+  const rv = `${right.int}${right.frac.padEnd(width, "0")}`;
+  const padded = Math.max(lv.length, rv.length);
+  const cmp = lv.padStart(padded, "0").localeCompare(rv.padStart(padded, "0"));
+  return left.negative ? -cmp : cmp;
+}

--- a/frontend/invest/src/components/buyPlan/format.ts
+++ b/frontend/invest/src/components/buyPlan/format.ts
@@ -1,27 +1,28 @@
 // Display formatting for the 매수 계획 board — §144차.
 //
-// The API sends money as exact decimal strings. Formatting needs a number, so
-// these helpers parse once at the render boundary and keep the original string
-// available for the `title` attribute; nothing here feeds a value back into a
-// calculation, so the parse cannot move a total the operator acts on.
-import { formatNumber } from "../../format/number";
+// The API sends money as exact decimal strings and this module keeps them that
+// way: every helper delegates to `formatDecimalString`, which carries digits
+// as strings from parse through rounding to grouping. `Number()` is
+// deliberately absent — verify-r1 B5 measured `"9007199254740993"` rendering
+// as `9,007,199,254,740,992` through the old `Number()` path, i.e. the
+// operator saw a deposit amount one won away from the API's.
+//
+// Every helper returns "-" for unparseable input so a missing value never
+// renders as a confident `0`.
 import type { BuyPlanCurrency } from "../../types/buyPlan";
+import { formatDecimalString } from "./decimal";
 
-export function toNumber(value: string | null | undefined): number | null {
-  if (value === null || value === undefined || value === "") return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
+export const MISSING = "-";
 
 export function money(
   value: string | null | undefined,
   currency: BuyPlanCurrency,
 ): string {
-  const n = toNumber(value);
-  if (n === null) return "-";
-  return currency === "KRW"
-    ? `₩${formatNumber(n, { maximumFractionDigits: 0 })}`
-    : `$${formatNumber(n, { maximumFractionDigits: 2 })}`;
+  const formatted = formatDecimalString(value, {
+    maxFractionDigits: currency === "KRW" ? 0 : 2,
+  });
+  if (formatted === null) return MISSING;
+  return `${currency === "KRW" ? "₩" : "$"}${formatted}`;
 }
 
 /** Price, not notional — keeps sub-won precision for cheap coins. */
@@ -29,31 +30,42 @@ export function price(
   value: string | null | undefined,
   currency: BuyPlanCurrency,
 ): string {
-  const n = toNumber(value);
-  if (n === null) return "-";
-  const digits = currency === "KRW" ? (Math.abs(n) < 100 ? 2 : 0) : 2;
-  const symbol = currency === "KRW" ? "₩" : "$";
-  return `${symbol}${formatNumber(n, { maximumFractionDigits: digits })}`;
+  // Two decimals are always allowed and then trimmed, so ₩1,000 stays clean
+  // while a 0.42 KRW coin keeps its cents. The old version branched on
+  // `Math.abs(n) < 100`, which needed a JS number.
+  const formatted = formatDecimalString(value, {
+    maxFractionDigits: 2,
+    trimFraction: true,
+  });
+  if (formatted === null) return MISSING;
+  return `${currency === "KRW" ? "₩" : "$"}${formatted}`;
 }
 
 /** The API sends percent already scaled (5 means 5%), unlike formatPercent. */
 export function pct(value: string | null | undefined, digits = 2): string {
-  const n = toNumber(value);
-  if (n === null) return "-";
-  const sign = n > 0 ? "+" : "";
-  return `${sign}${n.toFixed(digits)}%`;
+  const formatted = formatDecimalString(value, {
+    maxFractionDigits: digits,
+    explicitSign: true,
+  });
+  if (formatted === null) return MISSING;
+  return `${formatted}%`;
 }
 
 export function quantity(value: string | null | undefined): string {
-  const n = toNumber(value);
-  if (n === null) return "-";
-  return formatNumber(n, { maximumFractionDigits: 8 });
+  return (
+    formatDecimalString(value, { maxFractionDigits: 8, trimFraction: true }) ?? MISSING
+  );
+}
+
+/** The exact string the API sent, for a `title` tooltip. */
+export function exact(value: string | null | undefined): string | undefined {
+  return value === null || value === undefined || value === "" ? undefined : value;
 }
 
 export function dateTime(value: string | null | undefined): string {
-  if (!value) return "-";
+  if (!value) return MISSING;
   const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return "-";
+  if (Number.isNaN(parsed.getTime())) return MISSING;
   return parsed.toLocaleString("ko-KR", {
     month: "2-digit",
     day: "2-digit",

--- a/frontend/invest/src/components/buyPlan/format.ts
+++ b/frontend/invest/src/components/buyPlan/format.ts
@@ -1,0 +1,63 @@
+// Display formatting for the 매수 계획 board — §144차.
+//
+// The API sends money as exact decimal strings. Formatting needs a number, so
+// these helpers parse once at the render boundary and keep the original string
+// available for the `title` attribute; nothing here feeds a value back into a
+// calculation, so the parse cannot move a total the operator acts on.
+import { formatNumber } from "../../format/number";
+import type { BuyPlanCurrency } from "../../types/buyPlan";
+
+export function toNumber(value: string | null | undefined): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function money(
+  value: string | null | undefined,
+  currency: BuyPlanCurrency,
+): string {
+  const n = toNumber(value);
+  if (n === null) return "-";
+  return currency === "KRW"
+    ? `₩${formatNumber(n, { maximumFractionDigits: 0 })}`
+    : `$${formatNumber(n, { maximumFractionDigits: 2 })}`;
+}
+
+/** Price, not notional — keeps sub-won precision for cheap coins. */
+export function price(
+  value: string | null | undefined,
+  currency: BuyPlanCurrency,
+): string {
+  const n = toNumber(value);
+  if (n === null) return "-";
+  const digits = currency === "KRW" ? (Math.abs(n) < 100 ? 2 : 0) : 2;
+  const symbol = currency === "KRW" ? "₩" : "$";
+  return `${symbol}${formatNumber(n, { maximumFractionDigits: digits })}`;
+}
+
+/** The API sends percent already scaled (5 means 5%), unlike formatPercent. */
+export function pct(value: string | null | undefined, digits = 2): string {
+  const n = toNumber(value);
+  if (n === null) return "-";
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n.toFixed(digits)}%`;
+}
+
+export function quantity(value: string | null | undefined): string {
+  const n = toNumber(value);
+  if (n === null) return "-";
+  return formatNumber(n, { maximumFractionDigits: 8 });
+}
+
+export function dateTime(value: string | null | undefined): string {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "-";
+  return parsed.toLocaleString("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/frontend/invest/src/components/buyPlan/labels.ts
+++ b/frontend/invest/src/components/buyPlan/labels.ts
@@ -6,22 +6,47 @@
 import type {
   ApprovalLane,
   ApprovalLaneReason,
+  FundingBroker,
   FundingVerdict,
   GateConditionState,
   GateState,
   PlacementForm,
+  SourceState,
 } from "../../types/buyPlan";
 
+// verify-r1 B6: the backend classifies a notional against two caps and nothing
+// else. Calling that "자동승인" told the operator an approval decision had been
+// made, when real dispatch consults a default-off master gate plus conditions
+// this board never evaluates. The label now says what was actually checked.
 export const APPROVAL_LANE_LABEL: Record<ApprovalLane, string> = {
-  auto_submit: "자동승인",
+  auto_submit: "자동승인 가능(cap 기준)",
+  human_card: "카드(수동 승인)",
+};
+
+/** What the badge means once the master gate is known to be off. */
+export const APPROVAL_LANE_LABEL_GATE_OFF: Record<ApprovalLane, string> = {
+  auto_submit: "카드(자동승인 꺼짐)",
   human_card: "카드(수동 승인)",
 };
 
 export const APPROVAL_LANE_REASON_LABEL: Record<ApprovalLaneReason, string> = {
-  within_tier_auto_submit_notional: "티어 자동제출 한도 이내",
+  within_tier_auto_submit_notional: "티어 자동제출 한도 이내 (cap 기준 분류일 뿐, 승인 확정 아님)",
   above_tier_auto_submit_notional: "티어 자동제출 한도 초과",
   above_per_order_auto_approve_cap: "건당 자동승인 상한 초과",
   notional_unavailable: "금액을 확정하지 못해 fail-closed",
+};
+
+export const FUNDING_BROKER_LABEL: Record<FundingBroker, string> = {
+  kis: "한국투자증권",
+  upbit: "업비트",
+  toss: "토스증권",
+  unattributed: "계좌 미확정",
+};
+
+export const SOURCE_STATE_LABEL: Record<SourceState, string> = {
+  ok: "정상",
+  degraded: "일부 누락",
+  unavailable: "조회 불가",
 };
 
 export const PLACEMENT_FORM_LABEL: Record<PlacementForm, string> = {

--- a/frontend/invest/src/components/buyPlan/labels.ts
+++ b/frontend/invest/src/components/buyPlan/labels.ts
@@ -1,0 +1,56 @@
+// Closed-vocabulary label maps for the 매수 계획 board — §144차.
+//
+// Every backend enum is mapped exhaustively here so a value the UI does not
+// recognise shows as the raw token rather than silently rendering as an empty
+// cell that reads like "nothing to see".
+import type {
+  ApprovalLane,
+  ApprovalLaneReason,
+  FundingVerdict,
+  GateConditionState,
+  GateState,
+  PlacementForm,
+} from "../../types/buyPlan";
+
+export const APPROVAL_LANE_LABEL: Record<ApprovalLane, string> = {
+  auto_submit: "자동승인",
+  human_card: "카드(수동 승인)",
+};
+
+export const APPROVAL_LANE_REASON_LABEL: Record<ApprovalLaneReason, string> = {
+  within_tier_auto_submit_notional: "티어 자동제출 한도 이내",
+  above_tier_auto_submit_notional: "티어 자동제출 한도 초과",
+  above_per_order_auto_approve_cap: "건당 자동승인 상한 초과",
+  notional_unavailable: "금액을 확정하지 못해 fail-closed",
+};
+
+export const PLACEMENT_FORM_LABEL: Record<PlacementForm, string> = {
+  resting_order: "주문 상시형",
+  watch: "워치형",
+};
+
+export const GATE_STATE_LABEL: Record<GateState, string> = {
+  open: "열림",
+  closed: "닫힘",
+  indeterminate: "판정 불가",
+};
+
+export const GATE_CONDITION_STATE_LABEL: Record<GateConditionState, string> = {
+  met: "충족",
+  not_met: "미충족",
+  unavailable: "확인 불가",
+};
+
+export const FUNDING_VERDICT_LABEL: Record<FundingVerdict, string> = {
+  sufficient: "리저브 충분",
+  shortfall: "입금 필요",
+  unknown: "대조 보류",
+};
+
+export const COMPARISON_LABEL: Record<string, string> = {
+  gt: ">",
+  gte: "≥",
+  lt: "<",
+  lte: "≤",
+  eq: "=",
+};

--- a/frontend/invest/src/components/buyPlan/labels.ts
+++ b/frontend/invest/src/components/buyPlan/labels.ts
@@ -29,6 +29,14 @@ export const APPROVAL_LANE_LABEL_GATE_OFF: Record<ApprovalLane, string> = {
   human_card: "카드(수동 승인)",
 };
 
+// verify-r2 SHOULD-2: an unreadable gate used to render identically to a gate
+// known to be ON — same accent colour, same "자동승인 가능" wording. Not knowing
+// is its own state and must look like one.
+export const APPROVAL_LANE_LABEL_GATE_UNKNOWN: Record<ApprovalLane, string> = {
+  auto_submit: "레인 판정 불가(게이트 상태 불명)",
+  human_card: "카드(수동 승인)",
+};
+
 export const APPROVAL_LANE_REASON_LABEL: Record<ApprovalLaneReason, string> = {
   within_tier_auto_submit_notional: "티어 자동제출 한도 이내 (cap 기준 분류일 뿐, 승인 확정 아님)",
   above_tier_auto_submit_notional: "티어 자동제출 한도 초과",

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -6,6 +6,7 @@ const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "홈", end: true },
   { to: "/my", label: "MY" },
   { to: "/watches", label: "감시" },
+  { to: "/buy-plan", label: "매수 계획" },
   { to: "/feed/news", label: "뉴스" },
   { to: "/discover", label: "발견" },
   { to: "/calendar", label: "캘린더" },

--- a/frontend/invest/src/pages/BuyPlanRoute.tsx
+++ b/frontend/invest/src/pages/BuyPlanRoute.tsx
@@ -1,0 +1,9 @@
+// /invest/buy-plan — §144차. Viewport dispatch, mirrors WatchesRoute.tsx.
+import { useViewport } from "../hooks/useViewport";
+import { DesktopBuyPlanPage } from "./desktop/DesktopBuyPlanPage";
+import { MobileBuyPlanPage } from "./mobile/MobileBuyPlanPage";
+
+export function BuyPlanRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileBuyPlanPage /> : <DesktopBuyPlanPage />;
+}

--- a/frontend/invest/src/pages/desktop/DesktopBuyPlanPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopBuyPlanPage.tsx
@@ -1,0 +1,7 @@
+// /invest/buy-plan (desktop) — §144차.
+import { BuyPlanPageBody } from "../../components/buyPlan/BuyPlanPageBody";
+import { DesktopShell } from "../../desktop/DesktopShell";
+
+export function DesktopBuyPlanPage() {
+  return <DesktopShell center={<BuyPlanPageBody />} />;
+}

--- a/frontend/invest/src/pages/mobile/MobileBuyPlanPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileBuyPlanPage.tsx
@@ -1,0 +1,13 @@
+// /invest/buy-plan (mobile) — §144차.
+import { BuyPlanPageBody } from "../../components/buyPlan/BuyPlanPageBody";
+import { MobileShell } from "../../mobile/MobileShell";
+
+export function MobileBuyPlanPage() {
+  return (
+    <MobileShell title="매수 계획">
+      <div style={{ padding: "14px 16px 24px" }}>
+        <BuyPlanPageBody />
+      </div>
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -22,6 +22,8 @@
 // /invest/reports                 — Investment report list (ROB-265).
 // /invest/reports/:reportUuid     — Single investment report bundle.
 // /invest/stocks/:m/:sym    — Stock detail page.
+// /invest/buy-plan          — Read-only 매수 계획 (트리거 보드): 매수 트리거
+//                             행 + 계좌 현금 대비 소요액 대조 (§144차).
 // /invest/watches           — Watch-alert browsing, grouped by symbol
 //                             (ladder view). Mobile-first (INVEST-WATCH-UI
 //                             §57차 item ①).
@@ -53,6 +55,7 @@ import {
 } from "./pages/desktop/DesktopInvestmentReportsPage";
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
 import { WatchesRoute } from "./pages/WatchesRoute";
+import { BuyPlanRoute } from "./pages/BuyPlanRoute";
 import { OrderDetailRoute } from "./pages/OrderDetailRoute";
 import {
   LossCutApprovalRoute,
@@ -110,6 +113,7 @@ export const router = createBrowserRouter(
     { path: "/reports/:reportUuid", element: <InvestmentReportBundleRoute /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
     { path: "/watches", element: <WatchesRoute /> },
+    { path: "/buy-plan", element: <BuyPlanRoute /> },
     { path: "/orders/:broker/:market/:ledgerId", element: <OrderDetailRoute /> },
     {
       path: "/approvals/loss-cut/evidence/:symbol",

--- a/frontend/invest/src/types/buyPlan.ts
+++ b/frontend/invest/src/types/buyPlan.ts
@@ -27,11 +27,19 @@ export interface PolicyStamp {
   content_hash: string;
 }
 
+export interface ApprovalCondition {
+  /** The literal reject reason in evaluate_auto_approve_eligibility. */
+  code: string;
+  label: string;
+}
+
 export interface ApprovalContext {
+  /** `null` means the setting could not be read — not "off", and not "on". */
   master_gate_enabled: boolean | null;
   master_gate_setting: string;
   master_gate_source: string;
-  unevaluated_conditions: string[];
+  unevaluated_conditions: ApprovalCondition[];
+  evaluated_conditions: ApprovalCondition[];
   notice: string;
 }
 
@@ -70,6 +78,7 @@ export interface AveragingTriggerRow {
   market_rank: number;
   within_policy_add_cap: boolean;
   funding_broker: FundingBroker;
+  funding_broker_reason: string | null;
   notes: string[];
 }
 
@@ -137,6 +146,7 @@ export interface ActiveBuyWatchRow {
   planned_notional: string | null;
   planned_notional_source: string | null;
   funding_broker: FundingBroker;
+  funding_broker_reason: string | null;
   account_mode: string | null;
   approval_lane: ApprovalLane;
   approval_lane_reason: ApprovalLaneReason;
@@ -189,7 +199,8 @@ export interface ScopeReconciliation {
   required_active_watches: string;
   required_total: string;
   unattributed_same_currency: string;
-  worst_case_required: string;
+  /** NOT a worst case — the money may land at a broker with no row here. */
+  upper_bound_if_all_unattributed_lands_here: string;
   requirements_complete: boolean;
   incomplete_reasons: string[];
   verdict: FundingVerdict;

--- a/frontend/invest/src/types/buyPlan.ts
+++ b/frontend/invest/src/types/buyPlan.ts
@@ -1,0 +1,190 @@
+// /invest 매수 계획 (트리거 보드) — §144차.
+//
+// Every money field arrives as an exact decimal *string*, never a JSON number:
+// these are the amounts the operator moves cash against, so no float rounding
+// is allowed between the policy arithmetic and the screen.
+
+export type BuyPlanMarketFilter = "all" | "kr" | "us" | "crypto";
+export type BuyPlanMarket = "kr" | "us" | "crypto";
+export type BuyPlanCurrency = "KRW" | "USD";
+export type ApprovalLane = "auto_submit" | "human_card";
+export type ApprovalLaneReason =
+  | "within_tier_auto_submit_notional"
+  | "above_tier_auto_submit_notional"
+  | "above_per_order_auto_approve_cap"
+  | "notional_unavailable";
+export type PlacementForm = "resting_order" | "watch";
+export type GateConditionState = "met" | "not_met" | "unavailable";
+export type GateState = "open" | "closed" | "indeterminate";
+export type FundingVerdict = "sufficient" | "shortfall" | "unknown";
+
+export interface PolicyStamp {
+  version: string;
+  content_hash: string;
+}
+
+export interface ValueSource {
+  field: string;
+  source: string;
+  note: string | null;
+}
+
+export interface AveragingSampleRow {
+  offset_from_turn_point_pct: string;
+  price: string;
+  additional_notional: string;
+  target_average_price: string;
+  approval_lane: ApprovalLane;
+  approval_lane_reason: ApprovalLaneReason;
+}
+
+export interface AveragingTriggerRow {
+  market: BuyPlanMarket;
+  symbol: string;
+  symbol_name: string | null;
+  currency: BuyPlanCurrency;
+  account_sources: string[];
+  quantity: string;
+  average_price: string;
+  cost_basis: string;
+  current_price: string;
+  unrealized_pnl_pct: string | null;
+  k: string;
+  turn_point_price: string;
+  distance_to_turn_point_pct: string;
+  turn_point_reached: boolean;
+  samples: AveragingSampleRow[];
+  reserve_plan_notional: string;
+  market_rank: number;
+  within_policy_add_cap: boolean;
+  notes: string[];
+}
+
+export interface SupportNetPlacement {
+  form: PlacementForm;
+  reference: string;
+  anchor_price: string | null;
+  quantity: string | null;
+  notional: string | null;
+  distance_from_current_pct: string | null;
+  valid_until: string | null;
+  within_policy_distance_band: boolean | null;
+}
+
+export interface SupportNetRow {
+  market: BuyPlanMarket;
+  symbol: string;
+  symbol_name: string | null;
+  currency: BuyPlanCurrency;
+  quantity: string;
+  average_price: string | null;
+  current_price: string | null;
+  unrealized_pnl_pct: string | null;
+  eligible: boolean;
+  ineligible_reason: string | null;
+  placements: SupportNetPlacement[];
+  placed_notional: string;
+  per_symbol_cap_notional: string;
+  remaining_headroom_notional: string;
+}
+
+export interface SupportNetTier {
+  policy_key: string;
+  enabled: boolean;
+  currency: BuyPlanCurrency;
+  tier_cap_notional: string | null;
+  per_symbol_cap_notional: string | null;
+  placed_notional: string;
+  remaining_notional: string | null;
+  distance_band_pct: string[];
+  review_date: string | null;
+  rows: SupportNetRow[];
+  notes: string[];
+}
+
+export interface ActiveBuyWatchRow {
+  market: BuyPlanMarket;
+  symbol: string;
+  symbol_name: string | null;
+  currency: BuyPlanCurrency;
+  alert_uuid: string;
+  metric: string;
+  operator: "above" | "below" | "between";
+  threshold: string;
+  threshold_high: string | null;
+  current_price: string | null;
+  distance_to_threshold_pct: string | null;
+  valid_until: string;
+  near_expiry: boolean;
+  planned_notional: string | null;
+  planned_notional_source: string | null;
+  approval_lane: ApprovalLane;
+  approval_lane_reason: ApprovalLaneReason;
+}
+
+export interface DiscoveryGateCondition {
+  condition_id: string;
+  metric: string;
+  comparison: string | null;
+  threshold: string | null;
+  unit: string | null;
+  current_value: string | null;
+  state: GateConditionState;
+  source: string | null;
+  note: string | null;
+}
+
+export interface DiscoveryGateRow {
+  market: BuyPlanMarket;
+  gate_key: string;
+  state: GateState;
+  min_conditions_met: number;
+  of: number;
+  met_count: number;
+  unavailable_count: number;
+  semantics: string | null;
+  conditions: DiscoveryGateCondition[];
+  notes: string[];
+}
+
+export interface CashAccountRow {
+  account_id: string;
+  display_name: string;
+  source: string;
+  currency: BuyPlanCurrency;
+  available_cash: string | null;
+  available_cash_source: string;
+  included_in_reserve: boolean;
+}
+
+export interface CurrencyReconciliation {
+  currency: BuyPlanCurrency;
+  available_cash: string | null;
+  required_averaging_adds: string;
+  required_support_net: string;
+  required_active_watches: string;
+  required_total: string;
+  verdict: FundingVerdict;
+  shortfall: string | null;
+  notes: string[];
+}
+
+export interface BuyPlanFunding {
+  accounts: CashAccountRow[];
+  currencies: CurrencyReconciliation[];
+}
+
+export interface BuyPlanResponse {
+  as_of: string;
+  policy: PolicyStamp;
+  cache_ttl_seconds: number;
+  approximation_notice: string;
+  market: BuyPlanMarketFilter;
+  averaging_triggers: AveragingTriggerRow[];
+  support_net: SupportNetTier;
+  active_buy_watches: ActiveBuyWatchRow[];
+  discovery_gates: DiscoveryGateRow[];
+  funding: BuyPlanFunding;
+  value_sources: ValueSource[];
+  warnings: string[];
+}

--- a/frontend/invest/src/types/buyPlan.ts
+++ b/frontend/invest/src/types/buyPlan.ts
@@ -17,10 +17,22 @@ export type PlacementForm = "resting_order" | "watch";
 export type GateConditionState = "met" | "not_met" | "unavailable";
 export type GateState = "open" | "closed" | "indeterminate";
 export type FundingVerdict = "sufficient" | "shortfall" | "unknown";
+export type SourceState = "ok" | "degraded" | "unavailable";
+/** Cash at one broker cannot fund an order placed at another (verify-r1 B1). */
+export type FundingBroker = "kis" | "upbit" | "toss" | "unattributed";
+export type RequirementKind = "averaging_add" | "support_net" | "active_watch";
 
 export interface PolicyStamp {
   version: string;
   content_hash: string;
+}
+
+export interface ApprovalContext {
+  master_gate_enabled: boolean | null;
+  master_gate_setting: string;
+  master_gate_source: string;
+  unevaluated_conditions: string[];
+  notice: string;
 }
 
 export interface ValueSource {
@@ -57,6 +69,7 @@ export interface AveragingTriggerRow {
   reserve_plan_notional: string;
   market_rank: number;
   within_policy_add_cap: boolean;
+  funding_broker: FundingBroker;
   notes: string[];
 }
 
@@ -83,9 +96,12 @@ export interface SupportNetRow {
   eligible: boolean;
   ineligible_reason: string | null;
   placements: SupportNetPlacement[];
-  placed_notional: string;
+  /** `null` when a placement source was degraded — unknown is not zero. */
+  placed_notional: string | null;
   per_symbol_cap_notional: string;
-  remaining_headroom_notional: string;
+  remaining_headroom_notional: string | null;
+  placements_state: SourceState;
+  placements_incomplete_reasons: string[];
 }
 
 export interface SupportNetTier {
@@ -94,8 +110,10 @@ export interface SupportNetTier {
   currency: BuyPlanCurrency;
   tier_cap_notional: string | null;
   per_symbol_cap_notional: string | null;
-  placed_notional: string;
+  placed_notional: string | null;
   remaining_notional: string | null;
+  placements_state: SourceState;
+  placements_incomplete_reasons: string[];
   distance_band_pct: string[];
   review_date: string | null;
   rows: SupportNetRow[];
@@ -118,6 +136,8 @@ export interface ActiveBuyWatchRow {
   near_expiry: boolean;
   planned_notional: string | null;
   planned_notional_source: string | null;
+  funding_broker: FundingBroker;
+  account_mode: string | null;
   approval_lane: ApprovalLane;
   approval_lane_reason: ApprovalLaneReason;
 }
@@ -151,27 +171,45 @@ export interface CashAccountRow {
   account_id: string;
   display_name: string;
   source: string;
+  broker: FundingBroker;
   currency: BuyPlanCurrency;
   available_cash: string | null;
   available_cash_source: string;
   included_in_reserve: boolean;
 }
 
-export interface CurrencyReconciliation {
+export interface ScopeReconciliation {
+  scope_key: string;
+  broker: FundingBroker;
   currency: BuyPlanCurrency;
+  account_ids: string[];
   available_cash: string | null;
   required_averaging_adds: string;
   required_support_net: string;
   required_active_watches: string;
   required_total: string;
+  unattributed_same_currency: string;
+  worst_case_required: string;
+  requirements_complete: boolean;
+  incomplete_reasons: string[];
   verdict: FundingVerdict;
   shortfall: string | null;
   notes: string[];
 }
 
+export interface UnattributedRequirement {
+  kind: RequirementKind;
+  label: string;
+  currency: BuyPlanCurrency;
+  amount: string | null;
+  reason: string;
+}
+
 export interface BuyPlanFunding {
   accounts: CashAccountRow[];
-  currencies: CurrencyReconciliation[];
+  scopes: ScopeReconciliation[];
+  unattributed: UnattributedRequirement[];
+  source_warnings: string[];
 }
 
 export interface BuyPlanResponse {
@@ -179,6 +217,7 @@ export interface BuyPlanResponse {
   policy: PolicyStamp;
   cache_ttl_seconds: number;
   approximation_notice: string;
+  approval_context: ApprovalContext;
   market: BuyPlanMarketFilter;
   averaging_triggers: AveragingTriggerRow[];
   support_net: SupportNetTier;

--- a/tests/routers/test_invest_buy_plan_router.py
+++ b/tests/routers/test_invest_buy_plan_router.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.schemas.invest_buy_plan import (
+    ApprovalCondition,
     ApprovalContext,
     BuyPlanFunding,
     BuyPlanResponse,
@@ -44,7 +45,16 @@ class _StubBuyPlanService:
                 master_gate_enabled=False,
                 master_gate_setting="ORDER_PROPOSALS_AUTO_APPROVE",
                 master_gate_source="settings.ORDER_PROPOSALS_AUTO_APPROVE",
-                unevaluated_conditions=["fresh preview 존재"],
+                unevaluated_conditions=[
+                    ApprovalCondition(
+                        code="preview_guard_failed", label="fresh preview 성공"
+                    )
+                ],
+                evaluated_conditions=[
+                    ApprovalCondition(
+                        code="per_order_cap_exceeded", label="건당 자동승인 상한"
+                    )
+                ],
                 notice="자동승인 마스터 게이트가 꺼져 있습니다.",
             ),
             market=market,  # type: ignore[arg-type]
@@ -71,7 +81,7 @@ class _StubBuyPlanService:
                         required_active_watches=Decimal("0"),
                         required_total=Decimal("120000"),
                         unattributed_same_currency=Decimal("0"),
-                        worst_case_required=Decimal("120000"),
+                        upper_bound_if_all_unattributed_lands_here=Decimal("120000"),
                         verdict="sufficient",
                         shortfall=Decimal("0"),
                     )

--- a/tests/routers/test_invest_buy_plan_router.py
+++ b/tests/routers/test_invest_buy_plan_router.py
@@ -16,10 +16,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.schemas.invest_buy_plan import (
+    ApprovalContext,
     BuyPlanFunding,
     BuyPlanResponse,
-    CurrencyReconciliation,
     PolicyStamp,
+    ScopeReconciliation,
     SupportNetTier,
 )
 
@@ -39,6 +40,13 @@ class _StubBuyPlanService:
             policy=PolicyStamp(version="2026-08-23.1", content_hash="abc123"),
             cache_ttl_seconds=180,
             approximation_notice="정책 산식의 표시용 근사입니다.",
+            approval_context=ApprovalContext(
+                master_gate_enabled=False,
+                master_gate_setting="ORDER_PROPOSALS_AUTO_APPROVE",
+                master_gate_source="settings.ORDER_PROPOSALS_AUTO_APPROVE",
+                unevaluated_conditions=["fresh preview 존재"],
+                notice="자동승인 마스터 게이트가 꺼져 있습니다.",
+            ),
             market=market,  # type: ignore[arg-type]
             averaging_triggers=[],
             support_net=SupportNetTier(
@@ -51,14 +59,19 @@ class _StubBuyPlanService:
             discovery_gates=[],
             funding=BuyPlanFunding(
                 accounts=[],
-                currencies=[
-                    CurrencyReconciliation(
+                scopes=[
+                    ScopeReconciliation(
+                        scope_key="upbit:KRW",
+                        broker="upbit",
                         currency="KRW",
+                        account_ids=["upbit-1"],
                         available_cash=Decimal("500000"),
                         required_averaging_adds=Decimal("120000"),
                         required_support_net=Decimal("0"),
                         required_active_watches=Decimal("0"),
                         required_total=Decimal("120000"),
+                        unattributed_same_currency=Decimal("0"),
+                        worst_case_required=Decimal("120000"),
                         verdict="sufficient",
                         shortfall=Decimal("0"),
                     )
@@ -143,7 +156,12 @@ def test_response_exposes_provenance_and_exact_decimal_strings() -> None:
     assert payload["policy"] == {"version": "2026-08-23.1", "content_hash": "abc123"}
     assert payload["cache_ttl_seconds"] == 180
     assert "근사" in payload["approximation_notice"]
-    krw = payload["funding"]["currencies"][0]
+    krw = payload["funding"]["scopes"][0]
     assert krw["available_cash"] == "500000"
     assert krw["required_total"] == "120000"
     assert krw["verdict"] == "sufficient"
+    # verify-r1 B1: the reconciliation names the account it applies to.
+    assert krw["broker"] == "upbit"
+    assert krw["account_ids"] == ["upbit-1"]
+    # verify-r1 B6: the approval gap ships with the response.
+    assert payload["approval_context"]["master_gate_enabled"] is False

--- a/tests/routers/test_invest_buy_plan_router.py
+++ b/tests/routers/test_invest_buy_plan_router.py
@@ -1,0 +1,149 @@
+"""§144차 — /invest 매수 계획 router contract.
+
+The route is read-only and the response is a funding aid, so what is pinned
+here is the surface: GET-only, authenticated, market filter validated, and the
+provenance fields the UI renders its disclaimer from.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.schemas.invest_buy_plan import (
+    BuyPlanFunding,
+    BuyPlanResponse,
+    CurrencyReconciliation,
+    PolicyStamp,
+    SupportNetTier,
+)
+
+NOW = dt.datetime(2026, 8, 23, 3, 0, tzinfo=dt.UTC)
+
+
+class _StubBuyPlanService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, str]] = []
+
+    async def build(
+        self, *, user_id: int, market: str = "all", now: dt.datetime | None = None
+    ) -> BuyPlanResponse:
+        self.calls.append((user_id, market))
+        return BuyPlanResponse(
+            as_of=NOW,
+            policy=PolicyStamp(version="2026-08-23.1", content_hash="abc123"),
+            cache_ttl_seconds=180,
+            approximation_notice="정책 산식의 표시용 근사입니다.",
+            market=market,  # type: ignore[arg-type]
+            averaging_triggers=[],
+            support_net=SupportNetTier(
+                policy_key="buy.held_majors_support_net",
+                enabled=True,
+                currency="KRW",
+                placed_notional=Decimal("0"),
+            ),
+            active_buy_watches=[],
+            discovery_gates=[],
+            funding=BuyPlanFunding(
+                accounts=[],
+                currencies=[
+                    CurrencyReconciliation(
+                        currency="KRW",
+                        available_cash=Decimal("500000"),
+                        required_averaging_adds=Decimal("120000"),
+                        required_support_net=Decimal("0"),
+                        required_active_watches=Decimal("0"),
+                        required_total=Decimal("120000"),
+                        verdict="sufficient",
+                        shortfall=Decimal("0"),
+                    )
+                ],
+            ),
+        )
+
+
+def _make_client(service: _StubBuyPlanService) -> TestClient:
+    from app.routers import invest_buy_plan
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(invest_buy_plan.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=7)
+    app.dependency_overrides[invest_buy_plan.get_buy_plan_service] = lambda: service
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_buy_plan_defaults_to_all_markets() -> None:
+    service = _StubBuyPlanService()
+    response = _make_client(service).get("/trading/api/invest/buy-plan")
+
+    assert response.status_code == 200
+    assert response.json()["market"] == "all"
+    assert service.calls == [(7, "all")]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("market", ["kr", "us", "crypto"])
+def test_buy_plan_accepts_each_market_filter(market: str) -> None:
+    service = _StubBuyPlanService()
+    response = _make_client(service).get(
+        f"/trading/api/invest/buy-plan?market={market}"
+    )
+
+    assert response.status_code == 200
+    assert service.calls == [(7, market)]
+
+
+@pytest.mark.unit
+def test_buy_plan_rejects_an_unknown_market() -> None:
+    response = _make_client(_StubBuyPlanService()).get(
+        "/trading/api/invest/buy-plan?market=forex"
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_buy_plan_is_read_only() -> None:
+    """No mutating verb is exposed on this prefix."""
+
+    client = _make_client(_StubBuyPlanService())
+    for method in ("post", "put", "patch", "delete"):
+        response = getattr(client, method)("/trading/api/invest/buy-plan")
+        assert response.status_code == 405
+
+
+@pytest.mark.unit
+def test_buy_plan_requires_authentication() -> None:
+    from app.routers import invest_buy_plan
+
+    app = FastAPI()
+    app.include_router(invest_buy_plan.router)
+    app.dependency_overrides[invest_buy_plan.get_buy_plan_service] = lambda: (
+        _StubBuyPlanService()
+    )
+    # get_authenticated_user is deliberately NOT overridden.
+    response = TestClient(app).get("/trading/api/invest/buy-plan")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.unit
+def test_response_exposes_provenance_and_exact_decimal_strings() -> None:
+    """Money is serialised as an exact string, never a lossy JSON float."""
+
+    payload = (
+        _make_client(_StubBuyPlanService()).get("/trading/api/invest/buy-plan").json()
+    )
+
+    assert payload["policy"] == {"version": "2026-08-23.1", "content_hash": "abc123"}
+    assert payload["cache_ttl_seconds"] == 180
+    assert "근사" in payload["approximation_notice"]
+    krw = payload["funding"]["currencies"][0]
+    assert krw["available_cash"] == "500000"
+    assert krw["required_total"] == "120000"
+    assert krw["verdict"] == "sufficient"

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -180,6 +180,16 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # to READ_ONLY_ADVISORY_TOOLS: a bare tool-name string in a Python
         # set literal, not a Binance HTTP/WS/signed reference.
         "app/mcp_server/tooling/route_request_lanes.py",
+        # §144차 — the /invest 매수 계획 board's discovery-gate metric reader.
+        # It resolves the two metrics named by
+        # ``market_rules.crypto.recovery_gate`` and reaches the long/short
+        # figures ONLY through the already-allow-listed
+        # ``fundamentals/_crypto.handle_get_long_short_ratio`` handler. No HTTP
+        # client, URL, websocket, signing, credential, or mutation code lives
+        # here; "Binance" appears in a docstring and one source-label string
+        # naming which upstream the reading came from. String reference only —
+        # same class as the other entries here.
+        "app/services/invest_view_model/buy_plan/gate_inputs.py",
     }
 )
 

--- a/tests/services/invest_view_model/buy_plan/test_computation.py
+++ b/tests/services/invest_view_model/buy_plan/test_computation.py
@@ -1,0 +1,229 @@
+"""§144차 — the 매수 계획 board's arithmetic, pinned.
+
+These are the numbers an operator moves money against, so the turn point, the
+sampled cash curve, and the approval-lane classification are all fixed here
+rather than left to whatever the aggregate happens to emit.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.invest_view_model.buy_plan.computation import (
+    approval_lane_for,
+    averaging_additional_notional,
+    averaging_turn_point,
+    turn_point_price,
+)
+
+
+@pytest.mark.unit
+def test_turn_point_is_average_over_one_plus_k() -> None:
+    # k=0.10 → an add only becomes valid once the price is ~9.09% under the
+    # average. This is the §136차 note made executable: raising k pushes the
+    # turn point *down*, which is why k was not raised.
+    assert turn_point_price(
+        average_price=Decimal("1100"), k=Decimal("0.10")
+    ) == Decimal("1000")
+
+
+@pytest.mark.unit
+def test_a_of_k_is_zero_exactly_at_the_turn_point() -> None:
+    """``a_limit_lte_zero: NO_ORDER`` — the boundary itself buys nothing."""
+
+    average = Decimal("1100")
+    star = turn_point_price(average_price=average, k=Decimal("0.10"))
+    assert (
+        averaging_additional_notional(
+            cost_basis=Decimal("1100000"),
+            average_price=average,
+            price=star,
+            k=Decimal("0.10"),
+        )
+        == 0
+    )
+
+
+@pytest.mark.unit
+def test_a_of_k_is_clamped_at_zero_above_the_turn_point() -> None:
+    """A raw negative must not surface as a negative "credit"."""
+
+    assert (
+        averaging_additional_notional(
+            cost_basis=Decimal("1000000"),
+            average_price=Decimal("1000"),
+            price=Decimal("1200"),
+            k=Decimal("0.10"),
+        )
+        == 0
+    )
+
+
+@pytest.mark.unit
+def test_a_of_k_actually_pulls_the_average_into_the_k_band() -> None:
+    """The formula's defining property, checked by re-deriving the new average."""
+
+    cost_basis = Decimal("1000000")
+    average = Decimal("1000")
+    quantity = cost_basis / average
+    k = Decimal("0.10")
+    price = Decimal("800")
+
+    added = averaging_additional_notional(
+        cost_basis=cost_basis, average_price=average, price=price, k=k
+    )
+    assert added > 0
+
+    new_average = (cost_basis + added) / (quantity + added / price)
+    assert new_average == pytest.approx(float(price * (1 + k)), rel=Decimal("1e-12"))
+
+
+@pytest.mark.unit
+def test_turn_point_projection_samples_below_the_boundary() -> None:
+    projection = averaging_turn_point(
+        cost_basis=Decimal("1000000"),
+        average_price=Decimal("1100"),
+        current_price=Decimal("1050"),
+        k=Decimal("0.10"),
+    )
+
+    assert projection.turn_point_price == Decimal("1000")
+    # 1050 is still 5% above the turn point → NO_ORDER today.
+    assert projection.distance_to_turn_point_pct == Decimal("5")
+    assert projection.reached is False
+
+    offsets = [s.offset_from_turn_point_pct for s in projection.samples]
+    assert offsets == [Decimal("-1"), Decimal("-3")]
+    # Deeper price ⇒ strictly more cash required.
+    assert projection.samples[1].additional_notional > (
+        projection.samples[0].additional_notional
+    )
+    assert all(sample.additional_notional > 0 for sample in projection.samples)
+
+
+@pytest.mark.unit
+def test_turn_point_reached_requires_strictly_below() -> None:
+    at_boundary = averaging_turn_point(
+        cost_basis=Decimal("1000000"),
+        average_price=Decimal("1100"),
+        current_price=Decimal("1000"),
+        k=Decimal("0.10"),
+    )
+    assert at_boundary.reached is False
+
+    below = averaging_turn_point(
+        cost_basis=Decimal("1000000"),
+        average_price=Decimal("1100"),
+        current_price=Decimal("999"),
+        k=Decimal("0.10"),
+    )
+    assert below.reached is True
+    assert below.distance_to_turn_point_pct < 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"cost_basis": Decimal("0")},
+        {"average_price": Decimal("0")},
+        {"current_price": Decimal("-1")},
+        {"k": Decimal("0")},
+    ],
+)
+def test_turn_point_rejects_non_positive_inputs(bad: dict) -> None:
+    kwargs = {
+        "cost_basis": Decimal("1000"),
+        "average_price": Decimal("100"),
+        "current_price": Decimal("90"),
+        "k": Decimal("0.10"),
+    }
+    kwargs.update(bad)
+    with pytest.raises(ValueError):
+        averaging_turn_point(**kwargs)
+
+
+@pytest.mark.unit
+def test_approval_lane_auto_submits_within_the_tier_ceiling() -> None:
+    lane, reason = approval_lane_for(
+        notional=Decimal("150000"),
+        tier_auto_submit_notional=Decimal("200000"),
+        per_order_auto_approve_cap=Decimal("1000000"),
+    )
+    assert (lane, reason) == ("auto_submit", "within_tier_auto_submit_notional")
+
+
+@pytest.mark.unit
+def test_approval_lane_cards_above_the_tier_ceiling() -> None:
+    lane, reason = approval_lane_for(
+        notional=Decimal("250000"),
+        tier_auto_submit_notional=Decimal("200000"),
+        per_order_auto_approve_cap=Decimal("1000000"),
+    )
+    assert (lane, reason) == ("human_card", "above_tier_auto_submit_notional")
+
+
+@pytest.mark.unit
+def test_approval_lane_reports_the_per_order_cap_first() -> None:
+    """The cap is the harder boundary, so it owns the reason string."""
+
+    lane, reason = approval_lane_for(
+        notional=Decimal("1500000"),
+        tier_auto_submit_notional=Decimal("200000"),
+        per_order_auto_approve_cap=Decimal("1000000"),
+    )
+    assert (lane, reason) == ("human_card", "above_per_order_auto_approve_cap")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "notional,ceiling,cap",
+    [
+        (None, Decimal("200000"), Decimal("1000000")),
+        (Decimal("0"), Decimal("200000"), Decimal("1000000")),
+        (Decimal("100"), None, Decimal("1000000")),
+        (Decimal("100"), Decimal("200000"), None),
+    ],
+)
+def test_approval_lane_fails_closed_when_a_bound_is_unknown(
+    notional: Decimal | None, ceiling: Decimal | None, cap: Decimal | None
+) -> None:
+    """Never show 자동승인 for something the board could not actually check."""
+
+    lane, _ = approval_lane_for(
+        notional=notional,
+        tier_auto_submit_notional=ceiling,
+        per_order_auto_approve_cap=cap,
+    )
+    assert lane == "human_card"
+
+
+@pytest.mark.unit
+def test_matches_the_policy_table_implementation() -> None:
+    """Anti-drift: app/ and scripts/ must agree on A(k) to the last digit."""
+
+    from scripts.policy_table.core.averaging import averaging_math
+
+    cases = [
+        (Decimal("1000000"), Decimal("1000"), Decimal("800")),
+        (Decimal("3210000"), Decimal("1234.5"), Decimal("1000.25")),
+        (Decimal("500000"), Decimal("100"), Decimal("120")),
+    ]
+    for cost_basis, average_price, price in cases:
+        reference = averaging_math(
+            cost_basis=cost_basis,
+            average_price=average_price,
+            current_price=price,
+            k=Decimal("0.10"),
+        )
+        assert (
+            averaging_additional_notional(
+                cost_basis=cost_basis,
+                average_price=average_price,
+                price=price,
+                k=Decimal("0.10"),
+            )
+            == reference["additional_notional"]
+        )

--- a/tests/services/invest_view_model/buy_plan/test_service.py
+++ b/tests/services/invest_view_model/buy_plan/test_service.py
@@ -22,6 +22,8 @@ from app.schemas.invest_home import (
     GroupedSourceBreakdown,
     HomeSummary,
     InvestHomeResponse,
+    InvestHomeResponseMeta,
+    InvestHomeWarning,
 )
 from app.schemas.invest_watches import WatchAlertRow, WatchesResponse
 from app.schemas.open_orders import OpenOrderRow, OpenOrdersResponse
@@ -98,6 +100,7 @@ def _home(
     *,
     groups: list[GroupedHolding],
     accounts: list[Account] | None = None,
+    meta_warnings: list[InvestHomeWarning] | None = None,
 ) -> InvestHomeResponse:
     return InvestHomeResponse(
         homeSummary=HomeSummary(
@@ -108,6 +111,17 @@ def _home(
         accounts=accounts if accounts is not None else [],
         holdings=[],
         groupedHoldings=groups,
+        meta=InvestHomeResponseMeta(warnings=meta_warnings or []),
+    )
+
+
+def _scope(plan, broker: str, currency: str = "KRW"):
+    """The one reconciliation row for a (broker, currency) pair."""
+
+    return next(
+        row
+        for row in plan.funding.scopes
+        if row.broker == broker and row.currency == currency
     )
 
 
@@ -143,32 +157,54 @@ class _StubHome:
 
 
 class _StubWatches:
-    def __init__(self, items: list[WatchAlertRow] | None = None) -> None:
+    def __init__(
+        self,
+        items: list[WatchAlertRow] | None = None,
+        *,
+        data_state: str = "ok",
+        warnings: list[str] | None = None,
+        raises: Exception | None = None,
+    ) -> None:
         self._items = items or []
+        self._data_state = data_state
+        self._warnings = warnings or []
+        self._raises = raises
 
     async def list_watches(self, *, market: str, status: str) -> WatchesResponse:
+        if self._raises is not None:
+            raise self._raises
         return WatchesResponse(
             market=market,  # type: ignore[arg-type]
             status=status,  # type: ignore[arg-type]
             count=len(self._items),
-            data_state="ok",
+            data_state=self._data_state,  # type: ignore[arg-type]
             as_of=NOW,
             items=self._items,
+            warnings=self._warnings,
         )
 
 
 class _StubOpenOrders:
-    def __init__(self, items: list[OpenOrderRow] | None = None) -> None:
+    def __init__(
+        self,
+        items: list[OpenOrderRow] | None = None,
+        *,
+        data_state: str = "ok",
+        warnings: list[str] | None = None,
+    ) -> None:
         self._items = items or []
+        self._data_state = data_state
+        self._warnings = warnings or []
 
     async def list_open_orders(self, *, market: str) -> OpenOrdersResponse:
         return OpenOrdersResponse(
             market=market,  # type: ignore[arg-type]
             count=len(self._items),
-            data_state="ok",
+            data_state=self._data_state,  # type: ignore[arg-type]
             as_of=NOW,
             items=self._items,
             sources=[],
+            warnings=self._warnings,
         )
 
 
@@ -303,7 +339,7 @@ async def test_market_add_cap_bounds_the_funding_total() -> None:
     assert len(plan.averaging_triggers) == 3
     within = [row for row in plan.averaging_triggers if row.within_policy_add_cap]
     assert len(within) == 2
-    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    krw = _scope(plan, "upbit")
     assert krw.required_averaging_adds == sum(
         (row.reserve_plan_notional for row in within), Decimal(0)
     )
@@ -312,6 +348,15 @@ async def test_market_add_cap_bounds_the_funding_total() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_only_live_accounts_fund_the_reserve() -> None:
+    """Only live broker cash can actually be moved and spent by an order.
+
+    verify-r1 §3 found this test green against a mutant that added ``paper``
+    to ``_RESERVE_ACCOUNT_KINDS`` — the fixture held a manual account and no
+    paper one, so the assertion guarded nothing. Both non-live kinds are in
+    the fixture now, and each carries an absurd balance so an accidental
+    inclusion is impossible to miss.
+    """
+
     home = _home(
         groups=[],
         accounts=[
@@ -319,17 +364,32 @@ async def test_only_live_accounts_fund_the_reserve() -> None:
             _account(
                 account_id="pension", source="pension_manual", kind="manual", krw=9e9
             ),
+            _account(
+                account_id="alpaca-paper",
+                source="alpaca_paper",
+                kind="paper",
+                krw=9e9,
+            ),
+            _account(account_id="kis-mock", source="kis_mock", kind="paper", krw=9e9),
         ],
     )
     plan = await _service(home=_StubHome(home)).build(user_id=1, market="all", now=NOW)
 
-    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    krw = _scope(plan, "upbit")
     assert krw.available_cash == Decimal("500000")
     assert krw.verdict == "sufficient"
     included = {
         row.account_id for row in plan.funding.accounts if row.included_in_reserve
     }
     assert included == {"upbit-1"}
+    # No scope anywhere may hold the paper balance, whatever broker it maps to.
+    assert all(
+        scope.available_cash is None or scope.available_cash <= Decimal("500000")
+        for scope in plan.funding.scopes
+    )
+    assert "alpaca-paper" not in {
+        account_id for scope in plan.funding.scopes for account_id in scope.account_ids
+    }
 
 
 @pytest.mark.unit
@@ -368,7 +428,7 @@ async def test_shortfall_reports_the_deposit_amount() -> None:
         user_id=1, market="crypto", now=NOW
     )
 
-    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    krw = _scope(plan, "upbit")
     assert krw.verdict == "shortfall"
     assert krw.shortfall == krw.required_total - Decimal("1000")
     assert krw.shortfall > 0
@@ -388,10 +448,37 @@ async def test_partially_unknown_cash_holds_the_verdict_instead_of_understating(
     )
     plan = await _service(home=_StubHome(home)).build(user_id=1, market="all", now=NOW)
 
-    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
-    assert krw.verdict == "unknown"
-    assert krw.available_cash is None
+    # Broker scoping means an unreadable KIS account no longer taints the
+    # Upbit verdict — Upbit's own cash and requirements are both known.
+    assert _scope(plan, "upbit").verdict == "sufficient"
+    kis = _scope(plan, "kis")
+    assert kis.verdict == "unknown"
+    assert kis.available_cash is None
     assert any("가용 현금" in warning for warning in plan.warnings)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_one_unreadable_account_holds_its_own_scope() -> None:
+    """Two accounts at the same broker, one silent → that scope goes unknown.
+
+    Totalling only the account that answered would understate the broker's
+    cash and send the operator to deposit money they already hold.
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[
+            _account(account_id="kis-a", source="kis", krw=500000),
+            _account(account_id="kis-b", source="kis"),
+        ],
+    )
+    plan = await _service(home=_StubHome(home)).build(user_id=1, market="all", now=NOW)
+
+    kis = _scope(plan, "kis")
+    assert kis.verdict == "unknown"
+    assert kis.available_cash is None
+    assert sorted(kis.account_ids) == ["kis-a", "kis-b"]
 
 
 def _watch(
@@ -402,6 +489,11 @@ def _watch(
     max_action: dict | None = None,
     intent: str = "buy_review",
 ) -> WatchAlertRow:
+    """A watch whose ``max_action`` names its execution account by default.
+
+    ``account_mode`` is what attributes the cash to a broker; tests that need
+    the unattributed path pass a ``max_action`` without it.
+    """
     return WatchAlertRow(
         alert_uuid=uuid4(),
         source_report_uuid=None,
@@ -416,7 +508,7 @@ def _watch(
         intent=intent,
         action_mode="review",
         rationale="test",
-        max_action=max_action or {},
+        max_action=max_action if max_action is not None else {},
     )
 
 
@@ -425,8 +517,18 @@ def _watch(
 async def test_sell_watches_never_enter_the_buy_plan() -> None:
     watches = _StubWatches(
         [
-            _watch(symbol="KRW-XRP", max_action={"side": "buy", "notional": 100000}),
-            _watch(symbol="KRW-SOL", max_action={"side": "sell", "notional": 100000}),
+            _watch(
+                symbol="KRW-XRP",
+                max_action={"side": "buy", "account_mode": "upbit", "notional": 100000},
+            ),
+            _watch(
+                symbol="KRW-SOL",
+                max_action={
+                    "side": "sell",
+                    "account_mode": "upbit",
+                    "notional": 100000,
+                },
+            ),
         ]
     )
     plan = await _service(home=_StubHome(_home(groups=[])), watches=watches).build(
@@ -446,7 +548,11 @@ async def test_max_action_side_overrides_a_buy_review_intent() -> None:
             _watch(
                 symbol="KRW-XRP",
                 intent="buy_review",
-                max_action={"side": "sell", "notional": 100000},
+                max_action={
+                    "side": "sell",
+                    "account_mode": "upbit",
+                    "notional": 100000,
+                },
             )
         ]
     )
@@ -460,7 +566,9 @@ async def test_max_action_side_overrides_a_buy_review_intent() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_watch_without_a_notional_is_carded_not_auto_submitted() -> None:
-    watches = _StubWatches([_watch(symbol="KRW-XRP", max_action={"side": "buy"})])
+    watches = _StubWatches(
+        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "account_mode": "upbit"})]
+    )
     plan = await _service(home=_StubHome(_home(groups=[])), watches=watches).build(
         user_id=1, market="all", now=NOW
     )
@@ -552,7 +660,7 @@ async def test_resting_buy_order_consumes_headroom_but_not_new_cash() -> None:
     assert [p.form for p in row.placements] == ["resting_order"]
     assert row.placed_notional == Decimal("110000")
     assert row.remaining_headroom_notional == Decimal("190000")
-    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    krw = _scope(plan, "upbit")
     assert krw.required_support_net == 0
 
 
@@ -578,13 +686,22 @@ async def test_a_watch_rung_is_not_counted_twice() -> None:
         accounts=[_account(account_id="upbit-1", source="upbit", krw=1000000)],
     )
     watches = _StubWatches(
-        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "amount_krw": 120000})]
+        [
+            _watch(
+                symbol="KRW-XRP",
+                max_action={
+                    "side": "buy",
+                    "account_mode": "upbit",
+                    "amount_krw": 120000,
+                },
+            )
+        ]
     )
     plan = await _service(home=_StubHome(home), watches=watches).build(
         user_id=1, market="crypto", now=NOW
     )
 
-    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    krw = _scope(plan, "upbit")
     assert krw.required_support_net == Decimal("120000")
     assert krw.required_active_watches == 0
     assert krw.required_total == krw.required_averaging_adds + Decimal("120000")
@@ -667,8 +784,7 @@ async def test_a_dead_holdings_reader_degrades_instead_of_raising() -> None:
 
     assert plan.averaging_triggers == []
     assert any("보유·현금 조회 실패" in warning for warning in plan.warnings)
-    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
-    assert krw.verdict == "unknown"
+    assert all(scope.verdict == "unknown" for scope in plan.funding.scopes)
 
 
 @pytest.mark.unit
@@ -720,3 +836,305 @@ async def test_market_filter_scopes_every_block() -> None:
     assert plan.support_net.enabled is False
     # The crypto gate is not evaluated for a KR-scoped board.
     assert plan.discovery_gates == []
+
+
+# ---------------------------------------------------------------------------
+# verify-r1 BLOCKER regressions.
+#
+# Each test replays the exact disproof input from the T2 verification report
+# (s144-investboard-verify-20260823-1650) and pins the corrected output. They
+# are grouped here so the shared theme stays visible: an upstream that says it
+# is incomplete, or a requirement whose account is unknown, must never render
+# as a confident number.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b1_kis_cash_cannot_fund_an_upbit_order() -> None:
+    """verify-r1 B1 — Upbit XRP, Upbit KRW=0, KIS KRW=1,000,000.
+
+    The old currency-only total reported ``sufficient`` off KIS cash that no
+    Upbit order can spend, so the operator never saw the Upbit deposit.
+    """
+
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1100,
+                current_price=900,
+            )
+        ],
+        accounts=[
+            _account(account_id="upbit-1", source="upbit", krw=0),
+            _account(account_id="kis-1", source="kis", krw=1000000),
+        ],
+    )
+    plan = await _service(home=_StubHome(home)).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    upbit = _scope(plan, "upbit")
+    assert upbit.available_cash == Decimal("0")
+    assert upbit.required_averaging_adds > 0
+    assert upbit.verdict == "shortfall"
+    assert upbit.shortfall == upbit.required_total
+
+    # KIS cash is still shown, but in its own scope and with no crypto need.
+    kis = _scope(plan, "kis")
+    assert kis.available_cash == Decimal("1000000")
+    assert kis.required_total == 0
+    # Nothing anywhere aggregates the two.
+    assert not any(
+        scope.available_cash == Decimal("1000000")
+        for scope in plan.funding.scopes
+        if scope.broker == "upbit"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b1_requirement_without_an_account_holds_the_scope() -> None:
+    """An unattributed requirement is published and suspends the verdict.
+
+    It is not silently dropped from the total (which would understate the
+    deposit) and not charged to an arbitrary broker (which would misdirect it).
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=100000)],
+    )
+    watches = _StubWatches(
+        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "notional": 500000})]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    assert [row.funding_broker for row in plan.active_buy_watches] == ["unattributed"]
+    assert [row.amount for row in plan.funding.unattributed] == [Decimal("500000")]
+    upbit = _scope(plan, "upbit")
+    assert upbit.required_total == 0
+    assert upbit.unattributed_same_currency == Decimal("500000")
+    # 100,000 cannot cover the 500,000 that might land here → not "sufficient".
+    assert upbit.verdict == "unknown"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b1_scope_stays_sufficient_when_cash_covers_the_worst_case() -> None:
+    """Unattributed money only suspends a verdict it could actually break."""
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=900000)],
+    )
+    watches = _StubWatches(
+        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "notional": 500000})]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    upbit = _scope(plan, "upbit")
+    assert upbit.worst_case_required == Decimal("500000")
+    assert upbit.verdict == "sufficient"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b2_missing_home_source_surfaces_instead_of_shrinking_cash() -> None:
+    """verify-r1 B2 — KIS reader dies, ``get_home`` still returns 200.
+
+    Old behaviour: ``accounts`` simply lacked KIS, the board totalled what was
+    left, printed a 100,000 deposit and **no warning at all**.
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=500000)],
+        meta_warnings=[InvestHomeWarning(source="kis", message="KIS reader failed")],
+    )
+    watches = _StubWatches(
+        [
+            _watch(
+                symbol="KRW-XRP",
+                max_action={
+                    "side": "buy",
+                    "account_mode": "upbit",
+                    "amount_krw": 600000,
+                },
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    # The failure is now on the board rather than invisible.
+    assert any("KIS reader failed" in warning for warning in plan.warnings)
+    assert any("KIS reader failed" in reason for reason in plan.funding.source_warnings)
+
+    upbit = _scope(plan, "upbit")
+    # Upbit's own numbers are still known, so the proven deficit still shows...
+    assert upbit.shortfall == Decimal("100000")
+    # ...but the response no longer claims the requirement side is complete.
+    assert upbit.requirements_complete is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b3_watch_fetch_failure_does_not_fold_to_sufficient() -> None:
+    """verify-r1 B3 — watch store down → required 0 → ``리저브 충분``.
+
+    An unknown requirement is not a zero requirement.
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=0)],
+    )
+    watches = _StubWatches(raises=RuntimeError("watch store unavailable"))
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    upbit = _scope(plan, "upbit")
+    assert upbit.verdict == "unknown"
+    assert upbit.requirements_complete is False
+    assert any("워치 조회 실패" in reason for reason in upbit.incomplete_reasons)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b3_watch_data_state_and_item_skip_warnings_are_read() -> None:
+    """The panel usually degrades rather than raising — that path counts too."""
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=5000000)],
+    )
+    watches = _StubWatches(
+        [],
+        data_state="degraded",
+        warnings=["1 alert skipped: malformed max_action"],
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    upbit = _scope(plan, "upbit")
+    # Plenty of cash, zero visible requirement — and still not "sufficient",
+    # because the skipped alert's cash is unaccounted for.
+    assert upbit.verdict == "unknown"
+    assert any("alert skipped" in reason for reason in upbit.incomplete_reasons)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b4_unavailable_open_orders_do_not_publish_a_confident_headroom() -> None:
+    """verify-r1 B4 — upstream ``data_state='unavailable'``.
+
+    Old behaviour: 걸린 0원 / 여력 300,000원 as confident numbers, no warning.
+    """
+
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1000,
+                current_price=1200,
+            )
+        ],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=1000000)],
+    )
+    orders = _StubOpenOrders([], data_state="unavailable")
+    plan = await _service(home=_StubHome(home), open_orders=orders).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    row = next(r for r in plan.support_net.rows if r.symbol == "XRP")
+    assert row.placed_notional is None
+    assert row.remaining_headroom_notional is None
+    assert row.placements_state == "unavailable"
+    assert plan.support_net.placed_notional is None
+    assert plan.support_net.remaining_notional is None
+    assert any("미체결 주문 조회 상태" in warning for warning in plan.warnings)
+    assert _scope(plan, "upbit").requirements_complete is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b4_degraded_open_orders_also_suspend_the_headroom() -> None:
+    """A partial collector failure is still a partial order list."""
+
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1000,
+                current_price=1200,
+            )
+        ],
+    )
+    orders = _StubOpenOrders(
+        [], data_state="degraded", warnings=["upbit collector timed out"]
+    )
+    plan = await _service(home=_StubHome(home), open_orders=orders).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    row = next(r for r in plan.support_net.rows if r.symbol == "XRP")
+    assert row.remaining_headroom_notional is None
+    assert row.placements_state == "degraded"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b6_approval_context_publishes_the_master_gate() -> None:
+    """verify-r1 B6 — a cap check is not an approval decision.
+
+    ``ORDER_PROPOSALS_AUTO_APPROVE`` ships False, so the honest default is
+    "every proposal becomes a manual card" no matter what the caps say.
+    """
+
+    plan = await _service(home=_StubHome(_home(groups=[]))).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    context = plan.approval_context
+    assert context.master_gate_setting == "ORDER_PROPOSALS_AUTO_APPROVE"
+    assert context.master_gate_enabled is False
+    assert "꺼져" in context.notice
+    # The conditions the board does not evaluate are named, not implied.
+    assert "fresh preview 존재" in context.unevaluated_conditions
+    assert len(context.unevaluated_conditions) >= 5
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b6_master_gate_on_still_says_the_lane_is_cap_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even armed, the board checked two caps and nothing else."""
+
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True, raising=False)
+    plan = await _service(home=_StubHome(_home(groups=[]))).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    assert plan.approval_context.master_gate_enabled is True
+    assert "cap 두 개만" in plan.approval_context.notice

--- a/tests/services/invest_view_model/buy_plan/test_service.py
+++ b/tests/services/invest_view_model/buy_plan/test_service.py
@@ -601,6 +601,10 @@ async def test_gate_opens_when_both_conditions_pass() -> None:
     assert gate.state == "open"
     assert gate.met_count == 2
     assert gate.unavailable_count == 0
+    # Provenance is the policy's declared upstream list, not a constant the
+    # reader could drift away from.
+    breadth = next(c for c in gate.conditions if c.metric == "upbit_alt_breadth_24h")
+    assert breadth.source == "upbit_open_api_ticker_derived"
 
 
 @pytest.mark.unit

--- a/tests/services/invest_view_model/buy_plan/test_service.py
+++ b/tests/services/invest_view_model/buy_plan/test_service.py
@@ -9,6 +9,7 @@ unreadable gate metric is reported.
 from __future__ import annotations
 
 import datetime as dt
+import textwrap
 from decimal import Decimal
 from typing import Any
 from uuid import uuid4
@@ -921,14 +922,25 @@ async def test_b1_requirement_without_an_account_holds_the_scope() -> None:
     upbit = _scope(plan, "upbit")
     assert upbit.required_total == 0
     assert upbit.unattributed_same_currency == Decimal("500000")
-    # 100,000 cannot cover the 500,000 that might land here → not "sufficient".
     assert upbit.verdict == "unknown"
+    # The money also gets a destination row of its own so it is not merely a
+    # footnote on somebody else's card.
+    destination = _scope(plan, "unattributed")
+    assert destination.required_active_watches == Decimal("500000")
+    assert destination.verdict == "unknown"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_b1_scope_stays_sufficient_when_cash_covers_the_worst_case() -> None:
-    """Unattributed money only suspends a verdict it could actually break."""
+async def test_b1_covering_the_unattributed_pool_is_not_sufficiency() -> None:
+    """verify-r2 B1 — this test used to pin the opposite, and was wrong.
+
+    The old rule read "if this account can cover the whole unattributed pool,
+    it is sufficient". That treats *this* scope absorbing the money as the
+    worst case, but the money may be destined for a different broker whose
+    account is empty. Covering it here proves nothing about the account that
+    will actually place the order, so the honest verdict is unknown.
+    """
 
     home = _home(
         groups=[],
@@ -942,8 +954,10 @@ async def test_b1_scope_stays_sufficient_when_cash_covers_the_worst_case() -> No
     )
 
     upbit = _scope(plan, "upbit")
-    assert upbit.worst_case_required == Decimal("500000")
-    assert upbit.verdict == "sufficient"
+    assert upbit.unattributed_same_currency == Decimal("500000")
+    assert upbit.upper_bound_if_all_unattributed_lands_here == Decimal("500000")
+    assert upbit.verdict == "unknown"
+    assert upbit.shortfall is None
 
 
 @pytest.mark.unit
@@ -1118,8 +1132,12 @@ async def test_b6_approval_context_publishes_the_master_gate() -> None:
     assert context.master_gate_enabled is False
     assert "꺼져" in context.notice
     # The conditions the board does not evaluate are named, not implied.
-    assert "fresh preview 존재" in context.unevaluated_conditions
-    assert len(context.unevaluated_conditions) >= 5
+    codes = {condition.code for condition in context.unevaluated_conditions}
+    assert "preview_guard_failed" in codes
+    assert "daily_cap_exceeded" in codes
+    assert len(context.unevaluated_conditions) >= 15
+    # The one gate it does evaluate is on the other side of the split.
+    assert [c.code for c in context.evaluated_conditions] == ["per_order_cap_exceeded"]
 
 
 @pytest.mark.unit
@@ -1138,3 +1156,269 @@ async def test_b6_master_gate_on_still_says_the_lane_is_cap_only(
 
     assert plan.approval_context.master_gate_enabled is True
     assert "cap 두 개만" in plan.approval_context.notice
+
+
+# ---------------------------------------------------------------------------
+# verify-r2 regressions.
+#
+# Round 1's broker scoping closed the attributed path but opened an
+# unattributed one: a "this account covers the whole pool" rule handed a green
+# verdict to whichever broker happened to be funded. Each case below replays a
+# round-2 disproof input verbatim.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_r2a_funded_broker_never_greenlights_an_unattributed_need() -> None:
+    """verify-r2 (a) — Upbit KRW=0, KIS KRW=1,000,000, watch 330,000, no account_mode.
+
+    The old rule printed ``kis: sufficient``. The operator reads a green card,
+    skips the Upbit deposit, and the watch fires against an empty account —
+    the round-1 B1 mistake reached through the attribution-failure path.
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[
+            _account(account_id="upbit-1", source="upbit", krw=0),
+            _account(account_id="kis-1", source="kis", krw=1000000),
+        ],
+    )
+    watches = _StubWatches(
+        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "notional": 330000})]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    assert _scope(plan, "kis").verdict == "unknown"
+    assert _scope(plan, "upbit").verdict == "unknown"
+    # Nothing anywhere on the board reads green while this is unresolved.
+    assert all(scope.verdict != "sufficient" for scope in plan.funding.scopes)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_r2b_absent_broker_still_gets_a_destination_row() -> None:
+    """verify-r2 (b) — Upbit-only book, KRW 1,000,000, unattributed 600,000.
+
+    The old board showed only ``upbit`` and called it sufficient, so a need
+    bound for KIS or Toss had no account on screen to fund.
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=1000000)],
+    )
+    watches = _StubWatches(
+        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "notional": 600000})]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    assert _scope(plan, "upbit").verdict == "unknown"
+    destination = _scope(plan, "unattributed")
+    assert destination.required_active_watches == Decimal("600000")
+    assert destination.available_cash is None
+    assert destination.verdict == "unknown"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_r2d_unattributed_usd_is_held_even_with_no_usd_account() -> None:
+    """verify-r2 (d) — unattributed USD 200 on a KRW-only book.
+
+    ``scope_keys`` used to come only from attributed requirements and cash
+    accounts, so no USD row existed and the USD need reached no verdict at
+    all. The KRW scope stayed green because its own currency had nothing
+    unattributed — which was true, and beside the point.
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=1000000)],
+    )
+    watches = _StubWatches(
+        [
+            _watch(
+                symbol="AAPL",
+                market="us",
+                threshold="150",
+                max_action={"side": "buy", "notional": 200},
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    usd = _scope(plan, "unattributed", "USD")
+    assert usd.required_active_watches == Decimal("200")
+    assert usd.verdict == "unknown"
+    # The KRW scope is genuinely unaffected — no KRW money is unresolved.
+    assert _scope(plan, "upbit").verdict == "sufficient"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_mode", ["upbit_live", "kiwoom_mock", "", "KIS_LIVE"])
+async def test_r2f_unmapped_account_mode_lands_unattributed_with_its_real_reason(
+    bad_mode: str,
+) -> None:
+    """verify-r2 (f) — values outside the closed map fall through this path.
+
+    Two things are pinned: the value does not silently attribute to some
+    broker, and the published reason names the offending value instead of
+    claiming ``account_mode`` was missing (verify-r2 SHOULD-3).
+    """
+
+    home = _home(
+        groups=[],
+        accounts=[
+            _account(account_id="upbit-1", source="upbit", krw=0),
+            _account(account_id="kis-1", source="kis", krw=1000000),
+        ],
+    )
+    watches = _StubWatches(
+        [
+            _watch(
+                symbol="KRW-XRP",
+                max_action={
+                    "side": "buy",
+                    "account_mode": bad_mode,
+                    "notional": 330000,
+                },
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    row = plan.active_buy_watches[0]
+    assert row.funding_broker == "unattributed"
+    assert all(scope.verdict != "sufficient" for scope in plan.funding.scopes)
+
+    reason = plan.funding.unattributed[0].reason
+    if bad_mode.strip():
+        # The wrong value is quoted back rather than laundered into "missing".
+        assert bad_mode in reason
+        assert "지정하지 않았습니다" not in reason
+    else:
+        assert "account_mode" in reason
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_r2_unattributed_row_does_not_double_count_itself() -> None:
+    """The destination row holds the pool; it must not also be measured by it."""
+
+    home = _home(groups=[], accounts=[])
+    watches = _StubWatches(
+        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "notional": 300000})]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    destination = _scope(plan, "unattributed")
+    assert destination.required_total == Decimal("300000")
+    assert destination.unattributed_same_currency == Decimal("0")
+    assert destination.upper_bound_if_all_unattributed_lands_here == Decimal("300000")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_r2_fully_attributed_book_still_reaches_sufficient() -> None:
+    """The fix must not make every board permanently unknown."""
+
+    home = _home(
+        groups=[],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=900000)],
+    )
+    watches = _StubWatches(
+        [
+            _watch(
+                symbol="KRW-XRP",
+                max_action={
+                    "side": "buy",
+                    "account_mode": "upbit",
+                    "notional": 300000,
+                },
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    upbit = _scope(plan, "upbit")
+    assert upbit.required_active_watches == Decimal("300000")
+    assert upbit.unattributed_same_currency == Decimal("0")
+    assert upbit.verdict == "sufficient"
+    assert plan.funding.unattributed == []
+    assert not any(scope.broker == "unattributed" for scope in plan.funding.scopes)
+
+
+@pytest.mark.unit
+def test_s1_unevaluated_conditions_cover_every_real_eligibility_gate() -> None:
+    """verify-r2 SHOULD-1 — the published list must not be a short list.
+
+    The reject reasons are string literals inside
+    ``evaluate_auto_approve_eligibility``; they are extracted from its AST here
+    so the board's split cannot drift away from the function it describes. A
+    seven-item list against eighteen real gates still reads as "these are the
+    only things we skipped".
+    """
+
+    import ast
+    import inspect
+
+    from app.services.invest_view_model.buy_plan.service import (
+        AUTO_APPROVE_EVALUATED_CONDITIONS,
+        AUTO_APPROVE_UNEVALUATED_CONDITIONS,
+    )
+    from app.services.order_proposals import auto_approve
+
+    source = inspect.getsource(auto_approve.evaluate_auto_approve_eligibility)
+    tree = ast.parse(textwrap.dedent(source))
+
+    reasons: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (isinstance(node.func, ast.Name) and node.func.id == "reject"):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            reasons.add(first.value)
+        elif isinstance(first, ast.Subscript) and isinstance(first.value, ast.Dict):
+            # reject({...}[verdict], ...) — the sell-classification branch.
+            for value in first.value.values:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    reasons.add(value.value)
+        elif isinstance(first, ast.IfExp):
+            # reject("a" if expanded else "b", ...)
+            for value in (first.body, first.orelse):
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    reasons.add(value.value)
+
+    # Sanity: the extractor must actually find gates, or this test proves nothing.
+    assert len(reasons) >= 15, sorted(reasons)
+
+    published = {code for code, _ in AUTO_APPROVE_UNEVALUATED_CONDITIONS} | {
+        code for code, _ in AUTO_APPROVE_EVALUATED_CONDITIONS
+    }
+    assert reasons == published, {
+        "missing_from_board": sorted(reasons - published),
+        "not_in_function": sorted(published - reasons),
+    }
+
+    # The one gate the board really does check is on the evaluated side.
+    assert {code for code, _ in AUTO_APPROVE_EVALUATED_CONDITIONS} == {
+        "per_order_cap_exceeded"
+    }

--- a/tests/services/invest_view_model/buy_plan/test_service.py
+++ b/tests/services/invest_view_model/buy_plan/test_service.py
@@ -1,0 +1,718 @@
+"""§144차 — 매수 계획 aggregate contract.
+
+The board is a funding decision aid, so the properties pinned here are the
+ones that would send the operator to move the wrong amount of money: which
+holdings become rows, which cash counts, what is double-counted, and how an
+unreadable gate metric is reported.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.invest_home import (
+    Account,
+    CashAmounts,
+    GroupedHolding,
+    GroupedSourceBreakdown,
+    HomeSummary,
+    InvestHomeResponse,
+)
+from app.schemas.invest_watches import WatchAlertRow, WatchesResponse
+from app.schemas.open_orders import OpenOrderRow, OpenOrdersResponse
+from app.services.invest_view_model.buy_plan import gate_inputs
+from app.services.invest_view_model.buy_plan.gate_inputs import GateMetricReading
+from app.services.invest_view_model.buy_plan.service import BuyPlanService
+
+NOW = dt.datetime(2026, 8, 23, 3, 0, tzinfo=dt.UTC)
+
+
+def _breakdown(
+    *,
+    source: str,
+    quantity: float,
+    average_cost: float,
+    tradeable: bool = True,
+) -> GroupedSourceBreakdown:
+    return GroupedSourceBreakdown(
+        holdingId=f"{source}:{quantity}",
+        accountId=f"acct-{source}",
+        source=source,  # type: ignore[arg-type]
+        accountKind="live" if tradeable else "manual",
+        quantity=quantity,
+        averageCost=average_cost,
+        costBasis=quantity * average_cost,
+        isTradeable=tradeable,
+        sourceOfTruth=tradeable,
+        manualOnly=not tradeable,
+    )
+
+
+def _group(
+    *,
+    symbol: str,
+    market: str,
+    currency: str,
+    quantity: float,
+    average_cost: float,
+    current_price: float,
+    breakdown: list[GroupedSourceBreakdown] | None = None,
+) -> GroupedHolding:
+    parts = breakdown or [
+        _breakdown(
+            source="upbit" if market == "CRYPTO" else "kis",
+            quantity=quantity,
+            average_cost=average_cost,
+        )
+    ]
+    return GroupedHolding(
+        groupId=f"{market}:{symbol}",
+        symbol=symbol,
+        market=market,  # type: ignore[arg-type]
+        assetType="crypto" if market == "CRYPTO" else "equity",
+        assetCategory=(
+            "crypto"
+            if market == "CRYPTO"
+            else ("kr_stock" if market == "KR" else "us_stock")
+        ),
+        displayName=symbol,
+        currency=currency,  # type: ignore[arg-type]
+        totalQuantity=quantity,
+        tradeableQuantity=sum(p.quantity for p in parts if p.isTradeable),
+        averageCost=average_cost,
+        costBasis=quantity * average_cost,
+        valueNative=quantity * current_price,
+        pnlRate=(current_price - average_cost) / average_cost,
+        priceState="live",
+        includedSources=[p.source for p in parts],
+        sourceBreakdown=parts,
+    )
+
+
+def _home(
+    *,
+    groups: list[GroupedHolding],
+    accounts: list[Account] | None = None,
+) -> InvestHomeResponse:
+    return InvestHomeResponse(
+        homeSummary=HomeSummary(
+            includedSources=["kis", "upbit"],
+            excludedSources=[],
+            totalValueKrw=0.0,
+        ),
+        accounts=accounts if accounts is not None else [],
+        holdings=[],
+        groupedHoldings=groups,
+    )
+
+
+def _account(
+    *,
+    account_id: str,
+    source: str,
+    kind: str = "live",
+    krw: float | None = None,
+    usd: float | None = None,
+    buying_krw: float | None = None,
+) -> Account:
+    return Account(
+        accountId=account_id,
+        displayName=account_id,
+        source=source,  # type: ignore[arg-type]
+        accountKind=kind,  # type: ignore[arg-type]
+        includedInHome=True,
+        valueKrw=0.0,
+        cashBalances=CashAmounts(krw=krw, usd=usd),
+        buyingPower=CashAmounts(krw=buying_krw),
+    )
+
+
+class _StubHome:
+    def __init__(self, response: InvestHomeResponse | Exception) -> None:
+        self._response = response
+
+    async def get_home(self, *, user_id: int) -> InvestHomeResponse:
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+class _StubWatches:
+    def __init__(self, items: list[WatchAlertRow] | None = None) -> None:
+        self._items = items or []
+
+    async def list_watches(self, *, market: str, status: str) -> WatchesResponse:
+        return WatchesResponse(
+            market=market,  # type: ignore[arg-type]
+            status=status,  # type: ignore[arg-type]
+            count=len(self._items),
+            data_state="ok",
+            as_of=NOW,
+            items=self._items,
+        )
+
+
+class _StubOpenOrders:
+    def __init__(self, items: list[OpenOrderRow] | None = None) -> None:
+        self._items = items or []
+
+    async def list_open_orders(self, *, market: str) -> OpenOrdersResponse:
+        return OpenOrdersResponse(
+            market=market,  # type: ignore[arg-type]
+            count=len(self._items),
+            data_state="ok",
+            as_of=NOW,
+            items=self._items,
+            sources=[],
+        )
+
+
+def _service(
+    *,
+    home: Any,
+    watches: Any = None,
+    open_orders: Any = None,
+) -> BuyPlanService:
+    return BuyPlanService(
+        home_service=home,
+        watch_service=watches or _StubWatches(),
+        open_orders_service=open_orders or _StubOpenOrders(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_gate_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No network in unit tests; each test opts into its own gate readings."""
+
+    gate_inputs._reset_cache_for_tests()
+
+    async def _breadth() -> GateMetricReading:
+        return GateMetricReading(
+            metric="upbit_alt_breadth_24h", value=Decimal("62"), source="stub"
+        )
+
+    async def _lsr() -> GateMetricReading:
+        return GateMetricReading(
+            metric="btc_long_short_ratio", value=Decimal("1.2"), source="stub"
+        )
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.buy_plan.service.read_alt_breadth_24h", _breadth
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.buy_plan.service.read_btc_long_short_ratio",
+        _lsr,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_underwater_lot_becomes_an_averaging_row_with_a_turn_point() -> None:
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=100,
+                average_cost=1100,
+                current_price=1050,
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(home)).build(user_id=1, market="all", now=NOW)
+
+    assert [row.symbol for row in plan.averaging_triggers] == ["XRP"]
+    row = plan.averaging_triggers[0]
+    assert row.turn_point_price == Decimal("1000")
+    assert row.turn_point_reached is False
+    assert [s.offset_from_turn_point_pct for s in row.samples] == [
+        Decimal("-1"),
+        Decimal("-3"),
+    ]
+    # The reserve figure is the deeper (more expensive) of the two samples.
+    assert row.reserve_plan_notional == max(s.additional_notional for s in row.samples)
+    assert row.market_rank == 1
+    assert row.within_policy_add_cap is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_manual_reference_quantity_is_excluded_from_the_average() -> None:
+    """A manual lot cannot be added to through a broker.
+
+    Folding it into the average would move the turn point to a price no order
+    can act on, so it is excluded and the exclusion is reported.
+    """
+
+    home = _home(
+        groups=[
+            _group(
+                symbol="005930",
+                market="KR",
+                currency="KRW",
+                quantity=30,
+                average_cost=70000,
+                current_price=60000,
+                breakdown=[
+                    _breakdown(source="kis", quantity=10, average_cost=110000),
+                    _breakdown(
+                        source="toss_manual",
+                        quantity=20,
+                        average_cost=50000,
+                        tradeable=False,
+                    ),
+                ],
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(home)).build(user_id=1, market="kr", now=NOW)
+
+    row = plan.averaging_triggers[0]
+    assert row.quantity == Decimal("10")
+    assert row.average_price == Decimal("110000")
+    assert row.turn_point_price == Decimal("100000")
+    assert any("수동/참고" in note for note in row.notes)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_market_add_cap_bounds_the_funding_total() -> None:
+    """Only the top ``max_add_symbols_per_market`` rows are money to reserve."""
+
+    groups = [
+        _group(
+            symbol=symbol,
+            market="CRYPTO",
+            currency="KRW",
+            quantity=1000,
+            average_cost=1100,
+            current_price=price,
+        )
+        for symbol, price in (("AAA", 900), ("BBB", 910), ("CCC", 920))
+    ]
+    plan = await _service(home=_StubHome(_home(groups=groups))).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    assert len(plan.averaging_triggers) == 3
+    within = [row for row in plan.averaging_triggers if row.within_policy_add_cap]
+    assert len(within) == 2
+    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    assert krw.required_averaging_adds == sum(
+        (row.reserve_plan_notional for row in within), Decimal(0)
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_only_live_accounts_fund_the_reserve() -> None:
+    home = _home(
+        groups=[],
+        accounts=[
+            _account(account_id="upbit-1", source="upbit", krw=500000),
+            _account(
+                account_id="pension", source="pension_manual", kind="manual", krw=9e9
+            ),
+        ],
+    )
+    plan = await _service(home=_StubHome(home)).build(user_id=1, market="all", now=NOW)
+
+    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    assert krw.available_cash == Decimal("500000")
+    assert krw.verdict == "sufficient"
+    included = {
+        row.account_id for row in plan.funding.accounts if row.included_in_reserve
+    }
+    assert included == {"upbit-1"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buying_power_wins_over_the_raw_cash_balance() -> None:
+    home = _home(
+        groups=[],
+        accounts=[
+            _account(account_id="kis-1", source="kis", krw=1000000, buying_krw=400000)
+        ],
+    )
+    plan = await _service(home=_StubHome(home)).build(user_id=1, market="all", now=NOW)
+
+    row = next(r for r in plan.funding.accounts if r.currency == "KRW")
+    assert row.available_cash == Decimal("400000")
+    assert row.available_cash_source == "buyingPower"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shortfall_reports_the_deposit_amount() -> None:
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1100,
+                current_price=900,
+            )
+        ],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=1000)],
+    )
+    plan = await _service(home=_StubHome(home)).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    assert krw.verdict == "shortfall"
+    assert krw.shortfall == krw.required_total - Decimal("1000")
+    assert krw.shortfall > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_partially_unknown_cash_holds_the_verdict_instead_of_understating() -> (
+    None
+):
+    home = _home(
+        groups=[],
+        accounts=[
+            _account(account_id="upbit-1", source="upbit", krw=500000),
+            _account(account_id="kis-1", source="kis", usd=None, krw=None),
+        ],
+    )
+    plan = await _service(home=_StubHome(home)).build(user_id=1, market="all", now=NOW)
+
+    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    assert krw.verdict == "unknown"
+    assert krw.available_cash is None
+    assert any("가용 현금" in warning for warning in plan.warnings)
+
+
+def _watch(
+    *,
+    symbol: str,
+    market: str = "crypto",
+    threshold: str = "900",
+    max_action: dict | None = None,
+    intent: str = "buy_review",
+) -> WatchAlertRow:
+    return WatchAlertRow(
+        alert_uuid=uuid4(),
+        source_report_uuid=None,
+        market=market,  # type: ignore[arg-type]
+        symbol=symbol,
+        target_kind="asset",
+        metric="price_below",
+        operator="below",
+        threshold=Decimal(threshold),
+        status="active",
+        valid_until=NOW + dt.timedelta(days=5),
+        intent=intent,
+        action_mode="review",
+        rationale="test",
+        max_action=max_action or {},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_watches_never_enter_the_buy_plan() -> None:
+    watches = _StubWatches(
+        [
+            _watch(symbol="KRW-XRP", max_action={"side": "buy", "notional": 100000}),
+            _watch(symbol="KRW-SOL", max_action={"side": "sell", "notional": 100000}),
+        ]
+    )
+    plan = await _service(home=_StubHome(_home(groups=[])), watches=watches).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    assert [row.symbol for row in plan.active_buy_watches] == ["KRW-XRP"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_max_action_side_overrides_a_buy_review_intent() -> None:
+    """The typed execution plan is authoritative over the legacy intent field."""
+
+    watches = _StubWatches(
+        [
+            _watch(
+                symbol="KRW-XRP",
+                intent="buy_review",
+                max_action={"side": "sell", "notional": 100000},
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(_home(groups=[])), watches=watches).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    assert plan.active_buy_watches == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_watch_without_a_notional_is_carded_not_auto_submitted() -> None:
+    watches = _StubWatches([_watch(symbol="KRW-XRP", max_action={"side": "buy"})])
+    plan = await _service(home=_StubHome(_home(groups=[])), watches=watches).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    row = plan.active_buy_watches[0]
+    assert row.planned_notional is None
+    assert row.approval_lane == "human_card"
+    assert row.approval_lane_reason == "notional_unavailable"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_support_net_lists_profitable_holdings_and_excludes_losers() -> None:
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1000,
+                current_price=1200,
+            ),
+            _group(
+                symbol="SOL",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=10,
+                average_cost=200000,
+                current_price=150000,
+            ),
+        ]
+    )
+    plan = await _service(home=_StubHome(home)).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    by_symbol = {row.symbol: row for row in plan.support_net.rows}
+    assert by_symbol["XRP"].eligible is True
+    assert by_symbol["SOL"].eligible is False
+    assert by_symbol["SOL"].ineligible_reason == "이익권 아님 (평가손익 ≤ 0)"
+    # Ineligible coins get no headroom to spend.
+    assert by_symbol["SOL"].remaining_headroom_notional == 0
+    assert plan.support_net.per_symbol_cap_notional == Decimal("300000")
+    assert plan.support_net.tier_cap_notional == Decimal("900000")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resting_buy_order_consumes_headroom_but_not_new_cash() -> None:
+    """The broker already holds cash for a resting limit.
+
+    Counting it again as "money to deposit" would tell the operator to move
+    KRW that is already committed.
+    """
+
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1000,
+                current_price=1200,
+            )
+        ],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=1000000)],
+    )
+    orders = _StubOpenOrders(
+        [
+            OpenOrderRow(
+                broker="upbit",
+                market="crypto",
+                symbol="KRW-XRP",
+                side="buy",
+                price=Decimal("1100"),
+                quantity=Decimal("100"),
+                remaining_qty=Decimal("100"),
+                order_no="upbit-1",
+            )
+        ]
+    )
+    plan = await _service(home=_StubHome(home), open_orders=orders).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    row = next(r for r in plan.support_net.rows if r.symbol == "XRP")
+    assert [p.form for p in row.placements] == ["resting_order"]
+    assert row.placed_notional == Decimal("110000")
+    assert row.remaining_headroom_notional == Decimal("190000")
+    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    assert krw.required_support_net == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_watch_rung_is_not_counted_twice() -> None:
+    """The same watch appears in both the net and the watch list.
+
+    It must contribute its notional to the required total exactly once.
+    """
+
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1000,
+                current_price=1200,
+            )
+        ],
+        accounts=[_account(account_id="upbit-1", source="upbit", krw=1000000)],
+    )
+    watches = _StubWatches(
+        [_watch(symbol="KRW-XRP", max_action={"side": "buy", "amount_krw": 120000})]
+    )
+    plan = await _service(home=_StubHome(home), watches=watches).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    assert krw.required_support_net == Decimal("120000")
+    assert krw.required_active_watches == 0
+    assert krw.required_total == krw.required_averaging_adds + Decimal("120000")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate_opens_when_both_conditions_pass() -> None:
+    plan = await _service(home=_StubHome(_home(groups=[]))).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    gate = plan.discovery_gates[0]
+    assert gate.state == "open"
+    assert gate.met_count == 2
+    assert gate.unavailable_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unreadable_metric_never_counts_as_met(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``missing_or_null_threshold: do_not_infer_or_count_as_met``."""
+
+    async def _dead() -> GateMetricReading:
+        return GateMetricReading(
+            metric="upbit_alt_breadth_24h", value=None, source="stub", note="down"
+        )
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.buy_plan.service.read_alt_breadth_24h", _dead
+    )
+    plan = await _service(home=_StubHome(_home(groups=[]))).build(
+        user_id=1, market="crypto", now=NOW
+    )
+
+    gate = plan.discovery_gates[0]
+    assert gate.state == "indeterminate"
+    assert gate.met_count == 1
+    assert gate.unavailable_count == 1
+    breadth = next(c for c in gate.conditions if c.metric == "upbit_alt_breadth_24h")
+    assert breadth.state == "unavailable"
+    assert breadth.current_value is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_failing_condition_closes_the_gate() -> None:
+    async def _low() -> GateMetricReading:
+        return GateMetricReading(
+            metric="upbit_alt_breadth_24h", value=Decimal("30"), source="stub"
+        )
+
+    service = _service(home=_StubHome(_home(groups=[])))
+    import app.services.invest_view_model.buy_plan.service as service_module
+
+    original = service_module.read_alt_breadth_24h
+    service_module.read_alt_breadth_24h = _low  # type: ignore[assignment]
+    try:
+        plan = await service.build(user_id=1, market="crypto", now=NOW)
+    finally:
+        service_module.read_alt_breadth_24h = original  # type: ignore[assignment]
+
+    gate = plan.discovery_gates[0]
+    assert gate.state == "closed"
+    assert gate.met_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_dead_holdings_reader_degrades_instead_of_raising() -> None:
+    plan = await _service(home=_StubHome(RuntimeError("KIS down"))).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    assert plan.averaging_triggers == []
+    assert any("보유·현금 조회 실패" in warning for warning in plan.warnings)
+    krw = next(c for c in plan.funding.currencies if c.currency == "KRW")
+    assert krw.verdict == "unknown"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_response_carries_its_own_provenance() -> None:
+    plan = await _service(home=_StubHome(_home(groups=[]))).build(
+        user_id=1, market="all", now=NOW
+    )
+
+    assert plan.as_of == NOW
+    assert plan.policy.version
+    assert plan.policy.content_hash
+    assert "표시용 근사" in plan.approximation_notice
+    assert plan.cache_ttl_seconds > 0
+    assert {source.field for source in plan.value_sources} >= {
+        "averaging_triggers.*",
+        "funding.accounts[].available_cash",
+        "*.approval_lane",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_market_filter_scopes_every_block() -> None:
+    home = _home(
+        groups=[
+            _group(
+                symbol="XRP",
+                market="CRYPTO",
+                currency="KRW",
+                quantity=1000,
+                average_cost=1100,
+                current_price=900,
+            ),
+            _group(
+                symbol="005930",
+                market="KR",
+                currency="KRW",
+                quantity=10,
+                average_cost=110000,
+                current_price=90000,
+            ),
+        ]
+    )
+    plan = await _service(home=_StubHome(home)).build(user_id=1, market="kr", now=NOW)
+
+    assert [row.symbol for row in plan.averaging_triggers] == ["005930"]
+    assert plan.support_net.rows == []
+    assert plan.support_net.enabled is False
+    # The crypto gate is not evaluated for a KR-scoped board.
+    assert plan.discovery_gates == []

--- a/tests/test_invest_api_router_safety.py
+++ b/tests/test_invest_api_router_safety.py
@@ -87,3 +87,28 @@ def test_market_parity_service_no_mutation_imports() -> None:
     v = _violations(loaded, FORBIDDEN_MUTATION_MODULES)
     if v:
         pytest.fail(f"Forbidden imports in market_parity_service: {v}")
+
+
+@pytest.mark.unit
+def test_buy_plan_router_no_mutation_imports() -> None:
+    """§144차 — the 매수 계획 board is a read surface.
+
+    Its service dependency is resolved lazily inside the dependency function
+    for the same reason invest_api's is: importing the router must not pull the
+    broker/order chain into the process.
+    """
+
+    root = Path(__file__).resolve().parent.parent
+    loaded = _loaded("app.routers.invest_buy_plan", root)
+    v = _violations(loaded, FORBIDDEN_MUTATION_MODULES + ROUTER_FORBIDDEN_DIRECT)
+    if v:
+        pytest.fail(f"Forbidden imports in invest_buy_plan: {v}")
+
+
+@pytest.mark.unit
+def test_buy_plan_service_no_mutation_imports() -> None:
+    root = Path(__file__).resolve().parent.parent
+    loaded = _loaded("app.services.invest_view_model.buy_plan.service", root)
+    v = _violations(loaded, FORBIDDEN_MUTATION_MODULES)
+    if v:
+        pytest.fail(f"Forbidden imports in buy_plan.service: {v}")


### PR DESCRIPTION
## 무엇

운영자 원문: **"매수할 금액·계획을 /invest에서 보고 싶다 — 그래야 적절하게 돈을 옮겨두지."**

`/invest/buy-plan` 에 read-only "매수 계획(트리거 보드)" 를 신설한다. 행 단위는 매수 트리거이고, 맨 위 블록이 **계좌별** 현금 대 트리거 소요액 대조다.

## 상태 — draft (rework r2 반영, 재검증 대기 / 라운드 3-3)

| 라운드 | 검증자 | 판정 | 처리 |
|---|---|---|---|
| 1 | OpenAI/Codex | BLOCKER 6 | 전부 수리 → 라운드 2 에서 6/6 `CONFIRMED(닫힘)` |
| 2 | Grok 4.6 | BLOCKER 1 / SHOULD 5 | 이 커밋에서 전부 수리 |

exact-head required CI 6종 green (`d166336bb`).

## 행 정의

| 블록 | 출처 |
|---|---|
| ① 물타기 A(k) 전환점 | 보유 × `buy.support_reserve_net.add_candidate.k_used` |
| ② 지지 그물 티어 | `buy.held_majors_support_net` × 미체결 + 활성 워치 |
| ③ 활성 매수 워치 | WatchPanelService × `max_action` |
| ④ 발굴 게이트 | `market_rules.crypto.recovery_gate` |
| 자금 대조 | **(브로커, 통화) 쌍별** `Account.buyingPower ?? cashBalances` (live 계좌만) |

## verify-r2 BLOCKER — covering rule 제거

라운드 1 의 브로커 스코핑은 *귀속된* 경로를 닫았지만, 내가 함께 넣은 판정 규칙이 *귀속 실패* 경로로 같은 급소를 다시 열었다.

```
(구) attributed + unattributed > available -> unknown
     그 외                                  -> sufficient   ← 거짓
```

전제였던 "이 스코프가 unattributed 전액을 떠안는 게 최악"이 틀렸다 — **그 돈은 다른 브로커로 갈 수 있다.**

```
(신) available is None      -> unknown
     attributed > available -> shortfall   (증명된 하한, 유지)
     incomplete             -> unknown
     unattributed > 0       -> unknown     ← sufficient 불가
     그 외                   -> sufficient
```

추가로 **목적지 행**을 만든다: `scope_keys` 가 귀속 실패 소요에도 `(unattributed, currency)` 행을 생성해, 현금계좌가 없는 통화(USD 200)나 보드에 행이 없는 브로커로 갈 돈이 **어디서도 판정을 못 받는** 상태를 없앤다.

`worst_case_required` → `upper_bound_if_all_unattributed_lands_here`. 진짜 최악은 "빈 계좌로 떨어지는 것"이라 종전 이름 자체가 거짓이었다.

🔴 `test_b1_scope_stays_sufficient_when_cash_covers_the_worst_case` 는 **틀린 동작을 박아 둔 테스트**였다. 뒤집었다.

회귀: (a) 브로커 교차 · (b) 스코프 부재 · (d) 통화 스코프 부재 · (f) 맵 밖 `account_mode` 4종. 되돌리기 뮤턴트 2종(covering rule / 목적지 행) 각각 RED 확인.

## verify-r2 SHOULD 5건

| # | 수리 |
|---|---|
| S1 | `unevaluated_conditions` 7 → 18. `evaluate_auto_approve_eligibility` 의 `reject(...)` 리터럴을 **AST 로 추출해 대조**하는 테스트로 드리프트를 기계 차단. 보드가 실제로 보는 것은 `per_order_cap_exceeded` 하나뿐이라 evaluated/unevaluated 로 분리 |
| S2 | `master_gate_enabled=null` 이 ON 과 같은 accent 였다 → `레인 판정 불가(게이트 상태 불명)` + warn |
| S3 | `funding_broker_reason` 을 행에 실어 `kiwoom_mock` 같은 오값이 "account_mode 가 없습니다"로 세탁되지 않게 |
| S4 | `requirements_complete=false` 인 shortfall 을 `최소 ₩X 입금 필요` + 하한 명시 |
| S5 | BLOCKER 목적지 행과 같은 수리 (함께 처리) |

## 이 보드가 하지 않는 것

- **회차 판정을 재현하지 않는다** — 지지 품질·R-931·섹터 집중도·crash-day 미참조
- 주문·제안·워치 생성 0, 마이그레이션 0, 스케줄러 0, 정책 임계 변경 0
- 지지선 재계산 0

## 범위 밖 (다음 라운드 이후)

NICE 2건(`compareDecimalStrings("-0","0")` 보드 미사용 / UI 테스트 개수) · 라운드 1 잔여 SHOULD(`P*` 용어 동치 · −3% 화면 고지 · Toss lock 미확정 · 게이트 7 HTTP·60초 · upstream float ingress · frontend Vitest CI 실행 배선).

## 정지점

머지·배포·ready 전환 없음. browse-QA 미수행(운영자 입회 항목).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only “Buy Plan” page accessible from investment navigation.
  * Added market filters for all markets, Korean, US, and crypto assets.
  * Displays averaging triggers, support-net placements, active buy watches, discovery gates, approval status, and funding reconciliation.
  * Shows broker- and currency-specific balances, shortfalls, warnings, and unavailable data states.
  * Preserves exact values for large amounts, prices, percentages, and quantities.
* **Tests**
  * Added comprehensive coverage for calculations, API behavior, data handling, formatting, and responsive page rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->